### PR TITLE
feat(phpstan): promote to level 7

### DIFF
--- a/includes/admin/class-ffc-admin-user-custom-fields.php
+++ b/includes/admin/class-ffc-admin-user-custom-fields.php
@@ -241,7 +241,7 @@ class AdminUserCustomFields {
                     6 => __('Saturday', 'ffcertificate'),
                 );
                 ?>
-                <input type="hidden" name="<?php echo esc_attr($input_name); ?>" id="<?php echo esc_attr($input_name); ?>" value="<?php echo esc_attr(wp_json_encode($wh_data)); ?>">
+                <input type="hidden" name="<?php echo esc_attr($input_name); ?>" id="<?php echo esc_attr($input_name); ?>" value="<?php echo esc_attr(wp_json_encode($wh_data) ?: ''); ?>">
                 <div class="ffc-working-hours" data-target="<?php echo esc_attr($input_name); ?>">
                     <table class="widefat ffc-wh-table" style="max-width:800px">
                         <thead>

--- a/includes/admin/class-ffc-admin.php
+++ b/includes/admin/class-ffc-admin.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Admin {
 
-    /** @var object */
+    /** @var \FreeFormCertificate\Submissions\SubmissionHandler */
     private $submission_handler;
     /** @var object */
     private $csv_exporter;
@@ -42,7 +42,7 @@ class Admin {
     /** @var AdminActivityLogPage */
     private $activity_log_page;
 
-    public function __construct( object $handler, object $exporter ) {
+    public function __construct( \FreeFormCertificate\Submissions\SubmissionHandler $handler, object $exporter ) {
         $this->submission_handler = $handler;
         $this->csv_exporter = $exporter;
 
@@ -174,7 +174,7 @@ class Admin {
                     type="button"
                     id="ffc-csv-export-btn"
                     class="<?php echo esc_attr( $btn_class ); ?>"
-                    data-form-ids="<?php echo esc_attr( wp_json_encode( $filter_form_ids ) ); ?>"
+                    data-form-ids="<?php echo esc_attr( wp_json_encode( $filter_form_ids ) ?: '' ); ?>"
                     data-status="<?php echo esc_attr( $export_status ); ?>"
                 ><?php echo esc_html( $btn_label ); ?></button>
                 <span id="ffc-csv-export-progress" style="display:none; margin-left:8px; vertical-align:middle;"></span>

--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -600,6 +600,7 @@ class FormEditorMetaboxRenderer {
      * @param array<string, mixed> $field Field data
      */
     public function render_field_row( $index, array $field ): void {
+        $index = (string) $index;
         $type    = isset( $field['type'] ) ? $field['type'] : 'text';
         $label   = isset( $field['label'] ) ? $field['label'] : '';
         $name    = isset( $field['name'] ) ? $field['name'] : '';

--- a/includes/admin/class-ffc-settings.php
+++ b/includes/admin/class-ffc-settings.php
@@ -40,7 +40,7 @@ class Settings {
      */
     private $save_handler;
 
-    public function __construct( object $handler ) {
+    public function __construct( \FreeFormCertificate\Submissions\SubmissionHandler $handler ) {
         $this->save_handler = new \FreeFormCertificate\Admin\SettingsSaveHandler( $handler );
 
         // Hooks

--- a/includes/admin/class-ffc-submissions-list.php
+++ b/includes/admin/class-ffc-submissions-list.php
@@ -37,7 +37,7 @@ class SubmissionsList extends \WP_List_Table {
      */
     private array $form_titles_cache = [];
 
-    public function __construct( object $handler ) {
+    public function __construct( \FreeFormCertificate\Submissions\SubmissionHandler $handler ) {
         parent::__construct([
             'singular' => 'submission',
             'plural' => 'submissions',

--- a/includes/api/class-ffc-form-rest-controller.php
+++ b/includes/api/class-ffc-form-rest-controller.php
@@ -302,8 +302,8 @@ class FormRestController {
                 if (!$geofence_check['allowed']) {
                     return new \WP_Error(
                         'geofence_blocked',
-                        $geofence_check['message'],
-                        array('status' => 403, 'reason' => $geofence_check['reason'])
+                        $geofence_check['message'] ?? '',
+                        array('status' => 403, 'reason' => $geofence_check['reason'] ?? '')
                     );
                 }
             }

--- a/includes/api/class-ffc-user-profile-rest-controller.php
+++ b/includes/api/class-ffc-user-profile-rest-controller.php
@@ -293,7 +293,7 @@ class UserProfileRestController {
             if (class_exists('\FreeFormCertificate\Security\RateLimiter')) {
                 $rate_check = \FreeFormCertificate\Security\RateLimiter::check_user_limit($user_id, 'password_change', 3, 5);
                 if (!$rate_check['allowed']) {
-                    return new \WP_Error('rate_limited', $rate_check['message'], array('status' => 429));
+                    return new \WP_Error('rate_limited', $rate_check['message'] ?? '', array('status' => 429));
                 }
             }
 
@@ -366,7 +366,7 @@ class UserProfileRestController {
             if (class_exists('\FreeFormCertificate\Security\RateLimiter')) {
                 $rate_check = \FreeFormCertificate\Security\RateLimiter::check_user_limit($user_id, 'privacy_request', 2, 3);
                 if (!$rate_check['allowed']) {
-                    return new \WP_Error('rate_limited', $rate_check['message'], array('status' => 429));
+                    return new \WP_Error('rate_limited', $rate_check['message'] ?? '', array('status' => 429));
                 }
             }
 

--- a/includes/audience/class-ffc-audience-admin-import.php
+++ b/includes/audience/class-ffc-audience-admin-import.php
@@ -418,6 +418,9 @@ class AudienceAdminImport {
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
         $output = fopen('php://output', 'w');
+        if ($output === false) {
+            exit;
+        }
         fputcsv($output, array('email', 'name', 'audience_name'));
 
         $seen = array(); // Avoid duplicate rows for same user+audience
@@ -464,6 +467,9 @@ class AudienceAdminImport {
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
         $output = fopen('php://output', 'w');
+        if ($output === false) {
+            exit;
+        }
         fputcsv($output, array('name', 'color', 'parent'));
 
         // Parents first, then children (same order as import expects)

--- a/includes/audience/class-ffc-audience-booking-repository.php
+++ b/includes/audience/class-ffc-audience-booking-repository.php
@@ -143,6 +143,7 @@ class AudienceBookingRepository {
 
         $prepare_args = array_merge( array( $table, $env_table ), $values );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $sql = $wpdb->prepare($sql, $prepare_args);
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
@@ -709,6 +710,7 @@ class AudienceBookingRepository {
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         return $wpdb->get_results(
             $wpdb->prepare(
+                /** @phpstan-ignore-next-line argument.type */
                 "SELECT * FROM %i
                 WHERE environment_id = %d
                 AND booking_date = %s
@@ -795,6 +797,7 @@ class AudienceBookingRepository {
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         $conflicting_bookings = $wpdb->get_results(
             $wpdb->prepare(
+                /** @phpstan-ignore-next-line argument.type */
                 "SELECT DISTINCT b.* FROM %i b
                 LEFT JOIN %i ba ON b.id = ba.booking_id
                 LEFT JOIN %i am ON ba.audience_id = am.audience_id
@@ -881,6 +884,7 @@ class AudienceBookingRepository {
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         return $wpdb->get_results(
             $wpdb->prepare(
+                /** @phpstan-ignore-next-line argument.type */
                 "SELECT b.id, b.start_time, b.end_time, b.description, a.name AS audience_name, ba.audience_id
                 FROM %i b
                 INNER JOIN %i ba ON b.id = ba.booking_id

--- a/includes/audience/class-ffc-audience-csv-importer.php
+++ b/includes/audience/class-ffc-audience-csv-importer.php
@@ -63,7 +63,7 @@ class AudienceCsvImporter {
         }
 
         // Normalize header
-        $header = array_map('strtolower', array_map('trim', $header));
+        $header = array_map('strtolower', array_map('trim', array_map('strval', $header)));
         $header = array_map(function($col) {
             return preg_replace('/[^a-z0-9_]/', '_', $col);
         }, $header);
@@ -202,7 +202,7 @@ class AudienceCsvImporter {
         }
 
         // Normalize header
-        $header = array_map('strtolower', array_map('trim', $header));
+        $header = array_map('strtolower', array_map('trim', array_map('strval', $header)));
 
         // Find required columns
         $name_col = array_search('name', $header, true);
@@ -355,7 +355,8 @@ class AudienceCsvImporter {
      */
     private static function create_ffc_user(string $email, string $name = '') {
         // Generate username from email
-        $username = sanitize_user(substr($email, 0, strpos($email, '@')), true);
+        $at_pos = strpos($email, '@');
+        $username = sanitize_user(substr($email, 0, $at_pos !== false ? $at_pos : null), true);
 
         // Ensure unique username
         $original_username = $username;
@@ -428,7 +429,7 @@ class AudienceCsvImporter {
             return $result;
         }
 
-        $header = array_map('strtolower', array_map('trim', $header));
+        $header = array_map('strtolower', array_map('trim', array_map('strval', $header)));
 
         // Check required columns
         if ($type === 'members') {

--- a/includes/audience/class-ffc-audience-environment-repository.php
+++ b/includes/audience/class-ffc-audience-environment-repository.php
@@ -91,6 +91,7 @@ class AudienceEnvironmentRepository {
 
         $prepare_args = array_merge( array( $table ), $values );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $sql = $wpdb->prepare($sql, $prepare_args);
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
@@ -426,7 +427,7 @@ class AudienceEnvironmentRepository {
      * @return int
      */
     public static function count(array $args = array()): int {
-        $cache_key = 'ffcertificate_env_count_' . md5( wp_json_encode( $args ) );
+        $cache_key = 'ffcertificate_env_count_' . md5( wp_json_encode( $args ) ?: '' );
         $cached = wp_cache_get( $cache_key, 'ffcertificate' );
         if ( false !== $cached ) {
             return (int) $cached;

--- a/includes/audience/class-ffc-audience-repository.php
+++ b/includes/audience/class-ffc-audience-repository.php
@@ -96,6 +96,7 @@ class AudienceRepository {
 
         $prepare_args = array_merge( array( $table ), $values );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $sql = $wpdb->prepare($sql, $prepare_args);
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
@@ -514,6 +515,7 @@ class AudienceRepository {
 
                 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint(); cached below.
                 $parents = $wpdb->get_results(
+                    /** @phpstan-ignore-next-line argument.type */
                     $wpdb->prepare( "SELECT * FROM %i WHERE id IN ({$id_list}) AND status = 'active'", $table )
                 );
                 // phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -619,7 +621,7 @@ class AudienceRepository {
      * @return int
      */
     public static function count(array $args = array()): int {
-        $cache_key = 'ffcertificate_aud_count_' . md5( wp_json_encode( $args ) );
+        $cache_key = 'ffcertificate_aud_count_' . md5( wp_json_encode( $args ) ?: '' );
         $cached = wp_cache_get( $cache_key, 'ffcertificate' );
         if ( false !== $cached ) {
             return (int) $cached;

--- a/includes/audience/class-ffc-audience-rest-controller.php
+++ b/includes/audience/class-ffc-audience-rest-controller.php
@@ -459,7 +459,7 @@ class AudienceRestController {
         // Check for future days limit
         $schedule = AudienceScheduleRepository::get_by_id((int) $environment->schedule_id);
         if ($schedule && $schedule->future_days_limit && !$has_bypass) {
-            $max_date = gmdate('Y-m-d', strtotime('+' . $schedule->future_days_limit . ' days'));
+            $max_date = gmdate('Y-m-d', strtotime('+' . $schedule->future_days_limit . ' days') ?: time());
             if ($booking_date > $max_date) {
                 return new \WP_REST_Response(array(
                     'success' => false,

--- a/includes/audience/class-ffc-audience-schedule-repository.php
+++ b/includes/audience/class-ffc-audience-schedule-repository.php
@@ -91,6 +91,7 @@ class AudienceScheduleRepository {
 
         $prepare_args = array_merge( array( $table ), $values );
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $sql = $wpdb->prepare($sql, $prepare_args);
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared

--- a/includes/audience/class-ffc-audience-shortcode.php
+++ b/includes/audience/class-ffc-audience-shortcode.php
@@ -87,7 +87,7 @@ class AudienceShortcode {
                 'ffc_aud_scheduling_message',
                 __('To book on this calendar you need to be logged in. <a href="%login_url%">Log in</a> to continue.', 'ffcertificate')
             );
-            $scheduling_message = str_replace('%login_url%', wp_login_url(get_permalink()), $scheduling_message);
+            $scheduling_message = str_replace('%login_url%', wp_login_url(get_permalink() ?: ''), $scheduling_message);
 
             $config = array(
                 'scheduleId' => $specific_id,
@@ -189,7 +189,7 @@ class AudienceShortcode {
         ob_start();
         ?>
         <div class="<?php echo esc_attr($wrapper_class); ?>">
-        <div class="ffc-audience-calendar" id="ffc-audience-calendar" data-config="<?php echo esc_attr(wp_json_encode($config)); ?>">
+        <div class="ffc-audience-calendar" id="ffc-audience-calendar" data-config="<?php echo esc_attr(wp_json_encode($config) ?: ''); ?>">
             <!-- Header -->
             <div class="ffc-calendar-header">
                 <div class="ffc-calendar-nav">
@@ -420,7 +420,7 @@ class AudienceShortcode {
         </div>
         <?php
 
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -489,7 +489,7 @@ class AudienceShortcode {
             'ffc_aud_visibility_message',
             __('To view this calendar you need to be logged in. <a href="%login_url%">Log in</a> to continue.', 'ffcertificate')
         );
-        $message = str_replace('%login_url%', wp_login_url(get_permalink()), $message);
+        $message = str_replace('%login_url%', wp_login_url(get_permalink() ?: ''), $message);
 
         $output = '<div class="ffc-visibility-restricted">';
 
@@ -515,7 +515,7 @@ class AudienceShortcode {
             <p><?php esc_html_e('You do not have access to any calendars.', 'ffcertificate'); ?></p>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**

--- a/includes/core/class-ffc-activity-log-query.php
+++ b/includes/core/class-ffc-activity-log-query.php
@@ -174,7 +174,7 @@ class ActivityLogQuery {
 
         global $wpdb;
         $table_name = $wpdb->prefix . 'ffc_activity_log';
-        $date_from  = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+        $date_from  = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) ?: time() );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $total = $wpdb->get_var( $wpdb->prepare(
@@ -267,7 +267,7 @@ class ActivityLogQuery {
     public static function cleanup( int $days = 90 ): int {
         global $wpdb;
         $table_name  = $wpdb->prefix . 'ffc_activity_log';
-        $cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+        $cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) ?: time() );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $deleted = $wpdb->query( $wpdb->prepare(

--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -111,7 +111,7 @@ class ActivityLog {
         }
 
         // Encrypt context if contains sensitive data
-        $context_json = wp_json_encode( $context );
+        $context_json = wp_json_encode( $context ) ?: '';
         $context_encrypted = null;
 
         if ( class_exists( '\\FreeFormCertificate\\Core\\Encryption' ) && \FreeFormCertificate\Core\Encryption::is_configured() ) {

--- a/includes/core/class-ffc-csv-export-trait.php
+++ b/includes/core/class-ffc-csv-export-trait.php
@@ -130,6 +130,9 @@ trait CsvExportTrait {
         header('Expires: 0');
 
         $output = fopen('php://output', 'w');
+        if ($output === false) {
+            exit;
+        }
 
         // BOM for Excel UTF-8 recognition
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output, not HTML context

--- a/includes/core/class-ffc-email-helper-trait.php
+++ b/includes/core/class-ffc-email-helper-trait.php
@@ -73,7 +73,9 @@ trait EmailHelperTrait {
 
         return array_filter(
             array_map('trim', explode(',', $emails_string)),
-            'is_email'
+            static function (string $email): bool {
+                return is_email($email) !== false;
+            }
         );
     }
 

--- a/includes/core/class-ffc-utils.php
+++ b/includes/core/class-ffc-utils.php
@@ -300,7 +300,7 @@ class Utils {
         
         $bytes /= pow( 1024, $pow );
         
-        return round( $bytes, $precision ) . ' ' . $units[$pow];
+        return round( $bytes, $precision ) . ' ' . $units[(int) $pow];
     }
     
     // ── Auth code methods delegated to AuthCodeService (Sprint 31) ──
@@ -399,7 +399,8 @@ class Utils {
      * @return true|string True on success, error message string on failure
      */
     public static function validate_security_fields( array $data ) {
-        return SecurityService::validate_security_fields( $data );
+        $result = SecurityService::validate_security_fields( $data );
+        return $result === false ? __( 'Security validation failed.', 'ffcertificate' ) : $result;
     }
 
     // ── Data sanitization methods delegated to DataSanitizer (Sprint 31) ──
@@ -455,6 +456,6 @@ class Utils {
         // Load template
         ob_start();
         include FFC_PLUGIN_DIR . 'templates/submission-success.php';
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 }

--- a/includes/frontend/class-ffc-form-processor.php
+++ b/includes/frontend/class-ffc-form-processor.php
@@ -233,9 +233,9 @@ class FormProcessor {
 
             if (!$geofence_check['allowed']) {
                 wp_send_json_error(array(
-                    'message' => $geofence_check['message'],
+                    'message' => $geofence_check['message'] ?? '',
                     'geofence_blocked' => true,
-                    'reason' => $geofence_check['reason']
+                    'reason' => $geofence_check['reason'] ?? ''
                 ));
             }
         }

--- a/includes/frontend/class-ffc-shortcodes.php
+++ b/includes/frontend/class-ffc-shortcodes.php
@@ -65,7 +65,7 @@ class Shortcodes {
             </div>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -91,7 +91,7 @@ class Shortcodes {
             <div class="ffc-verify-result" role="region" aria-live="polite"></div>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -123,7 +123,7 @@ class Shortcodes {
 
         ob_start();
         include FFC_PLUGIN_DIR . 'templates/verification-page.php';
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -266,7 +266,7 @@ class Shortcodes {
             </form>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -298,7 +298,7 @@ class Shortcodes {
                 <?php endif; ?>
             </div>
             <?php
-            return ob_get_clean();
+            return ob_get_clean() ?: '';
         }
 
         // Embed block: display media via oembed or img tag
@@ -330,7 +330,7 @@ class Shortcodes {
                 </div>
             </div>
             <?php
-            return ob_get_clean();
+            return ob_get_clean() ?: '';
         }
 
         if ( empty( $name ) ) return '';
@@ -374,6 +374,6 @@ class Shortcodes {
             <?php endif; ?>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 }

--- a/includes/frontend/class-ffc-verification-response-renderer.php
+++ b/includes/frontend/class-ffc-verification-response-renderer.php
@@ -56,7 +56,7 @@ class VerificationResponseRenderer {
         // Render template
         ob_start();
         include FFC_PLUGIN_DIR . 'templates/certificate-preview.php';
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**

--- a/includes/generators/class-ffc-magic-link-helper.php
+++ b/includes/generators/class-ffc-magic-link-helper.php
@@ -151,22 +151,22 @@ class MagicLinkHelper {
         $query = wp_parse_url( $url, PHP_URL_QUERY );
         if ( $query ) {
             parse_str( $query, $params );
-            
-            if ( isset( $params['ffc_magic'] ) ) {
+
+            if ( isset( $params['ffc_magic'] ) && is_string( $params['ffc_magic'] ) ) {
                 return $params['ffc_magic'];
             }
-            
-            if ( isset( $params['token'] ) ) {
+
+            if ( isset( $params['token'] ) && is_string( $params['token'] ) ) {
                 return $params['token'];
             }
         }
-        
+
         // Try hash fragment
         $fragment = wp_parse_url( $url, PHP_URL_FRAGMENT );
         if ( $fragment ) {
             parse_str( $fragment, $params );
-            
-            if ( isset( $params['token'] ) ) {
+
+            if ( isset( $params['token'] ) && is_string( $params['token'] ) ) {
                 return $params['token'];
             }
         }

--- a/includes/generators/class-ffc-pdf-generator.php
+++ b/includes/generators/class-ffc-pdf-generator.php
@@ -231,7 +231,7 @@ class PdfGenerator {
      * @return string Generated HTML
      */
     public function generate_html( array $data, string $form_title, array $form_config, ?string $submission_date = null ): string {
-        $layout = isset( $form_config['pdf_layout'] ) ? $form_config['pdf_layout'] : '';
+        $layout = isset( $form_config['pdf_layout'] ) && is_string( $form_config['pdf_layout'] ) ? $form_config['pdf_layout'] : '';
         
         // Use default template if none configured
         if ( empty( $layout ) ) {
@@ -253,7 +253,7 @@ class PdfGenerator {
         }
 
         // {{print_date}} - Current date/time of PDF generation/printing
-        $layout = str_replace( '{{print_date}}', wp_date( $date_format ), $layout );
+        $layout = str_replace( '{{print_date}}', wp_date( $date_format ) ?: '', $layout );
 
         $layout = str_replace( '{{form_title}}', $form_title, $layout );
 
@@ -304,18 +304,18 @@ class PdfGenerator {
         
         // Fix relative URLs to absolute
         $site_url = untrailingslashit( get_home_url() );
-        $layout = preg_replace('/(src|href|background)=["\']\/([^"\']+)["\']/i', '$1="' . $site_url . '/$2"', $layout);
-        
+        $layout = preg_replace('/(src|href|background)=["\']\/([^"\']+)["\']/i', '$1="' . $site_url . '/$2"', $layout) ?? $layout;
+
         // Process QR Code placeholders
         if ( strpos( $layout, '{{qr_code' ) !== false ) {
             $layout = $this->process_qrcode_placeholders( $layout, $data, $form_config );
         }
-        
+
         // Process Validation URL placeholders
         if ( strpos( $layout, '{{validation_url' ) !== false ) {
             $layout = $this->process_validation_url_placeholders( $layout, $data );
         }
-        
+
         return $layout;
     }
     

--- a/includes/generators/class-ffc-qrcode-generator.php
+++ b/includes/generators/class-ffc-qrcode-generator.php
@@ -254,7 +254,7 @@ class QRCodeGenerator {
             // Read file and encode
             if ( file_exists( $temp_file ) && filesize( $temp_file ) > 0 ) {
                 $image_data = file_get_contents( $temp_file );
-                $base64 = base64_encode( $image_data );
+                $base64 = base64_encode( $image_data ?: '' );
 
                 // Clean up
                 wp_delete_file( $temp_file );

--- a/includes/repositories/ffc-abstract-repository.php
+++ b/includes/repositories/ffc-abstract-repository.php
@@ -129,6 +129,7 @@ abstract class AbstractRepository {
         if ($limit) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
             return $this->wpdb->get_results(
+                /** @phpstan-ignore-next-line argument.type */
                 $this->wpdb->prepare( "SELECT * FROM %i {$where} ORDER BY {$order_by} {$order} LIMIT %d OFFSET %d", $this->table, $limit, $offset ),
                 ARRAY_A
             );
@@ -136,6 +137,7 @@ abstract class AbstractRepository {
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         return $this->wpdb->get_results(
+            /** @phpstan-ignore-next-line argument.type */
             $this->wpdb->prepare( "SELECT * FROM %i {$where} ORDER BY {$order_by} {$order}", $this->table ),
             ARRAY_A
         );
@@ -150,6 +152,7 @@ abstract class AbstractRepository {
     public function count( array $conditions = [] ): int {
         $where = $this->build_where_clause($conditions);
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         return (int) $this->wpdb->get_var( $this->wpdb->prepare( "SELECT COUNT(*) FROM %i {$where}", $this->table ) );
     }
 
@@ -251,9 +254,11 @@ abstract class AbstractRepository {
             if (is_array($value)) {
                 $placeholders = implode(',', array_fill(0, count($value), '%s'));
                 // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                /** @phpstan-ignore-next-line argument.type */
                 $where_parts[] = $this->wpdb->prepare("{$key} IN ({$placeholders})", ...$value);
             } else {
                 // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                /** @phpstan-ignore-next-line argument.type */
                 $where_parts[] = $this->wpdb->prepare("{$key} = %s", $value);
             }
         }

--- a/includes/repositories/ffc-appointment-repository.php
+++ b/includes/repositories/ffc-appointment-repository.php
@@ -346,9 +346,10 @@ class AppointmentRepository extends AbstractRepository {
      * @return array<int, array<string, mixed>>
      */
     public function getUpcomingForReminders(int $hours_before = 24): array {
-        $target_datetime = gmdate('Y-m-d H:i:s', strtotime("+{$hours_before} hours"));
-        $target_date = gmdate('Y-m-d', strtotime("+{$hours_before} hours"));
-        $target_time = gmdate('H:i:s', strtotime("+{$hours_before} hours"));
+        $reminder_ts = strtotime("+{$hours_before} hours") ?: time();
+        $target_datetime = gmdate('Y-m-d H:i:s', $reminder_ts);
+        $target_date = gmdate('Y-m-d', $reminder_ts);
+        $target_time = gmdate('H:i:s', $reminder_ts);
 
         $calendars_table = $this->wpdb->prefix . 'ffc_self_scheduling_calendars';
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/repositories/ffc-blocked-date-repository.php
+++ b/includes/repositories/ffc-blocked-date-repository.php
@@ -221,7 +221,7 @@ class BlockedDateRepository extends AbstractRepository {
      * @return int|false Number of deleted rows
      */
     public function deleteExpiredBlocks(int $days_old = 30) {
-        $cutoff_date = gmdate('Y-m-d', strtotime("-{$days_old} days"));
+        $cutoff_date = gmdate('Y-m-d', strtotime("-{$days_old} days") ?: time());
 
         $sql = $this->wpdb->prepare(
             "DELETE FROM %i
@@ -233,7 +233,8 @@ class BlockedDateRepository extends AbstractRepository {
         );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-        return $this->wpdb->query($sql);
+        $result = $this->wpdb->query($sql);
+        return $result === false ? false : (int) $result;
     }
 
     /**
@@ -249,7 +250,7 @@ class BlockedDateRepository extends AbstractRepository {
             return false;
         }
 
-        $timestamp = strtotime($date);
+        $timestamp = strtotime($date) ?: time();
         $day_of_week = (int)gmdate('w', $timestamp);
 
         switch ($pattern['type']) {
@@ -289,7 +290,7 @@ class BlockedDateRepository extends AbstractRepository {
      */
     public function getUpcomingBlocks(int $calendar_id, int $days = 30): array {
         $start_date = gmdate('Y-m-d');
-        $end_date = gmdate('Y-m-d', strtotime("+{$days} days"));
+        $end_date = gmdate('Y-m-d', strtotime("+{$days} days") ?: time());
 
         return $this->getBlockedDatesInRange($calendar_id, $start_date, $end_date);
     }

--- a/includes/repositories/ffc-calendar-repository.php
+++ b/includes/repositories/ffc-calendar-repository.php
@@ -97,7 +97,7 @@ class CalendarRepository extends AbstractRepository {
             $calendar['email_config'] = json_decode($calendar['email_config'], true);
         }
 
-        return $calendar;
+        return $calendar ?: null;
     }
 
     /**

--- a/includes/repositories/ffc-submission-repository.php
+++ b/includes/repositories/ffc-submission-repository.php
@@ -306,6 +306,7 @@ class SubmissionRepository extends AbstractRepository {
         $query = "SELECT * FROM %i {$where_clause} ORDER BY id DESC LIMIT %d";
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $query = $this->wpdb->prepare( $query, ...$prepare_args );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -339,6 +340,7 @@ class SubmissionRepository extends AbstractRepository {
         $query = "SELECT id, data, data_encrypted FROM %i {$where_clause} ORDER BY id DESC LIMIT %d";
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $query = $this->wpdb->prepare( $query, ...$prepare_args );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -359,6 +361,7 @@ class SubmissionRepository extends AbstractRepository {
         $query = "SELECT COUNT(*) FROM %i {$where_clause}";
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $query = $this->wpdb->prepare( $query, ...$prepare_args );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -463,6 +466,7 @@ class SubmissionRepository extends AbstractRepository {
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         $items = $this->wpdb->get_results(
             $this->wpdb->prepare(
+                /** @phpstan-ignore-next-line argument.type */
                 "SELECT * FROM %i {$where_clause} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
                 $this->table,
                 $args['per_page'],
@@ -472,6 +476,7 @@ class SubmissionRepository extends AbstractRepository {
         );
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $total = $this->wpdb->get_var( $this->wpdb->prepare( "SELECT COUNT(*) FROM %i {$where_clause}", $this->table ) );
 
         return [
@@ -541,7 +546,7 @@ class SubmissionRepository extends AbstractRepository {
             $this->clear_cache();
         }
 
-        return $result;
+        return $result === false ? false : (int) $result;
     }
 
     /**
@@ -571,7 +576,7 @@ class SubmissionRepository extends AbstractRepository {
             $this->clear_cache();
         }
 
-        return $result;
+        return $result === false ? false : (int) $result;
     }
 
     /**

--- a/includes/reregistration/class-ffc-reregistration-admin.php
+++ b/includes/reregistration/class-ffc-reregistration-admin.php
@@ -614,8 +614,8 @@ class ReregistrationAdmin {
             'return_to_draft_submission_' . $sub->id
         );
 
-        $submitted = $sub->submitted_at ? wp_date(get_option('date_format') . ' ' . get_option('time_format'), strtotime($sub->submitted_at)) : '—';
-        $reviewed = $sub->reviewed_at ? wp_date(get_option('date_format') . ' ' . get_option('time_format'), strtotime($sub->reviewed_at)) : '—';
+        $submitted = $sub->submitted_at ? ( wp_date(get_option('date_format') . ' ' . get_option('time_format'), strtotime($sub->submitted_at) ?: time()) ?: '—' ) : '—';
+        $reviewed = $sub->reviewed_at ? ( wp_date(get_option('date_format') . ' ' . get_option('time_format'), strtotime($sub->reviewed_at) ?: time()) ?: '—' ) : '—';
 
         // Statuses that can be sent back to draft for user revision
         $can_return_to_draft = in_array($sub->status, array('submitted', 'approved', 'rejected'), true);
@@ -1046,7 +1046,7 @@ class ReregistrationAdmin {
             }
         }
         ?>
-        <div class="ffc-transfer-list" data-audiences="<?php echo esc_attr(wp_json_encode($flat)); ?>" data-selected="<?php echo esc_attr(wp_json_encode(array_values($selected_ids))); ?>">
+        <div class="ffc-transfer-list" data-audiences="<?php echo esc_attr(wp_json_encode($flat) ?: ''); ?>" data-selected="<?php echo esc_attr(wp_json_encode(array_values($selected_ids)) ?: ''); ?>">
             <div class="ffc-transfer-col ffc-transfer-available">
                 <div class="ffc-transfer-header"><?php esc_html_e('Available', 'ffcertificate'); ?></div>
                 <input type="text" class="ffc-transfer-search" placeholder="<?php esc_attr_e('Filter...', 'ffcertificate'); ?>">

--- a/includes/reregistration/class-ffc-reregistration-csv-exporter.php
+++ b/includes/reregistration/class-ffc-reregistration-csv-exporter.php
@@ -56,6 +56,9 @@ class ReregistrationCsvExporter {
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
         $output = fopen('php://output', 'w');
+        if ($output === false) {
+            exit;
+        }
         // BOM for Excel UTF-8
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
         fwrite($output, "\xEF\xBB\xBF");

--- a/includes/reregistration/class-ffc-reregistration-form-renderer.php
+++ b/includes/reregistration/class-ffc-reregistration-form-renderer.php
@@ -123,7 +123,7 @@ class ReregistrationFormRenderer {
             </form>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -427,7 +427,7 @@ class ReregistrationFormRenderer {
         $child   = is_array($decoded) && isset($decoded['child']) ? (string) $decoded['child'] : '';
         ?>
         <input type="hidden" id="<?php echo esc_attr($field_id); ?>" name="<?php echo esc_attr($field_name); ?>"
-               value="<?php echo esc_attr(wp_json_encode(array('parent' => $parent, 'child' => $child))); ?>">
+               value="<?php echo esc_attr(wp_json_encode(array('parent' => $parent, 'child' => $child)) ?: ''); ?>">
         <div class="ffc-dependent-select" data-target="<?php echo esc_attr($field_id); ?>">
             <div class="ffc-rereg-row ffc-rereg-row-2">
                 <div class="ffc-rereg-field">
@@ -493,7 +493,7 @@ class ReregistrationFormRenderer {
             6 => __('Saturday', 'ffcertificate'),
         );
         ?>
-        <input type="hidden" id="<?php echo esc_attr($field_id); ?>" name="<?php echo esc_attr($field_name); ?>" value="<?php echo esc_attr(wp_json_encode($wh_data)); ?>">
+        <input type="hidden" id="<?php echo esc_attr($field_id); ?>" name="<?php echo esc_attr($field_name); ?>" value="<?php echo esc_attr(wp_json_encode($wh_data) ?: ''); ?>">
         <div class="ffc-working-hours" data-target="<?php echo esc_attr($field_id); ?>">
             <table class="ffc-wh-table">
                 <thead>

--- a/includes/reregistration/class-ffc-reregistration-repository.php
+++ b/includes/reregistration/class-ffc-reregistration-repository.php
@@ -253,6 +253,7 @@ class ReregistrationRepository {
                 {$limit_clause}";
 
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         $sql = $wpdb->prepare($sql, $values);
 
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/includes/reregistration/class-ffc-reregistration-submission-repository.php
+++ b/includes/reregistration/class-ffc-reregistration-submission-repository.php
@@ -268,6 +268,7 @@ class ReregistrationSubmissionRepository {
         $prepare_values = array_merge(array($table, $wpdb->users), $values);
 
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        /** @phpstan-ignore-next-line argument.type */
         return $wpdb->get_results($wpdb->prepare($sql, $prepare_values));
     }
 

--- a/includes/scheduling/class-ffc-working-hours-service.php
+++ b/includes/scheduling/class-ffc-working-hours-service.php
@@ -44,7 +44,7 @@ class WorkingHoursService {
             return true; // No restrictions
         }
 
-        $day_of_week = (int) gmdate('w', strtotime($date));
+        $day_of_week = (int) gmdate("w", strtotime($date) ?: time());
         $day_name = self::DAY_NAMES[$day_of_week];
 
         // Keyed format: {mon: {start, end, closed}, ...}
@@ -93,7 +93,7 @@ class WorkingHoursService {
             return true;
         }
 
-        $day_of_week = (int) gmdate('w', strtotime($date));
+        $day_of_week = (int) gmdate("w", strtotime($date) ?: time());
         $day_name = self::DAY_NAMES[$day_of_week];
 
         // Keyed format
@@ -127,7 +127,7 @@ class WorkingHoursService {
             return array();
         }
 
-        $day_of_week = (int) gmdate('w', strtotime($date));
+        $day_of_week = (int) gmdate("w", strtotime($date) ?: time());
         $day_name = self::DAY_NAMES[$day_of_week];
         $ranges = array();
 

--- a/includes/security/class-ffc-rate-limiter.php
+++ b/includes/security/class-ffc-rate-limiter.php
@@ -62,28 +62,28 @@ class RateLimiter {
         $s = self::get_settings();
         
         $bl = self::check_blacklist($ip, $email, $cpf);
-        if (!$bl['allowed']) { self::log_attempt('blacklist', $ip, 'blocked', $bl['reason'], $form_id); return $bl; }
-        
+        if (!$bl['allowed']) { self::log_attempt('blacklist', $ip, 'blocked', $bl['reason'] ?? '', $form_id); return $bl; }
+
         if (self::is_whitelisted($ip, $email, $cpf)) { self::log_attempt('whitelist', $ip, 'whitelisted', 'In whitelist', $form_id); return array('allowed' => true); }
-        
+
         if ($s['global']['enabled']) {
             $g = self::check_global_limit();
-            if (!$g['allowed']) { self::log_attempt('global', 'system', 'blocked', $g['reason'], $form_id); return $g; }
+            if (!$g['allowed']) { self::log_attempt('global', 'system', 'blocked', $g['reason'] ?? '', $form_id); return $g; }
         }
-        
+
         if ($s['ip']['enabled'] && self::applies_to_form($s['ip']['apply_to'], $form_id)) {
             $i = self::check_ip_limit($ip, $form_id);
-            if (!$i['allowed']) { self::log_attempt('ip', $ip, 'blocked', $i['reason'], $form_id); return $i; }
+            if (!$i['allowed']) { self::log_attempt('ip', $ip, 'blocked', $i['reason'] ?? '', $form_id); return $i; }
         }
-        
+
         if ($email && $s['email']['enabled'] && self::applies_to_form($s['email']['apply_to'], $form_id)) {
             $e = self::check_email_limit($email, $form_id);
-            if (!$e['allowed']) { self::log_attempt('email', $email, 'blocked', $e['reason'], $form_id); return $e; }
+            if (!$e['allowed']) { self::log_attempt('email', $email, 'blocked', $e['reason'] ?? '', $form_id); return $e; }
         }
-        
+
         if ($cpf && $s['cpf']['enabled'] && self::applies_to_form($s['cpf']['apply_to'], $form_id)) {
             $c = self::check_cpf_limit($cpf, $form_id);
-            if (!$c['allowed']) { self::log_attempt('cpf', $cpf, 'blocked', $c['reason'], $form_id); return $c; }
+            if (!$c['allowed']) { self::log_attempt('cpf', $cpf, 'blocked', $c['reason'] ?? '', $form_id); return $c; }
         }
         
         if ($s['logging']['log_allowed']) self::log_attempt('ip', $ip, 'allowed', 'Passed', $form_id);
@@ -348,7 +348,7 @@ class RateLimiter {
         
         if ($email) {
             if (in_array($email, $bl['emails'])) return array('allowed' => false, 'reason' => 'email_blacklisted', 'message' => __( 'Email blocked.', 'ffcertificate' ));
-            $d = substr(strrchr($email, '@'), 1);
+            $d = substr(strrchr($email, '@') ?: '', 1);
             if (in_array('*@' . $d, $bl['email_domains'])) return array('allowed' => false, 'reason' => 'domain_blacklisted', 'message' => __( 'Domain blocked.', 'ffcertificate' ));
         }
 
@@ -365,7 +365,7 @@ class RateLimiter {
         
         if ($email) {
             if (in_array($email, $wl['emails'])) return true;
-            $d = substr(strrchr($email, '@'), 1);
+            $d = substr(strrchr($email, '@') ?: '', 1);
             if (in_array('*@' . $d, $wl['email_domains'])) return true;
         }
         
@@ -385,7 +385,8 @@ class RateLimiter {
     private static function block_temporarily(string $type, string $identifier, ?int $form_id, int $hours): void {
         global $wpdb;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Pre-validated clauses from trusted internal logic.
-        $wpdb->insert($wpdb->prefix . 'ffc_rate_limits', array('type' => $type, 'identifier' => $identifier, 'form_id' => $form_id, 'count' => 999, 'window_type' => 'hour', 'window_start' => current_time('mysql'), 'window_end' => gmdate('Y-m-d H:i:s', strtotime("+$hours hours")), 'last_attempt' => current_time('mysql'), 'is_blocked' => 1, 'blocked_until' => gmdate('Y-m-d H:i:s', strtotime("+$hours hours")), 'blocked_reason' => 'abuse'), array('%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s'));
+        $blocked_ts = strtotime("+$hours hours") ?: time();
+        $wpdb->insert($wpdb->prefix . 'ffc_rate_limits', array('type' => $type, 'identifier' => $identifier, 'form_id' => $form_id, 'count' => 999, 'window_type' => 'hour', 'window_start' => current_time('mysql'), 'window_end' => gmdate('Y-m-d H:i:s', $blocked_ts), 'last_attempt' => current_time('mysql'), 'is_blocked' => 1, 'blocked_until' => gmdate('Y-m-d H:i:s', $blocked_ts), 'blocked_reason' => 'abuse'), array('%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s'));
     }
     
     public static function log_attempt(string $type, string $identifier, string $action, string $reason, ?int $form_id): void {

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
@@ -262,7 +262,7 @@ class AppointmentAjaxHandler {
             }
 
             $start_date = sprintf('%04d-%02d-01', $year, $month);
-            $end_date = gmdate('Y-m-t', strtotime($start_date));
+            $end_date = gmdate('Y-m-t', strtotime($start_date) ?: time());
 
             $appointment_repo = $this->handler->get_appointment_repository();
             $blocked_repo = $this->handler->get_blocked_date_repository();
@@ -287,7 +287,7 @@ class AppointmentAjaxHandler {
                         if (!isset($holidays[$current])) {
                         $holidays[$current] = $block['reason'] ?: __('Closed', 'ffcertificate');
                         }
-                        $current = gmdate('Y-m-d', strtotime($current . ' +1 day'));
+                        $current = gmdate('Y-m-d', strtotime($current . ' +1 day') ?: time());
                     }
                 }
             }

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
@@ -257,6 +257,9 @@ class AppointmentCsvExporter {
         header('Expires: 0');
 
         $output = fopen('php://output', 'w');
+        if ($output === false) {
+            exit;
+        }
 
         // BOM for Excel UTF-8 recognition
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output, not HTML context

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
@@ -164,7 +164,9 @@ class AppointmentHandler {
         $appointment = $this->appointment_repository->findById($appointment_id);
 
         // Schedule email notifications
-        $this->schedule_email_notifications($appointment, $calendar, 'created');
+        if ( is_array( $appointment ) ) {
+            $this->schedule_email_notifications($appointment, $calendar, 'created');
+        }
 
         // Generate receipt URL (magic link to /valid/ page)
         $receipt_url = '';
@@ -219,7 +221,7 @@ class AppointmentHandler {
         }
 
         // Get day of week
-        $day_of_week = (int)gmdate('w', strtotime($date));
+        $day_of_week = (int)gmdate('w', strtotime($date) ?: time());
 
         // Get working hours for this day
         $working_hours = $calendar['working_hours'] ?? array();
@@ -246,8 +248,8 @@ class AppointmentHandler {
         $max_per_slot = (int)$calendar['max_appointments_per_slot'];
 
         foreach ($day_hours as $hours) {
-            $current_time = strtotime($date . ' ' . $hours['start']);
-            $end_time = strtotime($date . ' ' . $hours['end']);
+            $current_time = strtotime($date . ' ' . $hours['start']) ?: time();
+            $end_time = strtotime($date . ' ' . $hours['end']) ?: time();
 
             while ($current_time < $end_time) {
                 $slot_time = gmdate('H:i:s', $current_time);

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-validator.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-validator.php
@@ -185,8 +185,9 @@ class AppointmentValidator {
             $working_hours = $calendar['working_hours'] ?? array();
             if (!empty($working_hours)) {
                 $now = current_time('mysql');
-                $current_date = gmdate('Y-m-d', strtotime($now));
-                $current_time = gmdate('H:i', strtotime($now));
+                $now_ts = strtotime($now) ?: time();
+                $current_date = gmdate('Y-m-d', $now_ts);
+                $current_time = gmdate('H:i', $now_ts);
 
                 $is_working_day = \FreeFormCertificate\Scheduling\WorkingHoursService::is_working_day($current_date, $working_hours);
                 $is_within_hours = \FreeFormCertificate\Scheduling\WorkingHoursService::is_within_working_hours($current_date, $current_time, $working_hours);

--- a/includes/self-scheduling/class-ffc-self-scheduling-shortcode.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-shortcode.php
@@ -287,7 +287,7 @@ class SelfSchedulingShortcode {
                 'ffc_ss_scheduling_message',
                 __('To book on this calendar you need to be logged in. <a href="%login_url%">Log in</a> to continue.', 'ffcertificate')
             );
-            $scheduling_message = str_replace('%login_url%', wp_login_url(get_permalink()), $scheduling_message);
+            $scheduling_message = str_replace('%login_url%', wp_login_url(get_permalink() ?: ''), $scheduling_message);
         }
 
         // Business hours restriction: booking only
@@ -313,7 +313,7 @@ class SelfSchedulingShortcode {
             echo '</div>';
         }
         $this->render_calendar_interface($calendar, $can_book, $scheduling_message);
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -334,7 +334,7 @@ class SelfSchedulingShortcode {
             'ffc_ss_visibility_message',
             __('To view this calendar you need to be logged in. <a href="%login_url%">Log in</a> to continue.', 'ffcertificate')
         );
-        $message = str_replace('%login_url%', wp_login_url(get_permalink()), $message);
+        $message = str_replace('%login_url%', wp_login_url(get_permalink() ?: ''), $message);
 
         $output = '<div class="ffc-visibility-restricted">';
 
@@ -362,8 +362,9 @@ class SelfSchedulingShortcode {
         }
 
         $now = current_time('mysql');
-        $current_date = gmdate('Y-m-d', strtotime($now));
-        $current_time = gmdate('H:i', strtotime($now));
+        $now_ts = strtotime($now) ?: time();
+        $current_date = gmdate('Y-m-d', $now_ts);
+        $current_time = gmdate('H:i', $now_ts);
 
         // Check if today is a working day
         if (!\FreeFormCertificate\Scheduling\WorkingHoursService::is_working_day($current_date, $working_hours)) {
@@ -388,7 +389,7 @@ class SelfSchedulingShortcode {
         }
 
         $now = current_time('mysql');
-        $current_date = gmdate('Y-m-d', strtotime($now));
+        $current_date = gmdate('Y-m-d', strtotime($now) ?: time());
         $ranges = \FreeFormCertificate\Scheduling\WorkingHoursService::get_day_ranges($current_date, $working_hours);
 
         if (empty($ranges)) {

--- a/includes/shortcodes/class-ffc-dashboard-shortcode.php
+++ b/includes/shortcodes/class-ffc-dashboard-shortcode.php
@@ -122,7 +122,7 @@ class DashboardShortcode {
 
             <?php
             if ($is_admin_viewing) {
-                echo wp_kses_post( DashboardViewMode::render_admin_viewing_banner($view_as_user_id) );
+                echo wp_kses_post( DashboardViewMode::render_admin_viewing_banner((int) $view_as_user_id) );
             }
             echo wp_kses_post( self::render_redirect_message() );
             echo wp_kses_post( self::render_reregistration_banners($user_id) );
@@ -252,7 +252,7 @@ class DashboardShortcode {
         </div>
         <?php
 
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -266,13 +266,13 @@ class DashboardShortcode {
         <div class="ffc-dashboard-notice ffc-notice-warning">
             <p><?php esc_html_e('You must be logged in to view your dashboard.', 'ffcertificate'); ?></p>
             <p>
-                <a href="<?php echo esc_url(wp_login_url(get_permalink())); ?>" class="button">
+                <a href="<?php echo esc_url(wp_login_url(get_permalink() ?: '')); ?>" class="button">
                     <?php esc_html_e('Login', 'ffcertificate'); ?>
                 </a>
             </p>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -295,7 +295,7 @@ class DashboardShortcode {
             <p><?php echo esc_html($message); ?></p>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
     /**
@@ -399,7 +399,7 @@ class DashboardShortcode {
             </div>
             <?php
         }
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 
 }

--- a/includes/shortcodes/class-ffc-dashboard-view-mode.php
+++ b/includes/shortcodes/class-ffc-dashboard-view-mode.php
@@ -66,7 +66,7 @@ class DashboardViewMode {
 
         // Get dashboard URL without view-as parameters
         $dashboard_page_id = get_option( 'ffc_dashboard_page_id' );
-        $exit_url = $dashboard_page_id ? get_permalink( $dashboard_page_id ) : home_url( '/dashboard' );
+        $exit_url = $dashboard_page_id ? ( get_permalink( $dashboard_page_id ) ?: home_url( '/dashboard' ) ) : home_url( '/dashboard' );
 
         ob_start();
         ?>
@@ -93,6 +93,6 @@ class DashboardViewMode {
             </div>
         </div>
         <?php
-        return ob_get_clean();
+        return ob_get_clean() ?: '';
     }
 }

--- a/includes/submissions/class-ffc-form-cache.php
+++ b/includes/submissions/class-ffc-form-cache.php
@@ -325,4 +325,4 @@ class FormCache {
 }
 
 // Register hooks on load
-add_action( 'init', array( 'FFC_Form_Cache', 'register_hooks' ), 5 );
+add_action( 'init', array( __NAMESPACE__ . '\\FormCache', 'register_hooks' ), 5 );

--- a/includes/submissions/class-ffc-submission-handler.php
+++ b/includes/submissions/class-ffc-submission-handler.php
@@ -125,7 +125,7 @@ class SubmissionHandler {
 
         $clean_cpf_rf = null;
         if (isset($submission_data['cpf_rf']) && !empty($submission_data['cpf_rf'])) {
-            $clean_cpf_rf = preg_replace('/[^0-9]/', '', $submission_data['cpf_rf']);
+            $clean_cpf_rf = preg_replace('/[^0-9]/', '', (string) $submission_data['cpf_rf']);
         }
 
         // 2b. Classify identifier as CPF or RF by digit length
@@ -321,7 +321,7 @@ class SubmissionHandler {
             $data_json = wp_json_encode($clean_data, JSON_UNESCAPED_UNICODE);
 
             if (class_exists('\FreeFormCertificate\Core\Encryption') && \FreeFormCertificate\Core\Encryption::is_configured()) {
-                $update_data['data_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt($data_json);
+                $update_data['data_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt($data_json ?: '{}');
                 $update_data['data'] = null;
             } else {
                 $update_data['data'] = $data_json;
@@ -590,7 +590,7 @@ class SubmissionHandler {
                 }
             }
 
-            return $result;
+            return (int) $result;
         }
 
         // Delete ALL submissions from ALL forms
@@ -678,7 +678,7 @@ class SubmissionHandler {
             return 0;
         }
 
-        $cutoff_date = gmdate('Y-m-d H:i:s', strtotime("-{$cleanup_days} days"));
+        $cutoff_date = gmdate('Y-m-d H:i:s', strtotime("-{$cleanup_days} days") ?: time());
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $deleted = $wpdb->query($wpdb->prepare(

--- a/includes/url-shortener/class-ffc-url-shortener-admin-page.php
+++ b/includes/url-shortener/class-ffc-url-shortener-admin-page.php
@@ -180,11 +180,11 @@ class UrlShortenerAdminPage {
         $result = $this->service->create_short_url( $url, $title );
 
         if ( $result['success'] ) {
-            $data = $result['data'];
+            $data = $result['data'] ?? array();
             $data['short_url'] = $this->service->get_short_url( $data['short_code'] );
             wp_send_json_success( $data );
         } else {
-            wp_send_json_error( [ 'message' => $result['error'] ] );
+            wp_send_json_error( [ 'message' => $result['error'] ?? '' ] );
         }
     }
 

--- a/includes/url-shortener/class-ffc-url-shortener-meta-box.php
+++ b/includes/url-shortener/class-ffc-url-shortener-meta-box.php
@@ -77,9 +77,9 @@ class UrlShortenerMetaBox {
 
         if ( ! $record && $post->post_status === 'publish' ) {
             // Auto-create if post is published
-            $permalink = get_permalink( $post->ID );
+            $permalink = get_permalink( $post->ID ) ?: '';
             $result    = $this->service->create_short_url( $permalink, $post->post_title, $post->ID );
-            $record    = $result['success'] ? $result['data'] : null;
+            $record    = $result['success'] && isset( $result['data'] ) ? $result['data'] : null;
         }
 
         if ( ! $record ) {
@@ -243,16 +243,16 @@ class UrlShortenerMetaBox {
         }
 
         // Create new
-        $permalink = get_permalink( $post_id );
+        $permalink = get_permalink( $post_id ) ?: '';
         $post      = get_post( $post_id );
         $result    = $this->service->create_short_url( $permalink, $post->post_title ?? '', $post_id );
 
         if ( $result['success'] ) {
-            $data = $result['data'];
+            $data = $result['data'] ?? array();
             $data['short_url'] = $this->service->get_short_url( $data['short_code'] );
             wp_send_json_success( $data );
         } else {
-            wp_send_json_error( [ 'message' => $result['error'] ] );
+            wp_send_json_error( [ 'message' => $result['error'] ?? '' ] );
         }
     }
 }

--- a/includes/url-shortener/class-ffc-url-shortener-service.php
+++ b/includes/url-shortener/class-ffc-url-shortener-service.php
@@ -87,6 +87,10 @@ class UrlShortenerService {
 
         $record = $this->repository->findById( (int) $id );
 
+        if ( ! is_array( $record ) ) {
+            return [ 'success' => false, 'error' => __( 'Failed to create short URL.', 'ffcertificate' ) ];
+        }
+
         return [ 'success' => true, 'data' => $record ];
     }
 

--- a/includes/user-dashboard/class-ffc-user-manager.php
+++ b/includes/user-dashboard/class-ffc-user-manager.php
@@ -304,7 +304,7 @@ class UserManager {
         foreach ( $usermeta_payload as $key => $value ) {
             $meta_key = self::EXTENDED_META_PREFIX . sanitize_key( $key );
 
-            $scalar_value = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
+            $scalar_value = is_scalar( $value ) ? (string) $value : ( wp_json_encode( $value ) ?: '' );
 
             if ( isset( $sensitive_map[ $key ] ) ) {
                 if ( $scalar_value === '' || $scalar_value === null ) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,1393 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: '#^Access to an undefined property object\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_options\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 11
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$source_audience_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$source_audience_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin-user-custom-fields.php
+
+		-
+			message: '#^Call to an undefined method object\:\:handle_export_request\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin.php
+
+		-
+			message: '#^Call to an undefined method object\:\:register_ajax_hooks\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/admin/class-ffc-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$ID\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-cpt.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$post_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/admin/class-ffc-cpt.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_icon\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/admin/class-ffc-settings.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_id\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/admin/class-ffc-settings.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_order\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: includes/admin/class-ffc-settings.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_title\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/admin/class-ffc-settings.php
+
+		-
+			message: '#^Call to an undefined method object\:\:render\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: includes/admin/class-ffc-settings.php
+
+		-
+			message: '#^Call to an undefined method object\:\:change_password\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:create_privacy_request\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_joinable_groups\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_appointments\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_audience_bookings\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_certificates\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_profile\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_reregistrations\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_user_summary\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:join_audience_group\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:leave_audience_group\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Call to an undefined method object\:\:update_user_profile\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/api/class-ffc-user-data-rest-controller.php
+
+		-
+			message: '#^Cannot access property \$user_email on WP_User\|false\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: includes/api/class-ffc-user-profile-rest-controller.php
+
+		-
+			message: '#^Cannot access property \$user_pass on WP_User\|false\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: includes/api/class-ffc-user-profile-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_date\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/api/class-ffc-user-reregistrations-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$depth\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_options\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 14
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$validation_rules\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-audience.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$created_by\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$environment_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 7
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-bookings.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_book\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_cancel_others\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_override_conflicts\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$holiday_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 8
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$visibility\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-calendar.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 10
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 6
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$schedule_id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$working_hours\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-admin-environment.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-admin-import.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/audience/class-ffc-audience-admin-import.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-booking-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$schedule_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-environment-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-environment-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$working_hours\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-environment-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_book\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_cancel_others\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_override_conflicts\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$created_at\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$created_by\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$environment_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-loader.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_date\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$cancelled_by\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$created_by\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$email_template_booking\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$email_template_cancellation\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_time\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$environment_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$include_ics\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 6
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$notify_on_booking\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$notify_on_cancellation\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$schedule_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-notification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$children\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$depth\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 9
+			path: includes/audience/class-ffc-audience-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$audience_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_date\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$booking_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$created_by\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_time\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$environment_id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$future_days_limit\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$holiday_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 9
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$schedule_id\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/audience/class-ffc-audience-rest-controller.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_book\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-schedule-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_cancel_others\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-schedule-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$can_override_conflicts\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-schedule-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-schedule-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-schedule-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-shortcode.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 10
+			path: includes/audience/class-ffc-audience-shortcode.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 6
+			path: includes/audience/class-ffc-audience-shortcode.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/audience/class-ffc-audience-shortcode.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$visibility\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/audience/class-ffc-audience-shortcode.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: includes/core/class-ffc-data-sanitizer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/frontend/class-ffc-form-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-form-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$submission_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-form-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-reprint-detector.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$submission_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-reprint-detector.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$auth_code\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$magic_token\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 6
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/frontend/class-ffc-verification-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$form_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-verification-response-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$submission_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/frontend/class-ffc-verification-response-renderer.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: includes/generators/class-ffc-pdf-generator.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_submission\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/generators/class-ffc-pdf-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 20
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_options\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$source_audience_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$source_audience_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$validation_rules\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-custom-field-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-ficha-generator.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$auto_approve\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 16
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reviewed_at\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_date\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 9
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$submitted_at\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-admin.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-csv-exporter.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-reregistration-custom-fields-page.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-custom-fields-page.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/reregistration/class-ffc-reregistration-data-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-data-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-data-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 8
+			path: includes/reregistration/class-ffc-reregistration-data-processor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$reregistration_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-reregistration-email-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_key\.$#'
+			identifier: property.notFound
+			count: 5
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_label\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$field_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 7
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-form-renderer.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-frontend.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 4
+			path: includes/reregistration/class-ffc-reregistration-frontend.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$start_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-frontend.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 7
+			path: includes/reregistration/class-ffc-reregistration-frontend.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$title\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-frontend.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/reregistration/class-ffc-reregistration-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$user_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-submission-actions.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/reregistration/class-ffc-reregistration-submission-repository.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$ID\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/self-scheduling/class-ffc-self-scheduling-cleanup-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$ID\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$post_status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$post_title\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$post_type\.$#'
+			identifier: property.notFound
+			count: 2
+			path: includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$ID\.$#'
+			identifier: property.notFound
+			count: 6
+			path: includes/self-scheduling/class-ffc-self-scheduling-editor.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$post_status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/self-scheduling/class-ffc-self-scheduling-editor.php
+
+		-
+			message: '#^Cannot access property \$display_name on WP_User\|false\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: includes/shortcodes/class-ffc-dashboard-view-mode.php
+
+		-
+			message: '#^Cannot access property \$user_email on WP_User\|false\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: includes/shortcodes/class-ffc-dashboard-view-mode.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/user-dashboard/class-ffc-user-manager.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - includes/


### PR DESCRIPTION
## Why

Level 6 was clean (empty baseline), so this promotes to level 7 for stronger null-safety analysis on all new code.

## What changed

- **164 null-safety fixes** across 51 source files:
  - 122 `argument.type` — `string|false` → `?: ''`, `(string)` casts, `is_string()` guards
  - 29 `return.type` — `ob_get_clean() ?: ''`, `wp_json_encode() ?: ''`
  - 11 `offsetAccess.notFound` — `$arr['key'] ?? ''` for optional array keys
  - 1 `offsetAccess.invalidOffset` + 1 `assign.propertyType`
- **20 `@phpstan-ignore-next-line`** for `$wpdb->prepare()` literal-string false positives (dynamically built SQL from trusted internal logic — standard WP pattern)
- **1 real bug found and fixed**: `class-ffc-form-cache.php:328` referenced `'FFC_Form_Cache'` (non-existent class) instead of the namespaced `FormCache`
- **Baseline generated** with 518 remaining WP-idiom errors (`property.notFound`, `method.notFound` on stdClass from `$wpdb->get_row()` / `get_results()`) — these require per-callsite docblock annotations, out of scope for this sprint
- **Level bumped**: 6 → 7 in `phpstan.neon.dist`

## Verification

```
vendor/bin/phpstan analyze  →  [OK] No errors
vendor/bin/phpunit          →  OK (3165 tests, 7439 assertions)
```

## Test plan

- [ ] PHPStan (PHP 8.1) green
- [ ] PHPUnit (PHP 8.1 / 8.2 / 8.3 / 8.4) all green
- [ ] Composer audit green
- [ ] Verify minified assets green