### PR TITLE
chore: bump version to 5.3.0 and update changelog/readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 5.3.0 (2026-04-17)
+
+Full-page cache compatibility, per-form captcha isolation, and CI pipeline improvements.
+
+### New Features
+
+- Feat: **Full-page cache compatibility** — forms and calendars now work correctly with LiteSpeed Cache, WP Rocket, W3 Total Cache, and WP Super Cache. Self-scheduling shortcodes with business-hours restrictions send `DONOTCACHEPAGE` + `nocache_headers()` to prevent stale "closed" messages. Audience shortcodes for logged-in users prevent cached cross-user content leakage (#37)
+- Feat: **Dynamic Fragments geofence refresh** — the AJAX endpoint now accepts `form_ids[]` and returns fresh geofence date/time configs, so cached pages always display up-to-date availability windows after admin changes (#37)
+- Feat: **Automatic cache purge on save** — `FormCache::purge_page_cache()` finds pages embedding a saved form or calendar and purges them from LiteSpeed, WP Rocket, W3TC, and WP Super Cache. Called on both `save_post_ffc_form` and `save_post_ffc_self_scheduling` (#37)
+- Feat: **CSV Download Page URL setting** — new field on the General settings tab for configuring the public CSV download page URL (#34)
+- Feat: **Search forms by ID** — the admin forms list table (`edit.php?post_type=ffc_form`) now supports searching by numeric post ID (#39)
+
+### Bug Fixes
+
+- Fix: **Same captcha on all forms** — when multiple forms exist on a cached page, Dynamic Fragments now generates a unique math captcha per form instead of applying a single captcha to all forms (#38)
+- Fix: **PHPUnit test failures** — added missing mocks for `nocache_headers()` and `get_posts()` in `AudienceShortcodeTest` and `FormCacheTest` after cache compatibility changes (#39)
+- Fix: **Minified assets out of sync** — regenerated `ffc-dynamic-fragments.min.js` with `--source-map` to match the `npm run build` output (#39)
+
+### Refactoring
+
+- Refactor: **CustomFieldValidator extraction** — validation logic extracted from `CustomFieldRepository` into a dedicated `CustomFieldValidator` class for single-responsibility and testability (#35)
+- Refactor: **In-plugin documentation expansion** — expanded the Documentation settings tab with additional sections covering all shortcodes, settings, and features (#35)
+
+### Infrastructure
+
+- CI: Remove duplicate `push: main` trigger from CI and Assets workflows — each PR merge no longer runs the full suite twice (#39)
+- CI: Extract reusable composite action `.github/actions/setup-composer` for PHP + Composer setup (#30, #31)
+- CI: Remove CodeQL workflow (not applicable to PHP plugin) (#30)
+- CI: Add Dependabot auto-merge for patch and minor dependency updates (#29)
+- CI: Promote PHPCS from advisory to gating — PRs must pass WPCS on changed files (#28)
+- CI: Promote PHPStan from level 6 to **level 7** (#24)
+- CI: Re-introduce coverage with pcov, scoped to `includes/`, uploaded to Coveralls (#22)
+
+### Code Quality
+
+- Chore: Auto-fix ~83k PHPCS violations via PHPCBF (#25)
+- Chore: Annotate 223 PreparedSQL + NonceVerification false positives (#26)
+- Chore: Phase 3 PHPCS mechanical fixes + PSR-4 suppressions (#27)
+- Chore: Resolve remaining WPCS errors in cache-related files (file docblocks, class docblocks, short ternary operators, missing `@param` tags) (#36)
+
+---
+
 ## 5.2.0 (2026-04-15)
 
 Raise minimum PHP requirement from 7.4 to 8.1. PHP 7.4 reached end-of-life on 2022-11-28 and PHP 8.0 on 2023-11-26; both are unsupported. The previous lockfile was also resolving `doctrine/instantiator` 2.1.0 — which requires PHP 8.4 — silently breaking `composer install` on PHP 7.4/8.1/8.3 runners.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -1,17 +1,19 @@
 <?php
-/*
-Plugin Name:        Free Form Certificate
-Plugin URI:         https://github.com/rpgmem/ffcertificate
-Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
-Version:            5.3.0
-Requires PHP:       8.1
-Author:             Alex Meusburger
-Author URI:         https://github.com/rpgmem
-License:             GPLv3 or later
-License URI:         https://www.gnu.org/licenses/gpl-3.0.html
-Text Domain:        ffcertificate
-Domain Path:        /languages
-*/
+/**
+ * Plugin Name:        Free Form Certificate
+ * Plugin URI:         https://github.com/rpgmem/ffcertificate
+ * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
+ * Version:            5.3.0
+ * Requires PHP:       8.1
+ * Author:             Alex Meusburger
+ * Author URI:         https://github.com/rpgmem
+ * License:             GPLv3 or later
+ * License URI:         https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain:        ffcertificate
+ * Domain Path:        /languages
+ *
+ * @package FreeFormCertificate
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -60,10 +62,13 @@ $ffc_autoloader->register();
 register_activation_hook( __FILE__, array( '\FreeFormCertificate\Activator', 'activate' ) );
 
 /**
- * Run the plugin
+ * Bootstrap the plugin by instantiating the main Loader class.
+ *
+ * @return void
+ *
+ * phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Public API function
  */
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Public API function
-function ffcertificate_run() {
+function ffcertificate_run(): void {
 	new \FreeFormCertificate\Loader();
 }
 

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
 Plugin Name:        Free Form Certificate
 Plugin URI:         https://github.com/rpgmem/ffcertificate
 Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
-Version:            5.2.0
+Version:            5.3.0
 Requires PHP:       8.1
 Author:             Alex Meusburger
 Author URI:         https://github.com/rpgmem
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '5.2.0' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '5.3.0' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '2.5.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 5.2.0
+Stable tag: 5.3.0
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -174,6 +174,21 @@ In the certificate layout editor, use these dynamic tags:
 * Common examples: `{{name}}`, `{{email}}`, `{{cpf_rf}}`, `{{ticket}}`
 
 == Changelog ==
+
+= 5.3.0 (2026-04-17) =
+
+Full-page cache compatibility, per-form captcha isolation, and CI pipeline improvements.
+
+* Feat: **Full-page cache compatibility** — forms and calendars now work correctly with LiteSpeed Cache, WP Rocket, W3 Total Cache, and WP Super Cache. Business-hours restricted calendars send no-cache headers to prevent stale content; audience shortcodes prevent cross-user cache leakage for logged-in users.
+* Feat: **Dynamic Fragments geofence refresh** — AJAX endpoint returns fresh geofence configs per form so cached pages always show up-to-date availability windows.
+* Feat: **Automatic cache purge on save** — saving a form or calendar automatically purges cached pages that embed it (LiteSpeed, WP Rocket, W3TC, WP Super Cache).
+* Feat: **CSV Download Page URL setting** — new field on General settings tab.
+* Feat: **Search forms by ID** — admin forms list now supports searching by numeric post ID.
+* Fix: **Same captcha on all forms** — multiple forms on a cached page now each get a unique math captcha.
+* Refactor: **CustomFieldValidator extraction** from CustomFieldRepository for single-responsibility.
+* Refactor: Expanded in-plugin Documentation tab with additional sections.
+* CI: Remove duplicate push triggers, extract composite action, add Dependabot auto-merge, promote PHPCS to gating, promote PHPStan to level 7.
+* Chore: Auto-fix ~83k PHPCS violations, annotate 223 false positives, Phase 3 mechanical fixes.
 
 = 5.2.0 (2026-04-15) =
 


### PR DESCRIPTION
## Summary

- Bump version from **5.2.0 → 5.3.0** in `ffcertificate.php` (header + `FFC_VERSION` constant) and `readme.txt` (Stable tag)
- Add comprehensive changelog entry for all 18 PRs merged since 5.2.0, covering cache compatibility, captcha fix, CI improvements, PHPCS/PHPStan promotions, and new features
- Update `readme.txt` changelog section with condensed version

## Changes covered in 5.3.0

**Features**: cache compatibility (LiteSpeed/WP Rocket/W3TC/WP Super Cache), Dynamic Fragments geofence refresh, automatic cache purge on save, CSV Download Page URL setting, search forms by ID

**Fixes**: per-form unique captcha, test mocks, minified asset sync

**Refactoring**: CustomFieldValidator extraction, documentation expansion

**Infrastructure**: CI dedup, composite action, Dependabot automerge, PHPCS gating, PHPStan level 7, ~83k PHPCS fixes

https://claude.ai/code/session_013mTv5ethMq15faTc8FKta9