### PR TITLE
ci: stop double-running CI on PR branches; require composer audit

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -2,18 +2,20 @@ name: Asset Build Verification
 
 on:
   push:
-    branches: [main, 'claude/**']
+    branches: [main]
     paths:
       - 'assets/**'
       - 'package.json'
+      - 'package-lock.json'
   pull_request:
     paths:
       - 'assets/**'
       - 'package.json'
+      - 'package-lock.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   verify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,15 @@ name: CI
 
 on:
   push:
-    branches: [main, 'claude/**']
+    branches: [main]
   pull_request:
     branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Cancel superseded runs everywhere except main (where every commit
+  # represents a merged PR we want to keep on the record).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:
@@ -39,9 +41,6 @@ jobs:
   audit:
     name: Composer audit
     runs-on: ubuntu-latest
-    # Non-blocking: surfaces advisories without gating merges. Promote to a
-    # required check once the team is comfortable acting on every advisory.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,10 @@ generated `*.min.*` files.
 ## Branches
 
 - `main` is protected; all changes land via pull request.
-- Feature branches use the `claude/<short-description>` prefix so CI runs
-  on push (see `.github/workflows/ci.yml`).
+- Feature branches use the `claude/<short-description>` prefix.
+- CI runs on `pull_request` (and on `push` to `main` post-merge), so open
+  the PR — even as a draft — to get a green/red signal. Pushing to a
+  feature branch without a PR will not trigger CI.
 - Dependabot manages `chore(deps)` / `chore(ci)(deps)` branches.
 
 ## Commit messages


### PR DESCRIPTION
## Why

Every push to a feature branch with an open PR was firing **both** the `push` event (matched by `branches: [main, 'claude/**']`) and the `pull_request` event, so we were paying for ~2× CI on every push for the same signal. PR #18 visibly ran 23 check-runs to cover ~9 logical jobs.

## Changes

- `ci.yml` and `assets.yml`: drop `'claude/**'` from `push.branches`. Feature branches now run CI only via `pull_request`. Trade-off: pre-PR pushes get no signal — open the PR (draft is fine) to get one.
- `concurrency.cancel-in-progress`: changed from `event_name == 'pull_request'` to `github.ref != 'refs/heads/main'`, so superseded runs on any non-main ref get cancelled.
- `composer audit`: drop `continue-on-error: true`. Recent runs have been clean; promote it from advisory to required so regressions show red.
- `CONTRIBUTING.md`: document the PR-only signal flow.
- `assets.yml` paths now also trigger on `package-lock.json` (already implied by `package.json` in spirit, but explicit avoids surprise misses on lockfile-only bumps).

## Test plan

- [ ] Single round of CI on this PR (no duplicate push+pull_request runs)
- [ ] Composer audit runs and passes (now gating)
- [ ] PHPStan + PHPUnit matrix green
- [ ] Asset Build Verification skipped (no asset changes)