### PR TITLE
ci: promote PHPCS from advisory to gating

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -12,10 +12,9 @@ jobs:
   changed:
     name: WPCS on changed PHP files
     runs-on: ubuntu-latest
-    # Advisory only: 84k+ pre-existing violations need a dedicated cleanup
-    # sprint before this can gate merges. Surfaces issues on new/touched
-    # code without blocking.
-    continue-on-error: true
+    # Promoted to gating after cleanup sprints #25-#27 reduced violations
+    # from 88k to ~1.3k. Remaining violations only surface when a PR
+    # touches a file that still has legacy issues.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,4 +61,4 @@ jobs:
       - name: Run PHPCS on changed files
         if: steps.changed.outputs.files != ''
         run: |
-          vendor/bin/phpcs -q --report=checkstyle ${{ steps.changed.outputs.files }} | cs2pr || true
+          vendor/bin/phpcs -q --report=checkstyle ${{ steps.changed.outputs.files }} | cs2pr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,14 +52,14 @@ Run these before opening a PR — CI runs the same commands.
 vendor/bin/phpstan analyze        # static analysis
 vendor/bin/phpunit                # unit tests
 composer audit --locked           # security advisories
-vendor/bin/phpcs                  # WordPress Coding Standards (advisory)
+vendor/bin/phpcs                  # WordPress Coding Standards (gating)
 vendor/bin/phpcbf                 # auto-fix many WPCS violations
 ```
 
-PHPCS runs in CI on changed PHP files only and is currently advisory:
-the legacy codebase has thousands of pre-existing violations. New code
-should be WPCS-clean; a dedicated cleanup sprint will promote PHPCS to
-gating once the baseline shrinks.
+PHPCS runs in CI on changed PHP files and **gates merges**. If your PR
+touches a file with pre-existing violations, you must fix them (or run
+`vendor/bin/phpcbf` to auto-fix most). Run `vendor/bin/phpcs <file>`
+locally before pushing to catch issues early.
 
 If you edit anything under `assets/css/` or `assets/js/`, rebuild the
 minified bundles:


### PR DESCRIPTION
## Why

Cleanup sprints #25-#27 reduced PHPCS violations from 88,399 to ~1,295. The check can now gate merges without blocking legitimate work.

## What changed

- Removed `continue-on-error: true` from PHPCS job
- Removed `|| true` from phpcs command — non-zero exit now fails the check
- Updated CONTRIBUTING.md to reflect gating status

## How it works

PHPCS only scans PHP files changed in the PR. If a PR touches a file with pre-existing violations (~1,295 remain in legacy files, mostly missing docblocks), those violations block the merge. This incentivizes gradual cleanup as files are touched.

## After merge — user action

Add `WPCS on changed PHP files` as a **required check** in Settings → Rules (same ruleset where you added PHPUnit 8.1-8.4).

## Test plan

- [ ] CI passes (this PR only touches workflow + docs, no PHP changes → PHPCS skips)
- [ ] After merge, verify a PR touching a clean PHP file passes WPCS
- [ ] After merge, add check to branch protection ruleset