### PR TITLE
fix(encryption): audit decrypt failures via ActivityLog

### DIFF
--- a/includes/api/class-ffc-submission-rest-controller.php
+++ b/includes/api/class-ffc-submission-rest-controller.php
@@ -404,17 +404,18 @@ class SubmissionRestController {
 			return $data;
 		}
 
-		try {
-			$decrypted      = \FreeFormCertificate\Core\Encryption::decrypt( $submission['data_encrypted'] );
-			$decrypted_data = json_decode( $decrypted, true );
+		// Encryption::decrypt never throws; it returns null on failure and
+		// already logs the failure via ActivityLog. An explicit null-check
+		// keeps json_decode from receiving null (deprecated in PHP 8.1+)
+		// and makes the fallback-to-$data path obvious.
+		$decrypted = \FreeFormCertificate\Core\Encryption::decrypt( $submission['data_encrypted'] );
+		if ( null === $decrypted ) {
+			return $data;
+		}
 
-			if ( is_array( $decrypted_data ) ) {
-				return array_merge( $data, $decrypted_data );
-			}
-		} catch ( \Exception $e ) {
-			if ( class_exists( '\FreeFormCertificate\Core\Debug' ) ) {
-				\FreeFormCertificate\Core\Debug::log_rest_api( 'Decryption failed', $e->getMessage() );
-			}
+		$decrypted_data = json_decode( $decrypted, true );
+		if ( is_array( $decrypted_data ) ) {
+			return array_merge( $data, $decrypted_data );
 		}
 
 		return $data;

--- a/includes/core/class-ffc-encryption.php
+++ b/includes/core/class-ffc-encryption.php
@@ -119,14 +119,41 @@ class Encryption {
 	 * Accepts both v2 authenticated ciphertexts ("v2:base64(HMAC||IV||CT)")
 	 * and legacy v1 ciphertexts ("base64(IV||CT)", without HMAC).
 	 *
+	 * Any failure to decrypt a non-empty ciphertext (malformed envelope,
+	 * HMAC mismatch, openssl error, exception) is reported to ActivityLog
+	 * as a "decrypt_failure" warning so that silent callers — many use
+	 * `decrypt(...) ?? ''` or filter null silently — do not hide tampering
+	 * or key-rotation breakage. The log carries only metadata, never the
+	 * ciphertext or plaintext.
+	 *
 	 * @param string $encrypted Encrypted value.
 	 * @return string|null Decrypted value or null on failure
 	 */
 	public static function decrypt( string $encrypted ): ?string {
 		if ( empty( $encrypted ) ) {
+			// Empty input is not a failure; skip audit entry.
 			return null;
 		}
 
+		$result = self::decrypt_internal( $encrypted );
+
+		if ( null === $result ) {
+			self::log_decrypt_failure( $encrypted );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Internal decrypt implementation.
+	 *
+	 * Extracted so the public entry point can uniformly audit failures
+	 * without threading an ActivityLog call through five return-null paths.
+	 *
+	 * @param string $encrypted Encrypted value.
+	 * @return string|null
+	 */
+	private static function decrypt_internal( string $encrypted ): ?string {
 		try {
 			$enc_key = self::get_encryption_key();
 
@@ -183,6 +210,47 @@ class Encryption {
 				)
 			);
 			return null;
+		}
+	}
+
+	/**
+	 * Record a decrypt_failure audit entry. No-op when the WordPress
+	 * runtime is unavailable (unit tests, early bootstrap) or when
+	 * ActivityLog is disabled in settings.
+	 *
+	 * The context is intentionally metadata-only (length + v2 flag) so
+	 * this logging can never leak plaintext, and the payload contains no
+	 * keys classified as sensitive, so it will never recurse back into
+	 * Encryption::encrypt via the ActivityLog sensitivity gate.
+	 *
+	 * @param string $ciphertext Original ciphertext (inspected for metadata only).
+	 * @return void
+	 */
+	private static function log_decrypt_failure( string $ciphertext ): void {
+		if ( ! function_exists( 'get_option' ) ) {
+			return;
+		}
+		if ( ! class_exists( ActivityLog::class ) ) {
+			return;
+		}
+
+		try {
+			if ( ! ActivityLog::is_enabled() ) {
+				return;
+			}
+			ActivityLog::log(
+				'decrypt_failure',
+				ActivityLog::LEVEL_WARNING,
+				array(
+					'ciphertext_length' => strlen( $ciphertext ),
+					'v2_prefix'         => 0 === strpos( $ciphertext, self::V2_PREFIX ),
+				),
+				0,
+				0
+			);
+		} catch ( \Throwable $e ) {
+			// Never let logging failure propagate up into decryption callers.
+			unset( $e );
 		}
 	}
 

--- a/tests/Unit/DecryptFailureLoggingTest.php
+++ b/tests/Unit/DecryptFailureLoggingTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Tests for the decrypt_failure audit entry emitted by Encryption::decrypt.
+ *
+ * Centralizing the log there replaces a handful of silent-null fallbacks
+ * across the codebase (`decrypt(...) ?? ''`, swallowed try/catch, etc.).
+ * This file pins:
+ *   - the log fires when decrypt returns null from a non-empty input,
+ *   - it stays silent for empty input and for successful round-trips,
+ *   - the payload is metadata-only (so it cannot leak plaintext or
+ *     recurse back into Encryption via the ActivityLog sensitivity gate),
+ *   - the write is disabled when the activity log is disabled.
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Core\ActivityLog;
+use FreeFormCertificate\Core\Encryption;
+use FreeFormCertificate\Core\SensitiveFieldRegistry;
+
+/**
+ * @coversNothing
+ */
+class DecryptFailureLoggingTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var Mockery\MockInterface */
+    private $wpdb;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->resetActivityLogState();
+
+        global $wpdb;
+        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb->prefix     = 'wp_';
+        $wpdb->last_error = '';
+        $this->wpdb       = $wpdb;
+
+        Functions\when( 'absint' )->alias( function ( $v ) {
+            return abs( (int) $v );
+        } );
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'sanitize_key' )->returnArg();
+        Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+        Functions\when( 'current_time' )->justReturn( '2026-04-23 00:00:00' );
+        Functions\when( 'get_current_user_id' )->justReturn( 0 );
+        Functions\when( 'add_action' )->justReturn( true );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () {
+            return func_get_args()[0];
+        } )->byDefault();
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array() )->byDefault();
+    }
+
+    protected function tearDown(): void {
+        $this->resetActivityLogState();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Enable the activity log via ffc_settings. Must run inside the test,
+     * not setUp, because Brain\Monkey scopes stubs per test.
+     */
+    private function enableActivityLog(): void {
+        Functions\when( 'get_option' )->alias( function ( $key, $default = false ) {
+            if ( 'ffc_settings' === $key ) {
+                return array( 'enable_activity_log' => 1 );
+            }
+            return $default;
+        } );
+        Functions\when( 'FreeFormCertificate\\Core\\get_option' )->alias( function ( $key, $default = false ) {
+            return \get_option( $key, $default );
+        } );
+    }
+
+    /**
+     * Disable the activity log (default state). Log calls must no-op.
+     */
+    private function disableActivityLog(): void {
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'FreeFormCertificate\\Core\\get_option' )->alias( function ( $key, $default = false ) {
+            return \get_option( $key, $default );
+        } );
+    }
+
+    private function resetActivityLogState(): void {
+        $ref = new \ReflectionClass( ActivityLog::class );
+
+        $buffer = $ref->getProperty( 'write_buffer' );
+        $buffer->setAccessible( true );
+        $buffer->setValue( array() );
+
+        $shutdown = $ref->getProperty( 'shutdown_registered' );
+        $shutdown->setAccessible( true );
+        $shutdown->setValue( false );
+
+        $disabled = $ref->getProperty( 'logging_disabled' );
+        $disabled->setAccessible( true );
+        $disabled->setValue( false );
+
+        $columns = $ref->getProperty( 'table_columns_cache' );
+        $columns->setAccessible( true );
+        $columns->setValue( null );
+    }
+
+    private function getWriteBuffer(): array {
+        $ref = new \ReflectionClass( ActivityLog::class );
+        $p   = $ref->getProperty( 'write_buffer' );
+        $p->setAccessible( true );
+        return $p->getValue();
+    }
+
+    // ==================================================================
+    // Failure path
+    // ==================================================================
+
+    public function test_decrypt_failure_is_logged_when_activity_log_enabled(): void {
+        $this->enableActivityLog();
+
+        $result = Encryption::decrypt( '!!!invalid-base64!!!' );
+        $this->assertNull( $result, 'Decrypt should still return null on failure.' );
+
+        $buffer = $this->getWriteBuffer();
+        $this->assertCount( 1, $buffer, 'Exactly one audit entry should be buffered.' );
+        $this->assertSame( 'decrypt_failure', $buffer[0]['action'] );
+        $this->assertSame( ActivityLog::LEVEL_WARNING, $buffer[0]['level'] );
+    }
+
+    public function test_decrypt_failure_log_context_is_metadata_only(): void {
+        $this->enableActivityLog();
+
+        Encryption::decrypt( '!!!invalid-base64!!!' );
+        $buffer   = $this->getWriteBuffer();
+        $context  = json_decode( $buffer[0]['context'], true );
+
+        $this->assertIsArray( $context );
+        $this->assertSame( strlen( '!!!invalid-base64!!!' ), $context['ciphertext_length'] );
+        $this->assertFalse( $context['v2_prefix'] );
+        // No key in context should map to something SensitiveFieldRegistry considers sensitive
+        // — otherwise the log write would re-enter Encryption::encrypt on the gate path.
+        $this->assertFalse(
+            SensitiveFieldRegistry::contains_sensitive( $context ),
+            'decrypt_failure context must not contain any sensitive keys.'
+        );
+    }
+
+    public function test_decrypt_failure_log_flags_v2_prefix_when_present(): void {
+        $this->enableActivityLog();
+
+        // Well-formed v2: prefix but gibberish after — decoder should reject, still log.
+        Encryption::decrypt( 'v2:not-valid-base64!!!' );
+        $buffer  = $this->getWriteBuffer();
+        $this->assertCount( 1, $buffer );
+        $context = json_decode( $buffer[0]['context'], true );
+        $this->assertTrue( $context['v2_prefix'] );
+    }
+
+    // ==================================================================
+    // No-op paths
+    // ==================================================================
+
+    public function test_decrypt_empty_input_does_not_log(): void {
+        $this->enableActivityLog();
+
+        Encryption::decrypt( '' );
+        $this->assertSame( array(), $this->getWriteBuffer() );
+    }
+
+    public function test_successful_decrypt_does_not_log(): void {
+        $this->enableActivityLog();
+
+        $ct = Encryption::encrypt( 'hello' );
+        $this->assertNotNull( $ct );
+
+        $pt = Encryption::decrypt( $ct );
+        $this->assertSame( 'hello', $pt );
+        $this->assertSame( array(), $this->getWriteBuffer() );
+    }
+
+    public function test_decrypt_failure_is_silent_when_activity_log_disabled(): void {
+        $this->disableActivityLog();
+
+        $result = Encryption::decrypt( '!!!invalid-base64!!!' );
+        $this->assertNull( $result );
+
+        // No buffer entry because ActivityLog::is_enabled() returned false.
+        $this->assertSame( array(), $this->getWriteBuffer() );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #57 — audits decrypt failures via `ActivityLog` so silent-null fallbacks scattered across the codebase stop hiding real failures.

Answers audit item #4 ("silent decrypt failures"). The root cause: many call sites treat a null return from `Encryption::decrypt` as "empty/missing" and move on. HMAC mismatches, key-rotation breakage and plain corruption are therefore invisible in production. Instead of patching each site, emit the audit entry from the primitive itself.

## Changes

**`Encryption::decrypt` (`includes/core/class-ffc-encryption.php`)**
- Split into a public wrapper and a private `decrypt_internal` helper.
- The wrapper fires `ActivityLog::log('decrypt_failure', LEVEL_WARNING, ...)` whenever a non-empty input resolves to null.
- Context is metadata-only (`ciphertext_length`, `v2_prefix` flag). No plaintext, no ciphertext. Keys deliberately chosen to live outside `SensitiveFieldRegistry` so the log write can never recurse back into `encrypt()` via the sensitivity gate.
- Guarded with `function_exists('get_option')`, `ActivityLog::is_enabled()` and a catch-all `Throwable` — logging can never propagate up or break decryption (matters for unit tests without WordPress, early boot paths, and log-failure cascades).

**`submission-rest-controller.php:408`**
- The old `try/catch` around `decrypt` never fired because `decrypt` returns null rather than throwing. The subsequent `json_decode(null, true)` is deprecated in PHP 8.1+.
- Replaced with an explicit null-check that returns the fallback data; the audit entry is emitted centrally.

**Intentionally not touched**

The remaining `?? ''` / `is_email()` null filters in `reprint-detector.php:160`, `user-manager.php:520, 584, 723`, and `csv-export-trait.php:62` are legitimate product fallbacks. With the central log in place, their call-site silence is no longer opaque — admins see every failure in the audit trail.

## Cycle / layering concern

`Encryption::decrypt` → `ActivityLog::log` → (if context is sensitive) `Encryption::encrypt`. There is no cycle because the context `{ciphertext_length, v2_prefix}` contains no keys classified as sensitive by `SensitiveFieldRegistry`, so the gate returns false and `encrypt()` is never called. `DecryptFailureLoggingTest::test_decrypt_failure_log_context_is_metadata_only` explicitly asserts this invariant.

## Log storm

If a batch of ciphertext is corrupt (mass key-rotation failure), each decrypt call emits one warning. No rate limit for now — `WARNING` level makes them easy to filter and aggregate in the admin UI, and premature rate-limiting could mask a real incident. Revisit only if this bites in practice.

## Tests

- New `tests/Unit/DecryptFailureLoggingTest.php` — 6 cases:
  - failure logs a `decrypt_failure` warning entry,
  - context is metadata-only and passes `SensitiveFieldRegistry::contains_sensitive() === false`,
  - v2 prefix is flagged when present,
  - empty input is silent,
  - successful round-trip is silent,
  - disabled activity log makes the write a no-op.
- Full local suite: **3440 tests, 8649 assertions — green.**
- PHPCS clean on modified files.

## Follow-ups still open

- Dual-storage in `ActivityLog` (context plaintext alongside `context_encrypted` when encrypting) — documented in #57.
- `UserProfileService` for unified reads (audit section 7.4).
- Residual `class_exists ? Encryption::hash : hash('sha256')` fallbacks in `self-scheduling-appointment-handler.php:488` and `ffc-submission-repository.php:792`.

https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd)_