### PR TITLE
refactor(activity-log): payload-based gate via SensitiveFieldRegistry

### DIFF
--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -117,21 +117,19 @@ class ActivityLog {
 			$level = self::LEVEL_INFO;
 		}
 
-		// Encrypt context if contains sensitive data.
+		// Encrypt context if the payload carries a field we classify as
+		// sensitive. This replaces the older action-whitelist gate with a
+		// payload-inspection gate backed by SensitiveFieldRegistry, which
+		// unifies the static per-site lists with the dynamic is_sensitive=1
+		// reregistration fields. A log call with no sensitive data stays
+		// unencrypted regardless of action; conversely, any action carrying
+		// a sensitive field in its context now gets encrypted automatically.
 		$context_json_raw  = wp_json_encode( $context );
 		$context_json      = $context_json_raw ? $context_json_raw : '';
 		$context_encrypted = null;
 
 		if ( class_exists( '\\FreeFormCertificate\\Core\\Encryption' ) && \FreeFormCertificate\Core\Encryption::is_configured() ) {
-			$sensitive_actions = array(
-				'submission_created',
-				'data_accessed',
-				'data_modified',
-				'admin_searched',
-				'encryption_migration_batch',
-			);
-
-			if ( in_array( $action, $sensitive_actions, true ) ) {
+			if ( SensitiveFieldRegistry::contains_sensitive( $context ) ) {
 				$context_encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $context_json );
 			}
 		}

--- a/includes/core/class-ffc-sensitive-field-registry.php
+++ b/includes/core/class-ffc-sensitive-field-registry.php
@@ -181,4 +181,139 @@ final class SensitiveFieldRegistry {
 	public static function plaintext_keys( string $context ): array {
 		return array_keys( self::fields_for( $context ) );
 	}
+
+	/**
+	 * In-memory cache of the union of all static sensitive keys.
+	 *
+	 * @var array<string, bool>|null
+	 */
+	private static $universal_static_cache = null;
+
+	/**
+	 * Cache object key used for the dynamic (is_sensitive=1) set.
+	 */
+	private const DYNAMIC_CACHE_KEY = 'ffc_sensitive_field_keys_dynamic';
+
+	/**
+	 * Cache group for wp_cache_* of the dynamic set.
+	 */
+	private const DYNAMIC_CACHE_GROUP = 'ffc_sensitive_fields';
+
+	/**
+	 * Union of all static sensitive field keys across every context.
+	 *
+	 * Unlike fields_for(), this collapses per-context entries into a single
+	 * flat set useful for payload inspection ("does this blob contain any
+	 * field we consider sensitive?"). Cached in-memory per request.
+	 *
+	 * @return array<string, bool> Map of field_key => true for O(1) lookup.
+	 */
+	public static function universal_sensitive_keys(): array {
+		if ( null !== self::$universal_static_cache ) {
+			return self::$universal_static_cache;
+		}
+
+		$keys = array();
+		foreach ( self::FIELDS as $fields ) {
+			foreach ( array_keys( $fields ) as $key ) {
+				$keys[ $key ] = true;
+			}
+		}
+		self::$universal_static_cache = $keys;
+		return $keys;
+	}
+
+	/**
+	 * Dynamic sensitive field keys configured by admins via
+	 * wp_ffc_custom_fields.is_sensitive = 1.
+	 *
+	 * Cached via the WP object cache. Invalidate with
+	 * invalidate_dynamic_cache() when the custom fields table changes.
+	 *
+	 * @return array<string, bool> Map of field_key => true.
+	 */
+	public static function dynamic_sensitive_keys(): array {
+		$cached = wp_cache_get( self::DYNAMIC_CACHE_KEY, self::DYNAMIC_CACHE_GROUP );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'ffc_custom_fields';
+		$keys  = array();
+
+		// The table may not exist (fresh install, tests), so guard the query.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists === $table ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_col(
+				$wpdb->prepare(
+					'SELECT DISTINCT field_key FROM %i WHERE is_sensitive = 1 AND is_active = 1',
+					$table
+				)
+			);
+			foreach ( (array) $rows as $field_key ) {
+				if ( is_string( $field_key ) && '' !== $field_key ) {
+					$keys[ $field_key ] = true;
+				}
+			}
+		}
+
+		wp_cache_set( self::DYNAMIC_CACHE_KEY, $keys, self::DYNAMIC_CACHE_GROUP );
+		return $keys;
+	}
+
+	/**
+	 * Drop the dynamic key cache. Call whenever wp_ffc_custom_fields is
+	 * created, updated or deleted so the next read reflects the change.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_dynamic_cache(): void {
+		wp_cache_delete( self::DYNAMIC_CACHE_KEY, self::DYNAMIC_CACHE_GROUP );
+	}
+
+	/**
+	 * Whether the payload contains any key classified as sensitive.
+	 *
+	 * Recursively descends into nested arrays so a wrapper like
+	 * [ 'fields' => [ 'cpf' => '...' ] ] is correctly flagged. Matching is
+	 * exact on the key name — callers are expected to log using canonical
+	 * field keys ('cpf', not 'cpf_aluno') or risk a false negative.
+	 *
+	 * @param array<int|string, mixed> $payload Payload to inspect.
+	 * @return bool
+	 */
+	public static function contains_sensitive( array $payload ): bool {
+		if ( empty( $payload ) ) {
+			return false;
+		}
+
+		$sensitive = self::universal_sensitive_keys() + self::dynamic_sensitive_keys();
+		if ( empty( $sensitive ) ) {
+			return false;
+		}
+
+		return self::walk_for_sensitive( $payload, $sensitive );
+	}
+
+	/**
+	 * Depth-first scan for any array key that belongs to the sensitive set.
+	 *
+	 * @param array<int|string, mixed> $node Current node.
+	 * @param array<string, bool>      $sensitive Lookup table.
+	 * @return bool
+	 */
+	private static function walk_for_sensitive( array $node, array $sensitive ): bool {
+		foreach ( $node as $key => $value ) {
+			if ( is_string( $key ) && isset( $sensitive[ $key ] ) ) {
+				return true;
+			}
+			if ( is_array( $value ) && self::walk_for_sensitive( $value, $sensitive ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/includes/reregistration/class-ffc-custom-field-repository.php
+++ b/includes/reregistration/class-ffc-custom-field-repository.php
@@ -271,6 +271,10 @@ class CustomFieldRepository {
 			array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d' )
 		);
 
+		if ( $result ) {
+			self::invalidate_sensitive_registry_cache();
+		}
+
 		return $result ? $wpdb->insert_id : false;
 	}
 
@@ -357,6 +361,12 @@ class CustomFieldRepository {
 
 		static::cache_delete( "id_{$field_id}" );
 
+		// Changes to is_sensitive or is_active must reset the registry's
+		// dynamic cache so ActivityLog picks the new set on next call.
+		if ( false !== $result && ( array_key_exists( 'is_sensitive', $update_data ) || array_key_exists( 'is_active', $update_data ) || array_key_exists( 'field_key', $update_data ) ) ) {
+			self::invalidate_sensitive_registry_cache();
+		}
+
 		return false !== $result;
 	}
 
@@ -385,6 +395,10 @@ class CustomFieldRepository {
 		$result = $wpdb->delete( $table, array( 'id' => $field_id ), array( '%d' ) );
 
 		static::cache_delete( "id_{$field_id}" );
+
+		if ( false !== $result && $field && ! empty( $field->is_sensitive ) ) {
+			self::invalidate_sensitive_registry_cache();
+		}
 
 		return false !== $result;
 	}
@@ -717,6 +731,21 @@ class CustomFieldRepository {
 	// ─────────────────────────────────────────────.
 	// Helpers.
 	// ─────────────────────────────────────────────.
+
+	/**
+	 * Invalidate SensitiveFieldRegistry's dynamic cache.
+	 *
+	 * Called whenever a row in wp_ffc_custom_fields is created, changed or
+	 * deleted in a way that may alter the set of is_sensitive=1 keys, so
+	 * ActivityLog's payload inspection sees the latest state on next call.
+	 *
+	 * @return void
+	 */
+	private static function invalidate_sensitive_registry_cache(): void {
+		if ( class_exists( \FreeFormCertificate\Core\SensitiveFieldRegistry::class ) ) {
+			\FreeFormCertificate\Core\SensitiveFieldRegistry::invalidate_dynamic_cache();
+		}
+	}
 
 	/**
 	 * Generate a field key from a label.

--- a/tests/Unit/ActivityLogTest.php
+++ b/tests/Unit/ActivityLogTest.php
@@ -48,6 +48,20 @@ class ActivityLogTest extends TestCase {
         Functions\when('current_time')->justReturn('2026-03-01 10:00:00');
         Functions\when('get_current_user_id')->justReturn(1);
         Functions\when('add_action')->justReturn(true);
+
+        // SensitiveFieldRegistry::contains_sensitive() is invoked from the
+        // encryption gate in ActivityLog::log(). Keep its cache miss path
+        // cheap by returning false from wp_cache_get (always) and making
+        // the ffc_custom_fields table appear absent. Tests that exercise
+        // dynamic keys override these stubs locally.
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        $this->wpdb->shouldReceive('prepare')->andReturnUsing(function () {
+            return func_get_args()[0];
+        })->byDefault();
+        $this->wpdb->shouldReceive('get_var')->andReturn(null)->byDefault();
+        $this->wpdb->shouldReceive('get_col')->andReturn(array())->byDefault();
     }
 
     protected function tearDown(): void {
@@ -282,25 +296,61 @@ class ActivityLogTest extends TestCase {
         $this->assertSame(json_encode($context), $buffer[0]['context']);
     }
 
-    public function test_log_context_encrypted_is_set_for_sensitive_actions_when_encryption_available(): void {
+    public function test_log_context_encrypted_when_payload_contains_sensitive_key(): void {
         $this->enableActivityLog();
 
-        // The Encryption class is autoloaded and configured (via bootstrap constants),
-        // so sensitive actions like 'submission_created' get their context encrypted.
-        ActivityLog::log('submission_created', ActivityLog::LEVEL_INFO, ['sensitive' => 'data']);
+        // 'email' is a static sensitive key in SensitiveFieldRegistry; its presence
+        // in the context triggers encryption regardless of the action name.
+        ActivityLog::log('any_custom_action', ActivityLog::LEVEL_INFO, ['email' => 'alice@example.com']);
 
         $buffer = $this->getWriteBuffer();
-        // context_encrypted should be a non-null string (encrypted blob).
         $this->assertNotNull($buffer[0]['context_encrypted']);
         $this->assertIsString($buffer[0]['context_encrypted']);
         $this->assertNotEmpty($buffer[0]['context_encrypted']);
     }
 
-    public function test_log_context_encrypted_is_null_for_non_sensitive_actions(): void {
+    public function test_log_context_encrypted_when_nested_payload_contains_sensitive_key(): void {
         $this->enableActivityLog();
 
-        // Non-sensitive actions should NOT get encrypted context.
+        // Nested sensitive keys must trigger encryption — the registry walks
+        // arrays recursively so wrappers like {fields: {cpf: ...}} don't slip
+        // through.
+        ActivityLog::log('reregistration_submitted', ActivityLog::LEVEL_INFO, [
+            'audience_id' => 3,
+            'fields'      => ['cpf' => '12345678901'],
+        ]);
+
+        $buffer = $this->getWriteBuffer();
+        $this->assertNotNull($buffer[0]['context_encrypted']);
+        $this->assertIsString($buffer[0]['context_encrypted']);
+    }
+
+    public function test_log_context_not_encrypted_without_sensitive_keys(): void {
+        $this->enableActivityLog();
+
+        // Non-sensitive context carries no PII — skip encryption.
         ActivityLog::log('settings_changed', ActivityLog::LEVEL_INFO, ['key' => 'value']);
+
+        $buffer = $this->getWriteBuffer();
+        $this->assertNull($buffer[0]['context_encrypted']);
+    }
+
+    public function test_log_context_not_encrypted_for_empty_payload(): void {
+        $this->enableActivityLog();
+
+        ActivityLog::log('password_changed', ActivityLog::LEVEL_INFO, []);
+
+        $buffer = $this->getWriteBuffer();
+        $this->assertNull($buffer[0]['context_encrypted']);
+    }
+
+    public function test_log_sensitive_action_without_sensitive_payload_is_not_encrypted(): void {
+        $this->enableActivityLog();
+
+        // Previously the action name "submission_created" unconditionally triggered
+        // encryption; under the payload-inspection gate, a trivial payload no longer
+        // does so. This locks in the new contract: the decision is by data, not action.
+        ActivityLog::log('submission_created', ActivityLog::LEVEL_INFO, ['form_id' => 5, 'encrypted' => false]);
 
         $buffer = $this->getWriteBuffer();
         $this->assertNull($buffer[0]['context_encrypted']);

--- a/tests/Unit/SensitiveFieldRegistryTest.php
+++ b/tests/Unit/SensitiveFieldRegistryTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Tests for SensitiveFieldRegistry's payload-inspection helpers.
+ *
+ * Covers the additions that power the ActivityLog payload-based gate:
+ *   - universal_sensitive_keys(): static union across contexts
+ *   - dynamic_sensitive_keys(): is_sensitive=1 rows, cached
+ *   - contains_sensitive(): recursive payload scan
+ *   - invalidate_dynamic_cache(): drops the dynamic cache
+ *
+ * Static encryption behaviour is already pinned by SensitiveFieldPolicyTest;
+ * here we focus on the classification helpers.
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Core\SensitiveFieldRegistry;
+
+/**
+ * @covers \FreeFormCertificate\Core\SensitiveFieldRegistry
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SensitiveFieldRegistryTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var Mockery\MockInterface */
+    private $wpdb;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        global $wpdb;
+        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb->prefix = 'wp_';
+        $wpdb->last_error = '';
+        $this->wpdb = $wpdb;
+
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () {
+            return func_get_args()[0];
+        } )->byDefault();
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array() )->byDefault();
+
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+
+        // Reset in-memory static cache between tests (subclasses run in
+        // separate processes but be explicit anyway).
+        $ref = new \ReflectionClass( SensitiveFieldRegistry::class );
+        $prop = $ref->getProperty( 'universal_static_cache' );
+        $prop->setAccessible( true );
+        $prop->setValue( null );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_universal_sensitive_keys_unions_static_contexts(): void {
+        $keys = SensitiveFieldRegistry::universal_sensitive_keys();
+
+        // Every static field declared in either context must appear.
+        $expected = array( 'email', 'cpf', 'rf', 'user_ip', 'data', 'ticket', 'phone', 'custom_data' );
+        foreach ( $expected as $key ) {
+            $this->assertArrayHasKey( $key, $keys, "Missing universal key: $key" );
+        }
+        $this->assertCount( count( $expected ), $keys );
+    }
+
+    public function test_contains_sensitive_returns_false_for_empty_payload(): void {
+        $this->assertFalse( SensitiveFieldRegistry::contains_sensitive( array() ) );
+    }
+
+    public function test_contains_sensitive_returns_false_when_no_keys_match(): void {
+        $payload = array( 'form_id' => 5, 'audience_id' => 3, 'note' => 'x' );
+        $this->assertFalse( SensitiveFieldRegistry::contains_sensitive( $payload ) );
+    }
+
+    public function test_contains_sensitive_detects_top_level_static_key(): void {
+        $payload = array( 'email' => 'alice@example.com' );
+        $this->assertTrue( SensitiveFieldRegistry::contains_sensitive( $payload ) );
+    }
+
+    public function test_contains_sensitive_detects_nested_static_key(): void {
+        $payload = array(
+            'audience_id' => 3,
+            'fields'      => array( 'cpf' => '12345678901' ),
+        );
+        $this->assertTrue( SensitiveFieldRegistry::contains_sensitive( $payload ) );
+    }
+
+    public function test_contains_sensitive_detects_deeply_nested_key(): void {
+        $payload = array(
+            'wrapper' => array(
+                'outer' => array(
+                    'inner' => array( 'rf' => '1234567' ),
+                ),
+            ),
+        );
+        $this->assertTrue( SensitiveFieldRegistry::contains_sensitive( $payload ) );
+    }
+
+    public function test_dynamic_sensitive_keys_returns_distinct_field_keys(): void {
+        // Simulate wp_ffc_custom_fields present and two sensitive rows.
+        $this->wpdb->shouldReceive( 'get_var' )
+            ->once()
+            ->andReturn( 'wp_ffc_custom_fields' );
+        $this->wpdb->shouldReceive( 'get_col' )
+            ->once()
+            ->andReturn( array( 'rg', 'cpf_aluno', '' ) );
+
+        $keys = SensitiveFieldRegistry::dynamic_sensitive_keys();
+
+        $this->assertArrayHasKey( 'rg', $keys );
+        $this->assertArrayHasKey( 'cpf_aluno', $keys );
+        // Empty strings from the column are filtered out.
+        $this->assertArrayNotHasKey( '', $keys );
+    }
+
+    public function test_dynamic_sensitive_keys_returns_empty_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'get_var' )
+            ->once()
+            ->andReturn( null );
+        // get_col must NOT be called when the table is absent.
+        $this->wpdb->shouldNotReceive( 'get_col' );
+
+        $keys = SensitiveFieldRegistry::dynamic_sensitive_keys();
+        $this->assertSame( array(), $keys );
+    }
+
+    public function test_contains_sensitive_detects_dynamic_custom_field_key(): void {
+        // Admin has flagged 'rg' as is_sensitive=1 via the repository.
+        $this->wpdb->shouldReceive( 'get_var' )
+            ->andReturn( 'wp_ffc_custom_fields' );
+        $this->wpdb->shouldReceive( 'get_col' )
+            ->andReturn( array( 'rg' ) );
+
+        $payload = array( 'rg' => 'AB1234567' );
+        $this->assertTrue( SensitiveFieldRegistry::contains_sensitive( $payload ) );
+    }
+
+    public function test_invalidate_dynamic_cache_drops_wp_cache(): void {
+        // The method is a thin wrapper — assert it calls wp_cache_delete with
+        // the registry's cache key/group.
+        Monkey\tearDown();
+        Monkey\setUp();
+
+        Functions\expect( 'wp_cache_delete' )
+            ->once()
+            ->with( 'ffc_sensitive_field_keys_dynamic', 'ffc_sensitive_fields' )
+            ->andReturn( true );
+
+        SensitiveFieldRegistry::invalidate_dynamic_cache();
+        $this->assertTrue( true );  // Mockery handled the expectation.
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #56 — replaces the action-whitelist gate for ActivityLog context encryption with payload inspection via `SensitiveFieldRegistry`. Answers the question from the audit (item #3): "keep selective, but drive the decision off the `is_sensitive` rules we already have."

## Before

`ActivityLog::log()` encrypted `context` only when the action name was in a hard-coded list (`submission_created`, `data_accessed`, `data_modified`, `admin_searched`, `encryption_migration_batch`). Anything else stored `context` as plain JSON. A new action logging a payload with `email` or `cpf` would leak it silently.

## After

The gate now calls `SensitiveFieldRegistry::contains_sensitive($context)`:
- **Static keys** — union of every `CONTEXT_SUBMISSION`/`CONTEXT_APPOINTMENT` field: `email`, `cpf`, `rf`, `user_ip`, `data`, `ticket`, `phone`, `custom_data`.
- **Dynamic keys** — rows from `wp_ffc_custom_fields` where `is_sensitive = 1 AND is_active = 1`. Cached via `wp_cache_*`; invalidated by `CustomFieldRepository` on `create()`, `update()` (when `is_sensitive`/`is_active`/`field_key` changes) and `delete()` of a sensitive row.
- **Recursive scan** — walks nested arrays so wrappers like `{fields: {cpf: ...}}` are caught.

## Existing toggles preserved

Every existing control keeps working unchanged:
- `ffc_settings['enable_activity_log']` (admin toggle) — early-return before the gate.
- `disable_logging()`/`enable_logging()` (bulk-ops pause).
- Buffer + shutdown flush.
- Daily cleanup cron.
- Admin UI read path — `ActivityLogQuery` already decrypts `context_encrypted` when present, regardless of which mode wrote it.

## Observable behavior change

- Actions previously in the whitelist with trivial payloads (e.g. `submission_created` carrying only `{form_id: 1, encrypted: false}`) no longer produce a ciphertext blob.
- Actions previously outside the whitelist that happen to log PII (`['email' => ...]`, nested `['fields' => ['cpf' => ...]]`, etc.) now get encrypted automatically.
- Net effect: stricter adherence to "PII is encrypted at rest in the audit log."

## Files

**Registry (`includes/core/class-ffc-sensitive-field-registry.php`):**
- `universal_sensitive_keys()` — flat union of static contexts, in-memory cached.
- `dynamic_sensitive_keys()` — reads `wp_ffc_custom_fields` once and caches via `wp_cache_*`.
- `contains_sensitive(array $payload): bool` — recursive scan.
- `invalidate_dynamic_cache()` — drops the object-cache entry.

**ActivityLog (`includes/core/class-ffc-activity-log.php`):**
- Replaces the `$sensitive_actions` array + `in_array` check with a single `SensitiveFieldRegistry::contains_sensitive( $context )` call.

**CustomFieldRepository (`includes/reregistration/class-ffc-custom-field-repository.php`):**
- New private `invalidate_sensitive_registry_cache()` helper, called from `create()`, `update()` (conditionally) and `delete()` so the registry's dynamic set stays fresh without a per-request query.

**Tests:**
- `tests/Unit/SensitiveFieldRegistryTest.php` — 10 new tests covering universal/dynamic/contains/invalidate.
- `tests/Unit/ActivityLogTest.php` — the two action-based tests are replaced by five payload-based cases (including the "sensitive action with trivial payload is not encrypted" invariant, nested key detection, empty payload short-circuit).

## Test plan

- [x] New tests: `SensitiveFieldRegistryTest` (10) + updated `ActivityLogTest` payload cases.
- [x] Full local PHPUnit suite: 3434 tests, 8633 assertions — green.
- [x] PHPCS clean on all modified files.
- [x] CI matrix (PHPUnit 8.1–8.4, Coverage, PHPStan, WPCS).

## Known follow-up (out of scope)

The log still dual-stores `context` plaintext alongside `context_encrypted` when encrypting — the ciphertext is effectively advisory. Fixing that properly needs read-path changes in `ActivityLogQuery` (fall back to `context_decrypted` when `context IS NULL`) plus an optional migration for historical rows. Tracked for the next iteration; not folded into this PR to keep the gate change reviewable in isolation.

https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd)_