### PR TITLE
Add CSV Download Page URL setting to General tab

### DIFF
--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -938,11 +938,24 @@ class FormEditorMetaboxRenderer {
 					</p>
 
 					<?php if ( '1' === $enabled && '' !== $hash ) : ?>
-						<p class="description">
-							<?php esc_html_e( 'Example pre-filled link (append this as a query string to the page that contains the [ffc_csv_download] shortcode):', 'ffcertificate' ); ?>
-							<br>
-							<code>?form_id=<?php echo esc_html( (string) $post->ID ); ?>&amp;hash=<?php echo esc_html( $hash ); ?></code>
-						</p>
+						<?php
+						$ffc_settings          = get_option( 'ffc_settings', array() );
+						$csv_download_page_url = $ffc_settings['csv_download_page_url'] ?? '';
+						$ffc_query_string      = 'form_id=' . $post->ID . '&hash=' . $hash;
+						?>
+						<?php if ( '' !== $csv_download_page_url ) : ?>
+							<p class="description">
+								<?php esc_html_e( 'Download link:', 'ffcertificate' ); ?>
+								<br>
+								<code><?php echo esc_html( $csv_download_page_url . ( str_contains( $csv_download_page_url, '?' ) ? '&' : '?' ) . $ffc_query_string ); ?></code>
+							</p>
+						<?php else : ?>
+							<p class="description">
+								<?php esc_html_e( 'Example pre-filled link (append this as a query string to the page that contains the [ffc_csv_download] shortcode):', 'ffcertificate' ); ?>
+								<br>
+								<code>?<?php echo esc_html( $ffc_query_string ); ?></code>
+							</p>
+						<?php endif; ?>
 					<?php endif; ?>
 				</td>
 			</tr>

--- a/includes/admin/class-ffc-settings-save-handler.php
+++ b/includes/admin/class-ffc-settings-save-handler.php
@@ -136,6 +136,11 @@ class SettingsSaveHandler {
 			$clean['main_address'] = sanitize_text_field( $new['main_address'] );
 		}
 
+		// CSV Download Page URL.
+		if ( isset( $new['csv_download_page_url'] ) ) {
+			$clean['csv_download_page_url'] = esc_url_raw( $new['csv_download_page_url'] );
+		}
+
 		// v4.6.16: Activity Log + Debug moved to Advanced tab.
 		$ffc_tab = isset( $_POST['_ffc_tab'] ) ? sanitize_key( wp_unslash( $_POST['_ffc_tab'] ) ) : '';
 

--- a/includes/settings/views/ffc-tab-general.php
+++ b/includes/settings/views/ffc-tab-general.php
@@ -120,7 +120,18 @@ $ffcertificate_main_address   = $ffcertificate_get_option( 'main_address', '' );
 						</p>
 					</td>
 				</tr>
-			</tbody>
+				<tr>
+					<th scope="row">
+						<label for="csv_download_page_url"><?php esc_html_e( 'CSV Download Page URL', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<input type="url" name="ffc_settings[csv_download_page_url]" id="csv_download_page_url" value="<?php echo esc_attr( $ffcertificate_get_option( 'csv_download_page_url', '' ) ); ?>" class="large-text" placeholder="https://example.com/csv-download/">
+						<p class="description">
+							<?php esc_html_e( 'URL of the page containing the [ffc_csv_download] shortcode. When set, the form editor will display the full download link instead of just the query string.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
+				</tbody>
 		</table>
 
 		<!-- QR Code Defaults Section -->


### PR DESCRIPTION
## Summary

- New **CSV Download Page URL** field on the General settings tab (`ffc-settings&tab=general`) for configuring the base URL of the page containing the `[ffc_csv_download]` shortcode
- When configured, the form editor CSV download metabox displays the full link (e.g. `http://example.com/csv-download/?form_id=85&hash=...`) instead of just the query string
- Sanitized with `esc_url_raw()`, handles URLs that already contain `?`

## Test plan

- [ ] Go to FFC Settings → General → set a CSV Download Page URL and save
- [ ] Edit a form with CSV download enabled → verify the full URL appears in the metabox
- [ ] Clear the URL setting → verify the form editor falls back to showing just the query string
- [ ] Test with a URL containing existing query params (e.g. `https://example.com/page/?lang=en`)

https://claude.ai/code/session_013mTv5ethMq15faTc8FKta9