### PR TITLE
fix(phpcs): resolve all WPCS errors in recently changed files

### DIFF
--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -1,16 +1,15 @@
 <?php
-declare(strict_types=1);
-
 /**
- * FormEditorMetaboxRenderer
+ * Form Editor Metabox Renderer
  *
  * Handles rendering of all metaboxes for the Form Editor.
  * Extracted from FFC_Form_Editor class to follow Single Responsibility Principle.
  *
- * @since 3.1.1 (Extracted from FFC_Form_Editor)
- * @version 3.3.0 - Added strict types and type hints
- * @version 3.2.0 - Migrated to namespace (Phase 2)
+ * @since   3.1.1
+ * @package FreeFormCertificate\Admin
  */
+
+declare(strict_types=1);
 
 namespace FreeFormCertificate\Admin;
 
@@ -21,6 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Renders all metaboxes for the Form Editor screen.
+ *
+ * @since 3.1.1
+ */
 class FormEditorMetaboxRenderer {
 
 	/**
@@ -28,7 +32,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_shortcode_metabox( object $post ): void {
+	public function render_shortcode_metabox( WP_Post $post ): void {
 		?>
 		<div class="ffc-shortcode-box">
 			<p><strong><?php esc_html_e( 'Copy this Shortcode:', 'ffcertificate' ); ?></strong></p>
@@ -53,7 +57,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_layout( object $post ): void {
+	public function render_box_layout( WP_Post $post ): void {
 		$config   = get_post_meta( $post->ID, '_ffc_form_config', true );
 		$layout   = isset( $config['pdf_layout'] ) ? $config['pdf_layout'] : '';
 		$bg_image = isset( $config['bg_image'] ) ? $config['bg_image'] : '';
@@ -122,7 +126,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_builder( object $post ): void {
+	public function render_box_builder( WP_Post $post ): void {
 		$fields = get_post_meta( $post->ID, '_ffc_form_fields', true );
 
 		// Default fields for brand new forms.
@@ -184,7 +188,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_restriction( object $post ): void {
+	public function render_box_restriction( WP_Post $post ): void {
 		$config = get_post_meta( $post->ID, '_ffc_form_config', true );
 
 		// Get restrictions (new structure).
@@ -309,7 +313,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_email( object $post ): void {
+	public function render_box_email( WP_Post $post ): void {
 		$config     = get_post_meta( $post->ID, '_ffc_form_config', true );
 		$send_email = isset( $config['send_user_email'] ) ? $config['send_user_email'] : '0';
 		$subject    = isset( $config['email_subject'] ) ? $config['email_subject'] : __( 'Your Certificate', 'ffcertificate' );
@@ -351,7 +355,7 @@ class FormEditorMetaboxRenderer {
 	 * @since 3.0.0
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_geofence( object $post ): void {
+	public function render_box_geofence( WP_Post $post ): void {
 		$config = get_post_meta( $post->ID, '_ffc_geofence_config', true );
 		if ( ! is_array( $config ) ) {
 			$config = array();
@@ -391,7 +395,7 @@ class FormEditorMetaboxRenderer {
 			}
 		}
 
-		$all_locations   = GeofenceLocationRegistry::get_all();
+		$all_locations    = GeofenceLocationRegistry::get_all();
 		$geo_gps_ip_logic = $config['geo_gps_ip_logic'] ?? 'or';
 		$geo_hide_mode    = $config['geo_hide_mode'] ?? 'message';
 		$msg_geo_blocked  = $config['msg_geo_blocked'] ?? __( 'This form is not available in your location.', 'ffcertificate' );
@@ -651,7 +655,7 @@ class FormEditorMetaboxRenderer {
 	 *
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_quiz( object $post ): void {
+	public function render_box_quiz( WP_Post $post ): void {
 		$config = get_post_meta( $post->ID, '_ffc_form_config', true );
 		if ( ! is_array( $config ) ) {
 			$config = array();
@@ -829,7 +833,7 @@ class FormEditorMetaboxRenderer {
 	 * @since 5.1.0
 	 * @param WP_Post $post The post object.
 	 */
-	public function render_box_public_csv_download( object $post ): void {
+	public function render_box_public_csv_download( WP_Post $post ): void {
 		$enabled = (string) get_post_meta( $post->ID, '_ffc_csv_public_enabled', true );
 		$hash    = (string) get_post_meta( $post->ID, '_ffc_csv_public_hash', true );
 		$limit   = (int) get_post_meta( $post->ID, '_ffc_csv_public_limit', true );

--- a/includes/admin/class-ffc-settings-save-handler.php
+++ b/includes/admin/class-ffc-settings-save-handler.php
@@ -1,25 +1,15 @@
 <?php
-declare(strict_types=1);
-
 /**
- * SettingsSaveHandler
- * Handles saving and validation of all settings types
+ * Settings Save Handler
  *
- * Extracted from FFC_Settings (v3.1.1) following Single Responsibility Principle
+ * Handles saving and validation of all settings types.
+ * Extracted from FFC_Settings (v3.1.1) following Single Responsibility Principle.
  *
- * Responsibilities:
- * - Validate and sanitize all settings types
- * - Handle General, SMTP, QR Code, Date Format, User Access settings
- * - Handle Danger Zone (data deletion)
- * - Display success/error messages
- *
- * @package FFC
- * @since 3.1.1
- * @version 4.6.16 - Updated tab checks for reorganized settings (advanced, cache tabs)
- * @version 4.0.0 - Fixed type hint (Phase 4 Hotfix 8)
- * @version 3.3.0 - Added strict types and type hints
- * @version 3.2.0 - Migrated to namespace (Phase 2)
+ * @since   3.1.1
+ * @package FreeFormCertificate\Admin
  */
+
+declare(strict_types=1);
 
 namespace FreeFormCertificate\Admin;
 
@@ -29,9 +19,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Validates, sanitizes, and persists plugin settings.
+ *
+ * @since 3.1.1
+ */
 class SettingsSaveHandler {
 
-	/** @var SubmissionHandler */
+	/**
+	 * Submission handler for danger zone operations.
+	 *
+	 * @var SubmissionHandler
+	 */
 	private $submission_handler;
 
 	/**

--- a/includes/reregistration/class-ffc-custom-field-repository.php
+++ b/includes/reregistration/class-ffc-custom-field-repository.php
@@ -1,15 +1,15 @@
 <?php
-declare(strict_types=1);
-
 /**
  * Custom Field Repository
  *
  * Handles database operations for audience-specific custom field definitions.
  * Field data for users is stored in wp_usermeta as JSON (key: ffc_custom_fields_data).
  *
- * @since 4.11.0
+ * @since   4.11.0
  * @package FreeFormCertificate\Reregistration
  */
+
+declare(strict_types=1);
 
 namespace FreeFormCertificate\Reregistration;
 
@@ -21,6 +21,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
+/**
+ * Handles CRUD operations for audience-specific custom field definitions.
+ *
+ * @since 4.11.0
+ */
 class CustomFieldRepository {
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 
@@ -614,7 +619,7 @@ class CustomFieldRepository {
 			)
 		);
 
-		return $result ?: null;
+		return $result ? $result : null;
 	}
 
 	// ─────────────────────────────────────────────.
@@ -720,10 +725,11 @@ class CustomFieldRepository {
 	 * @return string
 	 */
 	private static function generate_field_key( string $label ): string {
-		$key = sanitize_title( $label );
-		$key = str_replace( '-', '_', $key );
-		$key = preg_replace( '/[^a-z0-9_]/', '', $key );
-		return substr( $key, 0, 100 ) ?: 'field';
+		$key       = sanitize_title( $label );
+		$key       = str_replace( '-', '_', $key );
+		$key       = preg_replace( '/[^a-z0-9_]/', '', $key );
+		$truncated = substr( $key, 0, 100 );
+		return '' !== $truncated ? $truncated : 'field';
 	}
 
 	/**
@@ -792,5 +798,4 @@ class CustomFieldRepository {
 		}
 		return is_array( $rules ) ? $rules : array();
 	}
-
 }

--- a/includes/reregistration/class-ffc-custom-field-validator.php
+++ b/includes/reregistration/class-ffc-custom-field-validator.php
@@ -1,6 +1,4 @@
 <?php
-declare(strict_types=1);
-
 /**
  * Custom Field Validator
  *
@@ -11,9 +9,11 @@ declare(strict_types=1);
  * Extracted from CustomFieldRepository to separate validation concerns
  * from data persistence.
  *
- * @since 5.2.0
+ * @since   5.2.0
  * @package FreeFormCertificate\Reregistration
  */
+
+declare(strict_types=1);
 
 namespace FreeFormCertificate\Reregistration;
 
@@ -21,6 +21,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Validates custom field values against their definitions.
+ *
+ * @since 5.2.0
+ */
 class CustomFieldValidator {
 
 	/**

--- a/includes/settings/views/ffc-tab-documentation.php
+++ b/includes/settings/views/ffc-tab-documentation.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Documentation Tab - COMPLETE VERSION
+ * Documentation Tab
  *
- * @version 5.2.0 - Added quiz, appointment, geofence locations, hooks sections; expanded ficha fields
- * @version 3.0.0 - All original content + improved structure
+ * @package FreeFormCertificate\Settings
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/settings/views/ffc-tab-general.php
+++ b/includes/settings/views/ffc-tab-general.php
@@ -2,7 +2,7 @@
 /**
  * General Settings Tab
  *
- * @version 4.6.16 - Simplified: moved debug/activity log/danger zone to Advanced, cache to Cache tab
+ * @package FreeFormCertificate\Settings
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary

- Move file docblocks before `declare(strict_types=1)` per PSR-12 header order
- Add missing class docblocks and `@package` tags to view files
- Replace short ternaries (`?:`) with explicit conditionals in CustomFieldRepository
- Fix type hints: `object` → `WP_Post` in FormEditorMetaboxRenderer method signatures
- Fix equals sign alignment in variable assignments

Resolves all 26 PHPCS/WPCS errors across the 6 files changed in PRs #33–#35.

## Test plan
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist` passes clean on all 6 files
- [x] `vendor/bin/phpstan analyse` passes with no new errors
- [ ] CI phpcs workflow passes

https://claude.ai/code/session_013mTv5ethMq15faTc8FKta9