### PR TITLE
refactor(sensitive-fields): centralize policy in SensitiveFieldRegistry

### DIFF
--- a/docs/USER_DATA_AUDIT.md
+++ b/docs/USER_DATA_AUDIT.md
@@ -236,3 +236,47 @@ submissões; consolidar a convenção facilita o cruzamento entre tabelas.
   deve ser removida em passo seguinte.
 - Criptografia seletiva em `ActivityLog` e silêncio em `decrypt` permanecem
   abertos — endereçados pelos itens 2 e 3 da seção 7.
+
+## 9. Correções aplicadas (item 2 — política de campo sensível)
+
+### Fase 0 — testes de caracterização
+`tests/Unit/SensitiveFieldPolicyTest.php` fixa em um só lugar o contrato que
+cada write path mantém:
+
+- `SubmissionHandler::process_submission` encripta `email`, `cpf|rf`,
+  `user_ip`, `data`; faz hash de `email`, `cpf|rf`, `ticket`.
+- `AppointmentRepository::createAppointment` encripta `email`, `cpf|rf`,
+  `phone`, `custom_data`, `user_ip`; faz hash de `email`, `cpf|rf`; remove
+  plaintext.
+- Também tranca o invariante estabelecido pelo item 1:
+  `email_hash == Encryption::hash(decrypt(email_encrypted))`.
+
+### Fase 1 — `SensitiveFieldRegistry`
+Classe `FreeFormCertificate\Core\SensitiveFieldRegistry` em
+`includes/core/class-ffc-sensitive-field-registry.php`. Mapa declarativo
+indexado por contexto (`CONTEXT_SUBMISSION`, `CONTEXT_APPOINTMENT`); cada
+campo informa `encrypted_column` e `hash_column`. API:
+
+- `encrypt_fields( $context, $values )` — retorna o mapa de colunas a
+  serem escritas. No-op quando a criptografia não está configurada.
+- `plaintext_keys( $context )` — chaves cujo texto claro precisa ser
+  removido antes do insert.
+
+Consumidores:
+
+- `SubmissionHandler::process_submission` / `update_submission` trocam os
+  blocos inline por uma chamada ao registry.
+- `AppointmentRepository::createAppointment` normaliza `cpf_rf → cpf|rf`
+  antes da chamada e faz um único `foreach` para remover o plaintext.
+
+Activity log permanece fora do escopo: a política de encriptação dele é
+por *ação*, não por campo.
+
+### Fase 2 — auditoria de migração
+Comparado o registry com o estado hoje escrito por cada write path: todos
+os campos declarados já eram criptografados no mesmo par de colunas pelos
+call sites atuais. **Nenhuma migração adicional foi necessária.** As
+migrações legadas continuam cobrindo os dois casos históricos:
+
+- `split_cpf_rf` para linhas com `cpf_rf_hash` combinado.
+- `email_hash_rehash` (item 1) para hashes de e-mail sem salt.

--- a/includes/core/class-ffc-sensitive-field-registry.php
+++ b/includes/core/class-ffc-sensitive-field-registry.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * SensitiveFieldRegistry
+ *
+ * Declarative registry of fields treated as sensitive per write context.
+ * Consolidates policy that was previously duplicated across SubmissionHandler
+ * and AppointmentRepository, where each site carried its own hard-coded list
+ * of fields to encrypt and hash.
+ *
+ * Adding or removing a sensitive field is now a single edit to the FIELDS
+ * map instead of a hunt across three files. The encrypted/hash column names
+ * per field remain visible in one place, so storage schema and encryption
+ * policy stay aligned.
+ *
+ * Activity log encryption is intentionally out of scope: it gates by action
+ * name, not by field, and belongs to its own concern.
+ *
+ * @package FreeFormCertificate\Core
+ * @since 5.4.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensitive Field Registry.
+ */
+final class SensitiveFieldRegistry {
+
+	/**
+	 * Context key: wp_ffc_submissions write path.
+	 */
+	public const CONTEXT_SUBMISSION = 'submission';
+
+	/**
+	 * Context key: wp_ffc_self_scheduling_appointments write path.
+	 */
+	public const CONTEXT_APPOINTMENT = 'appointment';
+
+	/**
+	 * Field descriptors per context.
+	 *
+	 * Each entry maps a logical field key (e.g. "email") to the columns that
+	 * must be populated when the plaintext is encrypted.
+	 *
+	 *   - encrypted_column: string|null  Column for ciphertext. Null = no
+	 *                                    ciphertext stored (hash-only).
+	 *   - hash_column:      string|null  Column for Encryption::hash lookup.
+	 *                                    Null = no lookup hash stored.
+	 *
+	 * @var array<string, array<string, array{encrypted_column: ?string, hash_column: ?string}>>
+	 */
+	private const FIELDS = array(
+		self::CONTEXT_SUBMISSION  => array(
+			'email'   => array(
+				'encrypted_column' => 'email_encrypted',
+				'hash_column'      => 'email_hash',
+			),
+			'cpf'     => array(
+				'encrypted_column' => 'cpf_encrypted',
+				'hash_column'      => 'cpf_hash',
+			),
+			'rf'      => array(
+				'encrypted_column' => 'rf_encrypted',
+				'hash_column'      => 'rf_hash',
+			),
+			'user_ip' => array(
+				'encrypted_column' => 'user_ip_encrypted',
+				'hash_column'      => null,
+			),
+			'data'    => array(
+				'encrypted_column' => 'data_encrypted',
+				'hash_column'      => null,
+			),
+			'ticket'  => array(
+				'encrypted_column' => null,
+				'hash_column'      => 'ticket_hash',
+			),
+		),
+		self::CONTEXT_APPOINTMENT => array(
+			'email'       => array(
+				'encrypted_column' => 'email_encrypted',
+				'hash_column'      => 'email_hash',
+			),
+			'cpf'         => array(
+				'encrypted_column' => 'cpf_encrypted',
+				'hash_column'      => 'cpf_hash',
+			),
+			'rf'          => array(
+				'encrypted_column' => 'rf_encrypted',
+				'hash_column'      => 'rf_hash',
+			),
+			'phone'       => array(
+				'encrypted_column' => 'phone_encrypted',
+				'hash_column'      => null,
+			),
+			'custom_data' => array(
+				'encrypted_column' => 'custom_data_encrypted',
+				'hash_column'      => null,
+			),
+			'user_ip'     => array(
+				'encrypted_column' => 'user_ip_encrypted',
+				'hash_column'      => null,
+			),
+		),
+	);
+
+	/**
+	 * All field specs for a context.
+	 *
+	 * @param string $context One of the CONTEXT_* constants.
+	 * @return array<string, array{encrypted_column: ?string, hash_column: ?string}>
+	 */
+	public static function fields_for( string $context ): array {
+		return self::FIELDS[ $context ] ?? array();
+	}
+
+	/**
+	 * Whether a logical field is declared sensitive in a given context.
+	 *
+	 * @param string $context Context key.
+	 * @param string $field_key Logical field key.
+	 * @return bool
+	 */
+	public static function has( string $context, string $field_key ): bool {
+		return isset( self::FIELDS[ $context ][ $field_key ] );
+	}
+
+	/**
+	 * Encrypt and hash a batch of plaintext values into their column map.
+	 *
+	 * Empty or null values are skipped silently. When encryption is not
+	 * configured (no keys in wp-config), the returned array is empty and
+	 * the caller is expected to fall back to plaintext storage.
+	 *
+	 * @param string               $context Context key.
+	 * @param array<string, mixed> $values  Plaintext values keyed by logical field.
+	 * @return array<string, string|null> Columns to merge into the insert row.
+	 */
+	public static function encrypt_fields( string $context, array $values ): array {
+		if ( ! class_exists( Encryption::class ) || ! Encryption::is_configured() ) {
+			return array();
+		}
+
+		$out = array();
+
+		foreach ( self::fields_for( $context ) as $field_key => $spec ) {
+			if ( ! array_key_exists( $field_key, $values ) ) {
+				continue;
+			}
+			$value = $values[ $field_key ];
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$plain = is_string( $value ) ? $value : (string) $value;
+
+			if ( ! empty( $spec['encrypted_column'] ) ) {
+				$out[ $spec['encrypted_column'] ] = Encryption::encrypt( $plain );
+			}
+			if ( ! empty( $spec['hash_column'] ) ) {
+				$out[ $spec['hash_column'] ] = Encryption::hash( $plain );
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Logical keys whose plaintext must be removed from a row before insert
+	 * to avoid LGPD leaks.
+	 *
+	 * @param string $context Context key.
+	 * @return list<string>
+	 */
+	public static function plaintext_keys( string $context ): array {
+		return array_keys( self::fields_for( $context ) );
+	}
+}

--- a/includes/repositories/ffc-appointment-repository.php
+++ b/includes/repositories/ffc-appointment-repository.php
@@ -473,61 +473,41 @@ class AppointmentRepository extends AbstractRepository {
 	 * @return int|false
 	 */
 	public function createAppointment( array $data ) {
-		// Handle encryption if configured.
-		if ( class_exists( '\FreeFormCertificate\Core\Encryption' ) &&
-			\FreeFormCertificate\Core\Encryption::is_configured() ) {
-
-			if ( ! empty( $data['email'] ) ) {
-				// Match SubmissionHandler: hash the same value that gets encrypted (no normalization).
-				$data['email_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $data['email'] );
-				$data['email_hash']      = \FreeFormCertificate\Core\Encryption::hash( $data['email'] );
-				// Clear plain text - do not store unencrypted (LGPD compliance).
-				unset( $data['email'] );
-			}
-
-			if ( ! empty( $data['cpf_rf'] ) ) {
-				$clean_id = preg_replace( '/[^0-9]/', '', $data['cpf_rf'] );
-
-				// Write to split columns only — no legacy cpf_rf_* dual-write.
-				$id_len = strlen( $clean_id );
-				if ( 7 === $id_len ) {
-					$data['rf_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $clean_id );
-					$data['rf_hash']      = \FreeFormCertificate\Core\Encryption::hash( $clean_id );
+		// Normalize cpf_rf → split cpf/rf before the registry sees it; the
+		// registry knows about the split columns, not the combined input.
+		if ( ! empty( $data['cpf_rf'] ) ) {
+			$clean_id = preg_replace( '/[^0-9]/', '', (string) $data['cpf_rf'] );
+			if ( '' !== $clean_id ) {
+				if ( 7 === strlen( $clean_id ) ) {
+					$data['rf'] = $clean_id;
 				} else {
 					// 11 digits (CPF) or unknown length — default to CPF.
-					$data['cpf_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $clean_id );
-					$data['cpf_hash']      = \FreeFormCertificate\Core\Encryption::hash( $clean_id );
+					$data['cpf'] = $clean_id;
 				}
-
-				// Clear plain text - do not store unencrypted (LGPD compliance).
-				unset( $data['cpf_rf'] );
-			}
-
-			if ( ! empty( $data['phone'] ) ) {
-				$data['phone_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $data['phone'] );
-				// Clear plain text - do not store unencrypted (LGPD compliance).
-				unset( $data['phone'] );
-			}
-
-			if ( ! empty( $data['custom_data'] ) ) {
-				$custom_json                   = is_array( $data['custom_data'] ) ? wp_json_encode( $data['custom_data'] ) : $data['custom_data'];
-				$data['custom_data_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $custom_json );
-				// Clear plain text - do not store unencrypted (LGPD compliance).
-				unset( $data['custom_data'] );
-			}
-
-			if ( ! empty( $data['user_ip'] ) ) {
-				$data['user_ip_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $data['user_ip'] );
-				// Clear plain text - do not store unencrypted (LGPD compliance).
-				unset( $data['user_ip'] );
 			}
 		}
 
-		// Always remove non-column keys that only exist in encrypted form in the DB.
-		// When encryption is configured, these are unset inside the !empty() blocks above,.
-		// but if a value is empty the key stays in the array and causes wpdb->insert()
-		// to fail with "Unknown column". Remove them unconditionally.
-		unset( $data['email'], $data['cpf_rf'], $data['phone'], $data['custom_data'], $data['user_ip'] );
+		// custom_data may arrive as an array; the registry expects a scalar.
+		if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
+			$data['custom_data'] = wp_json_encode( $data['custom_data'] );
+		}
+
+		$encrypted_columns = \FreeFormCertificate\Core\SensitiveFieldRegistry::encrypt_fields(
+			\FreeFormCertificate\Core\SensitiveFieldRegistry::CONTEXT_APPOINTMENT,
+			$data
+		);
+		$data              = array_merge( $data, $encrypted_columns );
+
+		// Always strip plaintext from the row (whether encrypted above or
+		// left in place because encryption is disabled). wpdb->insert would
+		// fail with "Unknown column" otherwise, and storing plaintext breaks
+		// LGPD when keys are present.
+		foreach ( \FreeFormCertificate\Core\SensitiveFieldRegistry::plaintext_keys(
+			\FreeFormCertificate\Core\SensitiveFieldRegistry::CONTEXT_APPOINTMENT
+		) as $plain_key ) {
+			unset( $data[ $plain_key ] );
+		}
+		unset( $data['cpf_rf'] );
 
 		// Generate confirmation token for all appointments (allows receipt access without login).
 		if ( empty( $data['confirmation_token'] ) ) {

--- a/includes/submissions/class-ffc-submission-handler.php
+++ b/includes/submissions/class-ffc-submission-handler.php
@@ -176,46 +176,31 @@ class SubmissionHandler {
 		// 5b. Extract ticket value (for hash-based lookup)
 		$ticket_value = isset( $extra_data['ticket'] ) ? strtoupper( trim( (string) $extra_data['ticket'] ) ) : null;
 
-		// 6. Encryption.
-		$email_encrypted   = null;
-		$email_hash        = null;
-		$cpf_encrypted_val = null;
-		$cpf_hash_val      = null;
-		$rf_encrypted_val  = null;
-		$rf_hash_val       = null;
-		$ticket_hash       = null;
-		$ip_encrypted      = null;
-		$data_encrypted    = null;
+		// 6. Encryption via SensitiveFieldRegistry — single policy source for
+		// every field this handler treats as sensitive.
+		$encrypted = \FreeFormCertificate\Core\SensitiveFieldRegistry::encrypt_fields(
+			\FreeFormCertificate\Core\SensitiveFieldRegistry::CONTEXT_SUBMISSION,
+			array(
+				'email'   => $user_email,
+				'cpf'     => $clean_cpf,
+				'rf'      => $clean_rf,
+				'user_ip' => $user_ip,
+				'ticket'  => $ticket_value,
+				// The JSON "{}" means no extra data — skip encryption instead
+				// of writing a ciphertext for an empty payload.
+				'data'    => '{}' === $data_json ? null : $data_json,
+			)
+		);
 
-		if ( class_exists( '\FreeFormCertificate\Core\Encryption' ) && \FreeFormCertificate\Core\Encryption::is_configured() ) {
-			if ( ! empty( $user_email ) ) {
-				$email_encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $user_email );
-				$email_hash      = \FreeFormCertificate\Core\Encryption::hash( $user_email );
-			}
-
-			// Split columns only — no legacy cpf_rf_* dual-write.
-			if ( ! empty( $clean_cpf ) ) {
-				$cpf_encrypted_val = \FreeFormCertificate\Core\Encryption::encrypt( $clean_cpf );
-				$cpf_hash_val      = \FreeFormCertificate\Core\Encryption::hash( $clean_cpf );
-			}
-
-			if ( ! empty( $clean_rf ) ) {
-				$rf_encrypted_val = \FreeFormCertificate\Core\Encryption::encrypt( $clean_rf );
-				$rf_hash_val      = \FreeFormCertificate\Core\Encryption::hash( $clean_rf );
-			}
-
-			if ( ! empty( $user_ip ) ) {
-				$ip_encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $user_ip );
-			}
-
-			if ( ! empty( $ticket_value ) ) {
-				$ticket_hash = \FreeFormCertificate\Core\Encryption::hash( $ticket_value );
-			}
-
-			if ( '{}' !== $data_json ) {
-				$data_encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $data_json );
-			}
-		}
+		$email_encrypted   = $encrypted['email_encrypted'] ?? null;
+		$email_hash        = $encrypted['email_hash'] ?? null;
+		$cpf_encrypted_val = $encrypted['cpf_encrypted'] ?? null;
+		$cpf_hash_val      = $encrypted['cpf_hash'] ?? null;
+		$rf_encrypted_val  = $encrypted['rf_encrypted'] ?? null;
+		$rf_hash_val       = $encrypted['rf_hash'] ?? null;
+		$ticket_hash       = $encrypted['ticket_hash'] ?? null;
+		$ip_encrypted      = $encrypted['user_ip_encrypted'] ?? null;
+		$data_encrypted    = $encrypted['data_encrypted'] ?? null;
 
 		// 7. LGPD Consent.
 		$consent_given = isset( $submission_data['ffc_lgpd_consent'] ) && '1' === $submission_data['ffc_lgpd_consent'] ? 1 : 0;
@@ -321,26 +306,30 @@ class SubmissionHandler {
 		do_action( 'ffcertificate_before_submission_update', $id, $new_email, $clean_data );
 
 		$update_data = array();
+		$has_data    = ! empty( $clean_data );
+		$data_json   = null;
 
-		// Update email if provided (always encrypted).
-		if ( '' !== $new_email ) {
-			if ( class_exists( '\FreeFormCertificate\Core\Encryption' ) && \FreeFormCertificate\Core\Encryption::is_configured() ) {
-				$update_data['email_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $new_email );
-				$update_data['email_hash']      = \FreeFormCertificate\Core\Encryption::hash( $new_email );
-			}
+		if ( $has_data ) {
+			// Remove edit tracking from JSON data (should be in columns).
+			unset( $clean_data['is_edited'], $clean_data['edited_at'] );
+			$data_json = wp_json_encode( $clean_data, JSON_UNESCAPED_UNICODE );
 		}
 
-		// Update data if provided.
-		if ( ! empty( $clean_data ) ) {
-			// Remove edit tracking from JSON data (should be in columns).
-			unset( $clean_data['is_edited'] );
-			unset( $clean_data['edited_at'] );
+		// Route sensitive fields through the registry.
+		$encrypted   = \FreeFormCertificate\Core\SensitiveFieldRegistry::encrypt_fields(
+			\FreeFormCertificate\Core\SensitiveFieldRegistry::CONTEXT_SUBMISSION,
+			array(
+				'email' => '' !== $new_email ? $new_email : null,
+				'data'  => $has_data ? ( $data_json ? $data_json : '{}' ) : null,
+			)
+		);
+		$update_data = array_merge( $update_data, $encrypted );
 
-			$data_json = wp_json_encode( $clean_data, JSON_UNESCAPED_UNICODE );
-
-			if ( class_exists( '\FreeFormCertificate\Core\Encryption' ) && \FreeFormCertificate\Core\Encryption::is_configured() ) {
-				$update_data['data_encrypted'] = \FreeFormCertificate\Core\Encryption::encrypt( $data_json ? $data_json : '{}' );
-				$update_data['data']           = null;
+		// When data is updated and encryption is active, the plaintext column
+		// must be NULLed out; otherwise store the plaintext json.
+		if ( $has_data ) {
+			if ( isset( $encrypted['data_encrypted'] ) ) {
+				$update_data['data'] = null;
 			} else {
 				$update_data['data'] = $data_json;
 			}

--- a/tests/Unit/SensitiveFieldPolicyTest.php
+++ b/tests/Unit/SensitiveFieldPolicyTest.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Characterization tests for the "sensitive field" policy across write paths.
+ *
+ * These tests pin the contract that Phase 1 (SensitiveFieldRegistry) must
+ * preserve: the set of fields each repository/handler treats as sensitive
+ * (encrypted, optionally hashed for lookup) on write.
+ *
+ * The scope is intentionally narrow: each test asserts which columns are
+ * populated with encrypted/hash values and which plaintext columns are
+ * dropped. It does NOT re-test encryption primitives (see EncryptionTest).
+ *
+ * Sites covered:
+ *   - FreeFormCertificate\Submissions\SubmissionHandler::process_submission
+ *   - FreeFormCertificate\Repositories\AppointmentRepository::createAppointment
+ *
+ * Not covered here (evaluated separately): ReregistrationDataProcessor uses
+ * per-field is_sensitive flags read from wp_ffc_custom_fields at runtime;
+ * its contract is pinned in ReregistrationDataProcessorTest by field
+ * definition rather than hard-coded list.
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Core\Encryption;
+use FreeFormCertificate\Repositories\AppointmentRepository;
+use FreeFormCertificate\Submissions\SubmissionHandler;
+
+/**
+ * @coversNothing
+ * @runClassInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class SensitiveFieldPolicyTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var Mockery\MockInterface */
+    private $wpdb;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        global $wpdb;
+        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb->prefix = 'wp_';
+        $wpdb->last_error = '';
+        $wpdb->insert_id = 0;
+        $this->wpdb = $wpdb;
+
+        $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () {
+            return func_get_args()[0];
+        } )->byDefault();
+        $wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();
+        $wpdb->shouldReceive( 'query' )->andReturn( 0 )->byDefault();
+
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'current_time' )->justReturn( '2026-05-01 12:00:00' );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'do_action' )->justReturn( null );
+        Functions\when( 'get_option' )->justReturn( 0 );
+        Functions\when( 'absint' )->alias( function ( $val ) {
+            return abs( intval( $val ) );
+        } );
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'sanitize_key' )->alias( function ( $k ) {
+            return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $k ) );
+        } );
+        Functions\when( 'wp_rand' )->alias( function ( $min = 0, $max = null ) {
+            return random_int( $min, $max ?? PHP_INT_MAX );
+        } );
+        Functions\when( 'is_wp_error' )->alias( function ( $t ) {
+            return $t instanceof \WP_Error;
+        } );
+        Functions\when( 'apply_filters' )->alias( function () {
+            $a = func_get_args();
+            return $a[1] ?? null;
+        } );
+        Functions\when( 'get_user_by' )->justReturn( false );
+        Functions\when( 'get_userdata' )->justReturn( null );
+        Functions\when( 'wp_generate_password' )->justReturn( 'TestPass123!' );
+        Functions\when( 'sanitize_user' )->returnArg();
+        Functions\when( 'remove_accents' )->returnArg();
+        Functions\when( 'username_exists' )->justReturn( false );
+        Functions\when( 'wp_create_user' )->justReturn( 100 );
+        Functions\when( 'wp_update_user' )->justReturn( 100 );
+        Functions\when( 'update_user_meta' )->justReturn( true );
+        Functions\when( 'wp_new_user_notification' )->justReturn( null );
+
+        Functions\when( 'FreeFormCertificate\Core\get_option' )->alias( function ( $k, $d = false ) {
+            return \get_option( $k, $d );
+        } );
+        Functions\when( 'FreeFormCertificate\Core\get_current_user_id' )->alias( function () {
+            return \get_current_user_id();
+        } );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ==================================================================
+    // SubmissionHandler::process_submission
+    // ==================================================================
+
+    /**
+     * The set of columns the submission write path must populate with
+     * encrypted / hashed values is the "sensitive field contract" of
+     * SubmissionHandler. Centralizing policy must not change this set.
+     */
+    public function test_submission_handler_encrypts_and_hashes_expected_columns(): void {
+        $handler  = new SubmissionHandler();
+        $mockRepo = Mockery::mock( 'FreeFormCertificate\\Repositories\\SubmissionRepository' );
+        $ref      = new \ReflectionClass( $handler );
+        $prop     = $ref->getProperty( 'repository' );
+        $prop->setAccessible( true );
+        $prop->setValue( $handler, $mockRepo );
+
+        $captured = null;
+        $mockRepo->shouldReceive( 'insert' )
+            ->once()
+            ->withArgs( function ( $data ) use ( &$captured ) {
+                $captured = $data;
+                return true;
+            } )
+            ->andReturn( 42 );
+
+        $data = array(
+            'name'     => 'Carol',
+            'email'    => 'carol@test.com',
+            'cpf_rf'   => '12345678901',
+            'ticket'   => 'ABC-123',
+            'extra1'   => 'payload',
+        );
+        $handler->process_submission( 1, 'Form', $data, 'carol@test.com', array(), array() );
+
+        $this->assertIsArray( $captured );
+
+        // Encrypted / hashed columns that must be populated on any sensitive
+        // write. Adding or removing a key here is a behavior change that the
+        // registry refactor must be deliberate about.
+        $this->assertNotNull( $captured['email_encrypted'], 'email must be encrypted' );
+        $this->assertNotNull( $captured['email_hash'], 'email must have a lookup hash' );
+        $this->assertNotNull( $captured['cpf_encrypted'], 'cpf must be encrypted' );
+        $this->assertNotNull( $captured['cpf_hash'], 'cpf must have a lookup hash' );
+        $this->assertNotNull( $captured['ticket_hash'], 'ticket must have a lookup hash' );
+        $this->assertNotNull( $captured['data_encrypted'], 'extra form data must be encrypted' );
+
+        // Hash length must match Encryption::hash (SHA-256 hex).
+        $this->assertSame( 64, strlen( $captured['email_hash'] ) );
+        $this->assertSame( 64, strlen( $captured['cpf_hash'] ) );
+        $this->assertSame( 64, strlen( $captured['ticket_hash'] ) );
+    }
+
+    /**
+     * Seven-digit cpf_rf values route to rf_* columns instead of cpf_*. This
+     * split is policy, not a detail — preserve it through the refactor.
+     */
+    public function test_submission_handler_seven_digit_identifier_routes_to_rf_columns(): void {
+        $handler  = new SubmissionHandler();
+        $mockRepo = Mockery::mock( 'FreeFormCertificate\\Repositories\\SubmissionRepository' );
+        $ref      = new \ReflectionClass( $handler );
+        $prop     = $ref->getProperty( 'repository' );
+        $prop->setAccessible( true );
+        $prop->setValue( $handler, $mockRepo );
+
+        $captured = null;
+        $mockRepo->shouldReceive( 'insert' )
+            ->once()
+            ->withArgs( function ( $data ) use ( &$captured ) {
+                $captured = $data;
+                return true;
+            } )
+            ->andReturn( 43 );
+
+        $submission = array( 'email' => 'x@y.z', 'cpf_rf' => '1234567' );
+        $handler->process_submission(
+            1,
+            'Form',
+            $submission,
+            'x@y.z',
+            array(),
+            array()
+        );
+
+        $this->assertNotNull( $captured['rf_encrypted'] );
+        $this->assertNotNull( $captured['rf_hash'] );
+        $this->assertNull( $captured['cpf_encrypted'] );
+        $this->assertNull( $captured['cpf_hash'] );
+    }
+
+    /**
+     * Verifies that the hash stored is the *exact* output of Encryption::hash
+     * on the plaintext value — not a raw sha256, not a normalized variant.
+     * This invariant is what PR #55 established and it must survive the
+     * registry refactor.
+     */
+    public function test_submission_handler_hash_matches_encryption_hash_of_plaintext(): void {
+        $handler  = new SubmissionHandler();
+        $mockRepo = Mockery::mock( 'FreeFormCertificate\\Repositories\\SubmissionRepository' );
+        $ref      = new \ReflectionClass( $handler );
+        $prop     = $ref->getProperty( 'repository' );
+        $prop->setAccessible( true );
+        $prop->setValue( $handler, $mockRepo );
+
+        $captured = null;
+        $mockRepo->shouldReceive( 'insert' )
+            ->once()
+            ->withArgs( function ( $data ) use ( &$captured ) {
+                $captured = $data;
+                return true;
+            } )
+            ->andReturn( 44 );
+
+        $email = 'John@Example.com';
+        $cpf   = '12345678901';
+        $submission = array( 'email' => $email, 'cpf_rf' => $cpf );
+        $handler->process_submission( 1, 'F', $submission, $email, array(), array() );
+
+        $this->assertSame( Encryption::hash( $email ), $captured['email_hash'] );
+        $this->assertSame( Encryption::hash( $cpf ), $captured['cpf_hash'] );
+    }
+
+    // ==================================================================
+    // AppointmentRepository::createAppointment
+    // ==================================================================
+
+    /**
+     * Appointments encrypt a slightly different set of fields (adds phone
+     * and custom_data; no ticket). Pinning the exact set so the refactor
+     * can declare each one in the registry without losing coverage.
+     */
+    public function test_appointment_repository_encrypts_and_hashes_expected_columns(): void {
+        $repo = new AppointmentRepository();
+
+        $captured = null;
+        $this->wpdb->shouldReceive( 'insert' )
+            ->once()
+            ->andReturnUsing( function ( $table, $data ) use ( &$captured ) {
+                $captured = $data;
+                return 1;
+            } );
+        $this->wpdb->insert_id = 1;
+
+        $repo->createAppointment( array(
+            'calendar_id'        => 5,
+            'appointment_date'   => '2026-05-10',
+            'start_time'         => '09:00:00',
+            'status'             => 'pending',
+            'confirmation_token' => 'tok-123',
+            'validation_code'    => 'VAL1234567AB',
+            'email'              => 'alice@example.com',
+            'cpf_rf'             => '12345678901',
+            'phone'              => '5511999990000',
+            'custom_data'        => array( 'notes' => 'vip' ),
+            'user_ip'            => '192.0.2.1',
+        ) );
+
+        $this->assertIsArray( $captured );
+
+        // Encrypted columns.
+        $this->assertNotNull( $captured['email_encrypted'] );
+        $this->assertNotNull( $captured['cpf_encrypted'] );
+        $this->assertNotNull( $captured['phone_encrypted'] );
+        $this->assertNotNull( $captured['custom_data_encrypted'] );
+        $this->assertNotNull( $captured['user_ip_encrypted'] );
+
+        // Hash columns: email, cpf, rf only (phone/custom_data/user_ip are
+        // encrypted-only — no lookup hash today).
+        $this->assertNotNull( $captured['email_hash'] );
+        $this->assertNotNull( $captured['cpf_hash'] );
+        $this->assertArrayNotHasKey( 'phone_hash', $captured );
+        $this->assertArrayNotHasKey( 'custom_data_hash', $captured );
+        $this->assertArrayNotHasKey( 'user_ip_hash', $captured );
+
+        // Plaintext columns must be stripped.
+        $this->assertArrayNotHasKey( 'email', $captured );
+        $this->assertArrayNotHasKey( 'cpf_rf', $captured );
+        $this->assertArrayNotHasKey( 'phone', $captured );
+        $this->assertArrayNotHasKey( 'custom_data', $captured );
+        $this->assertArrayNotHasKey( 'user_ip', $captured );
+    }
+
+    /**
+     * Appointment findByCpfRf / findByEmail build the lookup hash through
+     * Encryption::hash. A row created by createAppointment must therefore
+     * store a hash computed the same way. This was the exact regression
+     * PR #55 fixed; lock it in.
+     */
+    public function test_appointment_repository_hashes_match_encryption_hash_of_plaintext(): void {
+        $repo = new AppointmentRepository();
+
+        $captured = null;
+        $this->wpdb->shouldReceive( 'insert' )
+            ->once()
+            ->andReturnUsing( function ( $table, $data ) use ( &$captured ) {
+                $captured = $data;
+                return 1;
+            } );
+        $this->wpdb->insert_id = 1;
+
+        $email = 'Bob@Example.com';
+        $cpf   = '98765432100';
+        $repo->createAppointment( array(
+            'calendar_id'        => 5,
+            'confirmation_token' => 't',
+            'validation_code'    => 'VAL1234567AB',
+            'email'              => $email,
+            'cpf_rf'             => $cpf,
+        ) );
+
+        $this->assertSame( Encryption::hash( $email ), $captured['email_hash'] );
+        $this->assertSame( Encryption::hash( $cpf ), $captured['cpf_hash'] );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #55 — centralizes the "which fields are sensitive" policy that was previously duplicated across three call sites. Three phases in one PR so the refactor lands with a safety net (characterization tests) and with the migration audit already done.

## Phase 0 — characterization tests (`tests/Unit/SensitiveFieldPolicyTest.php`)

Pin the current contract each write path enforces, so Phase 1 cannot silently drop coverage:

- `SubmissionHandler::process_submission` — encrypts `email`, `cpf|rf`, `user_ip`, `data`; hashes `email`, `cpf|rf`, `ticket`.
- `AppointmentRepository::createAppointment` — encrypts `email`, `cpf|rf`, `phone`, `custom_data`, `user_ip`; hashes `email`, `cpf|rf`; strips plaintext.
- Also locks in the PR #55 invariant `email_hash == Encryption::hash(decrypted_email)`.

## Phase 1 — `SensitiveFieldRegistry` (`includes/core/class-ffc-sensitive-field-registry.php`)

Declarative map keyed by write context. Each entry names the encrypted and hash columns per logical field. Adding or removing a sensitive field is now a one-line change.

API:
- `CONTEXT_SUBMISSION`, `CONTEXT_APPOINTMENT` constants.
- `encrypt_fields(string $context, array $values): array` — returns columns to merge into a row. Empty when encryption is not configured.
- `plaintext_keys(string $context): list<string>` — keys to strip before insert.
- `fields_for()`, `has()` — introspection helpers.

Consumers migrated:
- `SubmissionHandler::process_submission` / `update_submission`: replaced inline `Encryption::encrypt`/`hash` blocks with one call; local variables preserved for downstream user linking.
- `AppointmentRepository::createAppointment`: splits `cpf_rf` into `cpf|rf` before calling the registry; single foreach strips plaintext.

Activity log is intentionally still out of scope — it gates by action name, not field.

## Phase 2 — migration audit

Goal: if the registry declares a field as sensitive that is currently stored in plaintext somewhere, produce a migration to catch up.

**Result: no migration needed.** The registry entries mirror the exact fields each site already encrypts today. `cpf_rf_hash` legacy rows are still handled by `split_cpf_rf`, and unsalted `email_hash` rows by `email_hash_rehash` (both from #55). The refactor is strictly a policy consolidation with no schema implications.

## Test plan

- [x] `SensitiveFieldPolicyTest` — 5 tests, 39 assertions.
- [x] `SubmissionHandlerTest` + `AppointmentRepositoryTest` + `SensitiveFieldPolicyTest` — 153 tests, 442 assertions.
- [x] Full local PHPUnit suite running — no regressions expected; PR starts draft so CI is the authoritative signal.
- [x] PHPCS clean on all modified files.

## Follow-ups (still deferred)

- Item #3 (MEDIUM) — activity log selective encryption.
- Item #4 (MEDIUM) — silent `decrypt()` failures in `reprint-detector` and submission REST controller.
- `UserProfileService` for unified reads and bulk exports.
- Remove residual `class_exists ? Encryption::hash : hash('sha256')` fallbacks in `self-scheduling-appointment-handler.php:488` and `ffc-submission-repository.php:792`.

https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd)_