### PR TITLE
ci: add Dependabot auto-merge for patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+
+      - name: Auto-merge patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

Dependabot generates weekly PRs for composer, npm, and GitHub Actions dependencies. Currently all require manual review and merge. Patch and minor bumps that pass all CI checks are safe to auto-merge, reducing manual git work.

## What changed

New workflow `.github/workflows/dependabot-automerge.yml`:
- Triggers on Dependabot PRs only (`github.actor == 'dependabot[bot]'`)
- Uses `dependabot/fetch-metadata@v2` to determine semver update type
- Auto-merges (squash) **patch** and **minor** updates after CI passes
- **Major** version bumps still require manual review

## How it works

1. Dependabot opens a PR (e.g., `phpstan 2.1.3 → 2.1.4`)
2. All CI checks run (PHPUnit, PHPStan, PHPCS, etc.)
3. If checks pass AND update is patch/minor → auto-squash-merge
4. If checks fail OR update is major → stays open for manual review

## Test plan

- [ ] Workflow file is valid YAML
- [ ] Next Dependabot PR (Monday) triggers the workflow
- [ ] Patch/minor updates auto-merge after CI
- [ ] Major updates stay open