### PR TITLE
Raise minimum PHP to 8.1 and fix lockfile reproducibility (v5.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.1', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 5.2.0 (2026-04-15)
+
+Raise minimum PHP requirement from 7.4 to 8.1. PHP 7.4 reached end-of-life on 2022-11-28 and PHP 8.0 on 2023-11-26; both are unsupported. The previous lockfile was also resolving `doctrine/instantiator` 2.1.0 — which requires PHP 8.4 — silently breaking `composer install` on PHP 7.4/8.1/8.3 runners.
+
+### Breaking Changes
+
+- Breaking: Minimum PHP bumped from **7.4 → 8.1**. Update your server before upgrading. `Plugin Name` header, `FFC_MIN_PHP_VERSION`, `composer.json#require.php` and `readme.txt#Requires PHP` all updated.
+
+### Chore
+
+- Chore: `composer.json#config.platform.php` pinned to `"8.1"` so the lockfile resolves to versions compatible with the declared minimum regardless of the developer's local PHP version.
+- Chore: `composer.lock` regenerated under PHP 8.1 platform; `doctrine/instantiator` now resolves to `2.0.0` (compatible with PHP ^8.1) instead of `2.1.0` (which required PHP ^8.4).
+- Chore: CI matrix now covers PHP **8.1, 8.2, 8.3, 8.4** (added 8.2, removed 7.4).
+
+### Code Quality
+
+- Chore: Zero PHPStan level 6 errors — cleared 4 findings exposed by newer `php-stubs/wordpress-stubs` (v6.9.1) and `szepeviktor/phpstan-wordpress` (v2.0.3):
+  - `AdminActivityLogPage::output_csv()` PHPDoc: `array<int, array<string, mixed>> $rows` → `array<int, array<array-key, mixed>> $rows` (the method iterates and passes values directly to `fputcsv()` without accessing keys by name; the caller builds rows with positional int keys).
+  - `UserAudienceRestController::build_joinable_node()` PHPDoc: added `array<string, mixed>` value type to `@param $node` and `@return`.
+  - `ReregistrationAdmin` details markup: removed dead `|| $formatted === null` branch — `FichaGenerator::format_field_value()` returns a non-nullable `string`.
+
+---
+
 ## 5.1.0 (2026-04-11)
 
 Public CSV download feature: form organizers without WordPress admin access can now retrieve the submissions CSV of a specific form via a revocable per-form hash, gated by form expiration and a configurable download quota. No new dependencies and no schema changes.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "require-dev": {
         "brain/monkey": "^2.6",
@@ -27,6 +27,9 @@
         }
     },
     "config": {
+        "platform": {
+            "php": "8.1"
+        },
         "sort-packages": true
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9345eaa0d73120e45c048e6a4fbf263",
+    "content-hash": "8f687c77c0e02271c0ea6f0008ea9d63",
     "packages": [],
     "packages-dev": [
         {
@@ -127,29 +127,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -176,7 +177,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -192,7 +193,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -618,11 +619,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.39",
+            "version": "2.1.47",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
-                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/79015445d8bd79e62b29140f12e5bfced1dcca65",
+                "reference": "79015445d8bd79e62b29140f12e5bfced1dcca65",
                 "shasum": ""
             },
             "require": {
@@ -667,7 +668,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T14:48:56+00:00"
+            "time": "2026-04-13T15:49:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2293,8 +2294,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,8 +3,8 @@
 Plugin Name:        Free Form Certificate
 Plugin URI:         https://github.com/rpgmem/ffcertificate
 Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
-Version:            5.1.0
-Requires PHP:       7.4
+Version:            5.2.0
+Requires PHP:       8.1
 Author:             Alex Meusburger
 Author URI:         https://github.com/rpgmem
 License:             GPLv3 or later
@@ -20,14 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '5.1.0' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '5.2.0' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/
 define( 'FFC_JSPDF_VERSION', '2.5.1' );         // jsPDF - https://github.com/parallax/jsPDF
 define( 'FFC_JQUERY_UI_VERSION', '1.12.1' );    // jQuery UI theme (CDN) - https://code.jquery.com/ui/
 
 define( 'FFC_MIN_WP_VERSION', '6.2' );          // Minimum WordPress (required for %i identifier placeholder)
-define( 'FFC_MIN_PHP_VERSION', '7.4' );         // Minimum PHP
+define( 'FFC_MIN_PHP_VERSION', '8.1' );         // Minimum PHP
 define( 'FFC_DEBUG', false );                   // Debug mode
 define( 'FFC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/api/class-ffc-user-audience-rest-controller.php
+++ b/includes/api/class-ffc-user-audience-rest-controller.php
@@ -330,9 +330,9 @@ class UserAudienceRestController {
     /**
      * Build a joinable node recursively, counting joined members.
      *
-     * @param array $node  Audience row with 'children' array.
-     * @param int   $count Reference counter for joined leaf audiences.
-     * @return array|null  Cleaned node or null if branch is empty.
+     * @param array<string, mixed> $node  Audience row with 'children' array.
+     * @param int                  $count Reference counter for joined leaf audiences.
+     * @return array<string, mixed>|null  Cleaned node or null if branch is empty.
      */
     private function build_joinable_node(array $node, int &$count): ?array {
         $children = array();

--- a/includes/core/class-ffc-csv-export-trait.php
+++ b/includes/core/class-ffc-csv-export-trait.php
@@ -117,9 +117,9 @@ trait CsvExportTrait {
      *
      * Handles BOM, UTF-8 encoding, HTTP headers, and row writing.
      *
-     * @param string                           $filename  Download filename (e.g. 'export-2024-01-01.csv').
-     * @param array<int, string>               $headers   Column headers.
-     * @param array<int, array<string, mixed>> $rows      Data rows (each is an array of values).
+     * @param string                              $filename  Download filename (e.g. 'export-2024-01-01.csv').
+     * @param array<int, string>                  $headers   Column headers.
+     * @param array<int, array<array-key, mixed>> $rows      Data rows (each is an array of values passed directly to fputcsv).
      * @return void Exits after output.
      */
     protected function output_csv(string $filename, array $headers, array $rows): void {

--- a/includes/reregistration/class-ffc-reregistration-admin.php
+++ b/includes/reregistration/class-ffc-reregistration-admin.php
@@ -955,7 +955,7 @@ class ReregistrationAdmin {
                             ?>
                             <dt><?php echo esc_html((string) $field->field_label); ?></dt>
                             <dd>
-                                <?php if ($formatted === '' || $formatted === null) : ?>
+                                <?php if ($formatted === '') : ?>
                                     <span class="ffc-details-empty">&mdash;</span>
                                 <?php elseif ($is_html_field) : ?>
                                     <?php echo wp_kses_post($formatted); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 5.1.0
-Requires PHP: 7.4
+Stable tag: 5.2.0
+Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -174,6 +174,16 @@ In the certificate layout editor, use these dynamic tags:
 * Common examples: `{{name}}`, `{{email}}`, `{{cpf_rf}}`, `{{ticket}}`
 
 == Changelog ==
+
+= 5.2.0 (2026-04-15) =
+
+Raise minimum PHP requirement from 7.4 to 8.1.
+
+* Breaking: Minimum PHP bumped from **7.4 → 8.1**. Update your server before upgrading.
+* Chore: `composer.json#config.platform.php` pinned to `8.1` so the lockfile is reproducible regardless of the developer's local PHP version.
+* Chore: Regenerated `composer.lock` — `doctrine/instantiator` now resolves to `2.0.0` (was `2.1.0`, which required PHP ^8.4 and silently broke `composer install` on 7.4/8.1/8.3 runners).
+* Chore: CI matrix now covers PHP **8.1, 8.2, 8.3, 8.4** (added 8.2, removed 7.4).
+* Chore: Zero PHPStan level 6 errors — cleared 4 findings exposed by newer WordPress stubs (widen `output_csv` PHPDoc, add array value types to `build_joinable_node`, remove dead `$formatted === null` branch).
 
 = 5.1.0 (2026-04-11) =
 


### PR DESCRIPTION
## Summary

Raise minimum PHP requirement from **7.4 to 8.1** and fix a lockfile reproducibility issue that was silently breaking CI on every PHP runner except 8.4.

## Why

1. **PHP 7.4 EOL since 2022-11-28**, PHP 8.0 EOL since 2023-11-26 — both unsupported.
2. **Pre-existing bug discovered during Dependabot PR reviews**: the committed `composer.lock` had `doctrine/instantiator 2.1.0`, which requires `php ^8.4`. `composer install` was failing on PHP 7.4/8.1/8.3 runners. Only the PHP 8.4 job ever ran tests. This was hidden until the CI matrix expansion surfaced the pattern across unrelated PRs.

## Changes

### Metadata & version bump (5.1.0 → 5.2.0)
- `ffcertificate.php`: `Version`, `Requires PHP`, `FFC_VERSION`, `FFC_MIN_PHP_VERSION`.
- `readme.txt`: `Stable tag`, `Requires PHP`, new `5.2.0` changelog entry.
- `CHANGELOG.md`: new `5.2.0` entry.
- `composer.json#require.php`: `">=7.4"` → `">=8.1"`.

### Lockfile reproducibility
- Added `composer.json#config.platform.php = "8.1"` so the lock is resolved as if running on the declared minimum, independent of the developer's local PHP version.
- Regenerated `composer.lock`: `doctrine/instantiator` now `2.0.0` (PHP ^8.1 compatible) instead of `2.1.0` (PHP ^8.4 only).

### CI matrix
- `ci.yml` PHP matrix: `['7.4', '8.1', '8.3', '8.4']` → `['8.1', '8.2', '8.3', '8.4']`. Added 8.2 coverage, removed 7.4.

### PHPStan fixes (4 findings exposed by newer WP stubs pulled by the regenerated lock)

| File | Fix |
|---|---|
| `core/class-ffc-csv-export-trait.php` | Widen `output_csv()` `$rows` PHPDoc from `array<int, array<string, mixed>>` to `array<int, array<array-key, mixed>>`. Body never accesses keys by name; caller builds with positional int keys. |
| `api/class-ffc-user-audience-rest-controller.php` | Add `array<string, mixed>` value type to `build_joinable_node()` `@param $node` and `@return`. |
| `reregistration/class-ffc-reregistration-admin.php` | Remove dead `\|\| $formatted === null` branch — `FichaGenerator::format_field_value()` returns non-nullable `string`. |

## Test plan

- [x] `vendor/bin/phpunit` — 3165 tests, 7439 assertions, all green (PHP 8.4 local).
- [x] `vendor/bin/phpstan analyze` — 0 errors at level 6.
- [x] `composer audit --locked` — no advisories.
- [x] `composer validate --strict` — valid.
- [ ] CI matrix (8.1, 8.2, 8.3, 8.4) all green — will verify in this PR.

## Follow-ups after merge

- Close dependabot#11 (`yoast/phpunit-polyfills` 2 → 4) as obsoleted — the lockfile fix here supersedes the downgrade side-effect that made that PR attractive. It can be re-reviewed later on its own merits.
- dependabot#13 (`actions/checkout` 4 → 6) was recreated and should be mergeable once rebased on this.

https://claude.ai/code/session_01R9VorcXFuwNXToG5wZgjSv