### PR TITLE
docs(changelog): fix 5.0.1 KaC order + 1.0.7 date approximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,15 +461,15 @@ Security hardening, code quality improvements, URL Shortener test coverage, virt
 - Certificate verification card narrower than appointment card on `/valid/` — added `width: 100%` to `.ffc-certificate-preview` (root cause: `displayVerificationResult()` replaces container innerHTML, removing `.ffc-verify-result` wrapper, so flex `align-items: center` caused shrink-wrap)
 - **934 → 1051 tests, 1830 → 2076 assertions**
 
-### Documentation
-
-- Magic token endpoint documentation already complete (nonce intentionally omitted, rate limiting in place)
-- JSON fallback handling in Audience loader already
-
 ### Removed
 
 - Removed nonce fallback chain in AjaxTrait — each handler now verifies a single specific nonce action, eliminating timing side-channel
 - Removed `wp_rest` as fallback nonce in Self-Scheduling AJAX handlers — only `ffc_self_scheduling_nonce` accepted
+
+### Documentation
+
+- Magic token endpoint documentation already complete (nonce intentionally omitted, rate limiting in place)
+- JSON fallback handling in Audience loader already
 
 ---
 
@@ -2231,9 +2231,9 @@ Ticket system and form cloning.
 
 ---
 
-## 1.0.7 (~2025-12-12)
+## 1.0.7 (~2025-12-01)
 
-_Reconstructed from forensic source diff of `wp-ffcertificate_12_12_2025.zip`. The 1.0.x patch series between 1.0.0 and 1.5.0 was not separately documented in the developer's own changelog inside the 4.0.0 zip; this entry is reconstructed solely from that snapshot's plugin header (`Version: 1.0.7`) and file listing._
+_Reconstructed from forensic source diff of `wp-ffcertificate_12_12_2025.zip`. That snapshot was archived on 2025-12-12 and carried `Version: 1.0.7` in the plugin header — but the 1.0.x patch series logically released **between 1.0.0 (2025-11-25) and 1.5.0 (2025-12-05)**, so the snapshot date is later than the actual release date. The snapshot date (~2025-12-12) is the latest verifiable touchpoint of the 1.0.x line; the release date itself is approximated as ~2025-12-01 to keep the file in chronologically descending order. The 1.0.x patch series was not separately documented in the developer's own changelog inside the 4.0.0 zip; this entry is reconstructed solely from the snapshot's plugin header and file listing._
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Two cosmetic consistency fixes surfaced by post-merge audit of the latest `main`:

### 1. `## 5.0.1 (2026-02-22)` — sub-section order

Moved `### Documentation` to come **after** `### Removed` so the entry follows the canonical Keep-a-Changelog order used by all 94 other entries in the file:

```
Added → Changed → Fixed → Removed → Security → Documentation
```

Before:
```
### Added
### Changed
### Fixed
### Documentation   ← out of order
### Removed
```

After:
```
### Added
### Changed
### Fixed
### Removed
### Documentation
```

### 2. `## 1.0.7 (~2025-12-12)` → `## 1.0.7 (~2025-12-01)` — date approximation

The previous date placed 1.0.7 chronologically **after** 1.5.0 (2025-12-05), which is impossible — 1.0.7 is a patch on the 1.0.x branch and logically released before 1.5.0. The `2025-12-12` figure was actually the **snapshot date** (when the zip was archived), not the release date.

The new approximation `~2025-12-01` keeps 1.0.7 between 1.0.0 (2025-11-25) and 1.5.0 (2025-12-05) and restores the file's chronologically descending order. Body text now explicitly distinguishes:

- **Snapshot date** (2025-12-12) — the latest verifiable touchpoint of the 1.0.x line; this is when the `wp-ffcertificate_12_12_2025.zip` archive was created.
- **Release date** (~2025-12-01) — approximation bounded above by 1.5.0 and below by 1.0.0.

## Test plan

- [x] **KaC sub-section order check** across all 95 entries → 0 out-of-order.
- [x] **Date-descending order check** across all 95 entries → 0 out-of-order.
- [x] Diff scoped to `CHANGELOG.md` only (+7 / -7 lines). No code, no other docs.
- [ ] CI to confirm: WPCS, PHPStan, PHPUnit (no code touched, expect green).

https://claude.ai/code/session_01YcPrJdavcNK1Z5brtCLaoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcPrJdavcNK1Z5brtCLaoa)_