### PR TITLE
docs(changelog): consolidate [Unreleased] into 5.4.0, drop Phase markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **`UserProfileFieldMap`** — declarative per-field descriptor for user-profile fields. Each entry names its storage layer (`wp_users`, `ffc_user_profiles`, `wp_usermeta`), whether the value is sensitive, whether it is hashable for lookup, and optional mirror targets (e.g. `display_name` writes back to `wp_users.display_name` after the profile-table write). Sibling of `SensitiveFieldRegistry`; the registry is per write context (submission vs appointment), the map is per user field.
-- **`ViewPolicy` enum** — `FULL`, `MASKED`, `HASHED_ONLY`. Declares how a caller wants sensitive fields rendered on read. The service does not elevate privileges; callers validate capability (`current_user_can('manage_options')` or similar) before asking for `FULL`.
-- **`UserProfileService::read()` / `::write()`** — single entry point consolidating reads and writes across the three storage layers, with transparent encryption and hashing for sensitive fields. `read()` honours `ViewPolicy`, returns empty arrays for unknown users or empty field lists, and silently drops unregistered field keys. `write()` routes each field to its declared storage, encrypts + hashes sensitive values, and applies mirror targets last. A `FULL` read that touches a sensitive field emits one `user_profile_read_full` audit entry carrying only the requester, the target user id, and the field list — never the values.
-- Test coverage: **+31 tests** across `UserProfileFieldMapTest` (11, pure data class) and `UserProfileServiceTest` (20, exercises routing, masking, encryption + hash write, mirror, audit entry, and the `$extra_descriptors` dynamic-field path).
+_Nothing yet._
 
 ### Changed
 
-- **`UserManager::update_profile()`** is now a thin facade over `UserProfileService::write()`. The legacy `sanitize_text_field` + `wp_json_encode('preferences')` pre-processing stays at the facade layer for backward compatibility; routing, upsert and the `display_name → wp_users` mirror move into the service. The `SHOW TABLES LIKE` short-circuit is gone — callers land in the service even when the plugin is mid-activation, which matches every install reachable from admin screens.
-- **`UserManager::update_extended_profile()`** now routes every key through `UserProfileService::write()`. Keys registered in `UserProfileFieldMap` carry their own descriptor; arbitrary reregistration keys get an inline descriptor built at the facade layer (`$extra_descriptors`) and are treated by the service like any other usermeta-backed field. The legacy inline encrypt/hash path that used to live here is gone. Behavior improvement: clearing a sensitive field now also deletes the sibling `*_hash` meta row so a stale hash never outlives the ciphertext.
-- **`UserProfileService::write()`** accepts an optional `$extra_descriptors` parameter: a map of `field_key => descriptor` for fields outside the static `UserProfileFieldMap`. The descriptor shape matches a `FIELDS` entry (storage, meta_key/column, sensitive, hashable). Used by the reregistration flow; per-call scope, cleared via try/finally so overrides never leak between requests.
-- **`UserProfileService::write_profile_table()`** adjusted (via the PHPStan fix in the same pass) so `hash_meta_key()` no longer carries dead `??` fallbacks — the field map's `FIELDS` constant already guarantees `storage` / `meta_key` presence where relevant.
-- **`SECURITY.md`** — supported-versions table updated to mark `5.4.x` as supported (was stuck on `5.1.x`).
-- **`CONTRIBUTING.md`** — Branches section no longer mandates the AI-specific `claude/*` prefix for human contributors; Releasing section now documents the `[Unreleased] → [X.Y.Z]` flow (rename, insert fresh `[Unreleased]`, bump `Version:` + `FFC_VERSION` + `readme.txt` Stable tag in one step) to match the convention used from 5.4.0 onward.
+_Nothing yet._
 
 ### Removed
 
-- `docs/USER_DATA_AUDIT.md` — the point-in-time audit that drove PRs #55–#63. Every item it flagged is resolved in code (see the `5.4.0` section and the PR descriptions for the full narrative); keeping it would give the wrong impression that the refactor is still pending.
+_Nothing yet._
 
 ### Fixed
 
@@ -49,18 +41,22 @@ performance pass for admin submissions at scale.
 ### Added
 
 - **Centralized sensitive-field policy** via `FreeFormCertificate\Core\SensitiveFieldRegistry` — single declarative map of which fields are encrypted and hashed per write context. Consumed by `SubmissionHandler` and `AppointmentRepository`; replaces three hard-coded lists. Exposes `encrypt_fields()`, `plaintext_keys()`, `universal_sensitive_keys()`, `dynamic_sensitive_keys()` (reads `wp_ffc_custom_fields.is_sensitive = 1`, cached), and recursive `contains_sensitive()` for payload inspection.
+- **`UserProfileFieldMap`** — declarative per-field descriptor for user-profile fields. Each entry names its storage layer (`wp_users`, `ffc_user_profiles`, `wp_usermeta`), whether the value is sensitive, whether it is hashable for lookup, and optional mirror targets (e.g. `display_name` writes back to `wp_users.display_name` after the profile-table write). Sibling of `SensitiveFieldRegistry`; the registry is per write context (submission vs appointment), the map is per user field.
+- **`ViewPolicy` enum** — `FULL`, `MASKED`, `HASHED_ONLY`. Declares how a caller wants sensitive fields rendered on read. The service does not elevate privileges; callers validate capability (`current_user_can('manage_options')` or similar) before asking for `FULL`.
+- **`UserProfileService::read()` / `::write()`** — single entry point consolidating reads and writes across the three storage layers, with transparent encryption and hashing for sensitive fields. `read()` honours `ViewPolicy`, returns empty arrays for unknown users or empty field lists, and silently drops unregistered field keys. `write()` routes each field to its declared storage, encrypts + hashes sensitive values, and applies mirror targets last. A `FULL` read that touches a sensitive field emits one `user_profile_read_full` audit entry carrying only the requester, the target user id, and the field list — never the values. The `$extra_descriptors` parameter lets callers write fields outside the static map (used by the reregistration flow); overrides are per-call and cleared via try/finally so they cannot leak between requests.
 - **`email_hash_rehash` migration** — batched, idempotent, cursor-based. Walks `wp_ffc_submissions` and `wp_ffc_self_scheduling_appointments`, decrypts `email_encrypted`, recomputes the salted hash and writes only when it differs.
 - **`activity_log_clear_plaintext` migration** — batched UPDATE that NULLs `context` on activity log rows that already hold a ciphertext, closing the dual-storage leak on historical data.
 - **CSV download intermediate screen** — after hash validation and before the actual download, an info screen shows form configuration (restrictions, dates, geolocation, quiz, quota) so the operator understands the form context. The download button is only enabled after the form has ended; a certificate preview button is available before the collection period begins.
 - **Public CSV sync-export row cap** — new `public_csv_sync_max_rows` setting (Advanced tab, default 2000, range 100–10000). Public CSV downloads exceeding the cap are refused on the synchronous no-JS path and must use the AJAX batched flow, protecting shared hosting from execution-time timeouts on large exports.
-- **`docs/USER_DATA_AUDIT.md`** — full audit of user-related fields (5 storage layers, ~30 reregistration fields) and the encryption architecture, including the remediation trail for items 1–4.
-- Test coverage: +262 tests (3234 → 3455), including `SensitiveFieldPolicyTest`, `SensitiveFieldRegistryTest`, `DecryptFailureLoggingTest`, `CustomFieldValidatorTest`, `AutoloaderTest`, `UserContextTraitTest`, `MigrationDynamicReregFieldsTest`, `ReregistrationStandardFieldsSeederTest`, `AbstractRepositoryTest`, `GeofenceTest`, `FormListColumnsTest`, and new coverage for `UserManager::update_extended_profile` / `get_extended_profile`.
+- Test coverage: **3234 → 3485 tests** (+251), **8783 assertions**, 0 failures. New suites: `SensitiveFieldPolicyTest`, `SensitiveFieldRegistryTest`, `DecryptFailureLoggingTest`, `UserProfileFieldMapTest`, `UserProfileServiceTest`, `CustomFieldValidatorTest`, `AutoloaderTest`, `UserContextTraitTest`, `MigrationDynamicReregFieldsTest`, `ReregistrationStandardFieldsSeederTest`, `AbstractRepositoryTest`, `GeofenceTest`, `FormListColumnsTest`. Extended coverage for `UserManager::update_extended_profile` / `get_extended_profile`.
 
 ### Changed
 
 - **Activity log encryption gate** switched from a hard-coded action whitelist (`submission_created`, `data_accessed`, `data_modified`, `admin_searched`, `encryption_migration_batch`) to payload inspection via `SensitiveFieldRegistry::contains_sensitive()`. Any action carrying a sensitive field (including nested payloads like `{fields: {cpf: ...}}`) is encrypted automatically; actions with trivial payloads are no longer wrapped in a meaningless ciphertext.
 - **`ActivityLog::log()`** no longer dual-stores `context` plaintext alongside its ciphertext. Sensitive rows now NULL the plaintext column; `ActivityLogQuery::resolve_context()` decrypts on demand on read.
 - **`SubmissionHandler` and `AppointmentRepository`** replaced their inline encryption blocks with a single `SensitiveFieldRegistry::encrypt_fields()` call plus a `plaintext_keys()` strip, preserving the same output shape.
+- **`UserManager::update_profile()`** is now a thin facade over `UserProfileService::write()`. The legacy `sanitize_text_field` + `wp_json_encode('preferences')` pre-processing stays at the facade layer for backward compatibility; routing, upsert and the `display_name → wp_users` mirror move into the service. The `SHOW TABLES LIKE` short-circuit is gone — callers land in the service even when the plugin is mid-activation, which matches every install reachable from admin screens.
+- **`UserManager::update_extended_profile()`** now routes every key through `UserProfileService::write()`. Keys registered in `UserProfileFieldMap` carry their own descriptor; arbitrary reregistration keys get an inline descriptor built at the facade layer and are treated by the service like any other usermeta-backed field. The legacy inline encrypt/hash path that used to live here is gone. Behavior improvement: clearing a sensitive field now also deletes the sibling `*_hash` meta row so a stale hash never outlives the ciphertext.
 - **`Encryption::decrypt()`** split into a public wrapper and a private helper. The wrapper emits a `decrypt_failure` WARNING to `ActivityLog` whenever a non-empty ciphertext resolves to null, with metadata-only context (`ciphertext_length`, `v2_prefix`). Callers continue to receive `null`; silence is no longer opaque.
 - **`SubmissionRestController::decrypt_submission_data()`** replaced an inert `try/catch` (decrypt never throws) with an explicit null-check, avoiding the PHP 8.1+ `json_decode(null)` deprecation.
 - **Residual `class_exists ? Encryption::hash : hash('sha256')` fallbacks** removed from `SelfSchedulingAppointmentHandler` and `SubmissionRepository::hash()`. Encryption is a runtime dependency; the raw-`sha256` branch was unreachable and would have produced hashes no other call site could match.
@@ -69,7 +65,9 @@ performance pass for admin submissions at scale.
 - Perf: composite index `(form_id, status, submission_date)` on `ffc_submissions` — covers the common admin list pattern (filter by form + status, sort by `submission_date` DESC).
 - Perf: activity log cleanup falls back to `admin_init` (transient-gated, 24h) for low-traffic shared hosting where WP-Cron misses scheduled runs.
 - Perf: `findPaginated()` search — `magic_token` uses prefix match (`'term%'`) so the B-tree index helps; the unencrypted-`data` LIKE fallback is skipped for search terms shorter than 4 characters.
-- Code quality: PHPCS **1232 → 0 violations** (Phases 4–5). Includes 105× short-ternary expansion, 152× file header normalization, 142× class-docblock backfill, 299× resolved docblock violations. PHPStan level 7: 0 errors.
+- Code quality: PHPCS **1232 → 0 violations** (105× short-ternary expansion, 152× file header normalization, 142× class-docblock backfill, 299× resolved docblock violations). PHPStan level 7: **0 errors**.
+- `SECURITY.md` — supported-versions table updated to mark `5.4.x` as supported (was stuck on `5.1.x`).
+- `CONTRIBUTING.md` — Branches section no longer mandates the AI-specific `claude/*` prefix for human contributors; Releasing section now documents the `[Unreleased] → [X.Y.Z]` flow (rename, insert fresh `[Unreleased]`, bump `Version:` + `FFC_VERSION` + `readme.txt` Stable tag in one step) to match the convention used from 5.4.0 onward.
 
 ### Fixed
 
@@ -82,32 +80,24 @@ performance pass for admin submissions at scale.
 
 ### Security
 
-Privacy / LGPD hardening (this release):
-
-- **CRITICAL** — Cross-table hash consistency (see _Fixed_ above): dedup and reconciliation between submissions, appointments and user profile now works reliably.
-- **HIGH** — Activity log no longer dual-stores `context` plaintext alongside `context_encrypted` for sensitive rows. The ciphertext is now authoritative; reads transparently decrypt.
-- **MEDIUM** — Decrypt failures auditable via `ActivityLog::log('decrypt_failure', WARNING)`, with metadata-only context that cannot leak plaintext nor recurse into the encryption gate.
-
-Phase 1 — Tier 1 hardening:
-
+- **CRITICAL** (LGPD) — Cross-table hash consistency (see _Fixed_ above): dedup and reconciliation between submissions, appointments and user profile now works reliably.
+- **HIGH** (LGPD) — Activity log no longer dual-stores `context` plaintext alongside `context_encrypted` for sensitive rows. The ciphertext is authoritative; reads transparently decrypt.
 - **HIGH** — `AbstractRepository::build_where_clause()` now uses the `%i` identifier placeholder and a `get_allowed_where_columns()` allowlist to prevent column-name SQL injection.
+- **HIGH** — Timing-safe token comparison via `hash_equals()` in the appointment receipt handler.
+- **HIGH** (XSS) — Escape user-supplied values (description, cancellation reason, etc.) in audience email templates to prevent stored XSS in recipient mail clients.
+- **MEDIUM** (LGPD) — Decrypt failures auditable via `ActivityLog::log('decrypt_failure', WARNING)`, with metadata-only context that cannot leak plaintext nor recurse into the encryption gate.
 - **MEDIUM** — `SubmissionRestController` admin endpoints restricted to `manage_options` (was `edit_posts`, accessible to Authors who shouldn't see PII).
 - **MEDIUM** — `UserProfileRestController::update_user_profile()` sanitizes user input via `sanitize_text_field` + `wp_unslash`.
 - **MEDIUM** — `AudienceRepository::get_user_audiences()` replaces inline `$id_list` interpolation with parameterized placeholders.
-- **LOW** — removed `$e->getMessage()` from 5 client-facing error responses across 4 REST controllers to prevent information disclosure.
-
-Phase 2 — Tier 2 hardening:
-
-- **HIGH** — timing-safe token comparison via `hash_equals()` in the appointment receipt handler.
-- **HIGH** — escape user-supplied values (description, cancellation reason, etc.) in audience email templates to prevent stored XSS in recipient mail clients.
-- **MEDIUM / XSS** — escape `id`, form title, and action labels in `SubmissionsList::column_default()` / `render_actions()`; inline-literal output for `$required_attr` in the frontend field renderer; escape `{{form_title}}` before `str_replace` into PDF layouts; wrap admin-configured email body text with `wp_kses_post()`.
-- **MEDIUM / crypto** — encryption now produces authenticated v2 ciphertexts (encrypt-then-MAC, HMAC-SHA256 with a separately-derived MAC key); legacy v1 ciphertexts remain decryptable.
-- **MEDIUM / transport** — `IpGeolocation` HTTPS opt-in via `ffc_ipapi_use_https` filter; `sslverify` now follows the scheme.
-- **MEDIUM / IP spoofing** — `RateLimiter` only trusts `REMOTE_ADDR` by default; forwarded headers are gated behind `ffc_trust_forwarded_headers`.
-- **MEDIUM / data leak** — `MagicLinkHelper` replaces `chart.googleapis.com` QR URL with the local `QRCodeGenerator` so magic tokens never reach a third-party service.
-- **MEDIUM / path traversal** — `PdfGenerator` validates the receipt template path is inside the plugin or theme directories; `ReregistrationEmailHandler` allowlists template names; `AudienceNotificationHandler` moves temp ICS files from the public uploads dir to the system temp dir with try/finally cleanup.
+- **MEDIUM** (XSS) — Escape `id`, form title, and action labels in `SubmissionsList::column_default()` / `render_actions()`; inline-literal output for `$required_attr` in the frontend field renderer; escape `{{form_title}}` before `str_replace` into PDF layouts; wrap admin-configured email body text with `wp_kses_post()`.
+- **MEDIUM** (crypto) — Encryption produces authenticated v2 ciphertexts (encrypt-then-MAC, HMAC-SHA256 with a separately-derived MAC key); legacy v1 ciphertexts remain decryptable.
+- **MEDIUM** (transport) — `IpGeolocation` HTTPS opt-in via `ffc_ipapi_use_https` filter; `sslverify` now follows the scheme.
+- **MEDIUM** (IP spoofing) — `RateLimiter` only trusts `REMOTE_ADDR` by default; forwarded headers are gated behind `ffc_trust_forwarded_headers`.
+- **MEDIUM** (data leak) — `MagicLinkHelper` replaces `chart.googleapis.com` QR URL with the local `QRCodeGenerator` so magic tokens never reach a third-party service.
+- **MEDIUM** (path traversal) — `PdfGenerator` validates the receipt template path is inside the plugin or theme directories; `ReregistrationEmailHandler` allowlists template names; `AudienceNotificationHandler` moves temp ICS files from the public uploads dir to the system temp dir with try/finally cleanup.
+- **LOW** — Removed `$e->getMessage()` from 5 client-facing error responses across 4 REST controllers to prevent information disclosure.
 - **LOW** — `Admin::redirect_with_msg()` builds the redirect target from `page`/`post_type` instead of `REQUEST_URI`; removed duplicate `wp_nonce_field()` in `FormEditorMetaboxRenderer`; escaped return values in `VerificationResponseRenderer::format_field_value`; `ReprintDetector` hash-column query uses `%i`; `receipt-handler` escapes `bloginfo` with `esc_html` / `esc_url`.
-- **Privacy / LGPD** — hash PII identifiers before logging in `RateLimiter`; hash IP in `IpGeolocation` debug logs.
+- **LOW** (LGPD) — Hash PII identifiers before logging in `RateLimiter`; hash IP in `IpGeolocation` debug logs.
 
 ---
 

--- a/readme.txt
+++ b/readme.txt
@@ -177,15 +177,19 @@ In the certificate layout editor, use these dynamic tags:
 
 = 5.4.0 (2026-04-23) =
 
-Encryption and privacy hardening across the user-data surface, the accumulated security audit (Tier 1 + Tier 2), CSV download intermediate screen, and a performance pass for admin submissions at scale.
+Encryption and privacy hardening across the user-data surface, the accumulated security audit (Tier 1 + Tier 2), CSV download intermediate screen, a performance pass for admin submissions at scale, and the `UserProfileService` refactor consolidating profile reads and writes through a single entry point.
 
 * Feat: **Centralized sensitive-field policy** via `FreeFormCertificate\Core\SensitiveFieldRegistry` — single declarative map replacing three hard-coded lists. Consumed by `SubmissionHandler` and `AppointmentRepository`.
+* Feat: **`UserProfileFieldMap`** — per-field descriptor declaring storage layer (`wp_users`, `ffc_user_profiles`, `wp_usermeta`), sensitivity, hashability, and optional mirror targets (e.g. `display_name` → `wp_users.display_name`).
+* Feat: **`ViewPolicy` enum** (`FULL`, `MASKED`, `HASHED_ONLY`) declaring how sensitive fields are rendered on read. The service audits but does not elevate privileges; callers validate capability.
+* Feat: **`UserProfileService::read()` / `::write()`** — single entry point consolidating profile reads and writes across the three storage layers with transparent encryption, hashing, and mirror syncing. `FULL` reads that touch sensitive fields emit a metadata-only audit entry. `write()` accepts `$extra_descriptors` for dynamic reregistration keys outside the static map; overrides are per-call and cleared via try/finally.
 * Feat: **`email_hash_rehash` migration** — batched, idempotent, cursor-based. Rewrites legacy unsalted `email_hash` values in `wp_ffc_submissions` and `wp_ffc_self_scheduling_appointments`.
 * Feat: **`activity_log_clear_plaintext` migration** — NULLs the `context` plaintext column on activity log rows that already hold a ciphertext, closing the dual-storage leak on historical data.
 * Feat: **CSV download intermediate screen** — info screen showing form restrictions, dates, geolocation, quiz, and quota between hash validation and download. Download button only enabled after the form has ended; certificate preview available before the collection period begins.
 * Feat: **Public CSV sync-export row cap** — new `public_csv_sync_max_rows` setting (Advanced tab, default 2000, range 100–10000).
 * Change: **Activity log encryption gate** switched from a hard-coded action whitelist to payload inspection via `SensitiveFieldRegistry::contains_sensitive()`. Actions carrying sensitive fields (including nested payloads) are encrypted automatically; actions with trivial payloads are no longer wrapped in a meaningless ciphertext.
 * Change: **`ActivityLog::log()`** no longer dual-stores `context` plaintext alongside its ciphertext. Sensitive rows NULL the plaintext column; reads decrypt transparently via `ActivityLogQuery::resolve_context()`.
+* Change: **`UserManager::update_profile()` and `::update_extended_profile()`** are now thin facades over `UserProfileService::write()`. Legacy inline encrypt/hash paths are gone. Behavior improvement: clearing a sensitive field now also deletes the sibling `*_hash` meta row.
 * Change: **`Encryption::decrypt()`** split into a public wrapper and a private helper; emits a `decrypt_failure` WARNING to `ActivityLog` whenever a non-empty ciphertext resolves to null.
 * Change: Residual `class_exists ? Encryption::hash : hash('sha256')` fallbacks removed from `SelfSchedulingAppointmentHandler` and `SubmissionRepository::hash()`.
 * Change: Encryption envelope produces authenticated **v2 ciphertexts** (encrypt-then-MAC, HMAC-SHA256); legacy v1 ciphertexts remain decryptable.
@@ -207,7 +211,8 @@ Encryption and privacy hardening across the user-data surface, the accumulated s
 * Security (MEDIUM / path traversal): validate receipt template path; allowlist reregistration email templates; move ICS temp files out of public uploads.
 * Security (LOW): remove `$e->getMessage()` from client-facing error responses; `Admin::redirect_with_msg()` builds target from `page`/`post_type`; various minor output-escaping fixes.
 * Security (privacy): hash PII identifiers before logging (`RateLimiter`, `IpGeolocation`) for LGPD compliance.
-* Test: 3234 → **3455 tests** / 8698 assertions — new suites for `SensitiveFieldRegistry`, `SensitiveFieldPolicyTest`, `DecryptFailureLoggingTest`, `CustomFieldValidator`, `Autoloader`, `UserContextTrait`, `MigrationDynamicReregFields`, `ReregistrationStandardFieldsSeeder`, `AbstractRepository`, `Geofence`, `FormListColumns`, and new coverage for `UserManager::update_extended_profile` / `get_extended_profile`.
+* Docs: `SECURITY.md` supported-versions table updated to `5.4.x`. `CONTRIBUTING.md` Branches section no longer mandates the `claude/*` prefix for human contributors; Releasing section documents the `[Unreleased] → [X.Y.Z]` workflow.
+* Test: **3234 → 3485 tests** (+251) with **8783 assertions** — new suites for `SensitiveFieldRegistry`, `SensitiveFieldPolicyTest`, `DecryptFailureLoggingTest`, `UserProfileFieldMapTest`, `UserProfileServiceTest`, `CustomFieldValidator`, `Autoloader`, `UserContextTrait`, `MigrationDynamicReregFields`, `ReregistrationStandardFieldsSeeder`, `AbstractRepository`, `Geofence`, `FormListColumns`, and new coverage for `UserManager::update_extended_profile` / `get_extended_profile`.
 * Chore: WPCS **1232 → 0 errors** across 161 files; PHPStan level 7 **3 → 0 errors**.
 
 = 5.3.0 (2026-04-17) =


### PR DESCRIPTION
## Summary

Consolidate `[Unreleased]` into `5.4.0` (the current, not-yet-tagged release) and revise the section for consistency. No code touched.

## Why

5.4.0 was "cut" on 2026-04-23 (CHANGELOG dated, version bumped in `ffcertificate.php` and `readme.txt`) but never tagged or released. Subsequent PRs (#61, #62, #63, #64) added entries to `[Unreleased]` as if the release had shipped — leaving the repo looking like it had two in-flight releases when it only had one. Fold them in.

## Changelog revisions (5.4.0 only)

**Added**
- Merged `UserProfileFieldMap`, `ViewPolicy`, `UserProfileService::read/write` (including `$extra_descriptors`) from `[Unreleased]`.
- Corrected the aggregate test-coverage line to the true delta across all nine PRs (#55–#64): **3234 → 3485 tests (+251)**, **8783 assertions**.

**Changed**
- Folded in the `UserManager` facade rewire (Phase 2 + Phase 3 collapsed into one narrative).
- Folded in the `SECURITY.md` / `CONTRIBUTING.md` doc refreshes.
- Code-quality bullet no longer references "(Phases 4–5)" — the `1232 → 0` count tells the story.

**Removed**
- Dropped the `docs/USER_DATA_AUDIT.md` added+removed bookend. The file was internal tooling that came and went in the same release; cluttering the public changelog with an artifact that doesn't survive the release is noise.

**Security**
- Flattened `Phase 1 — Tier 1 hardening` and `Phase 2 — Tier 2 hardening` subheaders into a single severity-ordered list (CRITICAL, HIGH, MEDIUM, LOW, with `(LGPD)` / `(XSS)` / `(transport)` / etc. qualifiers). The tier/phase taxonomy was PR organization; readers of the changelog care about severity.

**Structure**
- `[Unreleased]` reset to a KaC stub with empty Added / Changed / Removed / Fixed / Security placeholders.

## `readme.txt`

Mirrors the same 5.4.0 section in the WordPress plugin `= X.Y.Z (date) =` format, updated with the `UserProfileService` entries and the corrected test count.

## Older sections

Left alone. Their internal "Phase N / Sprint N" references are accurate period pieces of when the work landed and shouldn't be rewritten.

## Test plan

- [x] `CHANGELOG.md` structure: `[Unreleased]` → `[5.4.0]` → older versions intact (spot-checked via `grep '^## '`).
- [x] No "Phase" references in the 5.4.0 block (`sed 33,103p | grep Phase` → empty).
- [x] `readme.txt` mirrors the consolidated 5.4.0.

https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeYQ2JoqHd9NgfTgPySyKd)_