### PR TITLE
feat(recruitment): module foundation [WIP]

### DIFF
--- a/includes/class-ffc-activator.php
+++ b/includes/class-ffc-activator.php
@@ -79,6 +79,10 @@ class Activator {
 			\FreeFormCertificate\Recruitment\RecruitmentActivator::create_tables();
 		}
 
+		if ( class_exists( '\FreeFormCertificate\UserDashboard\CapabilityManager' ) ) {
+			\FreeFormCertificate\UserDashboard\CapabilityManager::register_recruitment_manager_role();
+		}
+
 		self::add_composite_indexes();
 		self::add_foreign_keys();
 		self::run_migrations();

--- a/includes/class-ffc-activator.php
+++ b/includes/class-ffc-activator.php
@@ -75,6 +75,10 @@ class Activator {
 			\FreeFormCertificate\UrlShortener\UrlShortenerActivator::create_tables();
 		}
 
+		if ( class_exists( '\FreeFormCertificate\Recruitment\RecruitmentActivator' ) ) {
+			\FreeFormCertificate\Recruitment\RecruitmentActivator::create_tables();
+		}
+
 		self::add_composite_indexes();
 		self::add_foreign_keys();
 		self::run_migrations();

--- a/includes/class-ffc-autoloader.php
+++ b/includes/class-ffc-autoloader.php
@@ -265,6 +265,9 @@ class FFC_Autoloader {
 
 			// URL Shortener namespace (v5.1.0) - Short URLs + QR Codes.
 			'UrlShortener'           => 'url-shortener',
+
+			// Recruitment namespace (v6.0.0) - Brazilian public-tender candidate queue.
+			'Recruitment'            => 'recruitment',
 		);
 	}
 

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -228,6 +228,12 @@ class Loader {
 			$url_shortener->init();
 		}
 
+		// Recruitment module (v6.0.0).
+		if ( class_exists( '\FreeFormCertificate\Recruitment\RecruitmentLoader' ) ) {
+			$recruitment_loader = new \FreeFormCertificate\Recruitment\RecruitmentLoader();
+			$recruitment_loader->init();
+		}
+
 		new ActivityLogSubscriber();
 
 		// Ensure daily cleanup cron is scheduled.

--- a/includes/core/class-ffc-document-formatter.php
+++ b/includes/core/class-ffc-document-formatter.php
@@ -223,6 +223,42 @@ class DocumentFormatter {
 	}
 
 	/**
+	 * Mask RF (Registro Funcional) for privacy.
+	 *
+	 * RF is a Brazilian employee/civil-servant registration number whose
+	 * length varies by state and agency (typically 4–15 digits). Unlike CPF,
+	 * there is no canonical national format, so this mask is length-agnostic:
+	 *
+	 *   - input < 4 digits → returned unchanged (too short to mask meaningfully)
+	 *   - input ≥ 4 digits → first 3 digits, then `***`, then last 1 digit
+	 *
+	 * Non-digit characters are stripped before masking. The result format is
+	 * dot-separated to match the visual style of {@see self::mask_cpf()}:
+	 * `XXX.***.X` for typical 7-digit RFs, `XXX.***.X` for longer RFs too.
+	 *
+	 * Used by the recruitment public shortcode (sprint 11) when the
+	 * `rf_masked` column is opted-in via `notice.public_columns_config`, and
+	 * by the candidate-self dashboard (sprint 12).
+	 *
+	 * @since 6.0.0
+	 * @param string $value RF to mask (with or without punctuation).
+	 * @return string Masked RF, or the original input when too short.
+	 */
+	public static function mask_rf( string $value ): string {
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$clean = preg_replace( '/[^0-9]/', '', $value ) ?? '';
+
+		if ( strlen( $clean ) < 4 ) {
+			return $value;
+		}
+
+		return substr( $clean, 0, 3 ) . '.***.' . substr( $clean, -1 );
+	}
+
+	/**
 	 * Mask email address for privacy
 	 *
 	 * @since 3.2.0

--- a/includes/core/class-ffc-sensitive-field-registry.php
+++ b/includes/core/class-ffc-sensitive-field-registry.php
@@ -43,6 +43,17 @@ final class SensitiveFieldRegistry {
 	public const CONTEXT_APPOINTMENT = 'appointment';
 
 	/**
+	 * Context key: wp_ffc_recruitment_candidate write path.
+	 *
+	 * Used by the recruitment CSV importer (sprint 4) and manual candidate
+	 * edits (sprint 9.1) to encrypt CPF / RF / email plaintexts into the
+	 * matching `*_encrypted` + `*_hash` column pairs on the candidate row.
+	 *
+	 * @since 6.0.0
+	 */
+	public const CONTEXT_RECRUITMENT_CANDIDATE = 'recruitment_candidate';
+
+	/**
 	 * Field descriptors per context.
 	 *
 	 * Each entry maps a logical field key (e.g. "email") to the columns that
@@ -56,7 +67,7 @@ final class SensitiveFieldRegistry {
 	 * @var array<string, array<string, array{encrypted_column: ?string, hash_column: ?string}>>
 	 */
 	private const FIELDS = array(
-		self::CONTEXT_SUBMISSION  => array(
+		self::CONTEXT_SUBMISSION            => array(
 			'email'   => array(
 				'encrypted_column' => 'email_encrypted',
 				'hash_column'      => 'email_hash',
@@ -82,7 +93,7 @@ final class SensitiveFieldRegistry {
 				'hash_column'      => 'ticket_hash',
 			),
 		),
-		self::CONTEXT_APPOINTMENT => array(
+		self::CONTEXT_APPOINTMENT           => array(
 			'email'       => array(
 				'encrypted_column' => 'email_encrypted',
 				'hash_column'      => 'email_hash',
@@ -106,6 +117,20 @@ final class SensitiveFieldRegistry {
 			'user_ip'     => array(
 				'encrypted_column' => 'user_ip_encrypted',
 				'hash_column'      => null,
+			),
+		),
+		self::CONTEXT_RECRUITMENT_CANDIDATE => array(
+			'email' => array(
+				'encrypted_column' => 'email_encrypted',
+				'hash_column'      => 'email_hash',
+			),
+			'cpf'   => array(
+				'encrypted_column' => 'cpf_encrypted',
+				'hash_column'      => 'cpf_hash',
+			),
+			'rf'    => array(
+				'encrypted_column' => 'rf_encrypted',
+				'hash_column'      => 'rf_hash',
 			),
 		),
 	);

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -23,8 +23,9 @@
  * enforced at the repository/state-machine layer (matches the existing plugin
  * convention).
  *
- * All DATETIME columns store UTC; display in `wp_timezone()` is the consumer's
- * responsibility.
+ * All DATETIME columns are written via `current_time( 'mysql' )` (site
+ * timezone, matching the rest of the plugin); display likewise uses the WP
+ * site timezone (`wp_timezone()`).
  *
  * @package FreeFormCertificate\Recruitment
  * @since   6.0.0
@@ -125,8 +126,8 @@ class RecruitmentActivator {
             code varchar(64) NOT NULL COMMENT 'Normalized to UPPERCASE on storage',
             name varchar(255) NOT NULL,
             status enum('draft','preliminary','active','closed') NOT NULL DEFAULT 'draft',
-            opened_at datetime DEFAULT NULL COMMENT 'UTC; set on first transition to active, never modified afterwards',
-            closed_at datetime DEFAULT NULL COMMENT 'UTC; overwritten on each transition to closed',
+            opened_at datetime DEFAULT NULL COMMENT 'Site TZ; set on first transition to active, never modified afterwards',
+            closed_at datetime DEFAULT NULL COMMENT 'Site TZ; overwritten on each transition to closed',
             was_reopened tinyint(1) NOT NULL DEFAULT 0 COMMENT 'Flips to 1 on first closed -> active; drives reopen-freeze',
             public_columns_config longtext NOT NULL COMMENT 'JSON: per-notice column visibility for public shortcode',
             created_at datetime NOT NULL,
@@ -302,13 +303,13 @@ class RecruitmentActivator {
 		$sql = "CREATE TABLE {$table_name} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             classification_id bigint(20) unsigned NOT NULL,
-            called_at datetime NOT NULL COMMENT 'UTC',
-            date_to_assume date NOT NULL COMMENT 'Display in site timezone',
-            time_to_assume time NOT NULL COMMENT 'Display in site timezone',
+            called_at datetime NOT NULL COMMENT 'Site TZ',
+            date_to_assume date NOT NULL,
+            time_to_assume time NOT NULL,
             out_of_order tinyint(1) NOT NULL DEFAULT 0,
             out_of_order_reason text DEFAULT NULL COMMENT 'Required when out_of_order=1 (app-layer invariant)',
             cancellation_reason text DEFAULT NULL,
-            cancelled_at datetime DEFAULT NULL COMMENT 'UTC; set on cancel, never cleared (audit trail)',
+            cancelled_at datetime DEFAULT NULL COMMENT 'Site TZ; set on cancel, never cleared (audit trail)',
             cancelled_by bigint(20) unsigned DEFAULT NULL,
             notes text DEFAULT NULL,
             created_by bigint(20) unsigned NOT NULL,

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Recruitment Activator
+ *
+ * Creates database tables for the Recruitment module — Brazilian public-tender
+ * ("concurso público") candidate queue management.
+ *
+ * Six tables, all prefixed `{$wpdb->prefix}ffc_recruitment_`:
+ *
+ * - ffc_recruitment_adjutancy           Reusable subject/role definitions (matérias).
+ * - ffc_recruitment_notice              The edital lifecycle (draft → preliminary → active → closed).
+ * - ffc_recruitment_notice_adjutancy    N:N — which adjutancies belong to which notice.
+ * - ffc_recruitment_candidate           Standalone candidate list (linked to wp_users on promotion).
+ * - ffc_recruitment_classification      Candidate standing per (adjutancy, notice, list_type).
+ * - ffc_recruitment_call                Append-only convocation events (with cancellation columns).
+ *
+ * All tables use ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 — InnoDB is required for
+ * the atomic transactional CSV import (preserves the previous list on validation
+ * failure via ROLLBACK), and utf8mb4 ensures full Unicode coverage on free-form
+ * fields (accented names, emoji in notes).
+ *
+ * No DB-level FOREIGN KEY constraints are declared: cross-table integrity is
+ * enforced at the repository/state-machine layer (matches the existing plugin
+ * convention).
+ *
+ * All DATETIME columns store UTC; display in `wp_timezone()` is the consumer's
+ * responsibility.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange
+/**
+ * Plugin activation tasks for the Recruitment module.
+ *
+ * Public entry-point: {@see self::create_tables()} — invoked from the main
+ * plugin Activator on activation. Idempotent: each table is gated by an
+ * existence check before issuing CREATE TABLE.
+ */
+class RecruitmentActivator {
+
+	use \FreeFormCertificate\Core\DatabaseHelperTrait;
+
+	/**
+	 * Create all Recruitment-related tables.
+	 *
+	 * Called from \FreeFormCertificate\Activator::activate() during plugin
+	 * activation. Each individual create method is idempotent (skips when the
+	 * table already exists), so this method is safe to call repeatedly across
+	 * activation cycles.
+	 *
+	 * @return void
+	 */
+	public static function create_tables(): void {
+		self::create_adjutancy_table();
+		self::create_notice_table();
+		self::create_notice_adjutancy_table();
+		self::create_candidate_table();
+		self::create_classification_table();
+		self::create_call_table();
+	}
+
+	/**
+	 * Create `ffc_recruitment_adjutancy` table.
+	 *
+	 * Reusable subject/role definitions ("matérias"). One row per adjutancy,
+	 * shared across notices via the junction table.
+	 *
+	 * @return void
+	 */
+	private static function create_adjutancy_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_adjutancy';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            slug varchar(64) NOT NULL,
+            name varchar(255) NOT NULL,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_slug (slug)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create `ffc_recruitment_notice` table.
+	 *
+	 * The edital. Lifecycle is governed by the `status` column
+	 * (draft → preliminary → active → closed). `was_reopened` flips to 1 on
+	 * the first closed → active transition and drives the freeze rule for
+	 * `hired`/`not_shown` classifications. `public_columns_config` (JSON) is
+	 * the per-notice column-visibility config for the public shortcode.
+	 *
+	 * @return void
+	 */
+	private static function create_notice_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_notice';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            code varchar(64) NOT NULL COMMENT 'Normalized to UPPERCASE on storage',
+            name varchar(255) NOT NULL,
+            status enum('draft','preliminary','active','closed') NOT NULL DEFAULT 'draft',
+            opened_at datetime DEFAULT NULL COMMENT 'UTC; set on first transition to active, never modified afterwards',
+            closed_at datetime DEFAULT NULL COMMENT 'UTC; overwritten on each transition to closed',
+            was_reopened tinyint(1) NOT NULL DEFAULT 0 COMMENT 'Flips to 1 on first closed -> active; drives reopen-freeze',
+            public_columns_config longtext NOT NULL COMMENT 'JSON: per-notice column visibility for public shortcode',
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_code (code),
+            KEY idx_status (status)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create `ffc_recruitment_notice_adjutancy` junction table.
+	 *
+	 * N:N between notices and adjutancies — declares which adjutancies belong
+	 * to a given notice. PK is the composite `(notice_id, adjutancy_id)`; a
+	 * reverse-lookup index on `adjutancy_id` covers "which notices include
+	 * this adjutancy" queries.
+	 *
+	 * @return void
+	 */
+	private static function create_notice_adjutancy_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_notice_adjutancy';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            notice_id bigint(20) unsigned NOT NULL,
+            adjutancy_id bigint(20) unsigned NOT NULL,
+            PRIMARY KEY (notice_id, adjutancy_id),
+            KEY idx_adjutancy_id (adjutancy_id)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create `ffc_recruitment_candidate` table.
+	 *
+	 * Standalone candidate list (no wp_users link until promotion via the
+	 * three §4 triggers). Encrypted columns follow the existing plugin
+	 * convention: `*_encrypted` is TEXT, `*_hash` is VARCHAR(64). The hash
+	 * columns are computed via the existing Encryption helper so cross-table
+	 * matches against `ffc_submissions.cpf_hash` / `rf_hash` work (which is
+	 * how §4 trigger 2 looks up an existing wp_user).
+	 *
+	 * `pcd_hash` is NOT NULL with both domains: HMAC(salt, "1"||id) for PCD,
+	 * HMAC(salt, "0"||id) for non-PCD. This keeps the value verifiable
+	 * (recompute both candidate domains and compare) without being
+	 * enumerable on column scan.
+	 *
+	 * UNIQUE on `cpf_hash` and on `rf_hash` (each separately) prevents
+	 * duplicate candidate rows for the same CPF or RF — a candidate
+	 * classified in multiple notices/adjutancies reuses the same row via
+	 * additional rows in `ffc_recruitment_classification`.
+	 *
+	 * @return void
+	 */
+	private static function create_candidate_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_candidate';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            user_id bigint(20) unsigned DEFAULT NULL COMMENT 'wp_users.ID set on promotion (logical FK)',
+            name varchar(255) NOT NULL COMMENT 'Plain — classified list is public by law',
+            cpf_encrypted text DEFAULT NULL,
+            cpf_hash varchar(64) DEFAULT NULL,
+            rf_encrypted text DEFAULT NULL,
+            rf_hash varchar(64) DEFAULT NULL,
+            email_encrypted text DEFAULT NULL,
+            email_hash varchar(64) DEFAULT NULL,
+            phone varchar(32) DEFAULT NULL COMMENT 'Plain — admin-editable, low sensitivity',
+            notes text DEFAULT NULL,
+            pcd_hash varchar(64) NOT NULL COMMENT 'HMAC(salt, (1|0)||id); both domains so non-PCD is also verifiable',
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_cpf_hash (cpf_hash),
+            UNIQUE KEY uq_rf_hash (rf_hash),
+            KEY idx_email_hash (email_hash),
+            KEY idx_user_id (user_id)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create `ffc_recruitment_classification` table.
+	 *
+	 * The candidate's standing per (adjutancy, notice, list_type). `list_type`
+	 * discriminates between `preview` (preliminary list) and `definitive`
+	 * (final list); convocation acts only on `definitive` per the §5.2
+	 * invariant.
+	 *
+	 * Composite index `(notice_id, adjutancy_id, list_type, status, rank)`
+	 * covers the hot-path "lowest-rank empty" query used by the in-order
+	 * call check and by ranking displays — `status` is placed before `rank`
+	 * so the index serves filtered scans efficiently.
+	 *
+	 * @return void
+	 */
+	private static function create_classification_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_classification';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            candidate_id bigint(20) unsigned NOT NULL,
+            adjutancy_id bigint(20) unsigned NOT NULL,
+            notice_id bigint(20) unsigned NOT NULL,
+            list_type enum('preview','definitive') NOT NULL,
+            `rank` int unsigned NOT NULL COMMENT 'Ties allowed; tie-break is (rank ASC, candidate_id ASC)',
+            score decimal(10,4) NOT NULL,
+            status enum('empty','called','accepted','not_shown','hired') NOT NULL DEFAULT 'empty',
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_candidate_adjutancy_notice_list (candidate_id, adjutancy_id, notice_id, list_type),
+            KEY idx_notice_adjutancy_list_status_rank (notice_id, adjutancy_id, list_type, status, `rank`),
+            KEY idx_candidate_id (candidate_id)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create `ffc_recruitment_call` table.
+	 *
+	 * A convocation event. Append-only history: cancellation does not delete
+	 * the row; it sets `cancellation_reason`, `cancelled_at`, `cancelled_by`
+	 * on the existing row. A subsequent re-call for the same classification
+	 * creates a new row.
+	 *
+	 * The composite index `(classification_id, cancelled_at)` covers both
+	 * "active call for classification" lookups (`WHERE classification_id=?
+	 * AND cancelled_at IS NULL`) and "all calls history of classification"
+	 * listings used by GET /me/recruitment.
+	 *
+	 * The invariant "out_of_order=1 implies out_of_order_reason is non-empty"
+	 * is enforced at the application/repository layer (not as a DB CHECK).
+	 *
+	 * @return void
+	 */
+	private static function create_call_table(): void {
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'ffc_recruitment_call';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		if ( self::table_exists( $table_name ) ) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            classification_id bigint(20) unsigned NOT NULL,
+            called_at datetime NOT NULL COMMENT 'UTC',
+            date_to_assume date NOT NULL COMMENT 'Display in site timezone',
+            time_to_assume time NOT NULL COMMENT 'Display in site timezone',
+            out_of_order tinyint(1) NOT NULL DEFAULT 0,
+            out_of_order_reason text DEFAULT NULL COMMENT 'Required when out_of_order=1 (app-layer invariant)',
+            cancellation_reason text DEFAULT NULL,
+            cancelled_at datetime DEFAULT NULL COMMENT 'UTC; set on cancel, never cleared (audit trail)',
+            cancelled_by bigint(20) unsigned DEFAULT NULL,
+            notes text DEFAULT NULL,
+            created_by bigint(20) unsigned NOT NULL,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            PRIMARY KEY (id),
+            KEY idx_classification_cancelled (classification_id, cancelled_at)
+        ) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-activity-logger.php
+++ b/includes/recruitment/class-ffc-recruitment-activity-logger.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Recruitment Activity Logger
+ *
+ * Thin façade over `\FreeFormCertificate\Core\ActivityLog::log()` with one
+ * stable action code per §13 event in the implementation plan. Centralizes
+ * the action-name vocabulary (so callers can't drift) and pins the payload
+ * shape for each event so consumers (PRs reviewing recruitment changes,
+ * audit dashboards, future LGPD reports) get a consistent stream.
+ *
+ * Sensitive-payload protection is INHERITED automatically from the core
+ * ActivityLog: it inspects every payload via
+ * {@see \FreeFormCertificate\Core\SensitiveFieldRegistry::contains_sensitive}
+ * and encrypts the row's `context_encrypted` column when the payload contains
+ * any registered sensitive key (`cpf`, `rf`, `email`, …). Sprint 2 added
+ * `CONTEXT_RECRUITMENT_CANDIDATE` to that registry, so any recruitment log
+ * call carrying those keys is automatically protected without per-call code.
+ *
+ * Recruitment event vocabulary:
+ *
+ *   - recruitment_csv_imported          { notice_id, list_type, inserted_count }
+ *   - recruitment_csv_import_failed     { notice_id, list_type, error_count }
+ *   - recruitment_notice_status_changed { notice_id, from, to, reason? }
+ *   - recruitment_notice_promoted       { notice_id, mode, copied }
+ *   - recruitment_classification_status_changed
+ *                                       { classification_id, from, to, reason? }
+ *   - recruitment_call_created          { call_id, classification_id, out_of_order, ... }
+ *   - recruitment_bulk_call_created     { classification_ids, date_to_assume, time_to_assume, count }
+ *   - recruitment_call_cancelled        { call_id, classification_id, reason }
+ *   - recruitment_candidate_promoted    { candidate_id, user_id }
+ *   - recruitment_candidate_deleted     { candidate_id, reason? }
+ *   - recruitment_classification_deleted { classification_id, reason? }
+ *   - recruitment_adjutancy_deleted     { adjutancy_id }
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\ActivityLog;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stateless logger façade. All methods are best-effort: they swallow
+ * ActivityLog return values because instrumentation must never disrupt the
+ * caller's success path.
+ */
+final class RecruitmentActivityLogger {
+
+	/**
+	 * CSV import succeeded.
+	 *
+	 * @param int    $notice_id Target notice.
+	 * @param string $list_type `preview` or `definitive`.
+	 * @param int    $inserted_count Rows committed.
+	 * @return void
+	 */
+	public static function csv_imported( int $notice_id, string $list_type, int $inserted_count ): void {
+		ActivityLog::log(
+			'recruitment_csv_imported',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'notice_id'      => $notice_id,
+				'list_type'      => $list_type,
+				'inserted_count' => $inserted_count,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * CSV import failed (validation error or DB failure).
+	 *
+	 * Caller passes the count of errors rather than the messages themselves
+	 * — line-numbered messages can name candidates indirectly (e.g. "line 7"),
+	 * but the messages themselves don't carry sensitive plaintext, so a
+	 * count keeps the audit trail compact.
+	 *
+	 * @param int    $notice_id Target notice.
+	 * @param string $list_type `preview` or `definitive`.
+	 * @param int    $error_count Number of validation/DB errors.
+	 * @return void
+	 */
+	public static function csv_import_failed( int $notice_id, string $list_type, int $error_count ): void {
+		ActivityLog::log(
+			'recruitment_csv_import_failed',
+			ActivityLog::LEVEL_WARNING,
+			array(
+				'notice_id'   => $notice_id,
+				'list_type'   => $list_type,
+				'error_count' => $error_count,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Notice status transition succeeded.
+	 *
+	 * @param int         $notice_id Notice ID.
+	 * @param string      $from From status.
+	 * @param string      $to   To status.
+	 * @param string|null $reason Reason (when the transition required one, e.g. closed → active).
+	 * @return void
+	 */
+	public static function notice_status_changed( int $notice_id, string $from, string $to, ?string $reason = null ): void {
+		$context = array(
+			'notice_id' => $notice_id,
+			'from'      => $from,
+			'to'        => $to,
+		);
+		if ( null !== $reason && '' !== $reason ) {
+			$context['reason'] = $reason;
+		}
+
+		ActivityLog::log(
+			'recruitment_notice_status_changed',
+			ActivityLog::LEVEL_INFO,
+			$context,
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Notice promotion succeeded (snapshot mode).
+	 *
+	 * @param int    $notice_id Notice ID.
+	 * @param string $mode `snapshot` or `definitive_import`.
+	 * @param int    $copied Rows copied to definitive (0 for definitive_import).
+	 * @return void
+	 */
+	public static function notice_promoted( int $notice_id, string $mode, int $copied ): void {
+		ActivityLog::log(
+			'recruitment_notice_promoted',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'notice_id' => $notice_id,
+				'mode'      => $mode,
+				'copied'    => $copied,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Classification status transition succeeded.
+	 *
+	 * @param int         $classification_id Classification ID.
+	 * @param string      $from From status.
+	 * @param string      $to   To status.
+	 * @param string|null $reason Reason (when required).
+	 * @return void
+	 */
+	public static function classification_status_changed( int $classification_id, string $from, string $to, ?string $reason = null ): void {
+		$context = array(
+			'classification_id' => $classification_id,
+			'from'              => $from,
+			'to'                => $to,
+		);
+		if ( null !== $reason && '' !== $reason ) {
+			$context['reason'] = $reason;
+		}
+
+		ActivityLog::log(
+			'recruitment_classification_status_changed',
+			ActivityLog::LEVEL_INFO,
+			$context,
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Single convocation created.
+	 *
+	 * @param int  $call_id Call ID.
+	 * @param int  $classification_id Classification ID.
+	 * @param bool $out_of_order Whether the call bypassed the in-order rule.
+	 * @return void
+	 */
+	public static function call_created( int $call_id, int $classification_id, bool $out_of_order ): void {
+		ActivityLog::log(
+			'recruitment_call_created',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'call_id'           => $call_id,
+				'classification_id' => $classification_id,
+				'out_of_order'      => $out_of_order ? 1 : 0,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Bulk convocation created (one aggregated event for N call rows).
+	 *
+	 * @param array<int> $classification_ids Classifications convocated.
+	 * @param array<int> $call_ids Newly created call IDs (parallel to classification_ids).
+	 * @param string     $date_to_assume Shared date.
+	 * @param string     $time_to_assume Shared time.
+	 * @return void
+	 */
+	public static function bulk_call_created( array $classification_ids, array $call_ids, string $date_to_assume, string $time_to_assume ): void {
+		ActivityLog::log(
+			'recruitment_bulk_call_created',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'classification_ids' => array_values( array_map( 'intval', $classification_ids ) ),
+				'call_ids'           => array_values( array_map( 'intval', $call_ids ) ),
+				'date_to_assume'     => $date_to_assume,
+				'time_to_assume'     => $time_to_assume,
+				'count'              => count( $classification_ids ),
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Call cancelled.
+	 *
+	 * @param int    $call_id Call ID.
+	 * @param int    $classification_id Classification ID.
+	 * @param string $reason Cancellation reason.
+	 * @return void
+	 */
+	public static function call_cancelled( int $call_id, int $classification_id, string $reason ): void {
+		ActivityLog::log(
+			'recruitment_call_cancelled',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'call_id'           => $call_id,
+				'classification_id' => $classification_id,
+				'reason'            => $reason,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Candidate promoted to a `wp_user`.
+	 *
+	 * @param int $candidate_id Candidate row ID.
+	 * @param int $user_id Linked WP user ID.
+	 * @return void
+	 */
+	public static function candidate_promoted( int $candidate_id, int $user_id ): void {
+		ActivityLog::log(
+			'recruitment_candidate_promoted',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'candidate_id' => $candidate_id,
+				'user_id'      => $user_id,
+			),
+			$user_id
+		);
+	}
+
+	/**
+	 * Candidate hard-deleted (gate already checked by RecruitmentDeleteService).
+	 *
+	 * @param int         $candidate_id Candidate ID (the row no longer exists at log time).
+	 * @param string|null $reason       Reason (optional).
+	 * @return void
+	 */
+	public static function candidate_deleted( int $candidate_id, ?string $reason = null ): void {
+		$context = array( 'candidate_id' => $candidate_id );
+		if ( null !== $reason && '' !== $reason ) {
+			$context['reason'] = $reason;
+		}
+		ActivityLog::log(
+			'recruitment_candidate_deleted',
+			ActivityLog::LEVEL_WARNING,
+			$context,
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Classification individual delete.
+	 *
+	 * @param int         $classification_id Classification ID (row no longer exists at log time).
+	 * @param string|null $reason            Reason (optional).
+	 * @return void
+	 */
+	public static function classification_deleted( int $classification_id, ?string $reason = null ): void {
+		$context = array( 'classification_id' => $classification_id );
+		if ( null !== $reason && '' !== $reason ) {
+			$context['reason'] = $reason;
+		}
+		ActivityLog::log(
+			'recruitment_classification_deleted',
+			ActivityLog::LEVEL_INFO,
+			$context,
+			get_current_user_id()
+		);
+	}
+
+	/**
+	 * Adjutancy deletion.
+	 *
+	 * @param int $adjutancy_id Adjutancy ID (row no longer exists at log time).
+	 * @return void
+	 */
+	public static function adjutancy_deleted( int $adjutancy_id ): void {
+		ActivityLog::log(
+			'recruitment_adjutancy_deleted',
+			ActivityLog::LEVEL_INFO,
+			array( 'adjutancy_id' => $adjutancy_id ),
+			get_current_user_id()
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Adjutancy Repository
+ *
+ * CRUD for the global Adjutancy ("matéria") catalog. Adjutancies are reusable
+ * across notices via the `ffc_recruitment_notice_adjutancy` junction.
+ *
+ * Schema-level invariants enforced here:
+ *
+ * - `slug` is UNIQUE (DB constraint). Insert/update operations rely on the
+ *   constraint to surface duplicates as a `false` return.
+ * - Deletion gating (zero references in `notice_adjutancy` and zero references
+ *   in `classification`) is enforced by the service layer, not here — this
+ *   repository's `delete()` is unconditional. The deletion gate lives in the
+ *   REST controller / service so the gate can return a typed 409 with
+ *   reference counts instead of a silent failure.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for `ffc_recruitment_adjutancy` rows.
+ *
+ * @phpstan-type AdjutancyRow \stdClass&object{id: numeric-string, slug: string, name: string, created_at: string, updated_at: string}
+ */
+class AdjutancyRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_adjutancy';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_adjutancy';
+	}
+
+	/**
+	 * Get an adjutancy row by ID.
+	 *
+	 * Cached per-row in the object cache; cache is invalidated by
+	 * {@see self::update()} and {@see self::delete()}.
+	 *
+	 * @param int $id Adjutancy ID.
+	 * @return AdjutancyRow|null
+	 */
+	public static function get_by_id( int $id ): ?object {
+		$cached = static::cache_get( "id_{$id}" );
+		if ( false !== $cached ) {
+			/**
+			 * Object-cache return cast.
+			 *
+			 * @var AdjutancyRow|null $cached
+			 */
+			return $cached;
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var AdjutancyRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cached above and below; %i for table identifier.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $id )
+		);
+
+		if ( $result ) {
+			static::cache_set( "id_{$id}", $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get an adjutancy row by slug.
+	 *
+	 * Used by the CSV importer (which receives the slug in the `adjutancy`
+	 * column) and by the public shortcode (which accepts the slug in its
+	 * `adjutancy=` attribute).
+	 *
+	 * @param string $slug Adjutancy slug (lowercase, unique).
+	 * @return AdjutancyRow|null
+	 */
+	public static function get_by_slug( string $slug ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var AdjutancyRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Slug lookup is uncached intentionally; called rarely on CSV import / shortcode render.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE slug = %s LIMIT 1', $table, $slug )
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * List all adjutancies, ordered by name ASC.
+	 *
+	 * @return list<AdjutancyRow>
+	 */
+	public static function get_all(): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<AdjutancyRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Admin-only listing; small cardinality (~ tens of rows).
+		$results = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT * FROM %i ORDER BY name ASC', $table )
+		);
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Create a new adjutancy row.
+	 *
+	 * Caller is responsible for slug normalization. Returns `false` on
+	 * insert failure (e.g. duplicate slug rejected by the UNIQUE constraint).
+	 *
+	 * @param string $slug Unique slug.
+	 * @param string $name Display name.
+	 * @return int|false New adjutancy ID or false on failure.
+	 */
+	public static function create( string $slug, string $name ) {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now = current_time( 'mysql' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper; format array supplied.
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'slug'       => $slug,
+				'name'       => $name,
+				'created_at' => $now,
+				'updated_at' => $now,
+			),
+			array( '%s', '%s', '%s', '%s' )
+		);
+
+		if ( ! $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Update name and/or slug on an existing adjutancy.
+	 *
+	 * Only `slug` and `name` are accepted; any other key in `$data` is
+	 * silently ignored. `updated_at` is refreshed automatically.
+	 *
+	 * @param int                  $id   Adjutancy ID.
+	 * @param array<string, mixed> $data Subset of {slug, name}.
+	 * @return bool True on successful update (zero or more rows affected).
+	 */
+	public static function update( int $id, array $data ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$update = array();
+		$format = array();
+
+		if ( isset( $data['slug'] ) && is_string( $data['slug'] ) ) {
+			$update['slug'] = $data['slug'];
+			$format[]       = '%s';
+		}
+
+		if ( isset( $data['name'] ) && is_string( $data['name'] ) ) {
+			$update['name'] = $data['name'];
+			$format[]       = '%s';
+		}
+
+		if ( empty( $update ) ) {
+			return false;
+		}
+
+		$update['updated_at'] = current_time( 'mysql' );
+		$format[]             = '%s';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update via wpdb helper.
+		$result = $wpdb->update( $table, $update, array( 'id' => $id ), $format, array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete an adjutancy row unconditionally.
+	 *
+	 * Deletion gating (zero references in `notice_adjutancy` / `classification`)
+	 * lives in the REST controller / service layer; this method is a pure CRUD
+	 * primitive and assumes the caller has already verified the gate.
+	 *
+	 * @param int $id Adjutancy ID.
+	 * @return bool
+	 */
+	public static function delete( int $id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete via wpdb helper.
+		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @phpstan-type AdjutancyRow \stdClass&object{id: numeric-string, slug: string, name: string, created_at: string, updated_at: string}
  */
-class AdjutancyRepository {
+class RecruitmentAdjutancyRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 

--- a/includes/recruitment/class-ffc-recruitment-call-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-call-repository.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @phpstan-type CallRow \stdClass&object{id: numeric-string, classification_id: numeric-string, called_at: string, date_to_assume: string, time_to_assume: string, out_of_order: numeric-string, out_of_order_reason: string|null, cancellation_reason: string|null, cancelled_at: string|null, cancelled_by: numeric-string|null, notes: string|null, created_by: numeric-string, created_at: string, updated_at: string}
  */
-class CallRepository {
+class RecruitmentCallRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 
@@ -250,7 +250,7 @@ class CallRepository {
 	 * Idempotent within a single cancellation: the WHERE clause requires
 	 * `cancelled_at IS NULL`, so a second cancel attempt on an already
 	 * cancelled row returns 0. The state machine (sprint 5) calls this
-	 * AFTER {@see ClassificationRepository::set_status()} has already moved
+	 * AFTER {@see RecruitmentClassificationRepository::set_status()} has already moved
 	 * the classification back to `empty` atomically, so the two operations
 	 * together preserve the audit trail.
 	 *

--- a/includes/recruitment/class-ffc-recruitment-call-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-call-repository.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Call Repository
+ *
+ * CRUD-ish access to `ffc_recruitment_call` rows. Calls are append-only
+ * history: cancellation does NOT delete the row — it stamps
+ * `cancellation_reason` / `cancelled_at` / `cancelled_by` on the existing
+ * row. A subsequent re-call for the same classification creates a new row.
+ *
+ * "Active call for classification" = the most recent row for the
+ * classification with `cancelled_at IS NULL`. The composite index
+ * `(classification_id, cancelled_at)` covers this lookup directly.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for `ffc_recruitment_call` rows.
+ *
+ * @phpstan-type CallRow \stdClass&object{id: numeric-string, classification_id: numeric-string, called_at: string, date_to_assume: string, time_to_assume: string, out_of_order: numeric-string, out_of_order_reason: string|null, cancellation_reason: string|null, cancelled_at: string|null, cancelled_by: numeric-string|null, notes: string|null, created_by: numeric-string, created_at: string, updated_at: string}
+ */
+class CallRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_call';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_call';
+	}
+
+	/**
+	 * Get a call row by ID.
+	 *
+	 * @param int $id Call ID.
+	 * @return CallRow|null
+	 */
+	public static function get_by_id( int $id ): ?object {
+		$cached = static::cache_get( "id_{$id}" );
+		if ( false !== $cached ) {
+			/**
+			 * Object-cache return cast.
+			 *
+			 * @var CallRow|null $cached
+			 */
+			return $cached;
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CallRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Object-cached.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $id )
+		);
+
+		if ( $result ) {
+			static::cache_set( "id_{$id}", $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get the active (non-cancelled) call for a classification, if any.
+	 *
+	 * Returns the most recent row where `cancelled_at IS NULL`. There SHOULD
+	 * be at most one such row at any time (state machine enforces: a new
+	 * call is only issued when classification is `empty`, which only
+	 * happens after the previous call was cancelled and stamped). The
+	 * `LIMIT 1` is defensive.
+	 *
+	 * @param int $classification_id Classification ID.
+	 * @return CallRow|null
+	 */
+	public static function get_active_for_classification( int $classification_id ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CallRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Covered by INDEX (classification_id, cancelled_at).
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE classification_id = %d AND cancelled_at IS NULL ORDER BY called_at DESC LIMIT 1',
+				$table,
+				$classification_id
+			)
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * List all calls for a classification (history view, including cancelled).
+	 *
+	 * Sort is `called_at DESC` (most recent first) — matches the candidate
+	 * dashboard's "Histórico de convocações" sort.
+	 *
+	 * @param int $classification_id Classification ID.
+	 * @return list<CallRow>
+	 */
+	public static function get_history_for_classification( int $classification_id ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<CallRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Covered by INDEX on classification_id.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE classification_id = %d ORDER BY called_at DESC',
+				$table,
+				$classification_id
+			)
+		);
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Get all calls (history) for a list of classification IDs.
+	 *
+	 * Used by the candidate-self dashboard ({@see GET /me/recruitment}) to
+	 * batch-load the call history for all the user's classifications in a
+	 * single query.
+	 *
+	 * @param array<int> $classification_ids Classification IDs.
+	 * @return list<CallRow>
+	 */
+	public static function get_history_for_classifications( array $classification_ids ): array {
+		if ( empty( $classification_ids ) ) {
+			return array();
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$ids          = array_map( 'intval', $classification_ids );
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+
+		$sql = "SELECT * FROM %i WHERE classification_id IN ({$placeholders}) ORDER BY called_at DESC";
+
+		$prepare_args = array_merge( array( $table ), $ids );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic IN() built from %d placeholders only.
+		$prepared = $wpdb->prepare( $sql, $prepare_args );
+		if ( ! is_string( $prepared ) ) {
+			return array();
+		}
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<CallRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $prepared );
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Insert a new call row.
+	 *
+	 * Required keys: `classification_id`, `date_to_assume`, `time_to_assume`,
+	 * `created_by`. Optional keys: `out_of_order` (defaults to 0),
+	 * `out_of_order_reason`, `notes`, `called_at` (defaults to now).
+	 *
+	 * Invariant (enforced here, also at the service layer): when
+	 * `out_of_order = 1`, `out_of_order_reason` must be a non-empty string.
+	 * Returns `false` if the invariant is violated.
+	 *
+	 * @param array{classification_id: int, date_to_assume: string, time_to_assume: string, created_by: int, out_of_order?: int, out_of_order_reason?: string|null, notes?: string|null, called_at?: string} $data Call payload.
+	 * @return int|false New call ID or false on failure.
+	 */
+	public static function create( array $data ) {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$out_of_order        = isset( $data['out_of_order'] ) ? (int) $data['out_of_order'] : 0;
+		$out_of_order_reason = $data['out_of_order_reason'] ?? null;
+
+		// Repository-level guard for the §3.6 invariant.
+		if ( 1 === $out_of_order && ( ! is_string( $out_of_order_reason ) || '' === trim( $out_of_order_reason ) ) ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql' );
+
+		$insert = array(
+			'classification_id'   => $data['classification_id'],
+			'called_at'           => $data['called_at'] ?? $now,
+			'date_to_assume'      => $data['date_to_assume'],
+			'time_to_assume'      => $data['time_to_assume'],
+			'out_of_order'        => $out_of_order,
+			'out_of_order_reason' => $out_of_order_reason,
+			'notes'               => $data['notes'] ?? null,
+			'created_by'          => $data['created_by'],
+			'created_at'          => $now,
+			'updated_at'          => $now,
+		);
+		$format = array( '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%s', '%s' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper.
+		$result = $wpdb->insert( $table, $insert, $format );
+
+		if ( ! $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Stamp cancellation columns on an existing call row.
+	 *
+	 * Idempotent within a single cancellation: the WHERE clause requires
+	 * `cancelled_at IS NULL`, so a second cancel attempt on an already
+	 * cancelled row returns 0. The state machine (sprint 5) calls this
+	 * AFTER {@see ClassificationRepository::set_status()} has already moved
+	 * the classification back to `empty` atomically, so the two operations
+	 * together preserve the audit trail.
+	 *
+	 * @param int    $id Call ID.
+	 * @param string $reason Cancellation reason (mandatory; §5.2).
+	 * @param int    $cancelled_by WP user ID who performed the cancel.
+	 * @return int Number of rows affected (1 on first cancel, 0 if already cancelled).
+	 */
+	public static function mark_cancelled( int $id, string $reason, int $cancelled_by ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now = current_time( 'mysql' );
+
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET cancellation_reason = %s, cancelled_at = %s, cancelled_by = %d, updated_at = %s
+              WHERE id = %d AND cancelled_at IS NULL',
+			$table,
+			$reason,
+			$now,
+			$cancelled_by,
+			$now,
+			$id
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional UPDATE via wpdb->query for affected-rows return; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Update mutable, non-history fields on a call row.
+	 *
+	 * Only `notes` is writable post-creation; cancellation columns go
+	 * through {@see self::mark_cancelled()}, and audit columns
+	 * (`called_at`, `created_by`, `out_of_order*`) are immutable per the
+	 * append-only-history contract.
+	 *
+	 * @param int                  $id Call ID.
+	 * @param array<string, mixed> $data Update payload (only `notes` honored).
+	 * @return bool
+	 */
+	public static function update( int $id, array $data ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$update = array();
+		$format = array();
+
+		if ( array_key_exists( 'notes', $data ) ) {
+			$update['notes'] = $data['notes'];
+			$format[]        = '%s';
+		}
+
+		if ( empty( $update ) ) {
+			return false;
+		}
+
+		$update['updated_at'] = current_time( 'mysql' );
+		$format[]             = '%s';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update via wpdb helper.
+		$result = $wpdb->update( $table, $update, array( 'id' => $id ), $format, array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Count all calls for a classification, including cancelled.
+	 *
+	 * @param int $classification_id Classification ID.
+	 * @return int
+	 */
+	public static function count_for_classification( int $classification_id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Index range count.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE classification_id = %d', $table, $classification_id )
+		);
+
+		return $count;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-call-service.php
+++ b/includes/recruitment/class-ffc-recruitment-call-service.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Recruitment Call Service
+ *
+ * The convocation orchestrator: pairs each new `ffc_recruitment_call` row
+ * with the corresponding atomic classification status transition
+ * (`empty → called`), and pairs each cancellation with the inverse flow
+ * (`called|accepted → empty` plus stamping `cancelled_at` on the call row).
+ *
+ * Sprint 5's state machine handles status-only transitions; this service
+ * exists because call creation/cancellation needs both the status flip AND
+ * a row insert / column stamp on `ffc_recruitment_call` to land or not
+ * land together. Both are wrapped in InnoDB transactions and use the
+ * conditional UPDATE primitive on the repository so a lost race cleanly
+ * surfaces as `recruitment_state_locked` without leaving an orphan call
+ * row.
+ *
+ * Public surface:
+ *
+ *   - {@see self::call_single} — convocation for a single classification.
+ *     Detects "out of order" automatically by comparing the target row's
+ *     id to the result of {@see RecruitmentClassificationRepository::find_lowest_rank_empty}.
+ *     Out-of-order calls REQUIRE a non-empty `out_of_order_reason`; in-order
+ *     calls require none. Sets `out_of_order = 1` on the call row.
+ *
+ *   - {@see self::call_bulk} — atomic all-or-nothing bulk convocation. All
+ *     classifications must be `empty` and pass the same per-row gates as
+ *     `call_single`. Out-of-order reasons are looked up per-row in the
+ *     `$out_of_order_reasons` map (keyed by classification ID); a missing
+ *     reason for an out-of-order row aborts the bulk.
+ *
+ *   - {@see self::cancel_call} — append-only cancellation: the call row is
+ *     stamped (`cancelled_at` / `cancelled_by` / `cancellation_reason`)
+ *     instead of deleted, so the audit trail is preserved. The
+ *     classification atomically transitions back to `empty`.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+/**
+ * Service: orchestrate convocation creation and cancellation.
+ *
+ * Public methods return:
+ *
+ *   array{
+ *     success:  bool,
+ *     call_ids: list<int>,     // committed call row IDs (single: one element)
+ *     errors:   list<string>,
+ *   }
+ *
+ * @phpstan-type CallResult array{success: bool, call_ids: list<int>, errors: list<string>}
+ */
+final class RecruitmentCallService {
+
+	/**
+	 * Issue a single convocation for one classification.
+	 *
+	 * @param int         $classification_id   Target classification (must be `empty`).
+	 * @param string      $date_to_assume      `YYYY-MM-DD`.
+	 * @param string      $time_to_assume      `HH:MM` or `HH:MM:SS`.
+	 * @param int         $created_by          WP user ID issuing the call.
+	 * @param string|null $out_of_order_reason Required when the target is not the lowest-rank `empty` row.
+	 * @param string|null $notes               Optional.
+	 * @return CallResult
+	 */
+	public static function call_single(
+		int $classification_id,
+		string $date_to_assume,
+		string $time_to_assume,
+		int $created_by,
+		?string $out_of_order_reason = null,
+		?string $notes = null
+	): array {
+		global $wpdb;
+		$wpdb->query( 'START TRANSACTION' );
+
+		$result = self::call_one(
+			$classification_id,
+			$date_to_assume,
+			$time_to_assume,
+			$created_by,
+			$out_of_order_reason,
+			$notes
+		);
+
+		if ( ! $result['success'] ) {
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'success'  => false,
+				'call_ids' => array(),
+				'errors'   => $result['errors'],
+			);
+		}
+
+		$wpdb->query( 'COMMIT' );
+
+		return array(
+			'success'  => true,
+			'call_ids' => array( $result['call_id'] ),
+			'errors'   => array(),
+		);
+	}
+
+	/**
+	 * Issue a bulk convocation across N classifications, atomic.
+	 *
+	 * The shared `date_to_assume` / `time_to_assume` are applied to every
+	 * call row. Per-row out-of-order reasons are read from
+	 * `$out_of_order_reasons[$classification_id]` (string-keyed for
+	 * transport-friendliness when this surfaces as a REST body). Any
+	 * single-row failure rolls back the entire batch.
+	 *
+	 * @param array                 $classification_ids   Classifications to convocate (list<int>; must all be `empty`).
+	 * @phpstan-param list<int>     $classification_ids
+	 * @param string                $date_to_assume       `YYYY-MM-DD` shared across the batch.
+	 * @param string                $time_to_assume       `HH:MM` or `HH:MM:SS` shared across the batch.
+	 * @param int                   $created_by           WP user ID issuing the bulk call.
+	 * @param array<string, string> $out_of_order_reasons Keyed by classification ID (string).
+	 * @param string|null           $notes                Optional, applied to every call row.
+	 * @return CallResult
+	 */
+	public static function call_bulk(
+		array $classification_ids,
+		string $date_to_assume,
+		string $time_to_assume,
+		int $created_by,
+		array $out_of_order_reasons = array(),
+		?string $notes = null
+	): array {
+		if ( empty( $classification_ids ) ) {
+			return self::failure( 'recruitment_bulk_call_empty_id_list' );
+		}
+
+		global $wpdb;
+		$wpdb->query( 'START TRANSACTION' );
+
+		$call_ids = array();
+
+		foreach ( $classification_ids as $classification_id ) {
+			$reason = $out_of_order_reasons[ (string) $classification_id ] ?? null;
+
+			$result = self::call_one(
+				(int) $classification_id,
+				$date_to_assume,
+				$time_to_assume,
+				$created_by,
+				$reason,
+				$notes
+			);
+
+			if ( ! $result['success'] ) {
+				$wpdb->query( 'ROLLBACK' );
+				return array(
+					'success'  => false,
+					'call_ids' => array(),
+					'errors'   => array_merge(
+						array( 'recruitment_bulk_call_failed_at_classification: ' . $classification_id ),
+						$result['errors']
+					),
+				);
+			}
+
+			$call_ids[] = $result['call_id'];
+		}
+
+		$wpdb->query( 'COMMIT' );
+
+		return array(
+			'success'  => true,
+			'call_ids' => $call_ids,
+			'errors'   => array(),
+		);
+	}
+
+	/**
+	 * Cancel an active call. Atomic: classification rolls back to `empty`
+	 * AND the call row gets `cancelled_at` stamped, both inside one
+	 * transaction.
+	 *
+	 * @param int    $call_id      Active call row ID.
+	 * @param string $reason       Cancellation reason (REQUIRED, non-empty).
+	 * @param int    $cancelled_by WP user ID performing the cancel.
+	 * @return CallResult
+	 */
+	public static function cancel_call( int $call_id, string $reason, int $cancelled_by ): array {
+		if ( '' === trim( $reason ) ) {
+			return self::failure( 'recruitment_cancel_reason_required' );
+		}
+
+		$call = RecruitmentCallRepository::get_by_id( $call_id );
+		if ( null === $call ) {
+			return self::failure( 'recruitment_call_not_found' );
+		}
+
+		if ( null !== $call->cancelled_at ) {
+			return self::failure( 'recruitment_call_already_cancelled' );
+		}
+
+		$classification_id = (int) $call->classification_id;
+		$classification    = RecruitmentClassificationRepository::get_by_id( $classification_id );
+		if ( null === $classification ) {
+			return self::failure( 'recruitment_classification_not_found' );
+		}
+
+		$current_status = $classification->status;
+		if ( ! in_array( $current_status, array( 'called', 'accepted' ), true ) ) {
+			// `not_shown`/`hired`/`empty` mean the call has already moved on
+			// — admin should use a status transition instead.
+			return self::failure( 'recruitment_cancel_only_from_called_or_accepted' );
+		}
+
+		global $wpdb;
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			$transition = RecruitmentClassificationStateMachine::transition_to(
+				$classification_id,
+				'empty',
+				$reason
+			);
+			if ( ! $transition['success'] ) {
+				$wpdb->query( 'ROLLBACK' );
+				return array(
+					'success'  => false,
+					'call_ids' => array(),
+					'errors'   => $transition['errors'],
+				);
+			}
+
+			$affected = RecruitmentCallRepository::mark_cancelled( $call_id, $reason, $cancelled_by );
+			if ( 1 !== $affected ) {
+				$wpdb->query( 'ROLLBACK' );
+				return self::failure( 'recruitment_call_cancel_race_lost' );
+			}
+
+			$wpdb->query( 'COMMIT' );
+
+			return array(
+				'success'  => true,
+				'call_ids' => array( $call_id ),
+				'errors'   => array(),
+			);
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			return self::failure( 'recruitment_cancel_unexpected_error: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Inner per-classification call flow. Caller is responsible for
+	 * wrapping with `START TRANSACTION` / `COMMIT` / `ROLLBACK`.
+	 *
+	 * Performs:
+	 *
+	 *   1. Load classification (must exist, must be `empty`).
+	 *   2. Determine out-of-order via `find_lowest_rank_empty` comparison.
+	 *   3. Validate `out_of_order_reason` requirement.
+	 *   4. Conditional UPDATE classification status `empty → called`.
+	 *      If 0 affected, the row is no longer empty (concurrent writer)
+	 *      → return race-lost error.
+	 *   5. INSERT the call row with `out_of_order` flag set appropriately.
+	 *
+	 * @param int         $classification_id   Target classification ID.
+	 * @param string      $date_to_assume      Date the candidate is summoned to assume.
+	 * @param string      $time_to_assume      Time of day for the assumption.
+	 * @param int         $created_by          WP user ID issuing the call.
+	 * @param string|null $out_of_order_reason Required iff the row is not the lowest-rank empty.
+	 * @param string|null $notes               Optional notes attached to the call row.
+	 * @return array{success: bool, call_id: int, errors: list<string>}
+	 */
+	private static function call_one(
+		int $classification_id,
+		string $date_to_assume,
+		string $time_to_assume,
+		int $created_by,
+		?string $out_of_order_reason,
+		?string $notes
+	): array {
+		$classification = RecruitmentClassificationRepository::get_by_id( $classification_id );
+		if ( null === $classification ) {
+			return self::inner_failure( 'recruitment_classification_not_found' );
+		}
+
+		if ( 'empty' !== $classification->status ) {
+			return self::inner_failure( 'recruitment_classification_not_empty' );
+		}
+
+		// Out-of-order check.
+		$lowest_empty    = RecruitmentClassificationRepository::find_lowest_rank_empty(
+			(int) $classification->notice_id,
+			(int) $classification->adjutancy_id,
+			$classification->list_type
+		);
+		$is_out_of_order = ( null === $lowest_empty ) || ( (int) $lowest_empty->id !== $classification_id );
+
+		if ( $is_out_of_order ) {
+			if ( null === $out_of_order_reason || '' === trim( $out_of_order_reason ) ) {
+				return self::inner_failure( 'recruitment_out_of_order_requires_reason' );
+			}
+		}
+
+		// Atomic empty → called.
+		$affected = RecruitmentClassificationRepository::set_status(
+			$classification_id,
+			'empty',
+			'called'
+		);
+		if ( 1 !== $affected ) {
+			return self::inner_failure( 'recruitment_state_locked' );
+		}
+
+		// Insert the call row.
+		$payload = array(
+			'classification_id' => $classification_id,
+			'date_to_assume'    => $date_to_assume,
+			'time_to_assume'    => $time_to_assume,
+			'created_by'        => $created_by,
+			'out_of_order'      => $is_out_of_order ? 1 : 0,
+		);
+		if ( $is_out_of_order ) {
+			$payload['out_of_order_reason'] = $out_of_order_reason;
+		}
+		if ( null !== $notes && '' !== $notes ) {
+			$payload['notes'] = $notes;
+		}
+
+		$call_id = RecruitmentCallRepository::create( $payload );
+		if ( false === $call_id ) {
+			return self::inner_failure( 'recruitment_call_insert_failed' );
+		}
+
+		return array(
+			'success' => true,
+			'call_id' => (int) $call_id,
+			'errors'  => array(),
+		);
+	}
+
+	/**
+	 * Public-facing failure envelope.
+	 *
+	 * @param string $code Stable error code.
+	 * @return CallResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success'  => false,
+			'call_ids' => array(),
+			'errors'   => array( $code ),
+		);
+	}
+
+	/**
+	 * Inner-flow failure envelope (single classification).
+	 *
+	 * @param string $code Stable error code.
+	 * @return array{success: bool, call_id: int, errors: list<string>}
+	 */
+	private static function inner_failure( string $code ): array {
+		return array(
+			'success' => false,
+			'call_id' => 0,
+			'errors'  => array( $code ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-call-service.php
+++ b/includes/recruitment/class-ffc-recruitment-call-service.php
@@ -110,6 +110,10 @@ final class RecruitmentCallService {
 			null !== $out_of_order_reason && '' !== trim( (string) $out_of_order_reason )
 		);
 
+		// Best-effort email dispatch — failures here do NOT roll back the
+		// committed call (§7).
+		RecruitmentEmailDispatcher::send_for_call( $result['call_id'] );
+
 		return array(
 			'success'  => true,
 			'call_ids' => array( $result['call_id'] ),
@@ -187,6 +191,12 @@ final class RecruitmentCallService {
 			$date_to_assume,
 			$time_to_assume
 		);
+
+		// Best-effort email dispatch per row — failures here do NOT roll
+		// back the committed batch (§7).
+		foreach ( $call_ids as $cid ) {
+			RecruitmentEmailDispatcher::send_for_call( $cid );
+		}
 
 		return array(
 			'success'  => true,

--- a/includes/recruitment/class-ffc-recruitment-call-service.php
+++ b/includes/recruitment/class-ffc-recruitment-call-service.php
@@ -104,6 +104,12 @@ final class RecruitmentCallService {
 
 		$wpdb->query( 'COMMIT' );
 
+		RecruitmentActivityLogger::call_created(
+			$result['call_id'],
+			$classification_id,
+			null !== $out_of_order_reason && '' !== trim( (string) $out_of_order_reason )
+		);
+
 		return array(
 			'success'  => true,
 			'call_ids' => array( $result['call_id'] ),
@@ -175,6 +181,13 @@ final class RecruitmentCallService {
 
 		$wpdb->query( 'COMMIT' );
 
+		RecruitmentActivityLogger::bulk_call_created(
+			$classification_ids,
+			$call_ids,
+			$date_to_assume,
+			$time_to_assume
+		);
+
 		return array(
 			'success'  => true,
 			'call_ids' => $call_ids,
@@ -244,6 +257,8 @@ final class RecruitmentCallService {
 			}
 
 			$wpdb->query( 'COMMIT' );
+
+			RecruitmentActivityLogger::call_cancelled( $call_id, $classification_id, $reason );
 
 			return array(
 				'success'  => true,

--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Candidate Repository
+ *
+ * CRUD for `ffc_recruitment_candidate` rows. Candidates start standalone
+ * (no `wp_users` link) and are promoted via `UserCreator::get_or_create_user()`
+ * — promotion logic lives in the service layer (sprint 4 for CSV import,
+ * sprint 9.1 for manual edits via REST). This repository exposes only:
+ *
+ * - CRUD primitives ({@see self::create()}, {@see self::update()},
+ *   {@see self::delete()}).
+ * - Hash-based lookups ({@see self::get_by_cpf_hash()},
+ *   {@see self::get_by_rf_hash()}, {@see self::get_by_email_hash()}).
+ * - The `user_id` setter for promotion ({@see self::set_user_id()}).
+ *
+ * `cpf_hash` and `rf_hash` carry separate UNIQUE constraints (DB-level): a
+ * second insert with a colliding hash returns `false`. The REST controller
+ * is responsible for surfacing this as a 409 with `existing_candidate_id`
+ * (sprint 9.1).
+ *
+ * `pcd_hash` is NOT NULL with both candidate domains
+ * (`HMAC(salt, ("1"|"0") || candidate_id)`). Computation lives in the
+ * service layer (sprint 4) — the repository accepts whatever string the
+ * caller supplies.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for `ffc_recruitment_candidate` rows.
+ *
+ * Encrypted columns (`*_encrypted`) and their corresponding hash columns
+ * (`*_hash`) follow the existing plugin convention (cf. `Activator::add_columns`):
+ * `*_encrypted` is TEXT, `*_hash` is VARCHAR(64). Encryption / hashing is
+ * delegated to {@see \FreeFormCertificate\Core\Encryption} at the service
+ * layer; this repository never touches plaintext values.
+ *
+ * @phpstan-type CandidateRow \stdClass&object{id: numeric-string, user_id: numeric-string|null, name: string, cpf_encrypted: string|null, cpf_hash: string|null, rf_encrypted: string|null, rf_hash: string|null, email_encrypted: string|null, email_hash: string|null, phone: string|null, notes: string|null, pcd_hash: string, created_at: string, updated_at: string}
+ */
+class CandidateRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_candidate';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_candidate';
+	}
+
+	/**
+	 * Get a candidate by ID.
+	 *
+	 * @param int $id Candidate ID.
+	 * @return CandidateRow|null
+	 */
+	public static function get_by_id( int $id ): ?object {
+		$cached = static::cache_get( "id_{$id}" );
+		if ( false !== $cached ) {
+			/**
+			 * Object-cache return cast.
+			 *
+			 * @var CandidateRow|null $cached
+			 */
+			return $cached;
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CandidateRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Object-cached; %i for table identifier.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $id )
+		);
+
+		if ( $result ) {
+			static::cache_set( "id_{$id}", $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Look up a candidate by CPF hash.
+	 *
+	 * Used by the CSV importer to detect cross-CSV / cross-notice reuse: a
+	 * matching `cpf_hash` reuses the existing candidate row (with new
+	 * classifications added) instead of creating a duplicate.
+	 *
+	 * @param string $cpf_hash Hash produced by `Encryption::hash()`.
+	 * @return CandidateRow|null
+	 */
+	public static function get_by_cpf_hash( string $cpf_hash ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CandidateRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed by UNIQUE constraint.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE cpf_hash = %s LIMIT 1', $table, $cpf_hash )
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * Look up a candidate by RF hash.
+	 *
+	 * @param string $rf_hash Hash produced by `Encryption::hash()`.
+	 * @return CandidateRow|null
+	 */
+	public static function get_by_rf_hash( string $rf_hash ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CandidateRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed by UNIQUE constraint (RF).
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE rf_hash = %s LIMIT 1', $table, $rf_hash )
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * Look up the first candidate matching a given email hash.
+	 *
+	 * `email_hash` is NOT enforced UNIQUE (see schema rationale in §3.4 of
+	 * the implementation plan: candidates may share an email address —
+	 * e.g. family members — so the unique key is CPF/RF). When multiple
+	 * candidates share the same email, the FIRST inserted is returned;
+	 * callers needing all matches should use a different query.
+	 *
+	 * @param string $email_hash Hash produced by `Encryption::hash()`.
+	 * @return CandidateRow|null
+	 */
+	public static function get_by_email_hash( string $email_hash ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var CandidateRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed (non-unique) lookup.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE email_hash = %s ORDER BY id ASC LIMIT 1', $table, $email_hash )
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * Get the candidate row for a logged-in WP user.
+	 *
+	 * Powers the candidate-self dashboard section ({@see GET /me/recruitment}).
+	 * A candidate may be linked to at most one `wp_users.ID` per row, but a
+	 * single user could in principle have multiple candidate rows (across
+	 * notices) — although in practice the unique CPF/RF constraints keep
+	 * cardinality low. This method returns ALL candidate rows for a user.
+	 *
+	 * @param int $user_id WP user ID.
+	 * @return list<CandidateRow>
+	 */
+	public static function get_by_user_id( int $user_id ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<CandidateRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed by user_id.
+		$results = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE user_id = %d', $table, $user_id )
+		);
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Insert a new candidate row.
+	 *
+	 * Required keys: `name`, `pcd_hash`. At least one of `cpf_hash` or
+	 * `rf_hash` must be present (caller's responsibility; the schema does
+	 * NOT enforce this — both columns allow NULL because UNIQUE indexes
+	 * permit multiple NULLs in MySQL).
+	 *
+	 * Optional keys: `user_id`, `cpf_encrypted`, `cpf_hash`, `rf_encrypted`,
+	 * `rf_hash`, `email_encrypted`, `email_hash`, `phone`, `notes`.
+	 *
+	 * Returns `false` on UNIQUE collision (`cpf_hash` or `rf_hash` already
+	 * present on another row) or other DB failure.
+	 *
+	 * @param array<string, mixed> $data Candidate payload (see allowed keys above).
+	 * @return int|false New candidate ID or false on failure.
+	 */
+	public static function create( array $data ) {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		if ( ! isset( $data['name'], $data['pcd_hash'] ) || ! is_string( $data['name'] ) || ! is_string( $data['pcd_hash'] ) ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql' );
+
+		$insert = array(
+			'name'       => $data['name'],
+			'pcd_hash'   => $data['pcd_hash'],
+			'created_at' => $now,
+			'updated_at' => $now,
+		);
+		$format = array( '%s', '%s', '%s', '%s' );
+
+		$optional_columns = array(
+			'user_id'         => '%d',
+			'cpf_encrypted'   => '%s',
+			'cpf_hash'        => '%s',
+			'rf_encrypted'    => '%s',
+			'rf_hash'         => '%s',
+			'email_encrypted' => '%s',
+			'email_hash'      => '%s',
+			'phone'           => '%s',
+			'notes'           => '%s',
+		);
+
+		foreach ( $optional_columns as $column => $column_format ) {
+			if ( array_key_exists( $column, $data ) && null !== $data[ $column ] ) {
+				$insert[ $column ] = $data[ $column ];
+				$format[]          = $column_format;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper.
+		$result = $wpdb->insert( $table, $insert, $format );
+
+		if ( ! $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Update mutable candidate fields.
+	 *
+	 * Accepted keys: `name`, `phone`, `notes`, `cpf_encrypted` + `cpf_hash`
+	 * (must be supplied together), `rf_encrypted` + `rf_hash` (together),
+	 * `email_encrypted` + `email_hash` (together).
+	 *
+	 * `user_id` is NOT writable here — use {@see self::set_user_id()} for
+	 * promotion. `pcd_hash` is NOT writable — PCD value is set on creation
+	 * only (sprint 4 enforces "PCD is CSV-only" per §12).
+	 *
+	 * @param int                  $id   Candidate ID.
+	 * @param array<string, mixed> $data Update payload.
+	 * @return bool
+	 */
+	public static function update( int $id, array $data ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$update = array();
+		$format = array();
+
+		$writable = array(
+			'name'            => '%s',
+			'phone'           => '%s',
+			'notes'           => '%s',
+			'cpf_encrypted'   => '%s',
+			'cpf_hash'        => '%s',
+			'rf_encrypted'    => '%s',
+			'rf_hash'         => '%s',
+			'email_encrypted' => '%s',
+			'email_hash'      => '%s',
+		);
+
+		foreach ( $writable as $column => $column_format ) {
+			if ( array_key_exists( $column, $data ) ) {
+				$update[ $column ] = $data[ $column ];
+				$format[]          = $column_format;
+			}
+		}
+
+		if ( empty( $update ) ) {
+			return false;
+		}
+
+		$update['updated_at'] = current_time( 'mysql' );
+		$format[]             = '%s';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update via wpdb helper.
+		$result = $wpdb->update( $table, $update, array( 'id' => $id ), $format, array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Set or clear the linked `wp_users.ID` (promotion / un-link).
+	 *
+	 * Called by the service layer after `UserCreator::get_or_create_user()`
+	 * resolves a `wp_user` ID. Pass `null` to detach (rare; mostly for tests).
+	 *
+	 * @param int      $id Candidate ID.
+	 * @param int|null $user_id WP user ID, or null to clear.
+	 * @return bool
+	 */
+	public static function set_user_id( int $id, ?int $user_id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update via wpdb helper.
+		$result = $wpdb->update(
+			$table,
+			array(
+				'user_id'    => $user_id,
+				'updated_at' => current_time( 'mysql' ),
+			),
+			array( 'id' => $id ),
+			array( '%d', '%s' ),
+			array( '%d' )
+		);
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Hard-delete a candidate row unconditionally.
+	 *
+	 * Deletion gating (zero classifications) lives in the REST controller
+	 * (sprint 7); this method is a pure CRUD primitive and assumes the
+	 * caller has already verified the gate. The linked `wp_user` (if any)
+	 * is preserved — the recruitment module never deletes WP users.
+	 *
+	 * @param int $id Candidate ID.
+	 * @return bool
+	 */
+	public static function delete( int $id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete via wpdb helper.
+		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @phpstan-type CandidateRow \stdClass&object{id: numeric-string, user_id: numeric-string|null, name: string, cpf_encrypted: string|null, cpf_hash: string|null, rf_encrypted: string|null, rf_hash: string|null, email_encrypted: string|null, email_hash: string|null, phone: string|null, notes: string|null, pcd_hash: string, created_at: string, updated_at: string}
  */
-class CandidateRepository {
+class RecruitmentCandidateRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 

--- a/includes/recruitment/class-ffc-recruitment-classification-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-repository.php
@@ -1,0 +1,420 @@
+<?php
+/**
+ * Classification Repository
+ *
+ * CRUD for `ffc_recruitment_classification` rows — a candidate's standing per
+ * (adjutancy, notice, list_type). Atomic state-machine transitions are
+ * exposed via {@see self::set_status()} for use by the state machine and
+ * convocation service (sprints 5 / 6) — those rely on conditional
+ * `UPDATE … WHERE status = '<expected>'` to win/lose races without losing
+ * data integrity.
+ *
+ * The hot path "lowest-rank empty for this adjutancy/notice/list_type" used
+ * by the in-order convocation check is served by the composite index
+ * `(notice_id, adjutancy_id, list_type, status, rank)` declared in the
+ * activator.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for `ffc_recruitment_classification` rows.
+ *
+ * Status enum values: `empty`, `called`, `accepted`, `not_shown`, `hired`.
+ * `list_type` enum values: `preview`, `definitive`. Per the §5.2 invariant,
+ * rows with `list_type='preview'` are always `status='empty'` (convocation
+ * acts only on `definitive`); the repository does NOT enforce this — the
+ * service layer (sprint 4 importer + sprint 6 convocation) is responsible.
+ *
+ * @phpstan-type ClassificationRow \stdClass&object{id: numeric-string, candidate_id: numeric-string, adjutancy_id: numeric-string, notice_id: numeric-string, list_type: string, rank: numeric-string, score: string, status: string, created_at: string, updated_at: string}
+ */
+class ClassificationRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_classification';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_classification';
+	}
+
+	/**
+	 * Get a classification row by ID.
+	 *
+	 * @param int $id Classification ID.
+	 * @return ClassificationRow|null
+	 */
+	public static function get_by_id( int $id ): ?object {
+		$cached = static::cache_get( "id_{$id}" );
+		if ( false !== $cached ) {
+			/**
+			 * Object-cache return cast.
+			 *
+			 * @var ClassificationRow|null $cached
+			 */
+			return $cached;
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var ClassificationRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Object-cached.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $id )
+		);
+
+		if ( $result ) {
+			static::cache_set( "id_{$id}", $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * List classifications for a notice, optionally filtered by list_type / adjutancy.
+	 *
+	 * Sort is `(rank ASC, candidate_id ASC)` — matches the public shortcode's
+	 * tie-break rule (§3 Naming & Conventions of the implementation plan).
+	 *
+	 * @param int         $notice_id Notice ID.
+	 * @param string|null $list_type Optional `preview` or `definitive`.
+	 * @param int|null    $adjutancy_id Optional adjutancy filter.
+	 * @return list<ClassificationRow>
+	 */
+	public static function get_for_notice( int $notice_id, ?string $list_type = null, ?int $adjutancy_id = null ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$where  = array( 'notice_id = %d' );
+		$values = array( $notice_id );
+
+		if ( null !== $list_type ) {
+			$where[]  = 'list_type = %s';
+			$values[] = $list_type;
+		}
+
+		if ( null !== $adjutancy_id ) {
+			$where[]  = 'adjutancy_id = %d';
+			$values[] = $adjutancy_id;
+		}
+
+		$where_sql = implode( ' AND ', $where );
+
+		$sql = "SELECT * FROM %i WHERE {$where_sql} ORDER BY `rank` ASC, candidate_id ASC";
+
+		$prepare_args = array_merge( array( $table ), $values );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $where_sql is built from internal placeholders only.
+		$prepared = $wpdb->prepare( $sql, $prepare_args );
+		if ( ! is_string( $prepared ) ) {
+			return array();
+		}
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<ClassificationRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $prepared );
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Get all classifications for a single candidate, across notices.
+	 *
+	 * Powers the candidate hard-delete gate (sprint 7: deletion requires
+	 * zero rows) and the candidate-self dashboard query (sprint 12).
+	 *
+	 * @param int $candidate_id Candidate ID.
+	 * @return list<ClassificationRow>
+	 */
+	public static function get_for_candidate( int $candidate_id ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb results to typed shape.
+		 *
+		 * @var list<ClassificationRow>|null $results
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed by candidate_id.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE candidate_id = %d ORDER BY notice_id ASC, adjutancy_id ASC',
+				$table,
+				$candidate_id
+			)
+		);
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Count classifications for a candidate. Powers the hard-delete gate.
+	 *
+	 * @param int $candidate_id Candidate ID.
+	 * @return int
+	 */
+	public static function count_for_candidate( int $candidate_id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Index-only count.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE candidate_id = %d', $table, $candidate_id )
+		);
+
+		return $count;
+	}
+
+	/**
+	 * Count classifications referencing a given adjutancy. Used by the
+	 * adjutancy deletion gate (sprint 7).
+	 *
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return int
+	 */
+	public static function count_for_adjutancy( int $adjutancy_id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Index range scan covered by composite (notice, adjutancy, list_type, status, rank).
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE adjutancy_id = %d', $table, $adjutancy_id )
+		);
+
+		return $count;
+	}
+
+	/**
+	 * Find the lowest-rank `empty` classification for a notice/adjutancy/list_type.
+	 *
+	 * Powers the in-order convocation check (sprint 6): if the candidate the
+	 * admin is calling does NOT match this row's id, the call is "out of
+	 * order" and requires a reason.
+	 *
+	 * Tie-break is `(rank ASC, candidate_id ASC)` — same as the public sort.
+	 *
+	 * @param int    $notice_id Notice ID.
+	 * @param int    $adjutancy_id Adjutancy ID.
+	 * @param string $list_type `preview` or `definitive` (typically `definitive`).
+	 * @return ClassificationRow|null
+	 */
+	public static function find_lowest_rank_empty( int $notice_id, int $adjutancy_id, string $list_type ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var ClassificationRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Hot path; covered by composite index.
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i
+                  WHERE notice_id = %d AND adjutancy_id = %d AND list_type = %s AND status = %s
+                  ORDER BY `rank` ASC, candidate_id ASC LIMIT 1',
+				$table,
+				$notice_id,
+				$adjutancy_id,
+				$list_type,
+				'empty'
+			)
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * Insert a new classification row.
+	 *
+	 * Required keys: `candidate_id`, `adjutancy_id`, `notice_id`, `list_type`,
+	 * `rank`, `score`. Optional `status` (defaults to `empty`).
+	 *
+	 * Returns `false` on UNIQUE collision
+	 * `(candidate_id, adjutancy_id, notice_id, list_type)`.
+	 *
+	 * @param array{candidate_id: int, adjutancy_id: int, notice_id: int, list_type: string, rank: int, score: string|float, status?: string} $data Classification payload.
+	 * @return int|false New classification ID or false on failure.
+	 */
+	public static function create( array $data ) {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now = current_time( 'mysql' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper.
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'candidate_id' => $data['candidate_id'],
+				'adjutancy_id' => $data['adjutancy_id'],
+				'notice_id'    => $data['notice_id'],
+				'list_type'    => $data['list_type'],
+				'rank'         => $data['rank'],
+				'score'        => (string) $data['score'],
+				'status'       => $data['status'] ?? 'empty',
+				'created_at'   => $now,
+				'updated_at'   => $now,
+			),
+			array( '%d', '%d', '%d', '%s', '%d', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( ! $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Atomic conditional status transition.
+	 *
+	 * Performs `UPDATE … SET status=$new WHERE id=$id AND status=$expected`.
+	 * Returns the affected-row count (0 or 1) so callers can detect a lost
+	 * race. The state machine wraps this with transition validity / reason
+	 * checks (sprint 5) and the convocation service uses it for atomic call
+	 * creation (sprint 6).
+	 *
+	 * @param int    $id Classification ID.
+	 * @param string $expected_current Expected current status.
+	 * @param string $new_status Target status.
+	 * @return int Number of rows affected.
+	 */
+	public static function set_status( int $id, string $expected_current, string $new_status ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET status = %s, updated_at = %s WHERE id = %d AND status = %s',
+			$table,
+			$new_status,
+			current_time( 'mysql' ),
+			$id,
+			$expected_current
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Atomic state transition; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Bulk-delete all classifications for a notice + list_type pair.
+	 *
+	 * Used by the CSV importer's atomic wipe-and-reinsert (sprint 4) and by
+	 * the promote-preview snapshot path (sprint 5). The caller is expected
+	 * to wrap this and the subsequent inserts in an InnoDB transaction so
+	 * the previous list is preserved on validation failure (see §6 of the
+	 * implementation plan).
+	 *
+	 * @param int    $notice_id Notice ID.
+	 * @param string $list_type `preview` or `definitive`.
+	 * @return int Number of rows deleted.
+	 */
+	public static function delete_all_for_notice_list( int $notice_id, string $list_type ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk delete; bounded by the notice's classification count.
+		$result = $wpdb->delete(
+			$table,
+			array(
+				'notice_id' => $notice_id,
+				'list_type' => $list_type,
+			),
+			array( '%d', '%s' )
+		);
+
+		return is_int( $result ) ? $result : 0;
+	}
+
+	/**
+	 * Hard-delete a single classification row.
+	 *
+	 * Deletion gating (`status='empty'` + notice in `draft`/`preliminary`)
+	 * lives at the service layer (sprint 7); this method is a pure CRUD
+	 * primitive.
+	 *
+	 * @param int $id Classification ID.
+	 * @return bool
+	 */
+	public static function delete( int $id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete via wpdb helper.
+		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Count calls in the entire history of a notice (across all classifications).
+	 *
+	 * Powers the `active → preliminary` gate (§5.1): the transition is only
+	 * allowed when zero calls have ever been issued on this notice
+	 * (including cancelled ones). This is implemented as a JOIN through
+	 * the call table because there's no direct notice_id column on calls.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @return int Total call rows for any classification of this notice.
+	 */
+	public static function count_calls_for_notice( int $notice_id ): int {
+		$wpdb        = self::db();
+		$table       = self::get_table_name();
+		$calls_table = self::db()->prefix . 'ffc_recruitment_call';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cross-table count for state-machine gate.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i c
+                  INNER JOIN %i cl ON cl.id = c.classification_id
+                  WHERE cl.notice_id = %d',
+				$calls_table,
+				$table,
+				$notice_id
+			)
+		);
+
+		return $count;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-classification-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-repository.php
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @phpstan-type ClassificationRow \stdClass&object{id: numeric-string, candidate_id: numeric-string, adjutancy_id: numeric-string, notice_id: numeric-string, list_type: string, rank: numeric-string, score: string, status: string, created_at: string, updated_at: string}
  */
-class ClassificationRepository {
+class RecruitmentClassificationRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 

--- a/includes/recruitment/class-ffc-recruitment-classification-state-machine.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-state-machine.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Recruitment Classification State Machine
+ *
+ * Authoritative source of truth for the §5.2 classification lifecycle:
+ *
+ *   empty → called → accepted → hired
+ *                ↓         ↓        (terminal)
+ *                ↓         not_shown → empty (reopen)
+ *                ↓
+ *                empty (cancel)
+ *
+ * Atomic transitions go through {@see RecruitmentClassificationRepository::set_status},
+ * which uses a `WHERE status = '<expected>'` guard. Lost races (concurrent
+ * writer claimed the row first) surface as `recruitment_state_locked`.
+ *
+ * Reason gating mirrors §5.2:
+ *
+ *   - empty → called (in order)     : no reason
+ *   - empty → called (out of order) : reason REQUIRED — handled by sprint 6
+ *                                     {@see RecruitmentCallService}, which
+ *                                     calls `transition_to()` only after
+ *                                     building the call row with
+ *                                     `out_of_order_reason` set.
+ *   - called → accepted             : no reason
+ *   - called → not_shown            : no reason
+ *   - called → hired                : no reason
+ *   - called → empty (cancel)       : reason REQUIRED
+ *   - accepted → hired              : no reason
+ *   - accepted → not_shown          : no reason
+ *   - accepted → empty (cancel)     : reason REQUIRED
+ *   - not_shown → empty (reopen)    : reason REQUIRED — BUT BLOCKED if
+ *                                     the parent notice's `was_reopened = 1`
+ *                                     (§5.1 reopen-freeze rule)
+ *   - hired → *                     : BLOCKED (terminal)
+ *
+ * The reopen-freeze rule: once a notice has gone through `closed → active`
+ * at least once, all classifications in `hired` or `not_shown` are
+ * permanently locked for that notice. Realized outcomes shouldn't be
+ * retroactively undone by a reopen.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Service: transition a classification's status with full lifecycle rules.
+ *
+ * Returns the same `array{success, errors}` envelope as
+ * {@see RecruitmentNoticeStateMachine}.
+ *
+ * @phpstan-type TransitionResult array{success: bool, errors: list<string>}
+ */
+final class RecruitmentClassificationStateMachine {
+
+	/**
+	 * Allowed transitions, expressed as `from => list<to>`.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const TRANSITIONS = array(
+		'empty'     => array( 'called' ),
+		'called'    => array( 'accepted', 'not_shown', 'hired', 'empty' ),
+		'accepted'  => array( 'hired', 'not_shown', 'empty' ),
+		'not_shown' => array( 'empty' ),
+		'hired'     => array(), // Terminal — no transitions out.
+	);
+
+	/**
+	 * Transitions that require a non-empty reason string.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const REASON_REQUIRED = array(
+		'called'    => array( 'empty' ),
+		'accepted'  => array( 'empty' ),
+		'not_shown' => array( 'empty' ),
+	);
+
+	/**
+	 * Attempt to transition a classification to a new status.
+	 *
+	 * Out-of-order calls (`empty → called` with a reason) are handled by
+	 * the convocation service in sprint 6, which performs the atomic UPDATE
+	 * directly on the repository to keep the call-creation and
+	 * status-change in a single conditional UPDATE per row. This method is
+	 * for the post-call lifecycle (called/accepted/hired/not_shown/cancel/reopen).
+	 *
+	 * @param int         $classification_id Target classification.
+	 * @param string      $new_status `empty|called|accepted|not_shown|hired`.
+	 * @param string|null $reason     Required when cancelling (`* → empty`).
+	 * @return TransitionResult
+	 */
+	public static function transition_to( int $classification_id, string $new_status, ?string $reason = null ): array {
+		$classification = RecruitmentClassificationRepository::get_by_id( $classification_id );
+		if ( null === $classification ) {
+			return self::failure( 'recruitment_classification_not_found' );
+		}
+
+		$current = $classification->status;
+
+		// Idempotent same-state.
+		if ( $current === $new_status ) {
+			return self::success();
+		}
+
+		// Validate the requested transition.
+		$allowed = self::TRANSITIONS[ $current ] ?? array();
+		if ( ! in_array( $new_status, $allowed, true ) ) {
+			if ( 'hired' === $current ) {
+				return self::failure( 'recruitment_state_terminal_hired' );
+			}
+			return self::failure( 'recruitment_invalid_transition: ' . $current . '->' . $new_status );
+		}
+
+		// Reason gating.
+		if ( self::is_reason_required( $current, $new_status ) ) {
+			if ( null === $reason || '' === trim( $reason ) ) {
+				return self::failure( 'recruitment_transition_reason_required' );
+			}
+		}
+
+		// Reopen-freeze rule: once `notice.was_reopened = 1`, transitions
+		// out of `hired` and `not_shown` are blocked. `hired` is already
+		// caught by the terminal check above; `not_shown → empty` would
+		// otherwise be allowed — gate it here.
+		if ( 'not_shown' === $current && 'empty' === $new_status ) {
+			$notice_id = (int) $classification->notice_id;
+			$notice    = RecruitmentNoticeRepository::get_by_id( $notice_id );
+			if ( null !== $notice && '1' === $notice->was_reopened ) {
+				return self::failure( 'recruitment_reopen_freeze_active' );
+			}
+		}
+
+		// Atomic transition (race-safe).
+		$affected = RecruitmentClassificationRepository::set_status(
+			$classification_id,
+			$current,
+			$new_status
+		);
+		if ( 1 !== $affected ) {
+			return self::failure( 'recruitment_state_locked' );
+		}
+
+		return self::success();
+	}
+
+	/**
+	 * Whether the given transition pair requires a reason.
+	 *
+	 * @param string $from From status.
+	 * @param string $to   To status.
+	 * @return bool
+	 */
+	private static function is_reason_required( string $from, string $to ): bool {
+		$gated = self::REASON_REQUIRED[ $from ] ?? array();
+		return in_array( $to, $gated, true );
+	}
+
+	/**
+	 * Build a successful transition envelope.
+	 *
+	 * @return TransitionResult
+	 */
+	private static function success(): array {
+		return array(
+			'success' => true,
+			'errors'  => array(),
+		);
+	}
+
+	/**
+	 * Build a failed transition envelope.
+	 *
+	 * @param string $code Stable error code.
+	 * @return TransitionResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success' => false,
+			'errors'  => array( $code ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-classification-state-machine.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-state-machine.php
@@ -150,6 +150,13 @@ final class RecruitmentClassificationStateMachine {
 			return self::failure( 'recruitment_state_locked' );
 		}
 
+		RecruitmentActivityLogger::classification_status_changed(
+			$classification_id,
+			$current,
+			$new_status,
+			$reason
+		);
+
 		return self::success();
 	}
 

--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -194,6 +194,8 @@ final class RecruitmentCsvImporter {
 
 			$wpdb->query( 'COMMIT' );
 
+			RecruitmentActivityLogger::csv_imported( $notice_id, $list_type, $inserted );
+
 			return array(
 				'success'  => true,
 				'inserted' => $inserted,
@@ -555,6 +557,7 @@ final class RecruitmentCsvImporter {
 
 		if ( is_int( $user_id ) && $user_id > 0 ) {
 			RecruitmentCandidateRepository::set_user_id( $candidate_id, $user_id );
+			RecruitmentActivityLogger::candidate_promoted( $candidate_id, $user_id );
 		}
 	}
 

--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -1,0 +1,692 @@
+<?php
+/**
+ * Recruitment CSV Importer
+ *
+ * Atomic CSV-driven population of the recruitment classification list for a
+ * given notice. The full input is parsed, validated, then either written in
+ * a single InnoDB transaction (wipe-and-reinsert) or rolled back so the
+ * previous list survives any validation failure.
+ *
+ * Acts as a service layer over the recruitment repositories: the importer
+ * never bypasses {@see RecruitmentCandidateRepository} / {@see
+ * RecruitmentClassificationRepository} writes, and it delegates wp_user
+ * promotion to the existing {@see \FreeFormCertificate\UserDashboard\UserCreator}
+ * (called with the new {@see CapabilityManager::CONTEXT_RECRUITMENT}).
+ *
+ * Validation rules implemented (mirroring §6 of the implementation plan):
+ *
+ *   - Headers in English only; missing required headers fail the import.
+ *   - At least one of `cpf` / `rf` per row.
+ *   - CPF / RF: digits only (punctuation rejected).
+ *   - email: lowercased on import; falsy is allowed (no email is the
+ *     "candidate not promoted yet" signal).
+ *   - score: dot-decimal only (comma rejected).
+ *   - adjutancy slug must exist AND be attached to the notice via the
+ *     `ffc_recruitment_notice_adjutancy` junction.
+ *   - duplicate (cpf + adjutancy) within the CSV → reject.
+ *   - same CPF appearing in N rows must agree on candidate-level fields
+ *     (name / rf / email / phone / pcd) — first row wins as reference.
+ *   - empty rows (every column blank/whitespace) are silently skipped.
+ *   - notice must be in `draft` or `preliminary` for `preview` imports.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\Encryption;
+use FreeFormCertificate\UserDashboard\CapabilityManager;
+use FreeFormCertificate\UserDashboard\UserCreator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+/**
+ * Service: parse + validate + write recruitment CSV imports atomically.
+ *
+ * All public methods return a result envelope:
+ *
+ *   array{
+ *     success:  bool,
+ *     inserted: int,                 // candidate+classification rows committed
+ *     errors:   list<string>,        // human-readable, line-numbered when row-specific
+ *   }
+ *
+ * On `success: false` the database is unchanged (rollback). On `success: true`
+ * the candidate and classification tables reflect the imported list and the
+ * previous list (if any) for the same `(notice_id, list_type)` has been
+ * wiped.
+ *
+ * @phpstan-type ImportResult array{success: bool, inserted: int, errors: list<string>}
+ */
+final class RecruitmentCsvImporter {
+
+	/**
+	 * Required CSV headers (all in English).
+	 */
+	private const REQUIRED_HEADERS = array( 'name', 'cpf', 'rf', 'email', 'adjutancy', 'rank', 'score', 'pcd' );
+
+	/**
+	 * Optional CSV headers.
+	 */
+	private const OPTIONAL_HEADERS = array( 'phone' );
+
+	/**
+	 * Run a `preview` import on a notice in `draft` or `preliminary` state.
+	 *
+	 * Used by `POST /notices/{id}/import` (sprint 9.1). Sprint 5's notice
+	 * state machine surfaces a friendlier error if the notice is in
+	 * `active` / `closed`; this importer just checks for the basic
+	 * write-eligible states.
+	 *
+	 * @param int    $notice_id Target notice.
+	 * @param string $csv_content Raw CSV bytes (UTF-8, with or without BOM).
+	 * @return ImportResult
+	 */
+	public static function import_preview( int $notice_id, string $csv_content ): array {
+		$notice = RecruitmentNoticeRepository::get_by_id( $notice_id );
+		if ( null === $notice ) {
+			return self::failure( 'recruitment_notice_not_found' );
+		}
+
+		$status = $notice->status;
+		if ( 'draft' !== $status && 'preliminary' !== $status ) {
+			return self::failure( 'recruitment_invalid_state_for_preview_import' );
+		}
+
+		return self::run( $notice_id, $csv_content, 'preview' );
+	}
+
+	/**
+	 * Run a `definitive` import on a notice during the promote-preview flow.
+	 *
+	 * Caller (sprint 5's PromotionService) is responsible for gating this on
+	 * the 15s countdown + zero-calls-history check. The importer only
+	 * verifies the notice exists and writes to `list_type='definitive'`,
+	 * wiping any pre-existing definitive rows in the same transaction.
+	 *
+	 * @param int    $notice_id Target notice.
+	 * @param string $csv_content Raw CSV bytes.
+	 * @return ImportResult
+	 */
+	public static function import_definitive( int $notice_id, string $csv_content ): array {
+		$notice = RecruitmentNoticeRepository::get_by_id( $notice_id );
+		if ( null === $notice ) {
+			return self::failure( 'recruitment_notice_not_found' );
+		}
+
+		return self::run( $notice_id, $csv_content, 'definitive' );
+	}
+
+	/**
+	 * Core import flow: parse → validate → atomic wipe-and-reinsert.
+	 *
+	 * Returns an envelope; never throws. The transaction is rolled back on
+	 * any validation error or DB failure. On success, all rows are committed
+	 * and the previous list for `(notice_id, list_type)` has been replaced.
+	 *
+	 * @param int    $notice_id Notice ID.
+	 * @param string $csv_content Raw CSV bytes.
+	 * @param string $list_type `preview` or `definitive`.
+	 * @return ImportResult
+	 */
+	private static function run( int $notice_id, string $csv_content, string $list_type ): array {
+		// Step 1: parse CSV into normalized row arrays.
+		$parse = self::parse( $csv_content );
+		if ( ! $parse['ok'] ) {
+			return self::failure_with_messages( $parse['errors'] );
+		}
+		$rows = $parse['rows'];
+
+		if ( empty( $rows ) ) {
+			return self::failure( 'recruitment_csv_empty' );
+		}
+
+		// Step 2: build adjutancy slug → id map for this notice.
+		$adjutancy_map = self::build_adjutancy_map( $notice_id );
+		if ( empty( $adjutancy_map ) ) {
+			return self::failure( 'recruitment_notice_has_no_adjutancies' );
+		}
+
+		// Step 3: domain-level validation across all rows.
+		$validation = self::validate( $rows, $notice_id, $list_type, $adjutancy_map );
+		if ( ! empty( $validation ) ) {
+			return self::failure_with_messages( $validation );
+		}
+
+		// Step 4: transactional write.
+		global $wpdb;
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			RecruitmentClassificationRepository::delete_all_for_notice_list( $notice_id, $list_type );
+
+			$inserted = 0;
+			foreach ( $rows as $row ) {
+				$candidate_id = self::upsert_candidate( $row );
+				if ( false === $candidate_id ) {
+					$wpdb->query( 'ROLLBACK' );
+					return self::failure( 'recruitment_candidate_upsert_failed' );
+				}
+
+				$classification_id = RecruitmentClassificationRepository::create(
+					array(
+						'candidate_id' => $candidate_id,
+						'adjutancy_id' => $adjutancy_map[ $row['adjutancy'] ],
+						'notice_id'    => $notice_id,
+						'list_type'    => $list_type,
+						'rank'         => $row['rank'],
+						'score'        => $row['score'],
+					)
+				);
+				if ( false === $classification_id ) {
+					$wpdb->query( 'ROLLBACK' );
+					return self::failure( 'recruitment_classification_insert_failed' );
+				}
+
+				++$inserted;
+			}
+
+			$wpdb->query( 'COMMIT' );
+
+			return array(
+				'success'  => true,
+				'inserted' => $inserted,
+				'errors'   => array(),
+			);
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			return self::failure( 'recruitment_import_unexpected_error: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Parse raw CSV content into normalized associative rows.
+	 *
+	 * @param string $content Raw CSV (UTF-8; BOM stripped if present).
+	 * @return array{ok: bool, rows: list<array<string, mixed>>, errors: list<string>}
+	 */
+	public static function parse( string $content ): array {
+		$content = self::strip_utf8_bom( $content );
+		if ( '' === trim( $content ) ) {
+			return array(
+				'ok'     => false,
+				'rows'   => array(),
+				'errors' => array( 'recruitment_csv_empty' ),
+			);
+		}
+
+		$lines = preg_split( "/\r\n|\n|\r/", $content );
+		if ( ! is_array( $lines ) ) {
+			return array(
+				'ok'     => false,
+				'rows'   => array(),
+				'errors' => array( 'recruitment_csv_unparseable' ),
+			);
+		}
+
+		// Header row.
+		$header_line = array_shift( $lines );
+		$headers     = self::parse_csv_line( (string) $header_line );
+		$headers     = array_map( 'strtolower', array_map( 'trim', $headers ) );
+
+		$missing = array_diff( self::REQUIRED_HEADERS, $headers );
+		if ( ! empty( $missing ) ) {
+			return array(
+				'ok'     => false,
+				'rows'   => array(),
+				'errors' => array( 'recruitment_csv_missing_headers: ' . implode( ',', $missing ) ),
+			);
+		}
+
+		// Build header → index map (keeps optional headers when present).
+		$index_map = array();
+		foreach ( $headers as $i => $name ) {
+			$index_map[ $name ] = $i;
+		}
+
+		$rows        = array();
+		$line_number = 1; // 1-based; header was line 1.
+		foreach ( $lines as $line ) {
+			++$line_number;
+			$line = (string) $line;
+
+			if ( '' === trim( $line ) ) {
+				continue; // empty rows skipped per §6.
+			}
+
+			$cells = self::parse_csv_line( $line );
+
+			// Skip rows that are all whitespace after parsing.
+			$any_value = false;
+			foreach ( $cells as $cell ) {
+				if ( '' !== trim( $cell ) ) {
+					$any_value = true;
+					break;
+				}
+			}
+			if ( ! $any_value ) {
+				continue;
+			}
+
+			$row          = self::build_row( $cells, $index_map );
+			$row['_line'] = $line_number;
+			$rows[]       = $row;
+		}
+
+		return array(
+			'ok'     => true,
+			'rows'   => $rows,
+			'errors' => array(),
+		);
+	}
+
+	/**
+	 * Validate every row against the §6 rules.
+	 *
+	 * @param list<array<string, mixed>> $rows Parsed rows.
+	 * @param int                        $notice_id Target notice.
+	 * @param string                     $list_type `preview` or `definitive`.
+	 * @param array<string, int>         $adjutancy_map Slug → id for the notice.
+	 * @return list<string> Validation errors (empty on success).
+	 */
+	private static function validate( array $rows, int $notice_id, string $list_type, array $adjutancy_map ): array {
+		$errors    = array();
+		$by_cpf    = array(); // cpf → first-seen row reference (for cross-row consistency).
+		$seen_pair = array(); // "cpf|adjutancy" → line number, for duplicate detection.
+
+		foreach ( $rows as $row ) {
+			$line = (int) $row['_line'];
+
+			// CPF / RF presence + digits-only.
+			$cpf = is_string( $row['cpf'] ) ? trim( $row['cpf'] ) : '';
+			$rf  = is_string( $row['rf'] ) ? trim( $row['rf'] ) : '';
+			if ( '' === $cpf && '' === $rf ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_missing_cpf_or_rf' );
+				continue;
+			}
+			if ( '' !== $cpf && ! ctype_digit( $cpf ) ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_cpf_must_be_digits_only' );
+				continue;
+			}
+			if ( '' !== $rf && ! ctype_digit( $rf ) ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_rf_must_be_digits_only' );
+				continue;
+			}
+
+			// Score: dot-decimal only (or integer).
+			$score_raw = is_string( $row['score'] ) ? trim( $row['score'] ) : (string) $row['score'];
+			if ( '' === $score_raw ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_missing_score' );
+				continue;
+			}
+			if ( false !== strpos( $score_raw, ',' ) ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_score_uses_comma_decimal' );
+				continue;
+			}
+			if ( ! preg_match( '/^-?\d+(\.\d+)?$/', $score_raw ) ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_score_invalid_format' );
+				continue;
+			}
+
+			// Rank: positive integer.
+			$rank_raw = is_string( $row['rank'] ) ? trim( $row['rank'] ) : (string) $row['rank'];
+			if ( ! ctype_digit( $rank_raw ) || (int) $rank_raw < 1 ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_rank_invalid' );
+				continue;
+			}
+
+			// Adjutancy slug must exist for this notice.
+			$slug = is_string( $row['adjutancy'] ) ? trim( $row['adjutancy'] ) : '';
+			if ( '' === $slug ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_missing_adjutancy' );
+				continue;
+			}
+			if ( ! isset( $adjutancy_map[ $slug ] ) ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_adjutancy_not_in_notice: ' . $slug );
+				continue;
+			}
+
+			// Duplicate (cpf + adjutancy) within CSV.
+			if ( '' !== $cpf ) {
+				$key = $cpf . '|' . $slug;
+				if ( isset( $seen_pair[ $key ] ) ) {
+					$errors[] = self::line_error(
+						$line,
+						sprintf( 'recruitment_csv_duplicate_cpf_adjutancy: matches line %d', $seen_pair[ $key ] )
+					);
+					continue;
+				}
+				$seen_pair[ $key ] = $line;
+			}
+
+			// Same-CPF rows must agree on candidate-level fields.
+			if ( '' !== $cpf ) {
+				if ( isset( $by_cpf[ $cpf ] ) ) {
+					$ref = $by_cpf[ $cpf ];
+					foreach ( array( 'name', 'rf', 'email', 'phone', 'pcd' ) as $field ) {
+						$current = isset( $row[ $field ] ) && is_string( $row[ $field ] ) ? trim( $row[ $field ] ) : '';
+						$prior   = isset( $ref[ $field ] ) && is_string( $ref[ $field ] ) ? trim( $ref[ $field ] ) : '';
+						if ( $current !== $prior ) {
+							$errors[] = self::line_error(
+								$line,
+								sprintf(
+									'recruitment_csv_candidate_field_divergence: field=%s, ref_line=%d',
+									$field,
+									(int) $ref['_line']
+								)
+							);
+							continue 2; // skip the rest of this row's checks.
+						}
+					}
+				} else {
+					$by_cpf[ $cpf ] = $row;
+				}
+			}
+		}
+
+		// Existing-row collision: CSV row's (cpf, adjutancy, notice, list_type)
+		// already in DB. This catches re-importing the same row when wipe was
+		// not called (defensive — `run()` always wipes first, so this is
+		// effectively a same-CSV duplicate check via DB).
+		// Skipped here — `delete_all_for_notice_list()` runs before inserts,
+		// so any pre-existing row is gone. Future-proofing comment.
+
+		return $errors;
+	}
+
+	/**
+	 * Find or create a candidate row for the given input row.
+	 *
+	 * Existing candidate (matched by cpf_hash, then rf_hash) is reused —
+	 * additional rows in `classification` will reference it. New candidates
+	 * are inserted with a placeholder `pcd_hash`, then updated with the
+	 * proper HMAC once `candidate_id` is known.
+	 *
+	 * Promotion to wp_user is delegated to {@see UserCreator::get_or_create_user}
+	 * with the recruitment context — failures are silent (candidate stays
+	 * with `user_id = NULL`, which is the intended "not yet promoted" state).
+	 *
+	 * @param array<string, mixed> $row Validated row.
+	 * @return int|false Candidate ID, or false on DB failure.
+	 */
+	private static function upsert_candidate( array $row ) {
+		$cpf   = is_string( $row['cpf'] ) ? trim( $row['cpf'] ) : '';
+		$rf    = is_string( $row['rf'] ) ? trim( $row['rf'] ) : '';
+		$email = is_string( $row['email'] ) ? strtolower( trim( $row['email'] ) ) : '';
+		$name  = is_string( $row['name'] ) ? trim( $row['name'] ) : '';
+		$phone = is_string( $row['phone'] ) ? trim( $row['phone'] ) : '';
+		$pcd   = self::parse_pcd_flag( $row['pcd'] );
+
+		$cpf_hash   = '' !== $cpf ? Encryption::hash( $cpf ) : null;
+		$rf_hash    = '' !== $rf ? Encryption::hash( $rf ) : null;
+		$email_hash = '' !== $email ? Encryption::hash( $email ) : null;
+
+		// Look up existing candidate by cpf, then rf.
+		$existing = null;
+		if ( null !== $cpf_hash ) {
+			$existing = RecruitmentCandidateRepository::get_by_cpf_hash( $cpf_hash );
+		}
+		if ( null === $existing && null !== $rf_hash ) {
+			$existing = RecruitmentCandidateRepository::get_by_rf_hash( $rf_hash );
+		}
+
+		if ( null !== $existing ) {
+			$candidate_id = (int) $existing->id;
+
+			// Refresh mutable + previously-empty fields on the existing row;
+			// re-derive PCD hash so the new value (if any) takes effect.
+			RecruitmentCandidateRepository::update(
+				$candidate_id,
+				array_filter(
+					array(
+						'name'            => '' !== $name ? $name : null,
+						'phone'           => '' !== $phone ? $phone : null,
+						'cpf_encrypted'   => '' !== $cpf ? Encryption::encrypt( $cpf ) : null,
+						'cpf_hash'        => $cpf_hash,
+						'rf_encrypted'    => '' !== $rf ? Encryption::encrypt( $rf ) : null,
+						'rf_hash'         => $rf_hash,
+						'email_encrypted' => '' !== $email ? Encryption::encrypt( $email ) : null,
+						'email_hash'      => $email_hash,
+					),
+					static fn( $v ): bool => null !== $v
+				)
+			);
+
+			self::refresh_pcd_hash( $candidate_id, $pcd );
+			self::maybe_promote_candidate( $candidate_id, $cpf_hash, $rf_hash, $email );
+
+			return $candidate_id;
+		}
+
+		// New candidate: insert with placeholder pcd_hash, then UPDATE.
+		$insert_payload = array(
+			'name'     => $name,
+			'pcd_hash' => 'pending',
+		);
+		if ( '' !== $cpf ) {
+			$insert_payload['cpf_encrypted'] = Encryption::encrypt( $cpf );
+			$insert_payload['cpf_hash']      = $cpf_hash;
+		}
+		if ( '' !== $rf ) {
+			$insert_payload['rf_encrypted'] = Encryption::encrypt( $rf );
+			$insert_payload['rf_hash']      = $rf_hash;
+		}
+		if ( '' !== $email ) {
+			$insert_payload['email_encrypted'] = Encryption::encrypt( $email );
+			$insert_payload['email_hash']      = $email_hash;
+		}
+		if ( '' !== $phone ) {
+			$insert_payload['phone'] = $phone;
+		}
+
+		$candidate_id = RecruitmentCandidateRepository::create( $insert_payload );
+		if ( false === $candidate_id ) {
+			return false;
+		}
+
+		self::refresh_pcd_hash( (int) $candidate_id, $pcd );
+		self::maybe_promote_candidate( (int) $candidate_id, $cpf_hash, $rf_hash, $email );
+
+		return (int) $candidate_id;
+	}
+
+	/**
+	 * Recompute and persist `pcd_hash` for a candidate.
+	 *
+	 * @param int  $candidate_id Candidate ID.
+	 * @param bool $is_pcd       Whether the candidate is registered as PCD.
+	 * @return void
+	 */
+	private static function refresh_pcd_hash( int $candidate_id, bool $is_pcd ): void {
+		global $wpdb;
+		$table = RecruitmentCandidateRepository::get_table_name();
+		$hash  = RecruitmentPcdHasher::compute( $candidate_id, $is_pcd );
+
+		$wpdb->update(
+			$table,
+			array(
+				'pcd_hash'   => $hash,
+				'updated_at' => current_time( 'mysql' ),
+			),
+			array( 'id' => $candidate_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Best-effort wp_user link via UserCreator (no-op when nothing matches).
+	 *
+	 * UserCreator handles the §4 trigger logic: hash lookup against
+	 * `ffc_submissions`, email lookup against `wp_users`, and (for new emails)
+	 * user creation. Failures (e.g. `wp_create_user` rejecting an empty email)
+	 * are intentionally swallowed — the candidate stays `user_id=NULL`, which
+	 * is the documented "not yet promoted" state.
+	 *
+	 * @param int         $candidate_id Candidate row ID.
+	 * @param string|null $cpf_hash     SHA-256 hash of CPF (or null).
+	 * @param string|null $rf_hash      SHA-256 hash of RF (or null).
+	 * @param string      $email        Lowercased email (may be empty).
+	 * @return void
+	 */
+	private static function maybe_promote_candidate( int $candidate_id, ?string $cpf_hash, ?string $rf_hash, string $email ): void {
+		// Choose the most specific hash to send to UserCreator (cpf > rf > email).
+		$hash = $cpf_hash ?? $rf_hash ?? '';
+		if ( '' === $hash && '' === $email ) {
+			return;
+		}
+
+		if ( ! class_exists( UserCreator::class ) ) {
+			return;
+		}
+
+		$user_id = UserCreator::get_or_create_user(
+			$hash,
+			$email,
+			array(),
+			CapabilityManager::CONTEXT_RECRUITMENT
+		);
+
+		if ( is_int( $user_id ) && $user_id > 0 ) {
+			RecruitmentCandidateRepository::set_user_id( $candidate_id, $user_id );
+		}
+	}
+
+	/**
+	 * Build the slug → id map for adjutancies attached to a notice.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @return array<string, int> Slug → adjutancy ID.
+	 */
+	private static function build_adjutancy_map( int $notice_id ): array {
+		$ids = RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( $notice_id );
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$map = array();
+		foreach ( $ids as $id ) {
+			$adjutancy = RecruitmentAdjutancyRepository::get_by_id( $id );
+			if ( null !== $adjutancy ) {
+				$map[ $adjutancy->slug ] = $id;
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Strip a UTF-8 BOM if present.
+	 *
+	 * @param string $content Raw bytes.
+	 * @return string Content with BOM removed.
+	 */
+	private static function strip_utf8_bom( string $content ): string {
+		if ( 0 === strncmp( $content, "\xEF\xBB\xBF", 3 ) ) {
+			return substr( $content, 3 );
+		}
+		return $content;
+	}
+
+	/**
+	 * Parse a single CSV line using `str_getcsv` with default settings.
+	 *
+	 * @param string $line CSV line.
+	 * @return list<string>
+	 */
+	private static function parse_csv_line( string $line ): array {
+		$cells = str_getcsv( $line );
+		// Coerce nulls (str_getcsv returns null for missing cells in some versions) to empty strings.
+		return array_map(
+			static function ( $cell ): string {
+				return is_string( $cell ) ? $cell : '';
+			},
+			$cells
+		);
+	}
+
+	/**
+	 * Build an associative row from positional CSV cells using the header map.
+	 *
+	 * Missing optional columns are filled with empty strings so downstream
+	 * code can treat them uniformly.
+	 *
+	 * @param array             $cells     Cell values (list<string>).
+	 * @phpstan-param list<string> $cells
+	 * @param array<string,int> $index_map Header → column index.
+	 * @return array<string, string>
+	 */
+	private static function build_row( array $cells, array $index_map ): array {
+		$row = array();
+		foreach ( array_merge( self::REQUIRED_HEADERS, self::OPTIONAL_HEADERS ) as $name ) {
+			if ( isset( $index_map[ $name ], $cells[ $index_map[ $name ] ] ) ) {
+				$row[ $name ] = (string) $cells[ $index_map[ $name ] ];
+			} else {
+				$row[ $name ] = '';
+			}
+		}
+		return $row;
+	}
+
+	/**
+	 * Parse the `pcd` column into a boolean.
+	 *
+	 * Accepts (case-insensitive): true, 1, sim, yes → true. Anything else → false.
+	 *
+	 * @param mixed $value Raw cell value.
+	 * @return bool
+	 */
+	private static function parse_pcd_flag( $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		$normalized = strtolower( trim( (string) $value ) );
+		return in_array( $normalized, array( 'true', '1', 'sim', 'yes' ), true );
+	}
+
+	/**
+	 * Format a per-line error for the result envelope.
+	 *
+	 * @param int    $line     1-based line number.
+	 * @param string $code     Stable error code.
+	 * @return string
+	 */
+	private static function line_error( int $line, string $code ): string {
+		return sprintf( 'line=%d: %s', $line, $code );
+	}
+
+	/**
+	 * Build a failed-import result envelope with a single error.
+	 *
+	 * @param string $code Error code.
+	 * @return ImportResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success'  => false,
+			'inserted' => 0,
+			'errors'   => array( $code ),
+		);
+	}
+
+	/**
+	 * Build a failed-import result envelope with N errors.
+	 *
+	 * @param array $messages Error codes / messages (list<string>).
+	 * @phpstan-param list<string> $messages
+	 * @return ImportResult
+	 */
+	private static function failure_with_messages( array $messages ): array {
+		return array(
+			'success'  => false,
+			'inserted' => 0,
+			'errors'   => $messages,
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-delete-service.php
+++ b/includes/recruitment/class-ffc-recruitment-delete-service.php
@@ -92,6 +92,8 @@ final class RecruitmentDeleteService {
 			return self::failure( 'recruitment_candidate_delete_failed' );
 		}
 
+		RecruitmentActivityLogger::candidate_deleted( $candidate_id );
+
 		return self::success();
 	}
 
@@ -130,6 +132,8 @@ final class RecruitmentDeleteService {
 		if ( ! $ok ) {
 			return self::failure( 'recruitment_classification_delete_failed' );
 		}
+
+		RecruitmentActivityLogger::classification_deleted( $classification_id );
 
 		return self::success();
 	}
@@ -171,6 +175,8 @@ final class RecruitmentDeleteService {
 		if ( ! $ok ) {
 			return self::failure( 'recruitment_adjutancy_delete_failed' );
 		}
+
+		RecruitmentActivityLogger::adjutancy_deleted( $adjutancy_id );
 
 		return self::success();
 	}

--- a/includes/recruitment/class-ffc-recruitment-delete-service.php
+++ b/includes/recruitment/class-ffc-recruitment-delete-service.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Recruitment Delete Service
+ *
+ * Centralizes the §7-bis deletion gates so the REST controller (sprint 9.1)
+ * doesn't reimplement them and so each gate exposes a typed result envelope
+ * with the blocking reference count when applicable. Three flavors:
+ *
+ *   - {@see self::delete_candidate} — candidate hard-delete. Allowed only
+ *     when the candidate has zero rows in `ffc_recruitment_classification`.
+ *     The linked `wp_user` (if any) is preserved untouched. ActivityLog
+ *     entries referencing the now-defunct `candidate_id` survive — sprint 8
+ *     ensures their payloads are already redacted.
+ *
+ *   - {@see self::delete_classification} — classification individual delete.
+ *     Allowed only when the row is in `status='empty'` AND the notice is in
+ *     `draft` or `preliminary`. Calls (`ffc_recruitment_call`) cannot exist
+ *     for an `empty` classification — the state machine ensures any call
+ *     creation transitions to `called` first — so no orphan rows are left
+ *     behind.
+ *
+ *   - {@see self::delete_adjutancy} — adjutancy delete. Allowed only when
+ *     zero rows reference the adjutancy in `ffc_recruitment_notice_adjutancy`
+ *     (no notice still uses it) AND zero rows reference it in
+ *     `ffc_recruitment_classification` (no historical classification
+ *     references either, including in closed notices).
+ *
+ * All gates are advisory: the underlying repositories' `delete()` methods
+ * are unconditional CRUD primitives. A caller bypassing this service can
+ * still corrupt referential integrity, so all REST/admin paths MUST go
+ * through this service.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Service: gated deletion for candidate / classification / adjutancy.
+ *
+ * Result envelope:
+ *
+ *   array{
+ *     success:  bool,
+ *     errors:   list<string>,                 // stable error code(s)
+ *     blocked_by?: array<string, int>,         // present when a gate fired;
+ *                                              // map of "what blocks" → count
+ *   }
+ *
+ * On a successful delete, `blocked_by` is omitted. On failure, `blocked_by`
+ * may be present with concrete reference counts so the REST controller can
+ * relay them (e.g. 409 with `{ "blocked_by": { "classifications": 3 } }`).
+ *
+ * @phpstan-type DeleteResult array{success: bool, errors: list<string>, blocked_by?: array<string, int>}
+ */
+final class RecruitmentDeleteService {
+
+	/**
+	 * Hard-delete a candidate row.
+	 *
+	 * Gate: zero `ffc_recruitment_classification` rows reference the
+	 * candidate. `user_id` (if non-null) is preserved on `wp_users` —
+	 * the recruitment module never deletes WordPress users.
+	 *
+	 * @param int $candidate_id Candidate ID.
+	 * @return DeleteResult
+	 */
+	public static function delete_candidate( int $candidate_id ): array {
+		$candidate = RecruitmentCandidateRepository::get_by_id( $candidate_id );
+		if ( null === $candidate ) {
+			return self::failure( 'recruitment_candidate_not_found' );
+		}
+
+		$classification_count = RecruitmentClassificationRepository::count_for_candidate( $candidate_id );
+		if ( $classification_count > 0 ) {
+			return array(
+				'success'    => false,
+				'errors'     => array( 'recruitment_candidate_has_classifications' ),
+				'blocked_by' => array( 'classifications' => $classification_count ),
+			);
+		}
+
+		$ok = RecruitmentCandidateRepository::delete( $candidate_id );
+		if ( ! $ok ) {
+			return self::failure( 'recruitment_candidate_delete_failed' );
+		}
+
+		return self::success();
+	}
+
+	/**
+	 * Delete a single classification row.
+	 *
+	 * Gate: status must be `empty` AND the parent notice must be in
+	 * `draft` or `preliminary`. Both gates protect against destroying
+	 * audit-relevant history: a non-empty status implies a call exists or
+	 * existed; a notice past `preliminary` has been promoted, so removing
+	 * a classification would silently rewrite the published list.
+	 *
+	 * @param int $classification_id Classification ID.
+	 * @return DeleteResult
+	 */
+	public static function delete_classification( int $classification_id ): array {
+		$classification = RecruitmentClassificationRepository::get_by_id( $classification_id );
+		if ( null === $classification ) {
+			return self::failure( 'recruitment_classification_not_found' );
+		}
+
+		if ( 'empty' !== $classification->status ) {
+			return self::failure( 'recruitment_classification_not_empty_for_delete' );
+		}
+
+		$notice = RecruitmentNoticeRepository::get_by_id( (int) $classification->notice_id );
+		if ( null === $notice ) {
+			return self::failure( 'recruitment_notice_not_found' );
+		}
+
+		if ( ! in_array( $notice->status, array( 'draft', 'preliminary' ), true ) ) {
+			return self::failure( 'recruitment_classification_delete_requires_draft_or_preliminary' );
+		}
+
+		$ok = RecruitmentClassificationRepository::delete( $classification_id );
+		if ( ! $ok ) {
+			return self::failure( 'recruitment_classification_delete_failed' );
+		}
+
+		return self::success();
+	}
+
+	/**
+	 * Delete an adjutancy row.
+	 *
+	 * Gate: zero references in `ffc_recruitment_notice_adjutancy` AND zero
+	 * references in `ffc_recruitment_classification`. Both checks together
+	 * mean "no notice currently uses this adjutancy AND no historical
+	 * classification ever did either" — safe to drop.
+	 *
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return DeleteResult
+	 */
+	public static function delete_adjutancy( int $adjutancy_id ): array {
+		$adjutancy = RecruitmentAdjutancyRepository::get_by_id( $adjutancy_id );
+		if ( null === $adjutancy ) {
+			return self::failure( 'recruitment_adjutancy_not_found' );
+		}
+
+		$attached_notice_ids = RecruitmentNoticeAdjutancyRepository::get_notice_ids_for_adjutancy( $adjutancy_id );
+		$attached_count      = count( $attached_notice_ids );
+
+		$classification_count = RecruitmentClassificationRepository::count_for_adjutancy( $adjutancy_id );
+
+		if ( $attached_count > 0 || $classification_count > 0 ) {
+			return array(
+				'success'    => false,
+				'errors'     => array( 'recruitment_adjutancy_in_use' ),
+				'blocked_by' => array(
+					'notice_adjutancies' => $attached_count,
+					'classifications'    => $classification_count,
+				),
+			);
+		}
+
+		$ok = RecruitmentAdjutancyRepository::delete( $adjutancy_id );
+		if ( ! $ok ) {
+			return self::failure( 'recruitment_adjutancy_delete_failed' );
+		}
+
+		return self::success();
+	}
+
+	/**
+	 * Build a successful delete envelope.
+	 *
+	 * @return DeleteResult
+	 */
+	private static function success(): array {
+		return array(
+			'success' => true,
+			'errors'  => array(),
+		);
+	}
+
+	/**
+	 * Build a failed delete envelope with a single error code.
+	 *
+	 * @param string $code Stable error code.
+	 * @return DeleteResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success' => false,
+			'errors'  => array( $code ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-email-dispatcher.php
+++ b/includes/recruitment/class-ffc-recruitment-email-dispatcher.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Recruitment Email Dispatcher
+ *
+ * Renders the §11 convocation email and sends it via `wp_mail`. Pulls the
+ * subject / from / body templates from {@see RecruitmentSettings},
+ * resolves all `{{placeholder}}` tokens against the call's
+ * candidate / classification / notice / adjutancy data, and fires once
+ * per call creation.
+ *
+ * Per §7 of the plan, send failures are deliberately NOT registered (no
+ * `email_sent` flag on the call row): the call is committed regardless,
+ * and high-volume installs are advised to install `rpgmem/total-mail-queue`
+ * for retry/visibility. Best-effort by design — instrumentation must
+ * never disrupt the convocation flow.
+ *
+ * Resolved placeholders (§11):
+ *
+ *   {{name}}, {{cpf_masked}}, {{rf_masked}}, {{email_masked}},
+ *   {{adjutancy}}, {{notice_code}}, {{notice_name}},
+ *   {{rank}}, {{score}}, {{is_pcd}},
+ *   {{date_to_assume}}, {{time_to_assume}},
+ *   {{called_at}}, {{site_name}}, {{site_url}}, {{notes}}
+ *
+ * `{{is_pcd}}` resolves to translatable `Yes` / `No` (English source so
+ * pt-BR `.po` produces `Sim` / `Não`). Sensitive fields (CPF/RF/email)
+ * are rendered MASKED via `DocumentFormatter` per §10-bis — the candidate
+ * receives only the redacted forms.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\DocumentFormatter;
+use FreeFormCertificate\Core\Encryption;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Service: render and send the convocation email.
+ *
+ * Returns `true` on attempted send (whether `wp_mail` actually succeeded
+ * is opaque — see §7 rationale). Returns `false` only when there's no
+ * email on file for the candidate (admin-side warning surface — the call
+ * still proceeds upstream).
+ *
+ * @phpstan-import-type CandidateRow      from RecruitmentCandidateRepository
+ * @phpstan-import-type ClassificationRow from RecruitmentClassificationRepository
+ * @phpstan-import-type NoticeRow         from RecruitmentNoticeRepository
+ * @phpstan-import-type AdjutancyRow      from RecruitmentAdjutancyRepository
+ * @phpstan-import-type CallRow           from RecruitmentCallRepository
+ */
+final class RecruitmentEmailDispatcher {
+
+	/**
+	 * Send the convocation email for a freshly-committed call row.
+	 *
+	 * Caller (sprint 6's `RecruitmentCallService`) invokes this after
+	 * `COMMIT`; failures here do NOT roll the call back. Returns `false`
+	 * when the candidate has no email on file (so the admin can show a
+	 * "no email — contact candidate manually" warning).
+	 *
+	 * @param int $call_id Newly created call row ID.
+	 * @return bool True on send attempted; false on missing email.
+	 */
+	public static function send_for_call( int $call_id ): bool {
+		$call = RecruitmentCallRepository::get_by_id( $call_id );
+		if ( null === $call ) {
+			return false;
+		}
+
+		$classification = RecruitmentClassificationRepository::get_by_id( (int) $call->classification_id );
+		if ( null === $classification ) {
+			return false;
+		}
+
+		$candidate = RecruitmentCandidateRepository::get_by_id( (int) $classification->candidate_id );
+		if ( null === $candidate ) {
+			return false;
+		}
+
+		$notice    = RecruitmentNoticeRepository::get_by_id( (int) $classification->notice_id );
+		$adjutancy = RecruitmentAdjutancyRepository::get_by_id( (int) $classification->adjutancy_id );
+		if ( null === $notice || null === $adjutancy ) {
+			return false;
+		}
+
+		$email_plain = self::decrypt_email( $candidate->email_encrypted );
+		if ( null === $email_plain || '' === $email_plain ) {
+			// No email on file — admin handles externally per §7.
+			return false;
+		}
+
+		$tokens   = self::build_token_map( $candidate, $classification, $notice, $adjutancy, $call );
+		$settings = RecruitmentSettings::all();
+
+		$subject   = self::render( $settings['email_subject'], $tokens );
+		$body      = self::render( $settings['email_body_html'], $tokens );
+		$plain     = wp_strip_all_tags( $body );
+		$headers   = array( 'Content-Type: text/html; charset=UTF-8' );
+		$from_pair = self::build_from_header( $settings );
+		if ( null !== $from_pair ) {
+			$headers[] = 'From: ' . $from_pair;
+		}
+
+		// Send HTML primary; the multipart/text alt is offered via the
+		// 'wp_mail_alternative_text' filter so SMTP plugins (or
+		// rpgmem/total-mail-queue) can pick it up. WP core lacks a
+		// first-class multipart helper, so we attach the plaintext via a
+		// scoped one-shot filter.
+		$plain_filter = static function ( string $alt ) use ( $plain ): string {
+			return '' === $alt ? $plain : $alt;
+		};
+		add_filter( 'wp_mail_alternative_text', $plain_filter );
+
+		wp_mail( $email_plain, $subject, $body, $headers );
+
+		remove_filter( 'wp_mail_alternative_text', $plain_filter );
+
+		return true;
+	}
+
+	/**
+	 * Build the `From: "Name" <addr>` header value, or null when both
+	 * settings are blank (let `wp_mail` use its default).
+	 *
+	 * @param array<string, mixed> $settings Output of `RecruitmentSettings::all()`.
+	 * @return string|null
+	 */
+	private static function build_from_header( array $settings ): ?string {
+		$addr = is_string( $settings['email_from_address'] ?? null ) ? trim( $settings['email_from_address'] ) : '';
+		$name = is_string( $settings['email_from_name'] ?? null ) ? trim( $settings['email_from_name'] ) : '';
+
+		if ( '' === $addr ) {
+			return null;
+		}
+
+		if ( '' === $name ) {
+			return $addr;
+		}
+
+		return sprintf( '"%s" <%s>', str_replace( '"', '', $name ), $addr );
+	}
+
+	/**
+	 * Compute the placeholder → value map for a single call row.
+	 *
+	 * @param object $candidate      Candidate row (CandidateRow shape).
+	 * @param object $classification Classification row (ClassificationRow shape).
+	 * @param object $notice         Notice row (NoticeRow shape).
+	 * @param object $adjutancy      Adjutancy row (AdjutancyRow shape).
+	 * @param object $call           Call row (CallRow shape).
+	 * @phpstan-param CandidateRow      $candidate
+	 * @phpstan-param ClassificationRow $classification
+	 * @phpstan-param NoticeRow         $notice
+	 * @phpstan-param AdjutancyRow      $adjutancy
+	 * @phpstan-param CallRow           $call
+	 * @return array<string, string>
+	 */
+	private static function build_token_map( object $candidate, object $classification, object $notice, object $adjutancy, object $call ): array {
+		$cpf_plain   = self::decrypt( $candidate->cpf_encrypted ?? null );
+		$rf_plain    = self::decrypt( $candidate->rf_encrypted ?? null );
+		$email_plain = self::decrypt_email( $candidate->email_encrypted ?? null );
+
+		$is_pcd = RecruitmentPcdHasher::verify( $candidate->pcd_hash, (int) $candidate->id );
+
+		return array(
+			'name'           => $candidate->name,
+			'cpf_masked'     => null === $cpf_plain ? '' : DocumentFormatter::mask_cpf( $cpf_plain ),
+			'rf_masked'      => null === $rf_plain ? '' : DocumentFormatter::mask_rf( $rf_plain ),
+			'email_masked'   => null === $email_plain ? '' : DocumentFormatter::mask_email( $email_plain ),
+			'adjutancy'      => $adjutancy->name,
+			'notice_code'    => $notice->code,
+			'notice_name'    => $notice->name,
+			'rank'           => (string) $classification->rank,
+			'score'          => $classification->score,
+			'is_pcd'         => true === $is_pcd ? __( 'Yes', 'ffcertificate' ) : __( 'No', 'ffcertificate' ),
+			'date_to_assume' => $call->date_to_assume,
+			'time_to_assume' => $call->time_to_assume,
+			'called_at'      => $call->called_at,
+			'site_name'      => wp_specialchars_decode( (string) get_option( 'blogname', '' ), ENT_QUOTES ),
+			'site_url'       => (string) get_option( 'siteurl', '' ),
+			'notes'          => null === $call->notes ? '' : $call->notes,
+		);
+	}
+
+	/**
+	 * Substitute every `{{token}}` in a template with its mapped value.
+	 *
+	 * Unknown tokens (not in the map) are left untouched so missing data
+	 * is visible in the rendered email — easier to spot than silent
+	 * empties. Token names are case-sensitive.
+	 *
+	 * @param string                $template Template string.
+	 * @param array<string, string> $tokens   Token → value map.
+	 * @return string
+	 */
+	private static function render( string $template, array $tokens ): string {
+		$replacements = array();
+		foreach ( $tokens as $key => $value ) {
+			$replacements[ '{{' . $key . '}}' ] = $value;
+		}
+		return strtr( $template, $replacements );
+	}
+
+	/**
+	 * Decrypt a `*_encrypted` column or return null.
+	 *
+	 * @param mixed $value Stored ciphertext or null.
+	 * @return string|null
+	 */
+	private static function decrypt( $value ): ?string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+		$plain = Encryption::decrypt( $value );
+		return null === $plain ? null : $plain;
+	}
+
+	/**
+	 * Decrypt the email column specifically — typed wrapper for clarity.
+	 *
+	 * @param mixed $value Stored ciphertext or null.
+	 * @return string|null
+	 */
+	private static function decrypt_email( $value ): ?string {
+		return self::decrypt( $value );
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-loader.php
+++ b/includes/recruitment/class-ffc-recruitment-loader.php
@@ -40,6 +40,7 @@ final class RecruitmentLoader {
 	 */
 	public function init(): void {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
+		add_action( 'admin_init', array( $this, 'register_settings' ), 10 );
 	}
 
 	/**
@@ -50,5 +51,14 @@ final class RecruitmentLoader {
 	public function register_rest_routes(): void {
 		$controller = new RecruitmentRestController();
 		$controller->register_routes();
+	}
+
+	/**
+	 * Register the recruitment settings option with the WP Settings API.
+	 *
+	 * @return void
+	 */
+	public function register_settings(): void {
+		RecruitmentSettings::register();
 	}
 }

--- a/includes/recruitment/class-ffc-recruitment-loader.php
+++ b/includes/recruitment/class-ffc-recruitment-loader.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Recruitment Loader
+ *
+ * Boot orchestrator for the recruitment module. Hooks `rest_api_init` to
+ * register the REST controller (sprint 9.1). Future sprints extend this
+ * loader: 9.2 wires the Settings tab, 11 registers the public shortcode,
+ * 12 hooks the admin pages.
+ *
+ * The recruitment activator (sprint 1.1) and the cap/role registration
+ * (sprint 3) run on plugin activation only — they don't need to live
+ * here.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Recruitment module loader.
+ *
+ * Registers WP hooks. Each hook is justified inline:
+ *
+ *   - `rest_api_init` (priority 10) — canonical hook for REST registration.
+ *     Default priority because no ordering constraint vs other plugins.
+ */
+final class RecruitmentLoader {
+
+	/**
+	 * Boot the module.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
+	}
+
+	/**
+	 * Instantiate and register REST routes.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes(): void {
+		$controller = new RecruitmentRestController();
+		$controller->register_routes();
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Notice ↔ Adjutancy Junction Repository
+ *
+ * Manages the N:N association declared by `ffc_recruitment_notice_adjutancy`.
+ * No `id` column on the junction — primary key is the composite
+ * `(notice_id, adjutancy_id)`. The repository exposes attach/detach/list
+ * primitives only; no `update`.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for the `ffc_recruitment_notice_adjutancy` junction.
+ */
+class NoticeAdjutancyRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_notice_adjutancy';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_notice_adjutancy';
+	}
+
+	/**
+	 * Attach an adjutancy to a notice.
+	 *
+	 * Idempotent under DB constraints: a duplicate `(notice_id, adjutancy_id)`
+	 * pair returns `false` (PK conflict). Callers that want "ensure attached"
+	 * semantics should check {@see self::is_attached()} first or treat
+	 * `false` as a no-op.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return bool True on insert, false on PK conflict or DB failure.
+	 */
+	public static function attach( int $notice_id, int $adjutancy_id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper; explicit formats.
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'notice_id'    => $notice_id,
+				'adjutancy_id' => $adjutancy_id,
+			),
+			array( '%d', '%d' )
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
+	 * Detach an adjutancy from a notice.
+	 *
+	 * Returns `false` if the pair didn't exist (or DB failure). Detach is
+	 * NOT gated by classification existence — that gate lives at the service
+	 * layer (sprint 7) so it can return a typed 409 with the blocking
+	 * classification count.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return bool
+	 */
+	public static function detach( int $notice_id, int $adjutancy_id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete via wpdb helper.
+		$result = $wpdb->delete(
+			$table,
+			array(
+				'notice_id'    => $notice_id,
+				'adjutancy_id' => $adjutancy_id,
+			),
+			array( '%d', '%d' )
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
+	 * Check whether the pair `(notice_id, adjutancy_id)` exists.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return bool
+	 */
+	public static function is_attached( int $notice_id, int $adjutancy_id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- PK lookup; small cardinality.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE notice_id = %d AND adjutancy_id = %d',
+				$table,
+				$notice_id,
+				$adjutancy_id
+			)
+		);
+
+		return $count > 0;
+	}
+
+	/**
+	 * Get all adjutancy IDs attached to a notice.
+	 *
+	 * Used by the CSV importer (to validate that the imported adjutancy
+	 * belongs to the target notice) and by the admin UI (to render the
+	 * adjutancy list in the notice detail).
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @return array<int> List of adjutancy IDs.
+	 */
+	public static function get_adjutancy_ids_for_notice( int $notice_id ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed by composite PK.
+		$results = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT adjutancy_id FROM %i WHERE notice_id = %d', $table, $notice_id )
+		);
+
+		return array_map( 'intval', $results );
+	}
+
+	/**
+	 * Get all notice IDs that include a given adjutancy.
+	 *
+	 * Powers the deletion gate for adjutancies (sprint 7): an adjutancy can
+	 * only be hard-deleted when zero notices reference it.
+	 *
+	 * @param int $adjutancy_id Adjutancy ID.
+	 * @return array<int> List of notice IDs.
+	 */
+	public static function get_notice_ids_for_adjutancy( int $adjutancy_id ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverse-lookup index on adjutancy_id.
+		$results = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT notice_id FROM %i WHERE adjutancy_id = %d', $table, $adjutancy_id )
+		);
+
+		return array_map( 'intval', $results );
+	}
+
+	/**
+	 * Detach all adjutancies from a notice.
+	 *
+	 * Convenience method used by the notice deletion path (if/when notice
+	 * deletion is added) and by tests. Not used in v1's main flows.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @return int Number of pairs removed.
+	 */
+	public static function detach_all_for_notice( int $notice_id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk delete; bounded by per-notice cardinality.
+		$result = $wpdb->delete( $table, array( 'notice_id' => $notice_id ), array( '%d' ) );
+
+		return is_int( $result ) ? $result : 0;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Database repository for the `ffc_recruitment_notice_adjutancy` junction.
  */
-class NoticeAdjutancyRepository {
+class RecruitmentNoticeAdjutancyRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 

--- a/includes/recruitment/class-ffc-recruitment-notice-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-repository.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Notice Repository
+ *
+ * CRUD for the `ffc_recruitment_notice` table — the edital lifecycle
+ * (draft → preliminary → active → closed).
+ *
+ * State transitions are NOT performed here: the repository exposes raw status
+ * setters used by the {@see NoticeStateMachine} (sprint 5). This separation
+ * keeps the repository as a thin CRUD primitive and the state machine as the
+ * single source of truth for transition validity, reason gating, and the
+ * `was_reopened` flag flip.
+ *
+ * The `code` column is normalized to UPPERCASE on insert/update; lookups via
+ * {@see self::get_by_code()} re-uppercase the input for consistency.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Database repository for `ffc_recruitment_notice` rows.
+ *
+ * `public_columns_config` is exposed as the raw JSON string; decoding into an
+ * associative array is the caller's responsibility (typically the renderer or
+ * the REST controller, which validates the shape against the schema in
+ * §3.2 / §8.2 of the implementation plan).
+ *
+ * @phpstan-type NoticeRow \stdClass&object{id: numeric-string, code: string, name: string, status: string, opened_at: string|null, closed_at: string|null, was_reopened: numeric-string, public_columns_config: string, created_at: string, updated_at: string}
+ */
+class NoticeRepository {
+
+	use \FreeFormCertificate\Core\StaticRepositoryTrait;
+
+	/**
+	 * Default `public_columns_config` JSON applied to new notices.
+	 *
+	 * Mirrors §3.2 of the implementation plan. `rank` and `name` are the
+	 * mandatory columns and cannot be toggled off via PATCH (validation
+	 * lives in the REST controller, not here).
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_PUBLIC_COLUMNS_CONFIG = '{"rank":true,"name":true,"status":true,"pcd_badge":true,"date_to_assume":true,"score":false,"cpf_masked":false,"rf_masked":false,"email_masked":false}';
+
+	/**
+	 * Cache group for this repository.
+	 *
+	 * @return string
+	 */
+	protected static function cache_group(): string {
+		return 'ffc_recruitment_notice';
+	}
+
+	/**
+	 * Get the fully-prefixed table name.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+		return self::db()->prefix . 'ffc_recruitment_notice';
+	}
+
+	/**
+	 * Get a notice by ID.
+	 *
+	 * @param int $id Notice ID.
+	 * @return NoticeRow|null
+	 */
+	public static function get_by_id( int $id ): ?object {
+		$cached = static::cache_get( "id_{$id}" );
+		if ( false !== $cached ) {
+			/**
+			 * Object-cache return cast.
+			 *
+			 * @var NoticeRow|null $cached
+			 */
+			return $cached;
+		}
+
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var NoticeRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Object-cached above; %i for table identifier.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $id )
+		);
+
+		if ( $result ) {
+			static::cache_set( "id_{$id}", $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get a notice by `code` (case-insensitive — input is uppercased before lookup).
+	 *
+	 * Used by the public shortcode to resolve `notice="EDITAL-2026-01"` and
+	 * by the admin import flow.
+	 *
+	 * @param string $code Notice code (any case; normalized internally).
+	 * @return NoticeRow|null
+	 */
+	public static function get_by_code( string $code ): ?object {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$normalized = strtoupper( $code );
+
+		/**
+		 * Cast wpdb result to typed shape.
+		 *
+		 * @var NoticeRow|null $result
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Lookup by indexed UNIQUE column.
+		$result = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE code = %s LIMIT 1', $table, $normalized )
+		);
+
+		return $result ? $result : null;
+	}
+
+	/**
+	 * List notices, optionally filtered by status.
+	 *
+	 * @param string|null $status One of {draft, preliminary, active, closed} or null for all.
+	 * @return list<NoticeRow>
+	 */
+	public static function get_all( ?string $status = null ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		if ( null !== $status ) {
+			/**
+			 * Cast wpdb results to typed shape.
+			 *
+			 * @var list<NoticeRow>|null $results
+			 */
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Admin listing; status column is indexed.
+			$results = $wpdb->get_results(
+				$wpdb->prepare( 'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC', $table, $status )
+			);
+		} else {
+			/**
+			 * Cast wpdb results to typed shape.
+			 *
+			 * @var list<NoticeRow>|null $results
+			 */
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Admin listing; small cardinality.
+			$results = $wpdb->get_results(
+				$wpdb->prepare( 'SELECT * FROM %i ORDER BY created_at DESC', $table )
+			);
+		}
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Create a new notice in `draft` status.
+	 *
+	 * `code` is uppercased on store. `public_columns_config` defaults to
+	 * {@see self::DEFAULT_PUBLIC_COLUMNS_CONFIG} when omitted; callers may
+	 * override by passing a `public_columns_config` JSON string.
+	 *
+	 * State-transition timestamps (`opened_at`, `closed_at`) and the
+	 * `was_reopened` flag are NOT set here — those are managed by the state
+	 * machine in sprint 5.
+	 *
+	 * @param string $code Notice code (will be uppercased).
+	 * @param string $name Human-readable name.
+	 * @param string $public_columns_config Optional JSON config; defaults to schema's defaults.
+	 * @return int|false New notice ID or false on failure (e.g. duplicate code).
+	 */
+	public static function create( string $code, string $name, string $public_columns_config = '' ) {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now    = current_time( 'mysql' );
+		$config = '' === $public_columns_config ? self::DEFAULT_PUBLIC_COLUMNS_CONFIG : $public_columns_config;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper; explicit formats.
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'code'                  => strtoupper( $code ),
+				'name'                  => $name,
+				'status'                => 'draft',
+				'was_reopened'          => 0,
+				'public_columns_config' => $config,
+				'created_at'            => $now,
+				'updated_at'            => $now,
+			),
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s' )
+		);
+
+		if ( ! $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Update mutable notice metadata.
+	 *
+	 * Accepted keys: `name`, `code` (uppercased), `public_columns_config`.
+	 * The state column and lifecycle timestamps go through dedicated
+	 * setters used by the state machine (sprint 5):
+	 * {@see self::set_status()}, {@see self::mark_opened()},
+	 * {@see self::mark_closed()}, {@see self::mark_reopened()}.
+	 *
+	 * @param int                  $id   Notice ID.
+	 * @param array<string, mixed> $data Update payload (see allowed keys above).
+	 * @return bool
+	 */
+	public static function update( int $id, array $data ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$update = array();
+		$format = array();
+
+		if ( isset( $data['name'] ) && is_string( $data['name'] ) ) {
+			$update['name'] = $data['name'];
+			$format[]       = '%s';
+		}
+
+		if ( isset( $data['code'] ) && is_string( $data['code'] ) ) {
+			$update['code'] = strtoupper( $data['code'] );
+			$format[]       = '%s';
+		}
+
+		if ( isset( $data['public_columns_config'] ) && is_string( $data['public_columns_config'] ) ) {
+			$update['public_columns_config'] = $data['public_columns_config'];
+			$format[]                        = '%s';
+		}
+
+		if ( empty( $update ) ) {
+			return false;
+		}
+
+		$update['updated_at'] = current_time( 'mysql' );
+		$format[]             = '%s';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update via wpdb helper.
+		$result = $wpdb->update( $table, $update, array( 'id' => $id ), $format, array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Set the notice status atomically, gated by an expected current status.
+	 *
+	 * Used by the state machine to enforce state-transition rules under
+	 * concurrency: the UPDATE only succeeds if the row is currently in
+	 * `$expected_current`. Returns the affected-row count (0 or 1) so the
+	 * caller can detect a lost race.
+	 *
+	 * @param int    $id Notice ID.
+	 * @param string $expected_current Current status the caller observed.
+	 * @param string $new_status Target status.
+	 * @return int Number of rows affected (1 on success, 0 if race lost).
+	 */
+	public static function set_status( int $id, string $expected_current, string $new_status ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET status = %s, updated_at = %s WHERE id = %d AND status = %s',
+			$table,
+			$new_status,
+			current_time( 'mysql' ),
+			$id,
+			$expected_current
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Atomic transition primitive; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Stamp `opened_at` on the first transition to `active`.
+	 *
+	 * Intended to be called only when `opened_at IS NULL` (state machine
+	 * enforces this; the WHERE clause double-guards). Subsequent reopens do
+	 * not touch this column.
+	 *
+	 * @param int $id Notice ID.
+	 * @return int Number of rows affected.
+	 */
+	public static function mark_opened( int $id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now      = current_time( 'mysql' );
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET opened_at = %s, updated_at = %s WHERE id = %d AND opened_at IS NULL',
+			$table,
+			$now,
+			$now,
+			$id
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- One-shot timestamp setter; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Stamp `closed_at` on every transition to `closed` (overwrites).
+	 *
+	 * @param int $id Notice ID.
+	 * @return int Number of rows affected.
+	 */
+	public static function mark_closed( int $id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$now      = current_time( 'mysql' );
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET closed_at = %s, updated_at = %s WHERE id = %d',
+			$table,
+			$now,
+			$now,
+			$id
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Timestamp setter; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Flip `was_reopened` to 1 on the first `closed → active` transition.
+	 *
+	 * One-way flip: once `was_reopened = 1`, this method is a no-op (the
+	 * WHERE clause guards against re-flipping). Drives the reopen-freeze
+	 * rule (§5.1 / §5.2) — once set, all transitions out of `hired` and
+	 * `not_shown` are blocked for this notice.
+	 *
+	 * @param int $id Notice ID.
+	 * @return int Number of rows affected (1 on first reopen, 0 otherwise).
+	 */
+	public static function mark_reopened( int $id ): int {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		$prepared = $wpdb->prepare(
+			'UPDATE %i SET was_reopened = 1, updated_at = %s WHERE id = %d AND was_reopened = 0',
+			$table,
+			current_time( 'mysql' ),
+			$id
+		);
+
+		if ( ! is_string( $prepared ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- One-way flag flip; $prepared came from $wpdb->prepare() on the line above.
+		$affected = $wpdb->query( $prepared );
+
+		static::cache_delete( "id_{$id}" );
+
+		return is_int( $affected ) ? $affected : 0;
+	}
+
+	/**
+	 * Delete a notice unconditionally.
+	 *
+	 * No deletion gates exist for notices in v1 — admin notices are kept
+	 * indefinitely (LGPD anonymization is a future issue per §16). This
+	 * method is provided for completeness and used only by tests.
+	 *
+	 * @param int $id Notice ID.
+	 * @return bool
+	 */
+	public static function delete( int $id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete via wpdb helper.
+		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+		static::cache_delete( "id_{$id}" );
+
+		return false !== $result;
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-notice-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-repository.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @phpstan-type NoticeRow \stdClass&object{id: numeric-string, code: string, name: string, status: string, opened_at: string|null, closed_at: string|null, was_reopened: numeric-string, public_columns_config: string, created_at: string, updated_at: string}
  */
-class NoticeRepository {
+class RecruitmentNoticeRepository {
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 

--- a/includes/recruitment/class-ffc-recruitment-notice-state-machine.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-state-machine.php
@@ -132,6 +132,8 @@ final class RecruitmentNoticeStateMachine {
 		// Side-effects after the UPDATE wins.
 		self::apply_side_effects( $notice_id, $new_status );
 
+		RecruitmentActivityLogger::notice_status_changed( $notice_id, $current, $new_status, $reason );
+
 		return self::success();
 	}
 

--- a/includes/recruitment/class-ffc-recruitment-notice-state-machine.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-state-machine.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Recruitment Notice State Machine
+ *
+ * Authoritative source of truth for the §5.1 notice lifecycle:
+ *
+ *   draft → preliminary → active → closed
+ *                ↑           ↓
+ *                └───────────┘    (active → preliminary if zero calls)
+ *                            ↓
+ *                          closed → active   (with reopen reason)
+ *
+ * Atomic transitions go through {@see RecruitmentNoticeRepository::set_status},
+ * which uses a `WHERE status = '<expected>'` guard so concurrent transition
+ * attempts safely fail with `affected_rows = 0`. Side-effects (stamping
+ * `opened_at` on the first → active, `closed_at` on every → closed,
+ * flipping `was_reopened = 1` on the first closed → active) are wired here
+ * after the conditional UPDATE wins.
+ *
+ * Reason gating mirrors §5.1:
+ *
+ *   - draft → preliminary  : no reason
+ *   - preliminary → active : no reason (snapshot/definitive-import handled
+ *                            by {@see RecruitmentPromotionService}, not here)
+ *   - active → preliminary : no reason; gated on `count_calls_for_notice = 0`
+ *   - active → closed      : no reason
+ *   - closed → active      : reason REQUIRED (logged); flips `was_reopened`
+ *
+ * Once `notice.was_reopened = 1` the classification-level reopen of
+ * `not_shown → empty` is permanently blocked for that notice — see
+ * {@see RecruitmentClassificationStateMachine}.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Service: transition a notice's status with full lifecycle rules.
+ *
+ * All public methods return the same envelope:
+ *
+ *   array{
+ *     success: bool,
+ *     errors:  list<string>,
+ *   }
+ *
+ * Errors use stable `recruitment_*` codes so REST controllers (sprint 9.1)
+ * can map them to user-facing messages.
+ *
+ * @phpstan-type TransitionResult array{success: bool, errors: list<string>}
+ */
+final class RecruitmentNoticeStateMachine {
+
+	/**
+	 * Allowed transitions, expressed as `from => list<to>`.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const TRANSITIONS = array(
+		'draft'       => array( 'preliminary' ),
+		'preliminary' => array( 'active' ),
+		'active'      => array( 'preliminary', 'closed' ),
+		'closed'      => array( 'active' ),
+	);
+
+	/**
+	 * Transitions that require a non-empty reason string.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const REASON_REQUIRED = array(
+		'closed' => array( 'active' ),
+	);
+
+	/**
+	 * Attempt to transition a notice to a new status.
+	 *
+	 * @param int         $notice_id Target notice.
+	 * @param string      $new_status `draft|preliminary|active|closed`.
+	 * @param string|null $reason     Required when transitioning closed → active.
+	 * @return TransitionResult
+	 */
+	public static function transition_to( int $notice_id, string $new_status, ?string $reason = null ): array {
+		$notice = RecruitmentNoticeRepository::get_by_id( $notice_id );
+		if ( null === $notice ) {
+			return self::failure( 'recruitment_notice_not_found' );
+		}
+
+		$current = $notice->status;
+
+		// Same-state transition is a no-op success — idempotent for callers
+		// that don't track the current state.
+		if ( $current === $new_status ) {
+			return self::success();
+		}
+
+		// Validate the requested transition.
+		$allowed = self::TRANSITIONS[ $current ] ?? array();
+		if ( ! in_array( $new_status, $allowed, true ) ) {
+			return self::failure( 'recruitment_invalid_transition: ' . $current . '->' . $new_status );
+		}
+
+		// Reason gating.
+		if ( self::is_reason_required( $current, $new_status ) ) {
+			if ( null === $reason || '' === trim( $reason ) ) {
+				return self::failure( 'recruitment_transition_reason_required' );
+			}
+		}
+
+		// `active → preliminary` requires zero calls in the notice's history.
+		if ( 'active' === $current && 'preliminary' === $new_status ) {
+			$call_count = RecruitmentClassificationRepository::count_calls_for_notice( $notice_id );
+			if ( $call_count > 0 ) {
+				return self::failure( 'recruitment_active_to_preliminary_blocked_by_calls' );
+			}
+		}
+
+		// Atomic transition (race-safe).
+		$affected = RecruitmentNoticeRepository::set_status( $notice_id, $current, $new_status );
+		if ( 1 !== $affected ) {
+			return self::failure( 'recruitment_transition_race_lost' );
+		}
+
+		// Side-effects after the UPDATE wins.
+		self::apply_side_effects( $notice_id, $new_status );
+
+		return self::success();
+	}
+
+	/**
+	 * Run the per-target-state lifecycle stamping.
+	 *
+	 * - `active`  : stamp `opened_at` on the first → active (idempotent
+	 *               via the WHERE guard in {@see RecruitmentNoticeRepository::mark_opened}).
+	 *               When the notice was previously `closed`, also flip
+	 *               `was_reopened = 1` (one-way) so the classification
+	 *               reopen-freeze rule kicks in.
+	 * - `closed`  : stamp `closed_at` (overwrites on each closure).
+	 * - other     : no-op.
+	 *
+	 * Determining "previously closed" is done by re-reading the notice
+	 * after the status transition committed: if `closed_at` is non-null,
+	 * the notice has been closed at least once. The first → active sets
+	 * `opened_at` for the first time and does NOT flip `was_reopened`
+	 * (because `closed_at IS NULL`); subsequent active transitions after
+	 * a close do flip the flag.
+	 *
+	 * @param int    $notice_id Notice ID.
+	 * @param string $new_status Target status.
+	 * @return void
+	 */
+	private static function apply_side_effects( int $notice_id, string $new_status ): void {
+		switch ( $new_status ) {
+			case 'active':
+				$notice = RecruitmentNoticeRepository::get_by_id( $notice_id );
+				if ( null === $notice ) {
+					return;
+				}
+
+				if ( null === $notice->opened_at ) {
+					RecruitmentNoticeRepository::mark_opened( $notice_id );
+				}
+
+				if ( null !== $notice->closed_at ) {
+					// We arrived at active via reopen — set the flag.
+					RecruitmentNoticeRepository::mark_reopened( $notice_id );
+				}
+				break;
+			case 'closed':
+				RecruitmentNoticeRepository::mark_closed( $notice_id );
+				break;
+		}
+	}
+
+	/**
+	 * Whether the given transition pair requires a reason.
+	 *
+	 * @param string $from From status.
+	 * @param string $to   To status.
+	 * @return bool
+	 */
+	private static function is_reason_required( string $from, string $to ): bool {
+		$gated = self::REASON_REQUIRED[ $from ] ?? array();
+		return in_array( $to, $gated, true );
+	}
+
+	/**
+	 * Build a successful transition envelope.
+	 *
+	 * @return TransitionResult
+	 */
+	private static function success(): array {
+		return array(
+			'success' => true,
+			'errors'  => array(),
+		);
+	}
+
+	/**
+	 * Build a failed transition envelope with a single error code.
+	 *
+	 * @param string $code Stable error code.
+	 * @return TransitionResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success' => false,
+			'errors'  => array( $code ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-pcd-hasher.php
+++ b/includes/recruitment/class-ffc-recruitment-pcd-hasher.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Recruitment PCD Hasher
+ *
+ * Computes the `pcd_hash` value stored on `ffc_recruitment_candidate`. The
+ * hash is verifiable for both PCD and non-PCD candidates while remaining
+ * non-enumerable on column scan: an attacker dumping the column sees only
+ * opaque hashes, but anyone with the candidate's row (i.e. with knowledge
+ * of `candidate_id` and the secret salt) can recompute both domains and
+ * confirm the PCD value.
+ *
+ * Formula (per §3.4 of the implementation plan):
+ *
+ *   pcd_hash = HMAC-SHA256(secret, ("1"|"0") || candidate_id)
+ *
+ * Both PCD=true and PCD=false produce a valid hash. The column is NOT NULL
+ * — every candidate carries either the PCD or non-PCD hash, never null.
+ *
+ * The HMAC key is derived from `wp_salt('auth')` so the hash is stable
+ * across requests within a site but differs across sites.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stateless helper that computes the candidate `pcd_hash` value.
+ *
+ * No dependencies beyond `wp_salt()`. Unit tests can stub `wp_salt` via
+ * Brain\Monkey to assert determinism.
+ */
+final class RecruitmentPcdHasher {
+
+	/**
+	 * Domain prefix prepended to the candidate ID for PCD candidates.
+	 */
+	private const DOMAIN_PCD = '1';
+
+	/**
+	 * Domain prefix prepended to the candidate ID for non-PCD candidates.
+	 */
+	private const DOMAIN_NOT_PCD = '0';
+
+	/**
+	 * Compute the `pcd_hash` for a given candidate.
+	 *
+	 * @param int  $candidate_id The candidate's row ID (auto-incremented at INSERT).
+	 * @param bool $is_pcd       Whether this candidate is registered as PCD.
+	 * @return string Hex-encoded SHA-256 HMAC (64 chars).
+	 */
+	public static function compute( int $candidate_id, bool $is_pcd ): string {
+		$domain = $is_pcd ? self::DOMAIN_PCD : self::DOMAIN_NOT_PCD;
+		$key    = self::secret_key();
+
+		return hash_hmac( 'sha256', $domain . $candidate_id, $key );
+	}
+
+	/**
+	 * Verify whether a stored hash matches a candidate's PCD claim.
+	 *
+	 * Used by the recruitment admin UI / REST handlers to display the PCD
+	 * badge without persisting plaintext anywhere. Both domains are tried
+	 * against the stored hash; if neither matches, the record has been
+	 * tampered with (or the salt rotated) and the caller should fall back
+	 * to "unknown".
+	 *
+	 * @param string $stored_hash  The `pcd_hash` column value.
+	 * @param int    $candidate_id The candidate's row ID.
+	 * @return bool|null True when PCD; false when not PCD; null when neither
+	 *                   domain matches (anomaly).
+	 */
+	public static function verify( string $stored_hash, int $candidate_id ): ?bool {
+		if ( '' === $stored_hash ) {
+			return null;
+		}
+
+		$pcd_hash     = self::compute( $candidate_id, true );
+		$not_pcd_hash = self::compute( $candidate_id, false );
+
+		if ( hash_equals( $pcd_hash, $stored_hash ) ) {
+			return true;
+		}
+		if ( hash_equals( $not_pcd_hash, $stored_hash ) ) {
+			return false;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Derive the HMAC secret key from the WP installation's auth salt.
+	 *
+	 * `wp_salt('auth')` is stable per site (rotates only when admin rotates
+	 * keys) and unguessable from outside the server, which is exactly the
+	 * property we need: on-server code can verify, off-server attackers
+	 * cannot enumerate the column.
+	 *
+	 * @return string
+	 */
+	private static function secret_key(): string {
+		// Suffix scopes the key to this module so a leak of one HMAC value
+		// cannot be replayed against unrelated `hash_hmac(_, _, wp_salt())`
+		// uses elsewhere in the codebase.
+		return wp_salt( 'auth' ) . '|ffc_recruitment_pcd';
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-promotion-service.php
+++ b/includes/recruitment/class-ffc-recruitment-promotion-service.php
@@ -126,6 +126,8 @@ final class RecruitmentPromotionService {
 
 			$wpdb->query( 'COMMIT' );
 
+			RecruitmentActivityLogger::notice_promoted( $notice_id, 'snapshot', $copied );
+
 			return array(
 				'success' => true,
 				'copied'  => $copied,

--- a/includes/recruitment/class-ffc-recruitment-promotion-service.php
+++ b/includes/recruitment/class-ffc-recruitment-promotion-service.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Recruitment Promotion Service
+ *
+ * Encapsulates the §5.1 `preliminary → active` promotion flow. The transition
+ * itself goes through {@see RecruitmentNoticeStateMachine}; this service
+ * adds the listing-side mechanics:
+ *
+ *   - **Snapshot mode** ({@see self::snapshot_to_definitive}) — duplicates
+ *     every `list_type='preview'` classification row into
+ *     `list_type='definitive'`, atomically, before flipping the notice
+ *     status. Wipes any existing `definitive` rows first (legacy from a
+ *     prior `preliminary → active → preliminary` cycle, which is the
+ *     only way `definitive` can pre-exist when promoting).
+ *
+ *   - **Definitive-import mode** is handled directly by
+ *     {@see RecruitmentCsvImporter::import_definitive()} — this service
+ *     only orchestrates the snapshot path. The REST controller (sprint 9.1)
+ *     dispatches between the two modes based on the request body.
+ *
+ * Both paths run inside a single InnoDB transaction so a failure during
+ * the row-copy or status flip rolls everything back, leaving the previous
+ * `preview` and `definitive` lists untouched.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+/**
+ * Service: orchestrate the promote-preview snapshot path.
+ *
+ * Result envelope is the same as the importer / state machines:
+ *
+ *   array{
+ *     success:  bool,
+ *     copied:   int,            // classification rows copied to `definitive`
+ *     errors:   list<string>,
+ *   }
+ *
+ * @phpstan-type SnapshotResult array{success: bool, copied: int, errors: list<string>}
+ */
+final class RecruitmentPromotionService {
+
+	/**
+	 * Snapshot the current `preview` rows into `definitive`, then flip the
+	 * notice status to `active`.
+	 *
+	 * The order of operations within the transaction is:
+	 *
+	 *   1. Verify the notice exists and is in `preliminary`.
+	 *   2. Wipe any pre-existing `list_type='definitive'` rows for this notice.
+	 *   3. Copy each `list_type='preview'` row into `list_type='definitive'`,
+	 *      preserving (candidate_id, adjutancy_id, rank, score) and resetting
+	 *      `status='empty'` (the §5.2 invariant: convocation acts only on
+	 *      definitive rows that start empty).
+	 *   4. Transition the notice via the state machine.
+	 *
+	 * Step 4 is delegated to {@see RecruitmentNoticeStateMachine::transition_to},
+	 * which performs the atomic conditional UPDATE and the lifecycle stamping
+	 * (`opened_at`).
+	 *
+	 * @param int $notice_id Notice ID to promote.
+	 * @return SnapshotResult
+	 */
+	public static function snapshot_to_definitive( int $notice_id ): array {
+		$notice = RecruitmentNoticeRepository::get_by_id( $notice_id );
+		if ( null === $notice ) {
+			return self::failure( 'recruitment_notice_not_found' );
+		}
+
+		if ( 'preliminary' !== $notice->status ) {
+			return self::failure( 'recruitment_promotion_requires_preliminary_state' );
+		}
+
+		$preview_rows = RecruitmentClassificationRepository::get_for_notice( $notice_id, 'preview' );
+		if ( empty( $preview_rows ) ) {
+			return self::failure( 'recruitment_promotion_no_preview_rows' );
+		}
+
+		global $wpdb;
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			RecruitmentClassificationRepository::delete_all_for_notice_list( $notice_id, 'definitive' );
+
+			$copied = 0;
+			foreach ( $preview_rows as $row ) {
+				$new_id = RecruitmentClassificationRepository::create(
+					array(
+						'candidate_id' => (int) $row->candidate_id,
+						'adjutancy_id' => (int) $row->adjutancy_id,
+						'notice_id'    => $notice_id,
+						'list_type'    => 'definitive',
+						'rank'         => (int) $row->rank,
+						'score'        => $row->score,
+					)
+				);
+				if ( false === $new_id ) {
+					$wpdb->query( 'ROLLBACK' );
+					return self::failure( 'recruitment_promotion_copy_failed' );
+				}
+				++$copied;
+			}
+
+			// Flip notice status to `active` via the state machine. This
+			// stamps `opened_at` on the first promotion (idempotent on
+			// subsequent ones) and runs the race-safe conditional UPDATE.
+			$transition = RecruitmentNoticeStateMachine::transition_to( $notice_id, 'active' );
+			if ( ! $transition['success'] ) {
+				$wpdb->query( 'ROLLBACK' );
+				return array(
+					'success' => false,
+					'copied'  => 0,
+					'errors'  => $transition['errors'],
+				);
+			}
+
+			$wpdb->query( 'COMMIT' );
+
+			return array(
+				'success' => true,
+				'copied'  => $copied,
+				'errors'  => array(),
+			);
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			return self::failure( 'recruitment_promotion_unexpected_error: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Build a failed snapshot envelope.
+	 *
+	 * @param string $code Stable error code.
+	 * @return SnapshotResult
+	 */
+	private static function failure( string $code ): array {
+		return array(
+			'success' => false,
+			'copied'  => 0,
+			'errors'  => array( $code ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-rest-controller.php
@@ -1,0 +1,1045 @@
+<?php
+/**
+ * Recruitment REST Controller
+ *
+ * Single entry point for every admin REST route under the
+ * `ffcertificate/v1/recruitment` namespace plus the candidate-self
+ * `/me/recruitment` endpoint. Every callback is a thin dispatcher: it
+ * sanitizes/validates input, delegates to the corresponding service or
+ * repository, and returns a `\WP_REST_Response` or `\WP_Error`.
+ *
+ * Authorization model:
+ *
+ *   - Admin endpoints: `permission_callback` checks
+ *     `current_user_can('ffc_manage_recruitment')`. The cap is granted to
+ *     the `administrator` role on activation (sprint 3) and to the
+ *     dedicated `ffc_recruitment_manager` role.
+ *   - Candidate-self endpoint (`GET /me/recruitment`): just
+ *     `is_user_logged_in()`. The query joins `candidate.user_id =
+ *     current_user_id` so users only ever see their own data.
+ *   - Public endpoints: NONE. The public shortcode (sprint 11) renders
+ *     server-side; deliberately no public REST so we avoid the
+ *     enumeration vector.
+ *
+ * Error contract: every failure returns a `\WP_Error` with a stable
+ * `recruitment_*` code, an HTTP status (400/403/404/409/500), and an
+ * optional `data` payload (e.g. `blocked_by` reference counts from the
+ * delete service).
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\DocumentFormatter;
+use FreeFormCertificate\Core\Encryption;
+use FreeFormCertificate\Core\SensitiveFieldRegistry;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST controller for the recruitment module.
+ *
+ * @phpstan-import-type CandidateRow from RecruitmentCandidateRepository
+ */
+final class RecruitmentRestController {
+
+	/** Namespace for all admin + candidate-self routes. */
+	private const NAMESPACE = 'ffcertificate/v1';
+
+	/** Resource base. */
+	private const REST_BASE = 'recruitment';
+
+	/** Admin capability gating every admin route. */
+	private const ADMIN_CAP = 'ffc_manage_recruitment';
+
+	/**
+	 * Hook callback for `rest_api_init`.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		$ns   = self::NAMESPACE;
+		$base = '/' . self::REST_BASE;
+
+		// ── Notices ─────────────────────────────────────────────────────
+		register_rest_route(
+			$ns,
+			$base . '/notices',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'list_notices' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+					'args'                => array(
+						'status' => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_notice' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+					'args'                => array(
+						'code' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'name' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/notices/(?P<id>\d+)',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_notice' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/notices/(?P<id>\d+)/classifications',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'list_classifications' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'list_type'    => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'adjutancy_id' => array(
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/notices/(?P<id>\d+)/import',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'import_csv' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/notices/(?P<id>\d+)/promote-preview',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'promote_preview' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'mode' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'enum'              => array( 'snapshot', 'definitive_import' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// ── Classifications ─────────────────────────────────────────────
+		register_rest_route(
+			$ns,
+			$base . '/classifications/(?P<id>\d+)/call',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'call_classification' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'date_to_assume'      => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'time_to_assume'      => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'out_of_order_reason' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'notes'               => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/classifications/bulk-call',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'bulk_call_classifications' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/classifications/(?P<id>\d+)/status',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'change_classification_status' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'status' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'reason' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/classifications/(?P<id>\d+)',
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_classification' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/classifications/(?P<id>\d+)/calls/(?P<call_id>\d+)/cancel',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'cancel_call' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'reason' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// ── Adjutancies ─────────────────────────────────────────────────
+		register_rest_route(
+			$ns,
+			$base . '/adjutancies',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'list_adjutancies' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_adjutancy' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+					'args'                => array(
+						'slug' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_title',
+						),
+						'name' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/adjutancies/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_adjutancy' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_adjutancy' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+			)
+		);
+
+		// ── Candidates ──────────────────────────────────────────────────
+		register_rest_route(
+			$ns,
+			$base . '/candidates',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'list_candidates' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'search'       => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'cpf'          => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'rf'           => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'notice_id'    => array(
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'adjutancy_id' => array(
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
+			$base . '/candidates/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_candidate' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_candidate' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_candidate' ),
+					'permission_callback' => array( $this, 'check_admin_cap' ),
+				),
+			)
+		);
+
+		// ── Candidate-self dashboard ────────────────────────────────────
+		register_rest_route(
+			$ns,
+			$base . '/me/recruitment',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_my_recruitment' ),
+				'permission_callback' => array( $this, 'check_logged_in' ),
+			)
+		);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Permission callbacks
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Permission gate for every admin endpoint.
+	 *
+	 * @return bool
+	 */
+	public function check_admin_cap(): bool {
+		return current_user_can( self::ADMIN_CAP );
+	}
+
+	/**
+	 * Permission gate for the candidate-self endpoint.
+	 *
+	 * @return bool
+	 */
+	public function check_logged_in(): bool {
+		return is_user_logged_in();
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Notices
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * GET /notices
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function list_notices( \WP_REST_Request $request ): \WP_REST_Response {
+		$status  = $request->get_param( 'status' );
+		$notices = RecruitmentNoticeRepository::get_all( is_string( $status ) && '' !== $status ? $status : null );
+
+		return new \WP_REST_Response( $notices, 200 );
+	}
+
+	/**
+	 * POST /notices
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function create_notice( \WP_REST_Request $request ) {
+		$code = (string) $request->get_param( 'code' );
+		$name = (string) $request->get_param( 'name' );
+
+		$id = RecruitmentNoticeRepository::create( $code, $name );
+		if ( false === $id ) {
+			return new \WP_Error(
+				'recruitment_notice_create_failed',
+				__( 'Failed to create notice (duplicate code?).', 'ffcertificate' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return new \WP_REST_Response( RecruitmentNoticeRepository::get_by_id( $id ), 201 );
+	}
+
+	/**
+	 * PATCH /notices/{id}
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_notice( \WP_REST_Request $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		// Status transitions go through the state machine so all gates and
+		// activity-log instrumentation fire correctly.
+		$new_status = $request->get_param( 'status' );
+		if ( is_string( $new_status ) && '' !== $new_status ) {
+			$reason     = $request->get_param( 'reason' );
+			$transition = RecruitmentNoticeStateMachine::transition_to(
+				$id,
+				$new_status,
+				is_string( $reason ) ? $reason : null
+			);
+			if ( ! $transition['success'] ) {
+				return $this->wp_error_from_envelope( $transition['errors'], 409 );
+			}
+		}
+
+		// Plain meta fields go through the repository update.
+		$meta = array_intersect_key(
+			$request->get_params(),
+			array_flip( array( 'name', 'code', 'public_columns_config' ) )
+		);
+		if ( ! empty( $meta ) ) {
+			$ok = RecruitmentNoticeRepository::update( $id, $meta );
+			if ( ! $ok ) {
+				return new \WP_Error(
+					'recruitment_notice_update_failed',
+					__( 'Notice update failed.', 'ffcertificate' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		$notice = RecruitmentNoticeRepository::get_by_id( $id );
+		if ( null === $notice ) {
+			return new \WP_Error( 'recruitment_notice_not_found', '', array( 'status' => 404 ) );
+		}
+
+		return new \WP_REST_Response( $notice, 200 );
+	}
+
+	/**
+	 * GET /notices/{id}/classifications
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function list_classifications( \WP_REST_Request $request ): \WP_REST_Response {
+		$id           = (int) $request->get_param( 'id' );
+		$list_type    = $request->get_param( 'list_type' );
+		$adjutancy_id = $request->get_param( 'adjutancy_id' );
+
+		$rows = RecruitmentClassificationRepository::get_for_notice(
+			$id,
+			is_string( $list_type ) && '' !== $list_type ? $list_type : null,
+			is_int( $adjutancy_id ) && $adjutancy_id > 0 ? $adjutancy_id : null
+		);
+
+		return new \WP_REST_Response( $rows, 200 );
+	}
+
+	/**
+	 * POST /notices/{id}/import
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function import_csv( \WP_REST_Request $request ) {
+		$id    = (int) $request->get_param( 'id' );
+		$files = $request->get_file_params();
+
+		if ( ! isset( $files['csv_file']['tmp_name'] ) || ! is_string( $files['csv_file']['tmp_name'] ) ) {
+			return new \WP_Error(
+				'recruitment_csv_file_missing',
+				__( 'CSV file is required.', 'ffcertificate' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$content = file_get_contents( $files['csv_file']['tmp_name'] );
+		if ( false === $content ) {
+			return new \WP_Error(
+				'recruitment_csv_file_unreadable',
+				__( 'Could not read CSV file.', 'ffcertificate' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = RecruitmentCsvImporter::import_preview( $id, $content );
+
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 400 );
+		}
+
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * POST /notices/{id}/promote-preview
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function promote_preview( \WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$mode = (string) $request->get_param( 'mode' );
+
+		if ( 'snapshot' === $mode ) {
+			$result = RecruitmentPromotionService::snapshot_to_definitive( $id );
+			if ( ! $result['success'] ) {
+				return $this->wp_error_from_envelope( $result['errors'], 409 );
+			}
+			return new \WP_REST_Response( $result, 200 );
+		}
+
+		// definitive_import mode requires an uploaded CSV.
+		$files = $request->get_file_params();
+		if ( ! isset( $files['csv_file']['tmp_name'] ) || ! is_string( $files['csv_file']['tmp_name'] ) ) {
+			return new \WP_Error(
+				'recruitment_csv_file_missing',
+				__( 'CSV file is required for definitive_import mode.', 'ffcertificate' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$content = file_get_contents( $files['csv_file']['tmp_name'] );
+		if ( false === $content ) {
+			return new \WP_Error(
+				'recruitment_csv_file_unreadable',
+				__( 'Could not read CSV file.', 'ffcertificate' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = RecruitmentCsvImporter::import_definitive( $id, $content );
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 400 );
+		}
+
+		// Flip status to active after a successful definitive_import.
+		$transition = RecruitmentNoticeStateMachine::transition_to( $id, 'active' );
+		if ( ! $transition['success'] ) {
+			return $this->wp_error_from_envelope( $transition['errors'], 409 );
+		}
+
+		RecruitmentActivityLogger::notice_promoted( $id, 'definitive_import', 0 );
+
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Classifications
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * POST /classifications/{id}/call
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function call_classification( \WP_REST_Request $request ) {
+		$id           = (int) $request->get_param( 'id' );
+		$reason_raw   = (string) ( $request->get_param( 'out_of_order_reason' ) ?? '' );
+		$notes_raw    = (string) ( $request->get_param( 'notes' ) ?? '' );
+		$reason_param = '' === $reason_raw ? null : $reason_raw;
+		$notes_param  = '' === $notes_raw ? null : $notes_raw;
+
+		$result = RecruitmentCallService::call_single(
+			$id,
+			(string) $request->get_param( 'date_to_assume' ),
+			(string) $request->get_param( 'time_to_assume' ),
+			get_current_user_id(),
+			$reason_param,
+			$notes_param
+		);
+
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 409 );
+		}
+
+		return new \WP_REST_Response( $result, 201 );
+	}
+
+	/**
+	 * POST /classifications/bulk-call
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function bulk_call_classifications( \WP_REST_Request $request ) {
+		$ids_raw = $request->get_param( 'classification_ids' );
+		if ( ! is_array( $ids_raw ) || empty( $ids_raw ) ) {
+			return new \WP_Error(
+				'recruitment_bulk_call_empty_id_list',
+				'',
+				array( 'status' => 400 )
+			);
+		}
+
+		$ids = array_values( array_filter( array_map( 'intval', $ids_raw ) ) );
+
+		$reasons_raw = $request->get_param( 'out_of_order_reasons' );
+		$reasons     = is_array( $reasons_raw ) ? array_map( 'sanitize_text_field', $reasons_raw ) : array();
+
+		$notes_raw   = (string) ( $request->get_param( 'notes' ) ?? '' );
+		$notes_param = '' === $notes_raw ? null : $notes_raw;
+
+		$result = RecruitmentCallService::call_bulk(
+			$ids,
+			(string) $request->get_param( 'date_to_assume' ),
+			(string) $request->get_param( 'time_to_assume' ),
+			get_current_user_id(),
+			$reasons,
+			$notes_param
+		);
+
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 409 );
+		}
+
+		return new \WP_REST_Response( $result, 201 );
+	}
+
+	/**
+	 * PATCH /classifications/{id}/status
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function change_classification_status( \WP_REST_Request $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$reason = $request->get_param( 'reason' );
+		$result = RecruitmentClassificationStateMachine::transition_to(
+			$id,
+			(string) $request->get_param( 'status' ),
+			is_string( $reason ) ? $reason : null
+		);
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 409 );
+		}
+
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * DELETE /classifications/{id}
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function delete_classification( \WP_REST_Request $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$result = RecruitmentDeleteService::delete_classification( $id );
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope_with_blocked( $result, 409 );
+		}
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * POST /classifications/{id}/calls/{call_id}/cancel
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function cancel_call( \WP_REST_Request $request ) {
+		$call_id = (int) $request->get_param( 'call_id' );
+		$result  = RecruitmentCallService::cancel_call(
+			$call_id,
+			(string) $request->get_param( 'reason' ),
+			get_current_user_id()
+		);
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope( $result['errors'], 409 );
+		}
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Adjutancies
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * GET /adjutancies — list every adjutancy.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function list_adjutancies(): \WP_REST_Response {
+		return new \WP_REST_Response( RecruitmentAdjutancyRepository::get_all(), 200 );
+	}
+
+	/**
+	 * POST /adjutancies — create a new adjutancy.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function create_adjutancy( \WP_REST_Request $request ) {
+		$id = RecruitmentAdjutancyRepository::create(
+			(string) $request->get_param( 'slug' ),
+			(string) $request->get_param( 'name' )
+		);
+		if ( false === $id ) {
+			return new \WP_Error(
+				'recruitment_adjutancy_create_failed',
+				__( 'Adjutancy creation failed (duplicate slug?).', 'ffcertificate' ),
+				array( 'status' => 409 )
+			);
+		}
+		return new \WP_REST_Response( RecruitmentAdjutancyRepository::get_by_id( $id ), 201 );
+	}
+
+	/**
+	 * PATCH /adjutancies/{id} — update slug or name.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_adjutancy( \WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$data = array_intersect_key( $request->get_params(), array_flip( array( 'slug', 'name' ) ) );
+		$ok   = RecruitmentAdjutancyRepository::update( $id, $data );
+		if ( ! $ok ) {
+			return new \WP_Error(
+				'recruitment_adjutancy_update_failed',
+				'',
+				array( 'status' => 400 )
+			);
+		}
+		return new \WP_REST_Response( RecruitmentAdjutancyRepository::get_by_id( $id ), 200 );
+	}
+
+	/**
+	 * DELETE /adjutancies/{id} — gated removal.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function delete_adjutancy( \WP_REST_Request $request ) {
+		$result = RecruitmentDeleteService::delete_adjutancy( (int) $request->get_param( 'id' ) );
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope_with_blocked( $result, 409 );
+		}
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Candidates
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * GET /candidates — filter by cpf/rf/name/notice/adjutancy.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function list_candidates( \WP_REST_Request $request ) {
+		// CPF/RF are passed as plaintext digits; hash here for the lookup.
+		$cpf = $request->get_param( 'cpf' );
+		if ( is_string( $cpf ) && '' !== $cpf ) {
+			$cpf_digits = preg_replace( '/[^0-9]/', '', $cpf ) ?? '';
+			if ( '' !== $cpf_digits ) {
+				$candidate = RecruitmentCandidateRepository::get_by_cpf_hash( (string) Encryption::hash( $cpf_digits ) );
+				return new \WP_REST_Response( null === $candidate ? array() : array( $this->shape_candidate_admin( $candidate ) ), 200 );
+			}
+		}
+
+		$rf = $request->get_param( 'rf' );
+		if ( is_string( $rf ) && '' !== $rf ) {
+			$rf_digits = preg_replace( '/[^0-9]/', '', $rf ) ?? '';
+			if ( '' !== $rf_digits ) {
+				$candidate = RecruitmentCandidateRepository::get_by_rf_hash( (string) Encryption::hash( $rf_digits ) );
+				return new \WP_REST_Response( null === $candidate ? array() : array( $this->shape_candidate_admin( $candidate ) ), 200 );
+			}
+		}
+
+		// Generic listing not yet implemented in repository (out of scope for
+		// sprint 9.1 MVP — search by name will land alongside the admin UI).
+		return new \WP_Error(
+			'recruitment_candidate_list_requires_filter',
+			__( 'Candidate listing requires a cpf or rf filter for now.', 'ffcertificate' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * GET /candidates/{id} — admin view with decrypted fields.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_candidate( \WP_REST_Request $request ) {
+		$id        = (int) $request->get_param( 'id' );
+		$candidate = RecruitmentCandidateRepository::get_by_id( $id );
+		if ( null === $candidate ) {
+			return new \WP_Error( 'recruitment_candidate_not_found', '', array( 'status' => 404 ) );
+		}
+		return new \WP_REST_Response( $this->shape_candidate_admin( $candidate ), 200 );
+	}
+
+	/**
+	 * PATCH /candidates/{id} — re-encrypts on cpf/rf/email change.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_candidate( \WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$data = $request->get_params();
+
+		$update = array_intersect_key( $data, array_flip( array( 'name', 'phone', 'notes' ) ) );
+
+		// Encrypt cpf/rf/email via the SensitiveFieldRegistry if supplied.
+		$plaintexts = array();
+		foreach ( array( 'cpf', 'rf', 'email' ) as $key ) {
+			if ( isset( $data[ $key ] ) && is_string( $data[ $key ] ) && '' !== trim( $data[ $key ] ) ) {
+				$value = trim( $data[ $key ] );
+				if ( 'email' === $key ) {
+					$value = strtolower( $value );
+				} else {
+					$value = preg_replace( '/[^0-9]/', '', $value ) ?? '';
+				}
+				$plaintexts[ $key ] = $value;
+			}
+		}
+
+		if ( ! empty( $plaintexts ) ) {
+			$encrypted = SensitiveFieldRegistry::encrypt_fields(
+				SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE,
+				$plaintexts
+			);
+			$update    = array_merge( $update, $encrypted );
+		}
+
+		if ( empty( $update ) ) {
+			return new \WP_Error(
+				'recruitment_candidate_update_no_writable_fields',
+				'',
+				array( 'status' => 400 )
+			);
+		}
+
+		$ok = RecruitmentCandidateRepository::update( $id, $update );
+		if ( ! $ok ) {
+			return new \WP_Error(
+				'recruitment_candidate_update_failed',
+				'',
+				array( 'status' => 409 )
+			);
+		}
+
+		$candidate = RecruitmentCandidateRepository::get_by_id( $id );
+		return new \WP_REST_Response(
+			null === $candidate ? null : $this->shape_candidate_admin( $candidate ),
+			200
+		);
+	}
+
+	/**
+	 * DELETE /candidates/{id} — gated hard-delete (zero classifications).
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function delete_candidate( \WP_REST_Request $request ) {
+		$result = RecruitmentDeleteService::delete_candidate( (int) $request->get_param( 'id' ) );
+		if ( ! $result['success'] ) {
+			return $this->wp_error_from_envelope_with_blocked( $result, 409 );
+		}
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Candidate-self dashboard
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * GET /me/recruitment.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function get_my_recruitment(): \WP_REST_Response {
+		$user_id = get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return new \WP_REST_Response( array(), 200 );
+		}
+
+		$candidates = RecruitmentCandidateRepository::get_by_user_id( $user_id );
+		if ( empty( $candidates ) ) {
+			return new \WP_REST_Response( array(), 200 );
+		}
+
+		// Group classifications by notice for the §9.2 grouped payload.
+		$out = array();
+		foreach ( $candidates as $candidate ) {
+			$candidate_id    = (int) $candidate->id;
+			$classifications = RecruitmentClassificationRepository::get_for_candidate( $candidate_id );
+
+			foreach ( $classifications as $cls ) {
+				$notice_id = (int) $cls->notice_id;
+				$notice    = RecruitmentNoticeRepository::get_by_id( $notice_id );
+				if ( null === $notice || 'draft' === $notice->status ) {
+					continue; // Draft notices are never exposed.
+				}
+
+				if ( ! isset( $out[ $notice_id ] ) ) {
+					$out[ $notice_id ] = array(
+						'notice'          => array(
+							'id'           => $notice_id,
+							'code'         => $notice->code,
+							'name'         => $notice->name,
+							'status'       => $notice->status,
+							'was_reopened' => '1' === $notice->was_reopened,
+						),
+						'classifications' => array(),
+					);
+				}
+
+				$out[ $notice_id ]['classifications'][] = array(
+					'id'        => (int) $cls->id,
+					'list_type' => $cls->list_type,
+					'rank'      => (int) $cls->rank,
+					'score'     => $cls->score,
+					'status'    => $cls->status,
+					'calls'     => RecruitmentCallRepository::get_history_for_classification( (int) $cls->id ),
+				);
+			}
+		}
+
+		return new \WP_REST_Response( array_values( $out ), 200 );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Decrypt sensitive fields for admin-side candidate responses.
+	 *
+	 * @param object $candidate Candidate row (CandidateRow shape).
+	 * @phpstan-param CandidateRow $candidate
+	 * @return array<string, mixed>
+	 */
+	private function shape_candidate_admin( object $candidate ): array {
+		$decrypt = static function ( $value ) {
+			if ( ! is_string( $value ) || '' === $value ) {
+				return null;
+			}
+			$plain = Encryption::decrypt( $value );
+			return null === $plain ? null : $plain;
+		};
+
+		$mask_or_plain_email = function ( ?string $plain ): ?string {
+			return null === $plain ? null : DocumentFormatter::mask_email( $plain );
+		};
+
+		return array(
+			'id'           => (int) $candidate->id,
+			'user_id'      => null === $candidate->user_id ? null : (int) $candidate->user_id,
+			'name'         => $candidate->name,
+			'cpf'          => $decrypt( $candidate->cpf_encrypted ),
+			'rf'           => $decrypt( $candidate->rf_encrypted ),
+			'email'        => $decrypt( $candidate->email_encrypted ),
+			'email_masked' => $mask_or_plain_email( $decrypt( $candidate->email_encrypted ) ),
+			'phone'        => $candidate->phone,
+			'notes'        => $candidate->notes,
+			'is_pcd'       => RecruitmentPcdHasher::verify( $candidate->pcd_hash, (int) $candidate->id ),
+			'created_at'   => $candidate->created_at,
+			'updated_at'   => $candidate->updated_at,
+		);
+	}
+
+	/**
+	 * Convert an envelope-style errors array into a `\WP_Error`.
+	 *
+	 * @param array<int, string> $errors  Error codes.
+	 * @param int                $status  HTTP status code.
+	 * @return \WP_Error
+	 */
+	private function wp_error_from_envelope( array $errors, int $status ): \WP_Error {
+		$code = $errors[0] ?? 'recruitment_error';
+		return new \WP_Error(
+			$code,
+			$code,
+			array(
+				'status' => $status,
+				'errors' => $errors,
+			)
+		);
+	}
+
+	/**
+	 * Same as `wp_error_from_envelope` but additionally surfaces a
+	 * `blocked_by` reference-count map (returned by the delete service).
+	 *
+	 * @param array{success: bool, errors: list<string>, blocked_by?: array<string, int>} $envelope Service-result envelope.
+	 * @param int                                                                         $status   HTTP status code.
+	 * @return \WP_Error
+	 */
+	private function wp_error_from_envelope_with_blocked( array $envelope, int $status ): \WP_Error {
+		$first = $envelope['errors'][0] ?? 'recruitment_error';
+		$data  = array(
+			'status' => $status,
+			'errors' => $envelope['errors'],
+		);
+		if ( isset( $envelope['blocked_by'] ) ) {
+			$data['blocked_by'] = $envelope['blocked_by'];
+		}
+		return new \WP_Error( $first, $first, $data );
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-rest-controller.php
@@ -511,6 +511,7 @@ final class RecruitmentRestController {
 			);
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local upload tmp file; wp_remote_get is for HTTP only.
 		$content = file_get_contents( $files['csv_file']['tmp_name'] );
 		if ( false === $content ) {
 			return new \WP_Error(
@@ -557,6 +558,7 @@ final class RecruitmentRestController {
 			);
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local upload tmp file; wp_remote_get is for HTTP only.
 		$content = file_get_contents( $files['csv_file']['tmp_name'] );
 		if ( false === $content ) {
 			return new \WP_Error(

--- a/includes/recruitment/class-ffc-recruitment-settings.php
+++ b/includes/recruitment/class-ffc-recruitment-settings.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Recruitment Settings
+ *
+ * Typed accessors over the single `ffc_recruitment_settings` WP option,
+ * registered via WordPress Settings API on `admin_init`. Per §15 of the
+ * implementation plan, all module-level configuration lives in one
+ * serialized option (matches plugin convention — cf. `ffc_settings`,
+ * `ffc_geolocation_settings`, `ffc_rate_limit_settings`).
+ *
+ * Sub-keys:
+ *
+ *   - email_subject              Subject template (placeholder-supporting).
+ *   - email_from_address         Override; falls back to `wp_mail` default.
+ *   - email_from_name            Override; falls back to site name.
+ *   - email_body_html            Body template (free-form HTML).
+ *   - public_cache_seconds       TTL for the public shortcode transient
+ *                                cache (default 60).
+ *   - public_rate_limit_per_minute
+ *                                Per-IP rate cap for shortcode HTTP
+ *                                requests (default 30).
+ *   - public_default_page_size   Default page size for both shortcode
+ *                                sections (default 50).
+ *
+ * Sprint 10 reads the email_* keys to render the convocation email;
+ * sprint 11 reads the public_* keys when registering the public
+ * shortcode. Sprint 12 surfaces the editor UI for these in the admin
+ * Settings tab.
+ *
+ * Uninstall (sprint 1.1's `uninstall.php`) drops the entire option in
+ * one `delete_option('ffc_recruitment_settings')` call.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Single source of truth for the recruitment module's configuration.
+ *
+ * @phpstan-type SettingsArray array{
+ *   email_subject:               string,
+ *   email_from_address:          string,
+ *   email_from_name:             string,
+ *   email_body_html:             string,
+ *   public_cache_seconds:        int,
+ *   public_rate_limit_per_minute: int,
+ *   public_default_page_size:    int,
+ * }
+ */
+final class RecruitmentSettings {
+
+	/** WP option key holding the serialized settings array. */
+	public const OPTION_NAME = 'ffc_recruitment_settings';
+
+	/** Settings group used by the Settings API + admin Settings tab (sprint 12). */
+	public const OPTION_GROUP = 'ffc_recruitment_settings_group';
+
+	/**
+	 * Register the option with the WordPress Settings API.
+	 *
+	 * Hooked from {@see RecruitmentLoader} on `admin_init` (priority 10:
+	 * canonical hook for `register_setting()` calls; default priority
+	 * because no ordering constraint vs other plugins).
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		register_setting(
+			self::OPTION_GROUP,
+			self::OPTION_NAME,
+			array(
+				'type'              => 'array',
+				'description'       => 'Recruitment module settings (email templates + public shortcode tuning).',
+				'sanitize_callback' => array( self::class, 'sanitize' ),
+				'default'           => self::defaults(),
+				'show_in_rest'      => false,
+			)
+		);
+	}
+
+	/**
+	 * Default values per sub-key.
+	 *
+	 * Subject and body defaults are translatable via `__()`. The body
+	 * default is a minimal HTML skeleton — sprint 12's CodeMirror editor
+	 * lets admins replace it; sprint 10's renderer treats the body as
+	 * trusted HTML (admin-only edit surface, gated by
+	 * `ffc_manage_recruitment`) so the only sanitization on display is
+	 * `wp_kses_post` on the rendered output.
+	 *
+	 * @return SettingsArray
+	 */
+	public static function defaults(): array {
+		return array(
+			'email_subject'                => __( 'Convocação - {{notice_code}} - {{adjutancy}}', 'ffcertificate' ),
+			'email_from_address'           => '',
+			'email_from_name'              => '',
+			'email_body_html'              => self::default_body_template(),
+			'public_cache_seconds'         => 60,
+			'public_rate_limit_per_minute' => 30,
+			'public_default_page_size'     => 50,
+		);
+	}
+
+	/**
+	 * Get the full settings array, merged with defaults.
+	 *
+	 * Used by sprint 10 (email dispatch) and sprint 11 (public shortcode)
+	 * to read configuration. The returned array always has every sub-key
+	 * present, even on a fresh install where the option doesn't yet exist.
+	 *
+	 * @return SettingsArray
+	 */
+	public static function all(): array {
+		$stored = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $stored ) ) {
+			$stored = array();
+		}
+
+		$merged = array_merge( self::defaults(), $stored );
+
+		return self::shape( $merged );
+	}
+
+	/**
+	 * Get a single sub-key, falling back to its default if missing or
+	 * stored with the wrong type.
+	 *
+	 * @param string $key One of the documented sub-keys.
+	 * @return mixed Typed value (string for text settings, int for numeric ones).
+	 */
+	public static function get( string $key ) {
+		$all = self::all();
+		return $all[ $key ] ?? null;
+	}
+
+	/**
+	 * Sanitize a settings payload before storage.
+	 *
+	 * Email body HTML is preserved as-is (admin-trusted edit surface; no
+	 * `wp_kses_post` here so admins can use any tags they need). Subject
+	 * and From fields go through `sanitize_text_field`. Numeric sub-keys
+	 * are coerced to non-negative integers with reasonable upper bounds
+	 * to prevent accidental misconfiguration.
+	 *
+	 * @param mixed $value Incoming option value.
+	 * @return SettingsArray Sanitized settings.
+	 */
+	public static function sanitize( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return self::defaults();
+		}
+
+		$defaults = self::defaults();
+		$out      = array();
+
+		$out['email_subject']      = isset( $value['email_subject'] ) && is_string( $value['email_subject'] )
+			? sanitize_text_field( $value['email_subject'] )
+			: $defaults['email_subject'];
+		$out['email_from_address'] = isset( $value['email_from_address'] ) && is_string( $value['email_from_address'] )
+			? sanitize_text_field( $value['email_from_address'] )
+			: $defaults['email_from_address'];
+		$out['email_from_name']    = isset( $value['email_from_name'] ) && is_string( $value['email_from_name'] )
+			? sanitize_text_field( $value['email_from_name'] )
+			: $defaults['email_from_name'];
+
+		// Body HTML: admin-trusted; preserve all tags admins typed. The
+		// rendering path (`wp_mail`) accepts arbitrary HTML.
+		$out['email_body_html'] = isset( $value['email_body_html'] ) && is_string( $value['email_body_html'] )
+			? $value['email_body_html']
+			: $defaults['email_body_html'];
+
+		$out['public_cache_seconds']         = self::clamp_int( $value['public_cache_seconds'] ?? null, 0, 86400, $defaults['public_cache_seconds'] );
+		$out['public_rate_limit_per_minute'] = self::clamp_int( $value['public_rate_limit_per_minute'] ?? null, 0, 6000, $defaults['public_rate_limit_per_minute'] );
+		$out['public_default_page_size']     = self::clamp_int( $value['public_default_page_size'] ?? null, 1, 1000, $defaults['public_default_page_size'] );
+
+		return $out;
+	}
+
+	/**
+	 * Coerce + bound an integer setting; fall back to default on bad input.
+	 *
+	 * @param mixed $value   Raw incoming value.
+	 * @param int   $min     Minimum accepted (inclusive).
+	 * @param int   $max     Maximum accepted (inclusive).
+	 * @param int   $default Default when input is unusable.
+	 * @return int
+	 */
+	private static function clamp_int( $value, int $min, int $max, int $default ): int {
+		if ( ! is_numeric( $value ) ) {
+			return $default;
+		}
+		$intval = (int) $value;
+		if ( $intval < $min ) {
+			return $default;
+		}
+		if ( $intval > $max ) {
+			return $max;
+		}
+		return $intval;
+	}
+
+	/**
+	 * Type-narrow a possibly-mixed array into the SettingsArray shape.
+	 *
+	 * Reused by `all()` after merging defaults+stored.
+	 *
+	 * @param array<string, mixed> $value Already merged-with-defaults array.
+	 * @return SettingsArray
+	 */
+	private static function shape( array $value ): array {
+		$defaults = self::defaults();
+		return array(
+			'email_subject'                => is_string( $value['email_subject'] ?? null ) ? $value['email_subject'] : $defaults['email_subject'],
+			'email_from_address'           => is_string( $value['email_from_address'] ?? null ) ? $value['email_from_address'] : $defaults['email_from_address'],
+			'email_from_name'              => is_string( $value['email_from_name'] ?? null ) ? $value['email_from_name'] : $defaults['email_from_name'],
+			'email_body_html'              => is_string( $value['email_body_html'] ?? null ) ? $value['email_body_html'] : $defaults['email_body_html'],
+			'public_cache_seconds'         => is_int( $value['public_cache_seconds'] ?? null ) ? $value['public_cache_seconds'] : $defaults['public_cache_seconds'],
+			'public_rate_limit_per_minute' => is_int( $value['public_rate_limit_per_minute'] ?? null ) ? $value['public_rate_limit_per_minute'] : $defaults['public_rate_limit_per_minute'],
+			'public_default_page_size'     => is_int( $value['public_default_page_size'] ?? null ) ? $value['public_default_page_size'] : $defaults['public_default_page_size'],
+		);
+	}
+
+	/**
+	 * Default email body template — minimal, edit-friendly HTML.
+	 *
+	 * Translatable via `__()` so pt-BR `.po` files can ship a localized
+	 * default. All `{{placeholder}}` markers documented in §11 of the plan
+	 * resolve at send time.
+	 *
+	 * @return string
+	 */
+	private static function default_body_template(): string {
+		return __( '<p>Olá {{name}},</p><p>Você foi convocado para o edital <strong>{{notice_code}} — {{notice_name}}</strong> na matéria <strong>{{adjutancy}}</strong>.</p><ul><li><strong>Posição:</strong> {{rank}}</li><li><strong>Pontuação:</strong> {{score}}</li><li><strong>Data para assumir:</strong> {{date_to_assume}}</li><li><strong>Horário:</strong> {{time_to_assume}}</li></ul><p>{{notes}}</p><p>— {{site_name}}<br>{{site_url}}</p>', 'ffcertificate' );
+	}
+}

--- a/includes/user-dashboard/class-ffc-capability-manager.php
+++ b/includes/user-dashboard/class-ffc-capability-manager.php
@@ -30,6 +30,21 @@ class CapabilityManager {
 	public const CONTEXT_AUDIENCE    = 'audience';
 
 	/**
+	 * Context key: recruitment-module candidate promotion path.
+	 *
+	 * Used by `UserCreator::get_or_create_user()` when the candidate is
+	 * being linked or created via the recruitment CSV importer (sprint 4) or
+	 * a manual admin edit (sprint 9.1). No per-user caps are granted on this
+	 * context — candidates rely on the `ffc_user` role's baseline `read` cap
+	 * to access their dashboard "Minhas Convocações" section. The
+	 * `ffc_manage_recruitment` admin cap is registered separately on plugin
+	 * activation (see {@see self::register_recruitment_manager_role()}).
+	 *
+	 * @since 6.0.0
+	 */
+	public const CONTEXT_RECRUITMENT = 'recruitment';
+
+	/**
 	 * All certificate-related capabilities
 	 */
 	public const CERTIFICATE_CAPABILITIES = array(
@@ -64,7 +79,19 @@ class CapabilityManager {
 	public const ADMIN_CAPABILITIES = array(
 		'ffc_scheduling_bypass',
 		'ffc_manage_reregistration',
+		'ffc_manage_recruitment',
 	);
+
+	/**
+	 * Slug for the dedicated recruitment-manager role.
+	 *
+	 * The role is granted `read` + `ffc_manage_recruitment` so site admins
+	 * can delegate recruitment management without giving out full
+	 * `manage_options`. Created on plugin activation, removed on uninstall.
+	 *
+	 * @since 6.0.0
+	 */
+	public const RECRUITMENT_MANAGER_ROLE = 'ffc_recruitment_manager';
 
 	/**
 	 * Future capabilities (disabled by default)
@@ -110,6 +137,12 @@ class CapabilityManager {
 				break;
 			case self::CONTEXT_AUDIENCE:
 				self::grant_audience_capabilities( $user_id );
+				break;
+			case self::CONTEXT_RECRUITMENT:
+				// Intentional no-op: recruitment candidates rely on the
+				// `ffc_user` role's baseline `read` cap. The admin-side
+				// `ffc_manage_recruitment` cap is registered on activation,
+				// not granted at promotion time.
 				break;
 		}
 	}
@@ -466,5 +499,56 @@ class CapabilityManager {
 	 */
 	public static function remove_role(): void {
 		remove_role( 'ffc_user' );
+	}
+
+	/**
+	 * Register the dedicated recruitment-manager role on plugin activation.
+	 *
+	 * Idempotent: if the role already exists, it is upgraded so any newly
+	 * introduced caps are added without disturbing other caps the admin may
+	 * have manually granted. Granted caps: `read` + `ffc_manage_recruitment`.
+	 *
+	 * Called from {@see \FreeFormCertificate\Activator::activate()}.
+	 *
+	 * @since 6.0.0
+	 * @return void
+	 */
+	public static function register_recruitment_manager_role(): void {
+		$existing_role = get_role( self::RECRUITMENT_MANAGER_ROLE );
+
+		if ( $existing_role ) {
+			// Upgrade path: ensure both caps are present without overwriting
+			// any admin-customized capability map.
+			if ( ! isset( $existing_role->capabilities['read'] ) ) {
+				$existing_role->add_cap( 'read', true );
+			}
+			if ( ! isset( $existing_role->capabilities['ffc_manage_recruitment'] ) ) {
+				$existing_role->add_cap( 'ffc_manage_recruitment', true );
+			}
+			return;
+		}
+
+		add_role(
+			self::RECRUITMENT_MANAGER_ROLE,
+			__( 'Recruitment Manager', 'ffcertificate' ),
+			array(
+				'read'                   => true,
+				'ffc_manage_recruitment' => true,
+			)
+		);
+	}
+
+	/**
+	 * Remove the recruitment-manager role on plugin uninstall.
+	 *
+	 * Called from `uninstall.php` after the cap-stripping loop has cleared
+	 * `ffc_manage_recruitment` from any user that had been granted it
+	 * directly.
+	 *
+	 * @since 6.0.0
+	 * @return void
+	 */
+	public static function remove_recruitment_manager_role(): void {
+		remove_role( self::RECRUITMENT_MANAGER_ROLE );
 	}
 }

--- a/tests/Unit/CapabilityManagerTest.php
+++ b/tests/Unit/CapabilityManagerTest.php
@@ -71,7 +71,8 @@ class CapabilityManagerTest extends TestCase {
         $caps = CapabilityManager::ADMIN_CAPABILITIES;
         $this->assertContains( 'ffc_scheduling_bypass', $caps );
         $this->assertContains( 'ffc_manage_reregistration', $caps );
-        $this->assertCount( 2, $caps );
+        $this->assertContains( 'ffc_manage_recruitment', $caps );
+        $this->assertCount( 3, $caps );
     }
 
     public function test_future_capabilities_contains_expected_caps(): void {

--- a/tests/Unit/DocumentFormatterTest.php
+++ b/tests/Unit/DocumentFormatterTest.php
@@ -317,6 +317,39 @@ class DocumentFormatterTest extends TestCase {
     }
 
     // ==================================================================
+    // mask_rf
+    // ==================================================================
+
+    public function test_mask_rf_with_4_digit_value(): void {
+        $this->assertSame('123.***.4', DocumentFormatter::mask_rf('1234'));
+    }
+
+    public function test_mask_rf_with_7_digit_value(): void {
+        $this->assertSame('123.***.7', DocumentFormatter::mask_rf('1234567'));
+    }
+
+    public function test_mask_rf_with_long_value(): void {
+        // 12-digit RFs exist in some Brazilian states/agencies; mask still
+        // shows first 3 + last 1 of the digit-only sequence.
+        $this->assertSame('123.***.2', DocumentFormatter::mask_rf('123456789012'));
+    }
+
+    public function test_mask_rf_strips_punctuation_before_masking(): void {
+        $this->assertSame('123.***.7', DocumentFormatter::mask_rf('123.456-7'));
+    }
+
+    public function test_mask_rf_returns_original_when_too_short(): void {
+        // < 4 digits → cannot mask meaningfully; return unchanged for
+        // observability (caller sees the raw input was malformed).
+        $this->assertSame('123', DocumentFormatter::mask_rf('123'));
+        $this->assertSame('1', DocumentFormatter::mask_rf('1'));
+    }
+
+    public function test_mask_rf_returns_empty_for_empty_input(): void {
+        $this->assertSame('', DocumentFormatter::mask_rf(''));
+    }
+
+    // ==================================================================
     // mask_email
     // ==================================================================
 

--- a/tests/Unit/RecruitmentActivatorTest.php
+++ b/tests/Unit/RecruitmentActivatorTest.php
@@ -1,0 +1,236 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentActivator;
+
+/**
+ * Tests for RecruitmentActivator — covers the six idempotent CREATE TABLE
+ * statements (one per recruitment table) and verifies the schema-level
+ * invariants encoded in each statement (UNIQUE constraints, ENGINE=InnoDB,
+ * indexes for the documented hot paths).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentActivator
+ */
+class RecruitmentActivatorTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		$this->wpdb->shouldReceive( 'get_charset_collate' )
+			->andReturn( 'DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' )
+			->byDefault();
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					$args = func_get_args();
+					$sql  = $args[0];
+					for ( $i = 1; $i < count( $args ); $i++ ) {
+						$val = is_string( $args[ $i ] ) ? "'{$args[$i]}'" : $args[ $i ];
+						$sql = preg_replace( '/%[isdf]/', (string) $val, $sql, 1 );
+					}
+					return $sql;
+				}
+			)
+			->byDefault();
+
+		Functions\when( 'dbDelta' )->justReturn( array() );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns a get_var stub that reports every recruitment table as missing.
+	 *
+	 * Used to force RecruitmentActivator to issue all six CREATE TABLE
+	 * statements (idempotency would otherwise short-circuit).
+	 */
+	private function stub_no_tables_exist(): void {
+		$this->wpdb->shouldReceive( 'get_var' )
+			->andReturnUsing(
+				function ( $query ) {
+					if ( false !== stripos( $query, 'SHOW TABLES LIKE' ) ) {
+						return null;
+					}
+					return null;
+				}
+			);
+	}
+
+	/**
+	 * Returns a get_var stub that reports every recruitment table as present.
+	 */
+	private function stub_all_tables_exist(): void {
+		$this->wpdb->shouldReceive( 'get_var' )
+			->andReturnUsing(
+				function ( $query ) {
+					if ( false !== stripos( $query, 'SHOW TABLES LIKE' ) ) {
+						if ( preg_match( "/SHOW TABLES LIKE\s+'([^']+)'/", $query, $m ) ) {
+							return $m[1];
+						}
+						return 'wp_ffc_recruitment_existing';
+					}
+					return null;
+				}
+			);
+	}
+
+	public function test_create_tables_issues_six_dbdelta_calls_when_none_exist(): void {
+		$this->stub_no_tables_exist();
+
+		$delta_sqls = array();
+		Functions\when( 'dbDelta' )->alias(
+			function ( $sql ) use ( &$delta_sqls ) {
+				$delta_sqls[] = $sql;
+			}
+		);
+
+		RecruitmentActivator::create_tables();
+
+		$this->assertCount( 6, $delta_sqls, 'dbDelta should be called 6 times — one per recruitment table' );
+	}
+
+	public function test_create_tables_is_idempotent_when_all_tables_exist(): void {
+		$this->stub_all_tables_exist();
+
+		$delta_called = false;
+		Functions\when( 'dbDelta' )->alias(
+			function () use ( &$delta_called ) {
+				$delta_called = true;
+			}
+		);
+
+		RecruitmentActivator::create_tables();
+
+		$this->assertFalse( $delta_called, 'No CREATE TABLE statements should be issued when every table already exists' );
+	}
+
+	public function test_all_six_tables_use_innodb_engine(): void {
+		$this->stub_no_tables_exist();
+
+		$delta_sqls = array();
+		Functions\when( 'dbDelta' )->alias(
+			function ( $sql ) use ( &$delta_sqls ) {
+				$delta_sqls[] = $sql;
+			}
+		);
+
+		RecruitmentActivator::create_tables();
+
+		$this->assertCount( 6, $delta_sqls );
+		foreach ( $delta_sqls as $sql ) {
+			$this->assertStringContainsString( 'ENGINE=InnoDB', $sql, 'Every recruitment table must declare ENGINE=InnoDB so the atomic CSV import works' );
+		}
+	}
+
+	public function test_adjutancy_table_has_unique_slug_constraint(): void {
+		$this->stub_no_tables_exist();
+
+		$adjutancy_sql = $this->capture_table_sql( 'ffc_recruitment_adjutancy' );
+
+		$this->assertStringContainsString( 'CREATE TABLE wp_ffc_recruitment_adjutancy', $adjutancy_sql );
+		$this->assertStringContainsString( 'UNIQUE KEY uq_slug (slug)', $adjutancy_sql );
+	}
+
+	public function test_notice_table_has_unique_code_status_index_and_was_reopened(): void {
+		$this->stub_no_tables_exist();
+
+		$notice_sql = $this->capture_table_sql( 'ffc_recruitment_notice' );
+
+		$this->assertStringContainsString( 'UNIQUE KEY uq_code (code)', $notice_sql );
+		$this->assertStringContainsString( 'KEY idx_status (status)', $notice_sql );
+		$this->assertStringContainsString( 'was_reopened tinyint(1) NOT NULL DEFAULT 0', $notice_sql );
+		$this->assertStringContainsString( 'public_columns_config longtext NOT NULL', $notice_sql );
+	}
+
+	public function test_candidate_table_has_separate_unique_constraints_on_cpf_and_rf_hashes(): void {
+		$this->stub_no_tables_exist();
+
+		$candidate_sql = $this->capture_table_sql( 'ffc_recruitment_candidate' );
+
+		$this->assertStringContainsString( 'UNIQUE KEY uq_cpf_hash (cpf_hash)', $candidate_sql );
+		$this->assertStringContainsString( 'UNIQUE KEY uq_rf_hash (rf_hash)', $candidate_sql );
+		$this->assertStringContainsString( 'KEY idx_email_hash (email_hash)', $candidate_sql, 'email_hash is indexed but NOT unique (family-shared emails are allowed)' );
+		$this->assertStringContainsString( 'pcd_hash varchar(64) NOT NULL', $candidate_sql, 'pcd_hash is NOT NULL — both PCD and non-PCD candidates carry a hash' );
+	}
+
+	public function test_classification_table_has_composite_indexes_for_hot_paths(): void {
+		$this->stub_no_tables_exist();
+
+		$classification_sql = $this->capture_table_sql( 'ffc_recruitment_classification' );
+
+		$this->assertStringContainsString( 'UNIQUE KEY uq_candidate_adjutancy_notice_list', $classification_sql );
+		$this->assertStringContainsString(
+			'KEY idx_notice_adjutancy_list_status_rank (notice_id, adjutancy_id, list_type, status, `rank`)',
+			$classification_sql,
+			'Composite index covering the lowest-rank-empty hot path; status precedes rank'
+		);
+		$this->assertStringContainsString( 'KEY idx_candidate_id (candidate_id)', $classification_sql );
+	}
+
+	public function test_call_table_has_classification_cancelled_index(): void {
+		$this->stub_no_tables_exist();
+
+		$call_sql = $this->capture_table_sql( 'ffc_recruitment_call' );
+
+		$this->assertStringContainsString( 'KEY idx_classification_cancelled (classification_id, cancelled_at)', $call_sql );
+		$this->assertStringContainsString( 'cancelled_at datetime DEFAULT NULL', $call_sql );
+		$this->assertStringContainsString( 'cancellation_reason text DEFAULT NULL', $call_sql );
+	}
+
+	public function test_notice_adjutancy_junction_has_composite_pk_and_reverse_lookup_index(): void {
+		$this->stub_no_tables_exist();
+
+		$junction_sql = $this->capture_table_sql( 'ffc_recruitment_notice_adjutancy' );
+
+		$this->assertStringContainsString( 'PRIMARY KEY (notice_id, adjutancy_id)', $junction_sql );
+		$this->assertStringContainsString( 'KEY idx_adjutancy_id (adjutancy_id)', $junction_sql );
+	}
+
+	/**
+	 * Capture the CREATE TABLE SQL emitted to dbDelta for a specific table suffix.
+	 *
+	 * @param string $table_suffix Table-name fragment (without `wp_` prefix).
+	 * @return string Full CREATE TABLE SQL.
+	 */
+	private function capture_table_sql( string $table_suffix ): string {
+		$captured = array();
+		Functions\when( 'dbDelta' )->alias(
+			function ( $sql ) use ( &$captured ) {
+				$captured[] = $sql;
+			}
+		);
+
+		RecruitmentActivator::create_tables();
+
+		foreach ( $captured as $sql ) {
+			if ( false !== stripos( $sql, $table_suffix ) ) {
+				return $sql;
+			}
+		}
+
+		$this->fail( "No CREATE TABLE captured for {$table_suffix}" );
+	}
+}

--- a/tests/Unit/RecruitmentActivityLoggerTest.php
+++ b/tests/Unit/RecruitmentActivityLoggerTest.php
@@ -1,0 +1,220 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentActivityLogger;
+use FreeFormCertificate\Core\ActivityLog;
+
+/**
+ * Tests for RecruitmentActivityLogger — verifies the action vocabulary,
+ * payload shape per event, and that sensitive-payload protection
+ * (inherited from the core ActivityLog) is wired correctly. We don't
+ * exercise the encrypt path itself (covered by SensitiveFieldRegistryTest);
+ * we verify the log call lands with the expected action code + context.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentActivityLogger
+ */
+class RecruitmentActivityLoggerTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		// Enable the activity log so ActivityLog::log() doesn't short-circuit.
+		Functions\when( 'get_option' )->justReturn( array( 'enable_activity_log' => 1 ) );
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'get_current_user_id' )->justReturn( 99 );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+
+		// Encryption module is class-detected via class_exists; ensure it's
+		// reported as "not configured" so the log path stays in plaintext
+		// (we test the action+payload, not the encryption itself).
+		$this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
+		$this->wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+		$this->wpdb->shouldReceive( 'get_col' )->andReturn( array() )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		// Reset the private static buffer so each test starts clean.
+		$ref = new \ReflectionProperty( ActivityLog::class, 'write_buffer' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, array() );
+
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Read the private static write_buffer via reflection.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function buffer(): array {
+		$ref = new \ReflectionProperty( ActivityLog::class, 'write_buffer' );
+		$ref->setAccessible( true );
+		$value = $ref->getValue();
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Capture the most recent buffered log entry.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function last_buffered_entry(): ?array {
+		$buffer = $this->buffer();
+		if ( empty( $buffer ) ) {
+			return null;
+		}
+		return end( $buffer );
+	}
+
+	public function test_csv_imported_logs_with_expected_payload(): void {
+		RecruitmentActivityLogger::csv_imported( 5, 'preview', 42 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertNotNull( $entry );
+		$this->assertSame( 'recruitment_csv_imported', $entry['action'] );
+		// Context is JSON-encoded in the log row when not encrypted.
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 5, $context['notice_id'] );
+		$this->assertSame( 'preview', $context['list_type'] );
+		$this->assertSame( 42, $context['inserted_count'] );
+	}
+
+	public function test_csv_import_failed_uses_warning_level(): void {
+		RecruitmentActivityLogger::csv_import_failed( 5, 'definitive', 7 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_csv_import_failed', $entry['action'] );
+		$this->assertSame( ActivityLog::LEVEL_WARNING, $entry['level'] );
+	}
+
+	public function test_notice_status_changed_omits_reason_when_null(): void {
+		RecruitmentActivityLogger::notice_status_changed( 5, 'draft', 'preliminary' );
+
+		$context = json_decode( (string) $this->last_buffered_entry()['context'], true );
+		$this->assertSame( 'draft', $context['from'] );
+		$this->assertSame( 'preliminary', $context['to'] );
+		$this->assertArrayNotHasKey( 'reason', $context );
+	}
+
+	public function test_notice_status_changed_includes_reason_when_provided(): void {
+		RecruitmentActivityLogger::notice_status_changed( 5, 'closed', 'active', 'Vacancy reopened' );
+
+		$context = json_decode( (string) $this->last_buffered_entry()['context'], true );
+		$this->assertSame( 'Vacancy reopened', $context['reason'] );
+	}
+
+	public function test_notice_promoted_records_mode_and_copy_count(): void {
+		RecruitmentActivityLogger::notice_promoted( 5, 'snapshot', 17 );
+
+		$context = json_decode( (string) $this->last_buffered_entry()['context'], true );
+		$this->assertSame( 5, $context['notice_id'] );
+		$this->assertSame( 'snapshot', $context['mode'] );
+		$this->assertSame( 17, $context['copied'] );
+	}
+
+	public function test_classification_status_changed_records_transition(): void {
+		RecruitmentActivityLogger::classification_status_changed( 10, 'called', 'hired' );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_classification_status_changed', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 10, $context['classification_id'] );
+		$this->assertSame( 'called', $context['from'] );
+		$this->assertSame( 'hired', $context['to'] );
+	}
+
+	public function test_call_created_includes_out_of_order_flag(): void {
+		RecruitmentActivityLogger::call_created( 7, 10, true );
+
+		$context = json_decode( (string) $this->last_buffered_entry()['context'], true );
+		$this->assertSame( 1, $context['out_of_order'] );
+	}
+
+	public function test_bulk_call_created_aggregates_into_single_event(): void {
+		RecruitmentActivityLogger::bulk_call_created(
+			array( 1, 2, 3 ),
+			array( 100, 101, 102 ),
+			'2026-06-01',
+			'08:00'
+		);
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_bulk_call_created', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( array( 1, 2, 3 ), $context['classification_ids'] );
+		$this->assertSame( array( 100, 101, 102 ), $context['call_ids'] );
+		$this->assertSame( 3, $context['count'] );
+	}
+
+	public function test_call_cancelled_records_reason(): void {
+		RecruitmentActivityLogger::call_cancelled( 7, 10, 'Admin reverted' );
+
+		$context = json_decode( (string) $this->last_buffered_entry()['context'], true );
+		$this->assertSame( 'Admin reverted', $context['reason'] );
+	}
+
+	public function test_candidate_promoted_uses_user_id_as_actor(): void {
+		RecruitmentActivityLogger::candidate_promoted( 50, 200 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_candidate_promoted', $entry['action'] );
+		$this->assertSame( 200, $entry['user_id'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 50, $context['candidate_id'] );
+		$this->assertSame( 200, $context['user_id'] );
+	}
+
+	public function test_candidate_deleted_uses_warning_level(): void {
+		RecruitmentActivityLogger::candidate_deleted( 50, 'cleanup' );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( ActivityLog::LEVEL_WARNING, $entry['level'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 'cleanup', $context['reason'] );
+	}
+
+	public function test_classification_deleted_records_id(): void {
+		RecruitmentActivityLogger::classification_deleted( 10 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_classification_deleted', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 10, $context['classification_id'] );
+		$this->assertArrayNotHasKey( 'reason', $context );
+	}
+
+	public function test_adjutancy_deleted_records_id(): void {
+		RecruitmentActivityLogger::adjutancy_deleted( 2 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_adjutancy_deleted', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 2, $context['adjutancy_id'] );
+	}
+}

--- a/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
+++ b/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository;
+
+/**
+ * Tests for RecruitmentAdjutancyRepository — the slug-keyed catalog of adjutancies
+ * (matérias) reused across notices.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository
+ */
+class RecruitmentRecruitmentAdjutancyRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 0;
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name_uses_plugin_prefix(): void {
+		$this->assertSame( 'wp_ffc_recruitment_adjutancy', RecruitmentAdjutancyRepository::get_table_name() );
+	}
+
+	public function test_get_by_id_returns_null_when_no_row_found(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$this->assertNull( RecruitmentAdjutancyRepository::get_by_id( 999 ) );
+	}
+
+	public function test_get_by_id_returns_typed_row_and_caches_it(): void {
+		$row       = (object) array(
+			'id'         => '5',
+			'slug'       => 'matematica',
+			'name'       => 'Matemática',
+			'created_at' => '2026-05-01 10:00:00',
+			'updated_at' => '2026-05-01 10:00:00',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$cache_set_called = false;
+		Functions\when( 'wp_cache_set' )->alias(
+			function () use ( &$cache_set_called ) {
+				$cache_set_called = true;
+				return true;
+			}
+		);
+
+		$result = RecruitmentAdjutancyRepository::get_by_id( 5 );
+
+		$this->assertSame( $row, $result );
+		$this->assertTrue( $cache_set_called, 'A successful lookup should populate the object cache' );
+	}
+
+	public function test_get_by_slug_returns_null_when_slug_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$this->assertNull( RecruitmentAdjutancyRepository::get_by_slug( 'nao-existe' ) );
+	}
+
+	public function test_get_by_slug_returns_row(): void {
+		$row = (object) array(
+			'id'   => '7',
+			'slug' => 'portugues',
+			'name' => 'Português',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$result = RecruitmentAdjutancyRepository::get_by_slug( 'portugues' );
+		$this->assertSame( $row, $result );
+	}
+
+	public function test_create_returns_new_id_on_success(): void {
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->with(
+				'wp_ffc_recruitment_adjutancy',
+				Mockery::on(
+					function ( $data ) {
+						return 'matematica' === $data['slug']
+							&& 'Matemática' === $data['name']
+							&& '2026-05-01 10:00:00' === $data['created_at']
+							&& '2026-05-01 10:00:00' === $data['updated_at'];
+					}
+				),
+				array( '%s', '%s', '%s', '%s' )
+			)
+			->andReturn( 1 );
+
+		$this->wpdb->insert_id = 42;
+
+		$id = RecruitmentAdjutancyRepository::create( 'matematica', 'Matemática' );
+		$this->assertSame( 42, $id );
+	}
+
+	public function test_create_returns_false_on_insert_failure(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+		$this->assertFalse( RecruitmentAdjutancyRepository::create( 'dup', 'Duplicate' ) );
+	}
+
+	public function test_update_only_writes_known_keys(): void {
+		$captured_data = null;
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data, $where ) use ( &$captured_data ) {
+					$captured_data = $data;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentAdjutancyRepository::update(
+			3,
+			array(
+				'name'             => 'Novo Nome',
+				'forbidden_field'  => 'should be ignored',
+				'created_at'       => 'should be ignored',
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertArrayHasKey( 'name', $captured_data );
+		$this->assertArrayHasKey( 'updated_at', $captured_data );
+		$this->assertArrayNotHasKey( 'forbidden_field', $captured_data );
+		$this->assertArrayNotHasKey( 'created_at', $captured_data );
+	}
+
+	public function test_update_returns_false_when_no_writable_fields_supplied(): void {
+		$this->wpdb->shouldNotReceive( 'update' );
+
+		$result = RecruitmentAdjutancyRepository::update( 3, array( 'forbidden' => 'x' ) );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_delete_returns_true_on_successful_delete(): void {
+		$this->wpdb->shouldReceive( 'delete' )
+			->once()
+			->with( 'wp_ffc_recruitment_adjutancy', array( 'id' => 9 ), array( '%d' ) )
+			->andReturn( 1 );
+
+		$this->assertTrue( RecruitmentAdjutancyRepository::delete( 9 ) );
+	}
+}

--- a/tests/Unit/RecruitmentCallRepositoryTest.php
+++ b/tests/Unit/RecruitmentCallRepositoryTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCallRepository;
+
+/**
+ * Tests for RecruitmentCallRepository — covers the append-only history
+ * contract, the §3.6 invariant on `out_of_order` + `out_of_order_reason`,
+ * and the idempotent `mark_cancelled` semantics.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCallRepository
+ */
+class RecruitmentCallRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 0;
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name(): void {
+		$this->assertSame( 'wp_ffc_recruitment_call', RecruitmentCallRepository::get_table_name() );
+	}
+
+	public function test_create_rejects_out_of_order_without_reason(): void {
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$result = RecruitmentCallRepository::create(
+			array(
+				'classification_id' => 1,
+				'date_to_assume'    => '2026-06-01',
+				'time_to_assume'    => '08:00',
+				'created_by'        => 1,
+				'out_of_order'      => 1,
+				// Missing out_of_order_reason.
+			)
+		);
+		$this->assertFalse( $result, '§3.6 invariant: out_of_order=1 requires non-empty reason' );
+	}
+
+	public function test_create_rejects_out_of_order_with_blank_reason(): void {
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$result = RecruitmentCallRepository::create(
+			array(
+				'classification_id'   => 1,
+				'date_to_assume'      => '2026-06-01',
+				'time_to_assume'      => '08:00',
+				'created_by'          => 1,
+				'out_of_order'        => 1,
+				'out_of_order_reason' => '   ',
+			)
+		);
+		$this->assertFalse( $result, 'Whitespace-only reason still violates the invariant' );
+	}
+
+	public function test_create_succeeds_with_out_of_order_and_reason(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		$this->wpdb->insert_id = 7;
+
+		$result = RecruitmentCallRepository::create(
+			array(
+				'classification_id'   => 1,
+				'date_to_assume'      => '2026-06-01',
+				'time_to_assume'      => '08:00',
+				'created_by'          => 1,
+				'out_of_order'        => 1,
+				'out_of_order_reason' => 'Candidate withdrew earlier in the day',
+			)
+		);
+		$this->assertSame( 7, $result );
+	}
+
+	public function test_create_in_order_call_does_not_require_reason(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		$this->wpdb->insert_id = 8;
+
+		$result = RecruitmentCallRepository::create(
+			array(
+				'classification_id' => 1,
+				'date_to_assume'    => '2026-06-01',
+				'time_to_assume'    => '08:00',
+				'created_by'        => 1,
+			)
+		);
+		$this->assertSame( 8, $result );
+	}
+
+	public function test_mark_cancelled_returns_one_on_first_cancel(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$this->assertSame( 1, RecruitmentCallRepository::mark_cancelled( 5, 'Admin reverted', 100 ) );
+	}
+
+	public function test_mark_cancelled_is_idempotent_within_a_single_cancel(): void {
+		// Second call hits a row already cancelled — WHERE cancelled_at IS NULL fails.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+
+		$this->assertSame( 0, RecruitmentCallRepository::mark_cancelled( 5, 'reason', 100 ) );
+	}
+
+	public function test_get_active_for_classification_returns_uncancelled_row(): void {
+		$row = (object) array(
+			'id'           => '9',
+			'cancelled_at' => null,
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$this->assertSame( $row, RecruitmentCallRepository::get_active_for_classification( 1 ) );
+	}
+
+	public function test_get_active_for_classification_returns_null_when_only_cancelled_calls_exist(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$this->assertNull( RecruitmentCallRepository::get_active_for_classification( 1 ) );
+	}
+
+	public function test_get_history_for_classifications_returns_empty_when_no_ids(): void {
+		$this->wpdb->shouldNotReceive( 'get_results' );
+
+		$this->assertSame( array(), RecruitmentCallRepository::get_history_for_classifications( array() ) );
+	}
+
+	public function test_count_for_classification_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '3' );
+
+		$this->assertSame( 3, RecruitmentCallRepository::count_for_classification( 5 ) );
+	}
+
+	public function test_update_only_writes_notes(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+
+		RecruitmentCallRepository::update(
+			3,
+			array(
+				'notes'        => 'Updated notes',
+				'cancelled_at' => 'should be ignored — append-only contract',
+				'created_by'   => 'should be ignored',
+			)
+		);
+
+		$this->assertArrayHasKey( 'notes', $captured );
+		$this->assertArrayNotHasKey( 'cancelled_at', $captured );
+		$this->assertArrayNotHasKey( 'created_by', $captured );
+	}
+}

--- a/tests/Unit/RecruitmentCallServiceTest.php
+++ b/tests/Unit/RecruitmentCallServiceTest.php
@@ -39,6 +39,13 @@ class RecruitmentCallServiceTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentCallServiceTest.php
+++ b/tests/Unit/RecruitmentCallServiceTest.php
@@ -101,9 +101,12 @@ class RecruitmentCallServiceTest extends TestCase {
 
 	public function test_call_single_succeeds_in_order(): void {
 		$classification = $this->classification_stub( 10, 'empty', 1 );
-		// Two get_row calls: load classification + find_lowest_rank_empty.
-		// Both return the same row (this IS the lowest empty), so call is in-order.
-		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $classification, $classification );
+		// 2 get_row calls from CallService (load classification +
+		// find_lowest_rank_empty), then up to 5 more from the email
+		// dispatcher (call/classification/candidate/notice/adjutancy);
+		// dispatcher gracefully gives up when any returns null.
+		$this->wpdb->shouldReceive( 'get_row' )
+			->andReturn( $classification, $classification, null );
 
 		$query_log = array();
 		$this->wpdb->shouldReceive( 'query' )
@@ -176,7 +179,8 @@ class RecruitmentCallServiceTest extends TestCase {
 	public function test_call_single_out_of_order_succeeds_with_reason(): void {
 		$target = $this->classification_stub( 10, 'empty', 5 );
 		$lowest = $this->classification_stub( 8, 'empty', 1 );
-		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $target, $lowest );
+		// Subsequent dispatcher lookups graceful-fail on null.
+		$this->wpdb->shouldReceive( 'get_row' )->andReturn( $target, $lowest, null );
 
 		$captured_call = null;
 		$this->wpdb->shouldReceive( 'insert' )
@@ -252,9 +256,10 @@ class RecruitmentCallServiceTest extends TestCase {
 		//  4. lowest empty after #1 was called → 11 (in-order)
 		$c10 = $this->classification_stub( 10, 'empty', 1 );
 		$c11 = $this->classification_stub( 11, 'empty', 2 );
+		// CallService needs 4 get_row calls (2 per classification);
+		// dispatcher's per-call lookups are graceful-failed via null.
 		$this->wpdb->shouldReceive( 'get_row' )
-			->times( 4 )
-			->andReturn( $c10, $c10, $c11, $c11 );
+			->andReturn( $c10, $c10, $c11, $c11, null );
 
 		$insert_count = 0;
 		$this->wpdb->shouldReceive( 'insert' )

--- a/tests/Unit/RecruitmentCallServiceTest.php
+++ b/tests/Unit/RecruitmentCallServiceTest.php
@@ -1,0 +1,406 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCallService;
+
+/**
+ * Tests for RecruitmentCallService — covers single, bulk, out-of-order
+ * detection, lost-race semantics, the §7 §3.6 reason invariant, and the
+ * append-only cancellation flow (classification rolls back to `empty`
+ * AND the call row gets `cancelled_at` stamped, atomic).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCallService
+ */
+class RecruitmentCallServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb            = Mockery::mock( 'wpdb' );
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = 0;
+		$this->wpdb      = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function classification_stub( int $id, string $status, int $rank = 1 ): object {
+		return (object) array(
+			'id'           => (string) $id,
+			'candidate_id' => '100',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'list_type'    => 'definitive',
+			'rank'         => (string) $rank,
+			'score'        => '90.0000',
+			'status'       => $status,
+			'created_at'   => '2026-05-01 10:00:00',
+			'updated_at'   => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function call_stub( int $id, int $classification_id, ?string $cancelled_at = null ): object {
+		return (object) array(
+			'id'                  => (string) $id,
+			'classification_id'   => (string) $classification_id,
+			'called_at'           => '2026-05-01 10:00:00',
+			'date_to_assume'      => '2026-06-01',
+			'time_to_assume'      => '08:00:00',
+			'out_of_order'        => '0',
+			'out_of_order_reason' => null,
+			'cancellation_reason' => null,
+			'cancelled_at'        => $cancelled_at,
+			'cancelled_by'        => null,
+			'notes'               => null,
+			'created_by'          => '1',
+			'created_at'          => '2026-05-01 10:00:00',
+			'updated_at'          => '2026-05-01 10:00:00',
+		);
+	}
+
+	// ==================================================================
+	// call_single — single-row convocation
+	// ==================================================================
+
+	public function test_call_single_succeeds_in_order(): void {
+		$classification = $this->classification_stub( 10, 'empty', 1 );
+		// Two get_row calls: load classification + find_lowest_rank_empty.
+		// Both return the same row (this IS the lowest empty), so call is in-order.
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $classification, $classification );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1; // status update wins.
+				}
+			);
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturnUsing(
+				function () {
+					$GLOBALS['wpdb']->insert_id = 7777;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_single( 10, '2026-06-01', '08:00', 1 );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 7777 ), $result['call_ids'] );
+		$this->assertContains( 'START TRANSACTION', $query_log );
+		$this->assertContains( 'COMMIT', $query_log );
+	}
+
+	public function test_call_single_rejects_when_classification_not_empty(): void {
+		$classification = $this->classification_stub( 10, 'called' );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $classification );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_single( 10, '2026-06-01', '08:00', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_classification_not_empty', $result['errors'] );
+		$this->assertContains( 'ROLLBACK', $query_log );
+		$this->assertNotContains( 'COMMIT', $query_log );
+	}
+
+	public function test_call_single_out_of_order_requires_reason(): void {
+		// Target classification is rank 5; lowest empty is rank 1 (a different row).
+		$target = $this->classification_stub( 10, 'empty', 5 );
+		$lowest = $this->classification_stub( 8, 'empty', 1 );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $target, $lowest );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_single( 10, '2026-06-01', '08:00', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_out_of_order_requires_reason', $result['errors'] );
+		$this->assertContains( 'ROLLBACK', $query_log );
+	}
+
+	public function test_call_single_out_of_order_succeeds_with_reason(): void {
+		$target = $this->classification_stub( 10, 'empty', 5 );
+		$lowest = $this->classification_stub( 8, 'empty', 1 );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $target, $lowest );
+
+		$captured_call = null;
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured_call ) {
+					$captured_call              = $data;
+					$GLOBALS['wpdb']->insert_id = 8888;
+					return 1;
+				}
+			);
+
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1 );
+
+		$result = RecruitmentCallService::call_single(
+			10,
+			'2026-06-01',
+			'08:00',
+			1,
+			'Lower-rank candidate withdrew earlier today',
+			null
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 8888 ), $result['call_ids'] );
+		$this->assertSame( 1, $captured_call['out_of_order'] );
+		$this->assertSame( 'Lower-rank candidate withdrew earlier today', $captured_call['out_of_order_reason'] );
+	}
+
+	public function test_call_single_lost_race_rolls_back(): void {
+		$classification = $this->classification_stub( 10, 'empty', 1 );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $classification, $classification );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					// Conditional UPDATE empty → called: 0 affected = lost race.
+					if ( false !== stripos( $sql, 'UPDATE' ) && false !== stripos( $sql, 'status' ) ) {
+						return 0;
+					}
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_single( 10, '2026-06-01', '08:00', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_state_locked', $result['errors'] );
+		$this->assertContains( 'ROLLBACK', $query_log );
+	}
+
+	// ==================================================================
+	// call_bulk
+	// ==================================================================
+
+	public function test_call_bulk_rejects_empty_id_list(): void {
+		// Should not even open a transaction.
+		$this->wpdb->shouldNotReceive( 'query' );
+
+		$result = RecruitmentCallService::call_bulk( array(), '2026-06-01', '08:00', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_bulk_call_empty_id_list' ), $result['errors'] );
+	}
+
+	public function test_call_bulk_succeeds_for_two_in_order_classifications(): void {
+		// Sequence of get_row calls:
+		//  1. classification 10 (call_one #1)
+		//  2. lowest empty for 10's adjutancy → 10 itself (in-order)
+		//  3. classification 11 (call_one #2)
+		//  4. lowest empty after #1 was called → 11 (in-order)
+		$c10 = $this->classification_stub( 10, 'empty', 1 );
+		$c11 = $this->classification_stub( 11, 'empty', 2 );
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 4 )
+			->andReturn( $c10, $c10, $c11, $c11 );
+
+		$insert_count = 0;
+		$this->wpdb->shouldReceive( 'insert' )
+			->andReturnUsing(
+				function () use ( &$insert_count ) {
+					++$insert_count;
+					$GLOBALS['wpdb']->insert_id = 9000 + $insert_count;
+					return 1;
+				}
+			);
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_bulk( array( 10, 11 ), '2026-06-01', '08:00', 1 );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 2, $result['call_ids'] );
+		$this->assertContains( 'COMMIT', $query_log );
+	}
+
+	public function test_call_bulk_rolls_back_when_one_row_fails(): void {
+		// First row succeeds (in-order); second row fails (already called).
+		$c10 = $this->classification_stub( 10, 'empty', 1 );
+		$c11 = $this->classification_stub( 11, 'called', 2 );
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 3 )
+			->andReturn( $c10, $c10, $c11 );
+
+		$this->wpdb->shouldReceive( 'insert' )
+			->andReturnUsing(
+				function () {
+					$GLOBALS['wpdb']->insert_id = 1234;
+					return 1;
+				}
+			);
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::call_bulk( array( 10, 11 ), '2026-06-01', '08:00', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array(), $result['call_ids'] );
+		$this->assertContains( 'ROLLBACK', $query_log );
+		$this->assertNotContains( 'COMMIT', $query_log );
+		// Bulk wraps the inner error code with a "failed at" marker.
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertStringContainsString( 'recruitment_bulk_call_failed_at_classification: 11', $result['errors'][0] );
+	}
+
+	// ==================================================================
+	// cancel_call
+	// ==================================================================
+
+	public function test_cancel_call_rejects_blank_reason(): void {
+		$this->wpdb->shouldNotReceive( 'query' );
+
+		$result = RecruitmentCallService::cancel_call( 7, '   ', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_cancel_reason_required' ), $result['errors'] );
+	}
+
+	public function test_cancel_call_rejects_unknown_call_id(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentCallService::cancel_call( 999, 'Reason', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_call_not_found' ), $result['errors'] );
+	}
+
+	public function test_cancel_call_rejects_already_cancelled(): void {
+		$call = $this->call_stub( 7, 10, '2026-05-01 09:00:00' );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $call );
+
+		$result = RecruitmentCallService::cancel_call( 7, 'Reason', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_call_already_cancelled' ), $result['errors'] );
+	}
+
+	public function test_cancel_call_rejects_when_classification_not_in_called_or_accepted(): void {
+		$call           = $this->call_stub( 7, 10 );
+		$classification = $this->classification_stub( 10, 'hired' );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $call, $classification );
+
+		$result = RecruitmentCallService::cancel_call( 7, 'Reason', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_cancel_only_from_called_or_accepted' ), $result['errors'] );
+	}
+
+	public function test_cancel_call_succeeds_from_called(): void {
+		$call           = $this->call_stub( 7, 10 );
+		$classification = $this->classification_stub( 10, 'called' );
+		// 1) cancel_call: load call.
+		// 2) cancel_call: load classification.
+		// 3) state-machine transition_to: load classification again.
+		$this->wpdb->shouldReceive( 'get_row' )->times( 3 )->andReturn( $call, $classification, $classification );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1; // every UPDATE wins.
+				}
+			);
+
+		$result = RecruitmentCallService::cancel_call( 7, 'Admin reverted', 1 );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 7 ), $result['call_ids'] );
+		$this->assertContains( 'COMMIT', $query_log );
+	}
+
+	public function test_cancel_call_rolls_back_when_state_machine_fails(): void {
+		$call           = $this->call_stub( 7, 10 );
+		$classification = $this->classification_stub( 10, 'called' );
+		$this->wpdb->shouldReceive( 'get_row' )->times( 3 )->andReturn( $call, $classification, $classification );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					// The state-machine UPDATE loses the race (status changed concurrently).
+					if ( false !== stripos( $sql, 'UPDATE' ) && false !== stripos( $sql, 'status' ) ) {
+						return 0;
+					}
+					return 1;
+				}
+			);
+
+		$result = RecruitmentCallService::cancel_call( 7, 'Admin reverted', 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_state_locked', $result['errors'] );
+		$this->assertContains( 'ROLLBACK', $query_log );
+		$this->assertNotContains( 'COMMIT', $query_log );
+	}
+}

--- a/tests/Unit/RecruitmentCandidateRepositoryTest.php
+++ b/tests/Unit/RecruitmentCandidateRepositoryTest.php
@@ -1,0 +1,198 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCandidateRepository;
+
+/**
+ * Tests for RecruitmentCandidateRepository — covers CRUD primitives plus the
+ * promotion link setter and the hash-based lookups (cpf, rf, email) used by
+ * the CSV importer for cross-CSV / cross-notice candidate reuse.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCandidateRepository
+ */
+class RecruitmentCandidateRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 0;
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name(): void {
+		$this->assertSame( 'wp_ffc_recruitment_candidate', RecruitmentCandidateRepository::get_table_name() );
+	}
+
+	public function test_get_by_cpf_hash_returns_null_when_not_found(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$this->assertNull( RecruitmentCandidateRepository::get_by_cpf_hash( 'abcd1234' ) );
+	}
+
+	public function test_get_by_cpf_hash_returns_row_on_match(): void {
+		$row = (object) array( 'id' => '1', 'cpf_hash' => 'abcd1234' );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$this->assertSame( $row, RecruitmentCandidateRepository::get_by_cpf_hash( 'abcd1234' ) );
+	}
+
+	public function test_create_rejects_when_required_fields_missing(): void {
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$this->assertFalse( RecruitmentCandidateRepository::create( array( 'name' => 'Alice' ) ) );
+		$this->assertFalse( RecruitmentCandidateRepository::create( array( 'pcd_hash' => 'h' ) ) );
+		$this->assertFalse( RecruitmentCandidateRepository::create( array() ) );
+	}
+
+	public function test_create_includes_only_supplied_optional_columns(): void {
+		$captured_data   = array();
+		$captured_format = array();
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data, $format ) use ( &$captured_data, &$captured_format ) {
+					$captured_data   = $data;
+					$captured_format = $format;
+					return 1;
+				}
+			);
+		$this->wpdb->insert_id = 50;
+
+		$id = RecruitmentCandidateRepository::create(
+			array(
+				'name'     => 'Alice',
+				'pcd_hash' => 'pcd_hash_value',
+				'cpf_hash' => 'cpf_hash_value',
+			)
+		);
+
+		$this->assertSame( 50, $id );
+		$this->assertArrayHasKey( 'name', $captured_data );
+		$this->assertArrayHasKey( 'pcd_hash', $captured_data );
+		$this->assertArrayHasKey( 'cpf_hash', $captured_data );
+		$this->assertArrayNotHasKey( 'rf_hash', $captured_data, 'rf_hash should not be in INSERT when not supplied' );
+		$this->assertArrayNotHasKey( 'email_hash', $captured_data );
+		$this->assertCount( count( $captured_data ), $captured_format, 'format array must match data array length' );
+	}
+
+	public function test_create_returns_false_on_insert_failure(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+		$result = RecruitmentCandidateRepository::create(
+			array(
+				'name'     => 'Alice',
+				'pcd_hash' => 'h',
+			)
+		);
+		$this->assertFalse( $result );
+	}
+
+	public function test_update_does_not_allow_user_id_or_pcd_hash(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+
+		RecruitmentCandidateRepository::update(
+			3,
+			array(
+				'name'     => 'New Name',
+				'phone'    => '555-0100',
+				'user_id'  => 99,
+				'pcd_hash' => 'tampered',
+			)
+		);
+
+		$this->assertArrayHasKey( 'name', $captured );
+		$this->assertArrayHasKey( 'phone', $captured );
+		$this->assertArrayNotHasKey( 'user_id', $captured, 'user_id is set via set_user_id, not update' );
+		$this->assertArrayNotHasKey( 'pcd_hash', $captured, 'PCD value is CSV-only per §12' );
+	}
+
+	public function test_set_user_id_writes_link(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data, $where ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+
+		$this->assertTrue( RecruitmentCandidateRepository::set_user_id( 5, 100 ) );
+		$this->assertSame( 100, $captured['user_id'] );
+	}
+
+	public function test_set_user_id_can_clear_link(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data, $where ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+
+		$this->assertTrue( RecruitmentCandidateRepository::set_user_id( 5, null ) );
+		$this->assertNull( $captured['user_id'] );
+	}
+
+	public function test_get_by_user_id_returns_array_for_each_match(): void {
+		$rows = array(
+			(object) array( 'id' => '1', 'user_id' => '100' ),
+			(object) array( 'id' => '2', 'user_id' => '100' ),
+		);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+		$result = RecruitmentCandidateRepository::get_by_user_id( 100 );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_delete_returns_true_on_success(): void {
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 1 );
+
+		$this->assertTrue( RecruitmentCandidateRepository::delete( 5 ) );
+	}
+}

--- a/tests/Unit/RecruitmentCapabilityManagerTest.php
+++ b/tests/Unit/RecruitmentCapabilityManagerTest.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\UserDashboard\CapabilityManager;
+
+/**
+ * Tests for the recruitment-specific extension of CapabilityManager.
+ *
+ * Sprint 3 adds:
+ *
+ *   - `CONTEXT_RECRUITMENT` constant for `UserCreator::get_or_create_user()`.
+ *   - `ffc_manage_recruitment` cap added to `ADMIN_CAPABILITIES`, which is
+ *     auto-granted to the `administrator` role on activation by
+ *     `Activator::activate()`.
+ *   - `RECRUITMENT_MANAGER_ROLE` slug + `register_recruitment_manager_role()`
+ *     creator (idempotent / upgrade-safe) + `remove_recruitment_manager_role()`
+ *     teardown.
+ *   - `grant_context_capabilities(CONTEXT_RECRUITMENT)` is an explicit no-op.
+ *
+ * @covers \FreeFormCertificate\UserDashboard\CapabilityManager
+ */
+class RecruitmentCapabilityManagerTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'get_userdata' )->justReturn( false );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_context_recruitment_constant_exists(): void {
+		$this->assertSame( 'recruitment', CapabilityManager::CONTEXT_RECRUITMENT );
+	}
+
+	public function test_recruitment_manager_role_slug(): void {
+		$this->assertSame( 'ffc_recruitment_manager', CapabilityManager::RECRUITMENT_MANAGER_ROLE );
+	}
+
+	public function test_admin_capabilities_includes_ffc_manage_recruitment(): void {
+		$this->assertContains(
+			'ffc_manage_recruitment',
+			CapabilityManager::ADMIN_CAPABILITIES,
+			'`ffc_manage_recruitment` must be in ADMIN_CAPABILITIES so Activator::activate() grants it to the administrator role'
+		);
+	}
+
+	public function test_get_all_capabilities_includes_ffc_manage_recruitment(): void {
+		$this->assertContains( 'ffc_manage_recruitment', CapabilityManager::get_all_capabilities() );
+	}
+
+	public function test_grant_context_capabilities_recruitment_is_a_no_op(): void {
+		// CONTEXT_RECRUITMENT is intentionally a no-op: candidates rely on
+		// the `ffc_user` role's baseline `read` cap. We verify the call
+		// completes without invoking any of the per-cap grant helpers
+		// (no get_userdata, no add_cap on the user).
+		$get_userdata_called = false;
+		Functions\when( 'get_userdata' )->alias(
+			function () use ( &$get_userdata_called ) {
+				$get_userdata_called = true;
+				return false;
+			}
+		);
+
+		CapabilityManager::grant_context_capabilities( 100, CapabilityManager::CONTEXT_RECRUITMENT );
+
+		$this->assertFalse(
+			$get_userdata_called,
+			'CONTEXT_RECRUITMENT should not invoke any grant helper — no per-user caps are granted on candidate promotion'
+		);
+	}
+
+	public function test_register_recruitment_manager_role_creates_new_role(): void {
+		$captured_role = null;
+		$captured_caps = null;
+
+		Functions\when( 'get_role' )->justReturn( null );
+		Functions\when( 'add_role' )->alias(
+			function ( $role, $label, $caps ) use ( &$captured_role, &$captured_caps ) {
+				$captured_role = $role;
+				$captured_caps = $caps;
+				return new \WP_Role();
+			}
+		);
+
+		CapabilityManager::register_recruitment_manager_role();
+
+		$this->assertSame( 'ffc_recruitment_manager', $captured_role );
+		$this->assertTrue( $captured_caps['read'] );
+		$this->assertTrue( $captured_caps['ffc_manage_recruitment'] );
+	}
+
+	public function test_register_recruitment_manager_role_upgrades_existing_role_idempotently(): void {
+		$role = new \WP_Role();
+		// Simulate a partial role: only `read` set; missing the recruitment cap.
+		$role->capabilities = array( 'read' => true );
+
+		Functions\when( 'get_role' )->alias(
+			function ( $slug ) use ( $role ) {
+				return 'ffc_recruitment_manager' === $slug ? $role : null;
+			}
+		);
+
+		// add_role MUST NOT be called when role already exists.
+		$add_role_called = false;
+		Functions\when( 'add_role' )->alias(
+			function () use ( &$add_role_called ) {
+				$add_role_called = true;
+				return new \WP_Role();
+			}
+		);
+
+		CapabilityManager::register_recruitment_manager_role();
+
+		$this->assertFalse( $add_role_called, 'Existing role takes the upgrade path, not add_role' );
+		$this->assertTrue( $role->capabilities['ffc_manage_recruitment'], 'Missing cap is added' );
+		$this->assertTrue( $role->capabilities['read'], 'Existing cap is preserved' );
+	}
+
+	public function test_register_recruitment_manager_role_does_not_overwrite_admin_customizations(): void {
+		$role               = new \WP_Role();
+		$role->capabilities = array(
+			'read'                   => true,
+			'ffc_manage_recruitment' => true,
+			'admin_custom_extra'     => true,
+		);
+
+		Functions\when( 'get_role' )->alias(
+			function ( $slug ) use ( $role ) {
+				return 'ffc_recruitment_manager' === $slug ? $role : null;
+			}
+		);
+
+		CapabilityManager::register_recruitment_manager_role();
+
+		$this->assertTrue(
+			$role->capabilities['admin_custom_extra'],
+			'Custom caps the admin added manually must survive role re-registration'
+		);
+	}
+
+	public function test_remove_recruitment_manager_role_calls_wp_remove_role(): void {
+		$captured_slug = null;
+
+		Functions\when( 'remove_role' )->alias(
+			function ( $slug ) use ( &$captured_slug ) {
+				$captured_slug = $slug;
+			}
+		);
+
+		CapabilityManager::remove_recruitment_manager_role();
+
+		$this->assertSame( 'ffc_recruitment_manager', $captured_slug );
+	}
+}

--- a/tests/Unit/RecruitmentClassificationRepositoryTest.php
+++ b/tests/Unit/RecruitmentClassificationRepositoryTest.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentClassificationRepository;
+
+/**
+ * Tests for RecruitmentClassificationRepository — covers the atomic
+ * state-transition primitive used by the state machine (sprint 5) and the
+ * convocation hot-path lookup `find_lowest_rank_empty()` used by the
+ * out-of-order check (sprint 6).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentClassificationRepository
+ */
+class RecruitmentClassificationRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 0;
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name(): void {
+		$this->assertSame( 'wp_ffc_recruitment_classification', RecruitmentClassificationRepository::get_table_name() );
+	}
+
+	public function test_set_status_returns_one_when_expected_current_matches(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$affected = RecruitmentClassificationRepository::set_status( 1, 'empty', 'called' );
+		$this->assertSame( 1, $affected, 'Atomic transition succeeds when status was empty as expected' );
+	}
+
+	public function test_set_status_returns_zero_when_race_lost(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+
+		$affected = RecruitmentClassificationRepository::set_status( 1, 'empty', 'called' );
+		$this->assertSame( 0, $affected, 'A concurrent writer claiming the row first leaves us with 0 affected rows' );
+	}
+
+	public function test_find_lowest_rank_empty_returns_typed_row(): void {
+		$row = (object) array(
+			'id'   => '5',
+			'rank' => '1',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$result = RecruitmentClassificationRepository::find_lowest_rank_empty( 1, 2, 'definitive' );
+		$this->assertSame( $row, $result );
+	}
+
+	public function test_find_lowest_rank_empty_returns_null_when_all_called(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentClassificationRepository::find_lowest_rank_empty( 1, 2, 'definitive' );
+		$this->assertNull( $result, 'When no empty row remains, the in-order check returns null' );
+	}
+
+	public function test_create_inserts_with_default_empty_status(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+		$this->wpdb->insert_id = 99;
+
+		$id = RecruitmentClassificationRepository::create(
+			array(
+				'candidate_id' => 1,
+				'adjutancy_id' => 2,
+				'notice_id'    => 3,
+				'list_type'    => 'preview',
+				'rank'         => 5,
+				'score'        => '87.5',
+			)
+		);
+
+		$this->assertSame( 99, $id );
+		$this->assertSame( 'empty', $captured['status'], 'Default status on creation is empty' );
+		$this->assertSame( '87.5', $captured['score'] );
+		$this->assertSame( 5, $captured['rank'] );
+	}
+
+	public function test_count_for_candidate_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '3' );
+
+		$this->assertSame( 3, RecruitmentClassificationRepository::count_for_candidate( 7 ) );
+	}
+
+	public function test_count_for_adjutancy_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '12' );
+
+		$this->assertSame( 12, RecruitmentClassificationRepository::count_for_adjutancy( 4 ) );
+	}
+
+	public function test_delete_all_for_notice_list_returns_count(): void {
+		$this->wpdb->shouldReceive( 'delete' )
+			->once()
+			->with(
+				'wp_ffc_recruitment_classification',
+				array( 'notice_id' => 5, 'list_type' => 'preview' ),
+				array( '%d', '%s' )
+			)
+			->andReturn( 17 );
+
+		$this->assertSame( 17, RecruitmentClassificationRepository::delete_all_for_notice_list( 5, 'preview' ) );
+	}
+
+	public function test_count_calls_for_notice_runs_cross_table_count(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '4' );
+
+		$this->assertSame( 4, RecruitmentClassificationRepository::count_calls_for_notice( 8 ) );
+	}
+
+	public function test_get_for_notice_filters_by_list_type_and_adjutancy(): void {
+		$rows = array(
+			(object) array( 'id' => '1', 'rank' => '1' ),
+			(object) array( 'id' => '2', 'rank' => '2' ),
+		);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+		$result = RecruitmentClassificationRepository::get_for_notice( 1, 'definitive', 2 );
+		$this->assertCount( 2, $result );
+	}
+}

--- a/tests/Unit/RecruitmentClassificationStateMachineTest.php
+++ b/tests/Unit/RecruitmentClassificationStateMachineTest.php
@@ -38,6 +38,13 @@ class RecruitmentClassificationStateMachineTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentClassificationStateMachineTest.php
+++ b/tests/Unit/RecruitmentClassificationStateMachineTest.php
@@ -1,0 +1,227 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentClassificationStateMachine;
+
+/**
+ * Tests for RecruitmentClassificationStateMachine — covers every legal
+ * transition, every blocked transition, reason gating, the `hired`
+ * terminal state, and the §5.1 reopen-freeze rule
+ * (`not_shown → empty` blocked when `notice.was_reopened = 1`).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentClassificationStateMachine
+ */
+class RecruitmentClassificationStateMachineTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a classification row stub.
+	 *
+	 * @param string $status Current classification status.
+	 * @return object
+	 */
+	private function classification_stub( string $status ): object {
+		return (object) array(
+			'id'           => '10',
+			'candidate_id' => '1',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'list_type'    => 'definitive',
+			'rank'         => '1',
+			'score'        => '90.0000',
+			'status'       => $status,
+			'created_at'   => '2026-05-01 10:00:00',
+			'updated_at'   => '2026-05-01 10:00:00',
+		);
+	}
+
+	/**
+	 * Build a notice row stub for the reopen-freeze gate.
+	 *
+	 * @param string $was_reopened String "0" or "1" matching numeric-string PHPDoc.
+	 * @return object
+	 */
+	private function notice_stub( string $was_reopened ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => 'EDITAL-2026-01',
+			'name'                  => 'Test',
+			'status'                => 'active',
+			'opened_at'             => '2026-04-01 09:00:00',
+			'closed_at'             => null,
+			'was_reopened'          => $was_reopened,
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_transition_returns_failure_when_classification_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 999, 'called' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_classification_not_found' ), $result['errors'] );
+	}
+
+	public function test_same_state_transition_is_idempotent_success(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'empty' ) );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_invalid_transition_is_rejected(): void {
+		// empty → hired is not allowed (must go through called first).
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'empty' ) );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'hired' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'recruitment_invalid_transition', $result['errors'][0] );
+	}
+
+	public function test_hired_is_terminal(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'hired' ) );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty', 'attempt to undo' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_state_terminal_hired' ), $result['errors'] );
+	}
+
+	public function test_called_to_empty_requires_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'called' ) );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_transition_reason_required' ), $result['errors'] );
+	}
+
+	public function test_called_to_empty_succeeds_with_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'called' ) );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty', 'Admin cancelled call' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_called_to_accepted_succeeds_without_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'called' ) );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'accepted' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_called_to_hired_succeeds(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'called' ) );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'hired' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_accepted_to_hired_succeeds(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'accepted' ) );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'hired' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_accepted_to_empty_requires_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'accepted' ) );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_transition_reason_required' ), $result['errors'] );
+	}
+
+	public function test_not_shown_to_empty_succeeds_when_notice_not_reopened(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->classification_stub( 'not_shown' ),
+				$this->notice_stub( '0' )
+			);
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty', 'Reopen' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_not_shown_to_empty_blocked_when_notice_was_reopened(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->classification_stub( 'not_shown' ),
+				$this->notice_stub( '1' )
+			);
+		// query() must NOT be called — the reopen-freeze gate fires first.
+		$this->wpdb->shouldNotReceive( 'query' );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'empty', 'Reopen' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_reopen_freeze_active' ), $result['errors'] );
+	}
+
+	public function test_set_status_lost_race_surfaces_error(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 'called' ) );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+
+		$result = RecruitmentClassificationStateMachine::transition_to( 10, 'accepted' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_state_locked' ), $result['errors'] );
+	}
+}

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -1,0 +1,244 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCsvImporter;
+
+/**
+ * Tests for RecruitmentCsvImporter.
+ *
+ * Two layers of coverage:
+ *
+ *   - `parse()` is a pure-function CSV reader; tested directly with no
+ *     database mocking required. Covers BOM stripping, header validation,
+ *     empty-row skipping, and the missing-required-headers error.
+ *
+ *   - `import_preview()` is exercised at the rejection boundary — valid
+ *     parsing followed by a state-machine reject (notice not in `draft`/
+ *     `preliminary`) — to verify the early-exit envelope shape without
+ *     wiring full transactional DB mocks. The happy path is covered by
+ *     integration tests in sprint 13.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCsvImporter
+ */
+class RecruitmentCsvImporterTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ==================================================================
+	// parse() — pure-function CSV reader
+	// ==================================================================
+
+	public function test_parse_rejects_empty_content(): void {
+		$result = RecruitmentCsvImporter::parse( '' );
+
+		$this->assertFalse( $result['ok'] );
+		$this->assertContains( 'recruitment_csv_empty', $result['errors'] );
+	}
+
+	public function test_parse_rejects_missing_required_headers(): void {
+		$csv = "name,cpf\nAlice,12345";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertFalse( $result['ok'] );
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertStringContainsString( 'recruitment_csv_missing_headers', $result['errors'][0] );
+	}
+
+	public function test_parse_strips_utf8_bom(): void {
+		$bom = "\xEF\xBB\xBF";
+		$csv = $bom . "name,cpf,rf,email,adjutancy,rank,score,pcd\nAlice,12345678901,,a@b.com,mat,1,90,Sim";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertCount( 1, $result['rows'] );
+		$this->assertSame( 'Alice', $result['rows'][0]['name'] );
+	}
+
+	public function test_parse_skips_completely_empty_rows(): void {
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim\n"
+			. "\n"
+			. "    \n"
+			. ",,,,,,,\n"
+			. "Bob,98765432100,,b@b.com,mat,2,80,Não\n";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertCount( 2, $result['rows'], 'Empty/whitespace-only rows are silently skipped' );
+		$this->assertSame( 'Alice', $result['rows'][0]['name'] );
+		$this->assertSame( 'Bob', $result['rows'][1]['name'] );
+	}
+
+	public function test_parse_records_line_numbers_for_each_row(): void {
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim\n"
+			. "\n"
+			. "Bob,98765432100,,b@b.com,mat,2,80,Não\n";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertSame( 2, $result['rows'][0]['_line'], 'Header is line 1; first data row is line 2' );
+		$this->assertSame( 4, $result['rows'][1]['_line'], 'Skipped empty line still increments the counter' );
+	}
+
+	public function test_parse_handles_optional_phone_column_when_present(): void {
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd,phone\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim,11999998888";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertSame( '11999998888', $result['rows'][0]['phone'] );
+	}
+
+	public function test_parse_defaults_phone_to_empty_when_column_missing(): void {
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertSame( '', $result['rows'][0]['phone'] );
+	}
+
+	public function test_parse_accepts_crlf_line_endings(): void {
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd\r\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim\r\n";
+
+		$result = RecruitmentCsvImporter::parse( $csv );
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertCount( 1, $result['rows'] );
+	}
+
+	// ==================================================================
+	// import_preview() — early-exit boundary behaviors
+	// ==================================================================
+
+	public function test_import_preview_rejects_unknown_notice(): void {
+		// Notice repo cache miss, then DB lookup returns null.
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentCsvImporter::import_preview( 999, 'unused' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 0, $result['inserted'] );
+		$this->assertContains( 'recruitment_notice_not_found', $result['errors'] );
+	}
+
+	public function test_import_preview_rejects_when_notice_is_active(): void {
+		$notice = (object) array(
+			'id'     => '5',
+			'status' => 'active',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $notice );
+
+		$result = RecruitmentCsvImporter::import_preview( 5, 'unused' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_invalid_state_for_preview_import', $result['errors'] );
+	}
+
+	public function test_import_preview_rejects_when_notice_is_closed(): void {
+		$notice = (object) array(
+			'id'     => '5',
+			'status' => 'closed',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $notice );
+
+		$result = RecruitmentCsvImporter::import_preview( 5, 'unused' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_invalid_state_for_preview_import', $result['errors'] );
+	}
+
+	public function test_import_preview_propagates_csv_parse_errors(): void {
+		$notice = (object) array(
+			'id'     => '5',
+			'status' => 'preliminary',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $notice );
+
+		// Empty CSV — parse() returns missing-headers error.
+		$result = RecruitmentCsvImporter::import_preview( 5, '' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 0, $result['inserted'] );
+		$this->assertContains( 'recruitment_csv_empty', $result['errors'] );
+	}
+
+	public function test_import_preview_rejects_csv_with_missing_headers_in_eligible_state(): void {
+		$notice = (object) array(
+			'id'     => '5',
+			'status' => 'draft',
+		);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $notice );
+
+		$bad_csv = "name,cpf\nAlice,12345";
+
+		$result = RecruitmentCsvImporter::import_preview( 5, $bad_csv );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertStringContainsString( 'recruitment_csv_missing_headers', $result['errors'][0] );
+	}
+
+	public function test_import_preview_rejects_when_notice_has_no_adjutancies(): void {
+		$notice = (object) array(
+			'id'     => '5',
+			'status' => 'draft',
+		);
+		// First get_row: notice lookup. Adjutancy lookups return empty.
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $notice );
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+
+		$csv = "name,cpf,rf,email,adjutancy,rank,score,pcd\n"
+			. "Alice,12345678901,,a@b.com,mat,1,90,Sim";
+
+		$result = RecruitmentCsvImporter::import_preview( 5, $csv );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_notice_has_no_adjutancies', $result['errors'] );
+	}
+}

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -47,6 +47,13 @@ class RecruitmentCsvImporterTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentDeleteServiceTest.php
+++ b/tests/Unit/RecruitmentDeleteServiceTest.php
@@ -37,6 +37,13 @@ class RecruitmentDeleteServiceTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentDeleteServiceTest.php
+++ b/tests/Unit/RecruitmentDeleteServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentDeleteService;
+
+/**
+ * Tests for RecruitmentDeleteService — pins each §7-bis gate (candidate,
+ * classification, adjutancy) and the `blocked_by` reference-count payload
+ * surfaced when a gate fires.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentDeleteService
+ */
+class RecruitmentDeleteServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function candidate_stub( int $id ): object {
+		return (object) array(
+			'id'              => (string) $id,
+			'user_id'         => null,
+			'name'            => 'Test',
+			'cpf_encrypted'   => null,
+			'cpf_hash'        => null,
+			'rf_encrypted'    => null,
+			'rf_hash'         => null,
+			'email_encrypted' => null,
+			'email_hash'      => null,
+			'phone'           => null,
+			'notes'           => null,
+			'pcd_hash'        => 'h',
+			'created_at'      => '2026-05-01 10:00:00',
+			'updated_at'      => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function classification_stub( int $id, string $status ): object {
+		return (object) array(
+			'id'           => (string) $id,
+			'candidate_id' => '1',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'list_type'    => 'preview',
+			'rank'         => '1',
+			'score'        => '90.0000',
+			'status'       => $status,
+			'created_at'   => '2026-05-01 10:00:00',
+			'updated_at'   => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function notice_stub( string $status ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => 'EDITAL-2026-01',
+			'name'                  => 'Test',
+			'status'                => $status,
+			'opened_at'             => null,
+			'closed_at'             => null,
+			'was_reopened'          => '0',
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function adjutancy_stub( int $id ): object {
+		return (object) array(
+			'id'         => (string) $id,
+			'slug'       => 'mat',
+			'name'       => 'Matemática',
+			'created_at' => '2026-05-01 10:00:00',
+			'updated_at' => '2026-05-01 10:00:00',
+		);
+	}
+
+	// ==================================================================
+	// delete_candidate
+	// ==================================================================
+
+	public function test_delete_candidate_rejects_unknown_id(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentDeleteService::delete_candidate( 999 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_candidate_not_found' ), $result['errors'] );
+	}
+
+	public function test_delete_candidate_blocked_by_classifications(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->candidate_stub( 1 ) );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '3' );
+
+		$result = RecruitmentDeleteService::delete_candidate( 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_candidate_has_classifications' ), $result['errors'] );
+		$this->assertSame( array( 'classifications' => 3 ), $result['blocked_by'] );
+	}
+
+	public function test_delete_candidate_succeeds_when_no_classifications(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->candidate_stub( 1 ) );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+		$this->wpdb->shouldReceive( 'delete' )
+			->once()
+			->with( 'wp_ffc_recruitment_candidate', array( 'id' => 1 ), array( '%d' ) )
+			->andReturn( 1 );
+
+		$result = RecruitmentDeleteService::delete_candidate( 1 );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayNotHasKey( 'blocked_by', $result );
+	}
+
+	// ==================================================================
+	// delete_classification
+	// ==================================================================
+
+	public function test_delete_classification_rejects_unknown_id(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentDeleteService::delete_classification( 999 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_classification_not_found' ), $result['errors'] );
+	}
+
+	public function test_delete_classification_rejects_when_not_empty(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->classification_stub( 10, 'called' ) );
+
+		$result = RecruitmentDeleteService::delete_classification( 10 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_classification_not_empty_for_delete' ), $result['errors'] );
+	}
+
+	public function test_delete_classification_rejects_when_notice_active(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->classification_stub( 10, 'empty' ),
+				$this->notice_stub( 'active' )
+			);
+
+		$result = RecruitmentDeleteService::delete_classification( 10 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame(
+			array( 'recruitment_classification_delete_requires_draft_or_preliminary' ),
+			$result['errors']
+		);
+	}
+
+	public function test_delete_classification_succeeds_when_empty_and_draft(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->classification_stub( 10, 'empty' ),
+				$this->notice_stub( 'draft' )
+			);
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 1 );
+
+		$result = RecruitmentDeleteService::delete_classification( 10 );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_delete_classification_succeeds_when_empty_and_preliminary(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->classification_stub( 10, 'empty' ),
+				$this->notice_stub( 'preliminary' )
+			);
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 1 );
+
+		$result = RecruitmentDeleteService::delete_classification( 10 );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	// ==================================================================
+	// delete_adjutancy
+	// ==================================================================
+
+	public function test_delete_adjutancy_rejects_unknown_id(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentDeleteService::delete_adjutancy( 999 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_adjutancy_not_found' ), $result['errors'] );
+	}
+
+	public function test_delete_adjutancy_blocked_by_notice_attachment(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->adjutancy_stub( 2 ) );
+		// notice_adjutancy lookup returns one notice ID; classification count is 0.
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( 5 ) );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+
+		$result = RecruitmentDeleteService::delete_adjutancy( 2 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_adjutancy_in_use' ), $result['errors'] );
+		$this->assertSame(
+			array(
+				'notice_adjutancies' => 1,
+				'classifications'    => 0,
+			),
+			$result['blocked_by']
+		);
+	}
+
+	public function test_delete_adjutancy_blocked_by_classification_history(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->adjutancy_stub( 2 ) );
+		// No notice attachment, but historical classifications still reference the slug.
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '7' );
+
+		$result = RecruitmentDeleteService::delete_adjutancy( 2 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame(
+			array(
+				'notice_adjutancies' => 0,
+				'classifications'    => 7,
+			),
+			$result['blocked_by']
+		);
+	}
+
+	public function test_delete_adjutancy_succeeds_when_unused(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->adjutancy_stub( 2 ) );
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+		$this->wpdb->shouldReceive( 'delete' )
+			->once()
+			->with( 'wp_ffc_recruitment_adjutancy', array( 'id' => 2 ), array( '%d' ) )
+			->andReturn( 1 );
+
+		$result = RecruitmentDeleteService::delete_adjutancy( 2 );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayNotHasKey( 'blocked_by', $result );
+	}
+}

--- a/tests/Unit/RecruitmentEmailDispatcherTest.php
+++ b/tests/Unit/RecruitmentEmailDispatcherTest.php
@@ -1,0 +1,224 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentEmailDispatcher;
+
+/**
+ * Tests for RecruitmentEmailDispatcher — verifies the §11 placeholder
+ * resolution, the from-header builder, the `wp_mail` call shape, and the
+ * "no email on file" early-exit (returns false without invoking `wp_mail`).
+ *
+ * Best-effort send semantics (§7) mean we don't surface `wp_mail` return
+ * codes; we just assert the call happened with the right payload.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentEmailDispatcher
+ */
+class RecruitmentEmailDispatcherTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'wp_specialchars_decode' )->returnArg();
+		Functions\when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+		Functions\when( 'wp_salt' )->justReturn( 'test-salt' );
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'remove_filter' )->justReturn( true );
+		Functions\when( 'is_email' )->alias(
+			static function ( $email ) {
+				return is_string( $email ) && false !== strpos( $email, '@' );
+			}
+		);
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing( static fn ( $sql ) => $sql )
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function call_stub( int $id ): object {
+		return (object) array(
+			'id'                  => (string) $id,
+			'classification_id'   => '10',
+			'called_at'           => '2026-05-01 10:00:00',
+			'date_to_assume'      => '2026-06-01',
+			'time_to_assume'      => '08:00:00',
+			'out_of_order'        => '0',
+			'out_of_order_reason' => null,
+			'cancellation_reason' => null,
+			'cancelled_at'        => null,
+			'cancelled_by'        => null,
+			'notes'               => null,
+			'created_by'          => '1',
+			'created_at'          => '2026-05-01 10:00:00',
+			'updated_at'          => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function classification_stub(): object {
+		return (object) array(
+			'id'           => '10',
+			'candidate_id' => '100',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'list_type'    => 'definitive',
+			'rank'         => '1',
+			'score'        => '90.0000',
+			'status'       => 'called',
+			'created_at'   => '2026-05-01 10:00:00',
+			'updated_at'   => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function candidate_stub( ?string $email_encrypted = null ): object {
+		return (object) array(
+			'id'              => '100',
+			'user_id'         => null,
+			'name'            => 'Alice',
+			'cpf_encrypted'   => 'cpf-cipher',
+			'cpf_hash'        => 'cpf-hash',
+			'rf_encrypted'    => null,
+			'rf_hash'         => null,
+			'email_encrypted' => $email_encrypted,
+			'email_hash'      => null === $email_encrypted ? null : 'email-hash',
+			'phone'           => null,
+			'notes'           => null,
+			'pcd_hash'        => 'pcd-hash',
+			'created_at'      => '2026-05-01 10:00:00',
+			'updated_at'      => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function notice_stub(): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => 'EDITAL-2026-01',
+			'name'                  => 'Edital de 2026',
+			'status'                => 'active',
+			'opened_at'             => '2026-04-01 09:00:00',
+			'closed_at'             => null,
+			'was_reopened'          => '0',
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function adjutancy_stub(): object {
+		return (object) array(
+			'id'         => '2',
+			'slug'       => 'matematica',
+			'name'       => 'Matemática',
+			'created_at' => '2026-05-01 10:00:00',
+			'updated_at' => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_returns_false_when_call_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$wp_mail_called = false;
+		Functions\when( 'wp_mail' )->alias(
+			static function () use ( &$wp_mail_called ) {
+				$wp_mail_called = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( RecruitmentEmailDispatcher::send_for_call( 999 ) );
+		$this->assertFalse( $wp_mail_called );
+	}
+
+	public function test_returns_false_when_candidate_has_no_email(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 5 )
+			->andReturn(
+				$this->call_stub( 7 ),
+				$this->classification_stub(),
+				$this->candidate_stub( null ),
+				$this->notice_stub(),
+				$this->adjutancy_stub()
+			);
+
+		$wp_mail_called = false;
+		Functions\when( 'wp_mail' )->alias(
+			static function () use ( &$wp_mail_called ) {
+				$wp_mail_called = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( RecruitmentEmailDispatcher::send_for_call( 7 ) );
+		$this->assertFalse( $wp_mail_called, 'No email = no wp_mail call' );
+	}
+
+	public function test_returns_false_when_classification_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 2 )
+			->andReturn( $this->call_stub( 7 ), null );
+
+		$wp_mail_called = false;
+		Functions\when( 'wp_mail' )->alias(
+			static function () use ( &$wp_mail_called ) {
+				$wp_mail_called = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( RecruitmentEmailDispatcher::send_for_call( 7 ) );
+		$this->assertFalse( $wp_mail_called );
+	}
+
+	public function test_returns_false_when_notice_or_adjutancy_unknown(): void {
+		// Notice lookup returns null — adjutancy lookup is also queried
+		// (both fetched before the null-check), but the result is the same:
+		// no send.
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 5 )
+			->andReturn(
+				$this->call_stub( 7 ),
+				$this->classification_stub(),
+				$this->candidate_stub( 'enc-email' ),
+				null, // notice missing
+				$this->adjutancy_stub()
+			);
+
+		$wp_mail_called = false;
+		Functions\when( 'wp_mail' )->alias(
+			static function () use ( &$wp_mail_called ) {
+				$wp_mail_called = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( RecruitmentEmailDispatcher::send_for_call( 7 ) );
+		$this->assertFalse( $wp_mail_called );
+	}
+}

--- a/tests/Unit/RecruitmentNoticeAdjutancyRepositoryTest.php
+++ b/tests/Unit/RecruitmentNoticeAdjutancyRepositoryTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository;
+
+/**
+ * Tests for RecruitmentNoticeAdjutancyRepository — the N:N junction.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository
+ */
+class RecruitmentNoticeAdjutancyRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name(): void {
+		$this->assertSame( 'wp_ffc_recruitment_notice_adjutancy', RecruitmentNoticeAdjutancyRepository::get_table_name() );
+	}
+
+	public function test_attach_returns_true_on_successful_insert(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+
+		$this->assertTrue( RecruitmentNoticeAdjutancyRepository::attach( 1, 2 ) );
+	}
+
+	public function test_attach_returns_false_on_pk_conflict(): void {
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+		$this->assertFalse( RecruitmentNoticeAdjutancyRepository::attach( 1, 2 ) );
+	}
+
+	public function test_detach_returns_true_when_pair_existed(): void {
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 1 );
+
+		$this->assertTrue( RecruitmentNoticeAdjutancyRepository::detach( 1, 2 ) );
+	}
+
+	public function test_detach_returns_false_when_pair_did_not_exist(): void {
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 0 );
+
+		$this->assertFalse( RecruitmentNoticeAdjutancyRepository::detach( 1, 2 ) );
+	}
+
+	public function test_is_attached_returns_true_when_count_positive(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '1' );
+
+		$this->assertTrue( RecruitmentNoticeAdjutancyRepository::is_attached( 1, 2 ) );
+	}
+
+	public function test_is_attached_returns_false_on_zero_count(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+
+		$this->assertFalse( RecruitmentNoticeAdjutancyRepository::is_attached( 1, 2 ) );
+	}
+
+	public function test_get_adjutancy_ids_for_notice_returns_int_array(): void {
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( '1', '2', '3' ) );
+
+		$result = RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( 5 );
+		$this->assertSame( array( 1, 2, 3 ), $result );
+	}
+
+	public function test_get_notice_ids_for_adjutancy_returns_int_array(): void {
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( '10', '20' ) );
+
+		$result = RecruitmentNoticeAdjutancyRepository::get_notice_ids_for_adjutancy( 7 );
+		$this->assertSame( array( 10, 20 ), $result );
+	}
+
+	public function test_detach_all_for_notice_returns_count_of_removed_pairs(): void {
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 3 );
+
+		$this->assertSame( 3, RecruitmentNoticeAdjutancyRepository::detach_all_for_notice( 5 ) );
+	}
+}

--- a/tests/Unit/RecruitmentNoticeRepositoryTest.php
+++ b/tests/Unit/RecruitmentNoticeRepositoryTest.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeRepository;
+
+/**
+ * Tests for RecruitmentNoticeRepository — covers CRUD primitives plus the
+ * atomic state-machine primitives used by the notice state machine
+ * (sprint 5): set_status, mark_opened, mark_closed, mark_reopened.
+ *
+ * The atomic primitives are tested for the "expected current matched"
+ * (returns 1) and "expected current did not match" (returns 0, race lost)
+ * scenarios — the core contract callers depend on.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeRepository
+ */
+class RecruitmentNoticeRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 0;
+		$wpdb->last_error = '';
+		$this->wpdb       = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_table_name(): void {
+		$this->assertSame( 'wp_ffc_recruitment_notice', RecruitmentNoticeRepository::get_table_name() );
+	}
+
+	public function test_get_by_code_uppercases_input_before_lookup(): void {
+		$captured_value = null;
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function ( $sql, ...$values ) use ( &$captured_value ) {
+					if ( false !== stripos( $sql, 'WHERE code = %s' ) ) {
+						$captured_value = $values[1];
+					}
+					return $sql;
+				}
+			);
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		RecruitmentNoticeRepository::get_by_code( 'edital-2026-01' );
+
+		$this->assertSame( 'EDITAL-2026-01', $captured_value, 'Code lookup should be case-normalized' );
+	}
+
+	public function test_create_uppercases_code_and_uses_default_columns_config(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+		$this->wpdb->insert_id = 11;
+
+		$id = RecruitmentNoticeRepository::create( 'edital-2026-01', 'Edital de 2026' );
+
+		$this->assertSame( 11, $id );
+		$this->assertSame( 'EDITAL-2026-01', $captured['code'] );
+		$this->assertSame( 'draft', $captured['status'] );
+		$this->assertSame( 0, $captured['was_reopened'] );
+		$this->assertSame(
+			RecruitmentNoticeRepository::DEFAULT_PUBLIC_COLUMNS_CONFIG,
+			$captured['public_columns_config']
+		);
+	}
+
+	public function test_set_status_returns_one_when_expected_current_matches(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$affected = RecruitmentNoticeRepository::set_status( 5, 'preliminary', 'active' );
+		$this->assertSame( 1, $affected );
+	}
+
+	public function test_set_status_returns_zero_when_expected_current_did_not_match(): void {
+		// Concurrent transition: another writer changed status before us.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+
+		$affected = RecruitmentNoticeRepository::set_status( 5, 'preliminary', 'active' );
+		$this->assertSame( 0, $affected );
+	}
+
+	public function test_mark_reopened_flips_flag_only_first_time(): void {
+		// First call hits the WHERE was_reopened = 0 row.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+		$this->assertSame( 1, RecruitmentNoticeRepository::mark_reopened( 7 ) );
+
+		// Second call: row already at was_reopened=1, so 0 affected.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+		$this->assertSame( 0, RecruitmentNoticeRepository::mark_reopened( 7 ) );
+	}
+
+	public function test_mark_opened_returns_zero_when_already_set(): void {
+		// WHERE opened_at IS NULL fails to match — already opened.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+		$this->assertSame( 0, RecruitmentNoticeRepository::mark_opened( 3 ) );
+	}
+
+	public function test_mark_closed_overwrites_existing_closed_at(): void {
+		// No WHERE guard on mark_closed — every call updates.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+		$this->assertSame( 1, RecruitmentNoticeRepository::mark_closed( 3 ) );
+	}
+
+	public function test_update_only_writes_meta_keys_and_uppercases_code(): void {
+		$captured = array();
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->andReturnUsing(
+				function ( $table, $data ) use ( &$captured ) {
+					$captured = $data;
+					return 1;
+				}
+			);
+
+		RecruitmentNoticeRepository::update(
+			3,
+			array(
+				'code'                  => 'lowercase-code',
+				'name'                  => 'Renamed',
+				'public_columns_config' => '{"rank":true}',
+				'status'                => 'should be ignored — use set_status',
+			)
+		);
+
+		$this->assertSame( 'LOWERCASE-CODE', $captured['code'] );
+		$this->assertSame( 'Renamed', $captured['name'] );
+		$this->assertSame( '{"rank":true}', $captured['public_columns_config'] );
+		$this->assertArrayNotHasKey( 'status', $captured );
+	}
+}

--- a/tests/Unit/RecruitmentNoticeStateMachineTest.php
+++ b/tests/Unit/RecruitmentNoticeStateMachineTest.php
@@ -37,6 +37,13 @@ class RecruitmentNoticeStateMachineTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentNoticeStateMachineTest.php
+++ b/tests/Unit/RecruitmentNoticeStateMachineTest.php
@@ -1,0 +1,228 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeStateMachine;
+
+/**
+ * Tests for RecruitmentNoticeStateMachine — covers every legal transition,
+ * every blocked transition, reason gating, the active→preliminary
+ * zero-calls gate, and the closed→active reopen flag side-effect.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeStateMachine
+ */
+class RecruitmentNoticeStateMachineTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a notice row stub.
+	 *
+	 * @param string      $status Current notice status.
+	 * @param string|null $closed_at Stored closed_at.
+	 * @return object
+	 */
+	private function notice_stub( string $status, ?string $closed_at = null, ?string $opened_at = null, string $was_reopened = '0' ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => 'EDITAL-2026-01',
+			'name'                  => 'Test',
+			'status'                => $status,
+			'opened_at'             => $opened_at,
+			'closed_at'             => $closed_at,
+			'was_reopened'          => $was_reopened,
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_transition_returns_failure_when_notice_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 999, 'preliminary' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_notice_not_found' ), $result['errors'] );
+	}
+
+	public function test_same_state_transition_is_idempotent_success(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'draft' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['errors'] );
+	}
+
+	public function test_invalid_transition_is_rejected(): void {
+		// draft → active is not allowed (must go through preliminary).
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'active' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'recruitment_invalid_transition', $result['errors'][0] );
+		$this->assertStringContainsString( 'draft->active', $result['errors'][0] );
+	}
+
+	public function test_draft_to_preliminary_succeeds(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+		// set_status: returns 1 affected row (race won).
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'preliminary' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_set_status_lost_race_surfaces_error(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+		// 0 affected rows = concurrent writer claimed the row first.
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'preliminary' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_transition_race_lost' ), $result['errors'] );
+	}
+
+	public function test_active_to_preliminary_blocked_when_calls_exist(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'active' ) );
+		// count_calls_for_notice returns 3 — gate fails.
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '3' );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'preliminary' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_active_to_preliminary_blocked_by_calls' ), $result['errors'] );
+	}
+
+	public function test_active_to_preliminary_succeeds_when_no_calls(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'active' ) );
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'preliminary' );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	public function test_active_to_closed_stamps_closed_at(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'active' ) );
+
+		// Two query calls expected: (1) set_status, (2) mark_closed.
+		$query_calls = 0;
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function () use ( &$query_calls ) {
+					++$query_calls;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'closed' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 2, $query_calls, 'set_status + mark_closed' );
+	}
+
+	public function test_closed_to_active_requires_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'closed' ) );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'active' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_transition_reason_required' ), $result['errors'] );
+	}
+
+	public function test_closed_to_active_rejects_blank_reason(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'closed' ) );
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'active', "   \t\n" );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_transition_reason_required' ), $result['errors'] );
+	}
+
+	public function test_closed_to_active_flips_was_reopened(): void {
+		// First get_row: load original notice (status=closed, closed_at set, was_reopened=0).
+		// Second get_row: side-effects re-read after status flip succeeded.
+		$pre  = $this->notice_stub( 'closed', '2026-05-01 09:00:00', '2026-04-01 09:00:00', '0' );
+		$post = $this->notice_stub( 'active', '2026-05-01 09:00:00', '2026-04-01 09:00:00', '0' );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $pre, $post );
+
+		// Three query calls expected: set_status + mark_reopened.
+		// (mark_opened is skipped because opened_at is non-null.)
+		$query_calls = 0;
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function () use ( &$query_calls ) {
+					++$query_calls;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'active', 'Vacancy reopened' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 2, $query_calls, 'set_status + mark_reopened (no mark_opened — already opened previously)' );
+	}
+
+	public function test_first_preliminary_to_active_stamps_opened_at_only(): void {
+		$pre  = $this->notice_stub( 'preliminary', null, null, '0' );
+		$post = $this->notice_stub( 'active', null, null, '0' );
+		$this->wpdb->shouldReceive( 'get_row' )->twice()->andReturn( $pre, $post );
+
+		$query_calls = 0;
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function () use ( &$query_calls ) {
+					++$query_calls;
+					return 1;
+				}
+			);
+
+		$result = RecruitmentNoticeStateMachine::transition_to( 5, 'active' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 2, $query_calls, 'set_status + mark_opened (no mark_reopened — never closed before)' );
+	}
+}

--- a/tests/Unit/RecruitmentPcdHasherTest.php
+++ b/tests/Unit/RecruitmentPcdHasherTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentPcdHasher;
+
+/**
+ * Tests for RecruitmentPcdHasher — verifies the §3.4 PCD-hash formula
+ * `HMAC-SHA256(secret, ("1"|"0") || candidate_id)` and the round-trip
+ * verification helper.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentPcdHasher
+ */
+class RecruitmentPcdHasherTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		// Stable salt across the test so `compute()` is deterministic.
+		Functions\when( 'wp_salt' )->justReturn( 'test-auth-salt' );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_pcd_and_non_pcd_hashes_differ_for_same_candidate(): void {
+		$pcd     = RecruitmentPcdHasher::compute( 42, true );
+		$not_pcd = RecruitmentPcdHasher::compute( 42, false );
+
+		$this->assertNotSame( $pcd, $not_pcd, 'Different PCD value must produce different hash' );
+	}
+
+	public function test_compute_is_deterministic_for_same_inputs(): void {
+		$first  = RecruitmentPcdHasher::compute( 7, true );
+		$second = RecruitmentPcdHasher::compute( 7, true );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( 64, strlen( $first ), 'SHA-256 hex digest is 64 chars' );
+	}
+
+	public function test_compute_differs_across_candidate_ids(): void {
+		$id_1 = RecruitmentPcdHasher::compute( 1, true );
+		$id_2 = RecruitmentPcdHasher::compute( 2, true );
+
+		$this->assertNotSame( $id_1, $id_2, 'candidate_id is part of the HMAC input' );
+	}
+
+	public function test_verify_returns_true_for_pcd_hash(): void {
+		$hash = RecruitmentPcdHasher::compute( 5, true );
+
+		$this->assertTrue( RecruitmentPcdHasher::verify( $hash, 5 ) );
+	}
+
+	public function test_verify_returns_false_for_non_pcd_hash(): void {
+		$hash = RecruitmentPcdHasher::compute( 5, false );
+
+		$this->assertFalse( RecruitmentPcdHasher::verify( $hash, 5 ) );
+	}
+
+	public function test_verify_returns_null_when_hash_does_not_match_either_domain(): void {
+		// Tampered hash (or wrong candidate_id) — neither domain matches.
+		$tampered = str_repeat( 'a', 64 );
+
+		$this->assertNull( RecruitmentPcdHasher::verify( $tampered, 5 ) );
+	}
+
+	public function test_verify_returns_null_for_empty_hash(): void {
+		$this->assertNull( RecruitmentPcdHasher::verify( '', 5 ) );
+	}
+
+	public function test_verify_returns_null_when_candidate_id_does_not_match_stored_hash(): void {
+		// Hash produced for candidate 5; verifying against candidate 6 should
+		// fail both domains because the candidate_id is part of the HMAC input.
+		$hash = RecruitmentPcdHasher::compute( 5, true );
+
+		$this->assertNull( RecruitmentPcdHasher::verify( $hash, 6 ) );
+	}
+}

--- a/tests/Unit/RecruitmentPromotionServiceTest.php
+++ b/tests/Unit/RecruitmentPromotionServiceTest.php
@@ -1,0 +1,237 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentPromotionService;
+
+/**
+ * Tests for RecruitmentPromotionService — covers the snapshot-mode
+ * promotion path: validate notice state, copy preview rows to definitive,
+ * flip status to active, all atomic.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentPromotionService
+ */
+class RecruitmentPromotionServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->insert_id = 0;
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function () {
+					return func_get_args()[0];
+				}
+			)
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function notice_stub( string $status ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => 'EDITAL-2026-01',
+			'name'                  => 'Test',
+			'status'                => $status,
+			'opened_at'             => null,
+			'closed_at'             => null,
+			'was_reopened'          => '0',
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_snapshot_rejects_unknown_notice(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$result = RecruitmentPromotionService::snapshot_to_definitive( 999 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 0, $result['copied'] );
+		$this->assertSame( array( 'recruitment_notice_not_found' ), $result['errors'] );
+	}
+
+	public function test_snapshot_rejects_when_notice_not_in_preliminary(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+
+		$result = RecruitmentPromotionService::snapshot_to_definitive( 5 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_promotion_requires_preliminary_state' ), $result['errors'] );
+	}
+
+	public function test_snapshot_rejects_when_no_preview_rows_to_copy(): void {
+		// First get_row: notice (preliminary).
+		// get_results for preview rows returns empty.
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'preliminary' ) );
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$result = RecruitmentPromotionService::snapshot_to_definitive( 5 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'recruitment_promotion_no_preview_rows' ), $result['errors'] );
+	}
+
+	public function test_snapshot_copies_preview_rows_and_flips_status(): void {
+		$preview_rows = array(
+			(object) array(
+				'id'           => '1',
+				'candidate_id' => '10',
+				'adjutancy_id' => '2',
+				'notice_id'    => '5',
+				'list_type'    => 'preview',
+				'rank'         => '1',
+				'score'        => '90.0000',
+				'status'       => 'empty',
+				'created_at'   => '2026-05-01 10:00:00',
+				'updated_at'   => '2026-05-01 10:00:00',
+			),
+			(object) array(
+				'id'           => '2',
+				'candidate_id' => '11',
+				'adjutancy_id' => '2',
+				'notice_id'    => '5',
+				'list_type'    => 'preview',
+				'rank'         => '2',
+				'score'        => '85.0000',
+				'status'       => 'empty',
+				'created_at'   => '2026-05-01 10:00:00',
+				'updated_at'   => '2026-05-01 10:00:00',
+			),
+		);
+
+		// 1st get_row: snapshot_to_definitive() loads notice (preliminary).
+		// 2nd get_row: state-machine transition_to() reloads the notice.
+		// 3rd get_row: side-effects re-read after status change.
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 3 )
+			->andReturn(
+				$this->notice_stub( 'preliminary' ),
+				$this->notice_stub( 'preliminary' ),
+				$this->notice_stub( 'active' )
+			);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $preview_rows );
+
+		// query() calls in order:
+		//  1. START TRANSACTION
+		//  2. delete_all_for_notice_list (definitive)  → returns null/int; we accept any
+		//  3. set_status (preliminary→active)          → 1 affected
+		//  4. mark_opened                              → 1 affected
+		//  5. COMMIT
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					return 1;
+				}
+			);
+
+		// Two insert calls expected (one per preview row); $wpdb->insert_id
+		// drives the new classification ID returned to the importer pipeline.
+		$inserts = 0;
+		$this->wpdb->shouldReceive( 'insert' )
+			->andReturnUsing(
+				function () use ( &$inserts ) {
+					++$inserts;
+					$GLOBALS['wpdb']->insert_id = 100 + $inserts;
+					return 1;
+				}
+			);
+
+		// Delete is called via wpdb->delete inside delete_all_for_notice_list().
+		$this->wpdb->shouldReceive( 'delete' )->once()->andReturn( 0 );
+
+		$result = RecruitmentPromotionService::snapshot_to_definitive( 5 );
+
+		$this->assertTrue( $result['success'], 'Snapshot expected to succeed; errors=' . implode( ',', $result['errors'] ) );
+		$this->assertSame( 2, $result['copied'] );
+		$this->assertSame( 2, $inserts, 'One INSERT per preview row copied' );
+
+		// Sanity: the transaction envelope is present.
+		$this->assertContains( 'START TRANSACTION', $query_log );
+		$this->assertContains( 'COMMIT', $query_log );
+	}
+
+	public function test_snapshot_rolls_back_when_state_machine_transition_loses_race(): void {
+		$preview_rows = array(
+			(object) array(
+				'id'           => '1',
+				'candidate_id' => '10',
+				'adjutancy_id' => '2',
+				'notice_id'    => '5',
+				'list_type'    => 'preview',
+				'rank'         => '1',
+				'score'        => '90.0000',
+				'status'       => 'empty',
+				'created_at'   => '2026-05-01 10:00:00',
+				'updated_at'   => '2026-05-01 10:00:00',
+			),
+		);
+
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 2 )
+			->andReturn(
+				$this->notice_stub( 'preliminary' ),
+				$this->notice_stub( 'preliminary' )
+			);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $preview_rows );
+
+		$query_log = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$query_log ) {
+					$query_log[] = $sql;
+					// Simulate the conditional UPDATE losing the race
+					// (`set_status` returns 0 affected rows).
+					if ( false !== stripos( $sql, 'UPDATE' ) && false !== stripos( $sql, 'status' ) ) {
+						return 0;
+					}
+					return 1;
+				}
+			);
+
+		$this->wpdb->shouldReceive( 'insert' )
+			->andReturnUsing(
+				function () {
+					$GLOBALS['wpdb']->insert_id = 200;
+					return 1;
+				}
+			);
+		$this->wpdb->shouldReceive( 'delete' )->andReturn( 0 );
+
+		$result = RecruitmentPromotionService::snapshot_to_definitive( 5 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertContains( 'recruitment_transition_race_lost', $result['errors'] );
+		$this->assertContains( 'ROLLBACK', $query_log, 'Transaction must be rolled back when the state-machine flip fails' );
+		$this->assertNotContains( 'COMMIT', $query_log );
+	}
+}

--- a/tests/Unit/RecruitmentPromotionServiceTest.php
+++ b/tests/Unit/RecruitmentPromotionServiceTest.php
@@ -38,6 +38,13 @@ class RecruitmentPromotionServiceTest extends TestCase {
 		Functions\when( 'wp_cache_set' )->justReturn( true );
 		Functions\when( 'wp_cache_delete' )->justReturn( true );
 		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_action' )->justReturn( true );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->andReturnUsing(

--- a/tests/Unit/RecruitmentRestControllerTest.php
+++ b/tests/Unit/RecruitmentRestControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentRestController;
+
+/**
+ * Tests for RecruitmentRestController — focused on permission gating and
+ * route registration. Endpoint dispatch logic is exercised indirectly by
+ * the service-layer tests (CallService, StateMachine, DeleteService) which
+ * cover every error code the controller surfaces. The controller is a thin
+ * adapter; full end-to-end integration tests for the REST surface land in
+ * sprint 13.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentRestController
+ */
+class RecruitmentRestControllerTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_check_admin_cap_returns_true_when_user_can_manage_recruitment(): void {
+		$captured_cap = '';
+		Functions\when( 'current_user_can' )->alias(
+			function ( $cap ) use ( &$captured_cap ) {
+				$captured_cap = $cap;
+				return true;
+			}
+		);
+
+		$controller = new RecruitmentRestController();
+		$this->assertTrue( $controller->check_admin_cap() );
+		$this->assertSame( 'ffc_manage_recruitment', $captured_cap );
+	}
+
+	public function test_check_admin_cap_returns_false_without_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$controller = new RecruitmentRestController();
+		$this->assertFalse( $controller->check_admin_cap() );
+	}
+
+	public function test_check_logged_in_returns_true_when_authenticated(): void {
+		Functions\when( 'is_user_logged_in' )->justReturn( true );
+
+		$controller = new RecruitmentRestController();
+		$this->assertTrue( $controller->check_logged_in() );
+	}
+
+	public function test_check_logged_in_returns_false_for_anonymous(): void {
+		Functions\when( 'is_user_logged_in' )->justReturn( false );
+
+		$controller = new RecruitmentRestController();
+		$this->assertFalse( $controller->check_logged_in() );
+	}
+
+	public function test_register_routes_calls_register_rest_route(): void {
+		$registered = array();
+		Functions\when( 'register_rest_route' )->alias(
+			function ( $namespace, $route, $args ) use ( &$registered ) {
+				$registered[] = array(
+					'namespace' => $namespace,
+					'route'     => $route,
+					'args'      => $args,
+				);
+			}
+		);
+
+		$controller = new RecruitmentRestController();
+		$controller->register_routes();
+
+		$this->assertNotEmpty( $registered, 'register_routes() must call register_rest_route at least once' );
+
+		// Every registered route should be under the recruitment namespace.
+		foreach ( $registered as $reg ) {
+			$this->assertSame( 'ffcertificate/v1', $reg['namespace'] );
+			$this->assertStringStartsWith( '/recruitment', $reg['route'] );
+		}
+	}
+
+	public function test_register_routes_includes_admin_endpoints(): void {
+		$registered = array();
+		Functions\when( 'register_rest_route' )->alias(
+			function ( $namespace, $route, $args ) use ( &$registered ) {
+				$registered[] = $route;
+			}
+		);
+
+		$controller = new RecruitmentRestController();
+		$controller->register_routes();
+
+		// Spot-check the major admin routes documented in §14 of the plan.
+		$this->assertContains( '/recruitment/notices', $registered );
+		$this->assertContains( '/recruitment/notices/(?P<id>\d+)', $registered );
+		$this->assertContains( '/recruitment/notices/(?P<id>\d+)/import', $registered );
+		$this->assertContains( '/recruitment/notices/(?P<id>\d+)/promote-preview', $registered );
+		$this->assertContains( '/recruitment/classifications/bulk-call', $registered );
+		$this->assertContains( '/recruitment/adjutancies', $registered );
+		$this->assertContains( '/recruitment/candidates', $registered );
+		$this->assertContains( '/recruitment/me/recruitment', $registered );
+	}
+}

--- a/tests/Unit/RecruitmentSensitiveFieldRegistryTest.php
+++ b/tests/Unit/RecruitmentSensitiveFieldRegistryTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Core\SensitiveFieldRegistry;
+
+/**
+ * Tests for the recruitment-specific extension of SensitiveFieldRegistry.
+ *
+ * Sprint 2 adds CONTEXT_RECRUITMENT_CANDIDATE — verifies the new context is
+ * registered with the expected three fields (cpf / rf / email), each pointing
+ * at the matching `*_encrypted` + `*_hash` columns on the candidate table.
+ *
+ * @covers \FreeFormCertificate\Core\SensitiveFieldRegistry
+ */
+class RecruitmentSensitiveFieldRegistryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_recruitment_candidate_context_constant_exists(): void {
+		$this->assertSame( 'recruitment_candidate', SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE );
+	}
+
+	public function test_fields_for_recruitment_candidate_returns_cpf_rf_email(): void {
+		$fields = SensitiveFieldRegistry::fields_for( SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE );
+
+		$this->assertArrayHasKey( 'cpf', $fields );
+		$this->assertArrayHasKey( 'rf', $fields );
+		$this->assertArrayHasKey( 'email', $fields );
+		$this->assertCount( 3, $fields, 'Recruitment candidate context exposes exactly 3 sensitive fields' );
+	}
+
+	public function test_recruitment_candidate_fields_map_to_expected_columns(): void {
+		$fields = SensitiveFieldRegistry::fields_for( SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE );
+
+		$this->assertSame( 'cpf_encrypted', $fields['cpf']['encrypted_column'] );
+		$this->assertSame( 'cpf_hash', $fields['cpf']['hash_column'] );
+
+		$this->assertSame( 'rf_encrypted', $fields['rf']['encrypted_column'] );
+		$this->assertSame( 'rf_hash', $fields['rf']['hash_column'] );
+
+		$this->assertSame( 'email_encrypted', $fields['email']['encrypted_column'] );
+		$this->assertSame( 'email_hash', $fields['email']['hash_column'] );
+	}
+
+	public function test_has_returns_true_for_each_recruitment_field(): void {
+		$context = SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE;
+
+		$this->assertTrue( SensitiveFieldRegistry::has( $context, 'cpf' ) );
+		$this->assertTrue( SensitiveFieldRegistry::has( $context, 'rf' ) );
+		$this->assertTrue( SensitiveFieldRegistry::has( $context, 'email' ) );
+	}
+
+	public function test_has_returns_false_for_unregistered_keys(): void {
+		$context = SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE;
+
+		// `phone` and `notes` are stored plain on the candidate row (low
+		// sensitivity per §3.4 of the implementation plan).
+		$this->assertFalse( SensitiveFieldRegistry::has( $context, 'phone' ) );
+		$this->assertFalse( SensitiveFieldRegistry::has( $context, 'notes' ) );
+		$this->assertFalse( SensitiveFieldRegistry::has( $context, 'name' ) );
+		$this->assertFalse( SensitiveFieldRegistry::has( $context, 'pcd' ) );
+	}
+
+	public function test_plaintext_keys_for_recruitment_returns_three_keys(): void {
+		$keys = SensitiveFieldRegistry::plaintext_keys( SensitiveFieldRegistry::CONTEXT_RECRUITMENT_CANDIDATE );
+
+		// Order doesn't matter for plaintext-key removal callers.
+		sort( $keys );
+
+		$this->assertSame( array( 'cpf', 'email', 'rf' ), $keys );
+	}
+}

--- a/tests/Unit/RecruitmentSettingsTest.php
+++ b/tests/Unit/RecruitmentSettingsTest.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentSettings;
+
+/**
+ * Tests for RecruitmentSettings — pins the OPTION_NAME contract (relied on
+ * by `uninstall.php`), the defaults shape (sub-keys present on a fresh
+ * install), the `all()` merge behavior, and the `sanitize()` int-clamping
+ * for the public_* numeric sub-keys.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentSettings
+ */
+class RecruitmentSettingsTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_option_name_matches_uninstall_constant(): void {
+		// `uninstall.php` calls `delete_option('ffc_recruitment_settings')` —
+		// the OPTION_NAME constant must match that exact string for the
+		// teardown to actually remove the row.
+		$this->assertSame( 'ffc_recruitment_settings', RecruitmentSettings::OPTION_NAME );
+	}
+
+	public function test_defaults_include_every_documented_subkey(): void {
+		$defaults = RecruitmentSettings::defaults();
+
+		$this->assertArrayHasKey( 'email_subject', $defaults );
+		$this->assertArrayHasKey( 'email_from_address', $defaults );
+		$this->assertArrayHasKey( 'email_from_name', $defaults );
+		$this->assertArrayHasKey( 'email_body_html', $defaults );
+		$this->assertArrayHasKey( 'public_cache_seconds', $defaults );
+		$this->assertArrayHasKey( 'public_rate_limit_per_minute', $defaults );
+		$this->assertArrayHasKey( 'public_default_page_size', $defaults );
+	}
+
+	public function test_defaults_match_plan_documented_values(): void {
+		$defaults = RecruitmentSettings::defaults();
+
+		// Per §15 of the plan.
+		$this->assertSame( 60, $defaults['public_cache_seconds'] );
+		$this->assertSame( 30, $defaults['public_rate_limit_per_minute'] );
+		$this->assertSame( 50, $defaults['public_default_page_size'] );
+		$this->assertSame( '', $defaults['email_from_address'] );
+		$this->assertSame( '', $defaults['email_from_name'] );
+	}
+
+	public function test_all_returns_defaults_on_fresh_install(): void {
+		Functions\when( 'get_option' )->justReturn( array() );
+
+		$all = RecruitmentSettings::all();
+
+		$this->assertSame( 60, $all['public_cache_seconds'] );
+		$this->assertSame( 30, $all['public_rate_limit_per_minute'] );
+		$this->assertSame( 50, $all['public_default_page_size'] );
+	}
+
+	public function test_all_merges_stored_values_over_defaults(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'public_cache_seconds' => 120,
+				'email_from_name'      => 'Recruitment Team',
+			)
+		);
+
+		$all = RecruitmentSettings::all();
+
+		$this->assertSame( 120, $all['public_cache_seconds'] );
+		$this->assertSame( 'Recruitment Team', $all['email_from_name'] );
+		// Untouched sub-keys keep their default.
+		$this->assertSame( 30, $all['public_rate_limit_per_minute'] );
+	}
+
+	public function test_get_returns_specific_subkey(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'public_default_page_size' => 25 ) );
+
+		$this->assertSame( 25, RecruitmentSettings::get( 'public_default_page_size' ) );
+	}
+
+	public function test_sanitize_returns_defaults_when_input_is_not_array(): void {
+		$out = RecruitmentSettings::sanitize( 'not-an-array' );
+
+		$this->assertSame( RecruitmentSettings::defaults(), $out );
+	}
+
+	public function test_sanitize_clamps_negative_cache_seconds_to_default(): void {
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$out = RecruitmentSettings::sanitize( array( 'public_cache_seconds' => -5 ) );
+
+		$this->assertSame( 60, $out['public_cache_seconds'], 'Negative input falls back to default per the clamp.' );
+	}
+
+	public function test_sanitize_caps_oversized_cache_seconds(): void {
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$out = RecruitmentSettings::sanitize( array( 'public_cache_seconds' => 999_999 ) );
+
+		$this->assertSame( 86_400, $out['public_cache_seconds'], 'Above-max input is capped at the documented ceiling.' );
+	}
+
+	public function test_sanitize_keeps_admin_html_in_body_template(): void {
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		// Admins are trusted to write the body HTML; sanitize MUST NOT strip
+		// tags, otherwise the email-body editor becomes unusable.
+		$html = '<p>Hello <strong>{{name}}</strong>, click <a href="{{site_url}}">here</a>.</p>';
+		$out  = RecruitmentSettings::sanitize( array( 'email_body_html' => $html ) );
+
+		$this->assertSame( $html, $out['email_body_html'] );
+	}
+
+	public function test_sanitize_text_field_runs_on_subject_and_from(): void {
+		$captured = array();
+		Functions\when( 'sanitize_text_field' )->alias(
+			static function ( $input ) use ( &$captured ): string {
+				$captured[] = $input;
+				return trim( (string) $input );
+			}
+		);
+
+		RecruitmentSettings::sanitize(
+			array(
+				'email_subject'      => '  Subject  ',
+				'email_from_address' => '  noreply@example.com  ',
+				'email_from_name'    => '  Recruiter  ',
+			)
+		);
+
+		$this->assertContains( '  Subject  ', $captured );
+		$this->assertContains( '  noreply@example.com  ', $captured );
+		$this->assertContains( '  Recruiter  ', $captured );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -102,6 +102,7 @@ if ( ! class_exists( 'WP_REST_Server' ) ) {
     class WP_REST_Server {
         const READABLE  = 'GET';
         const CREATABLE = 'POST';
+        const EDITABLE  = 'POST, PUT, PATCH';
         const DELETABLE = 'DELETE';
     }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -135,9 +135,10 @@ if ( ! empty( $ffcertificate_forms ) ) {
 }
 
 // ──────────────────────────────────────
-// 6. Remove ffc_user role
+// 6. Remove FFC roles
 // ──────────────────────────────────────
 remove_role( 'ffc_user' );
+remove_role( 'ffc_recruitment_manager' );
 
 // ──────────────────────────────────────
 // 7. Clean up user meta
@@ -158,6 +159,7 @@ $ffcertificate_caps = array(
 	'ffc_view_audience_bookings',
 	'ffc_scheduling_bypass',
 	'ffc_manage_reregistration',
+	'ffc_manage_recruitment',
 	'ffc_reregistration',
 	'ffc_certificate_update',
 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,6 +21,13 @@ global $wpdb;
 // (order: child tables first to avoid FK issues)
 // ──────────────────────────────────────
 $ffcertificate_tables = array(
+	// Recruitment (children first).
+	$wpdb->prefix . 'ffc_recruitment_call',
+	$wpdb->prefix . 'ffc_recruitment_classification',
+	$wpdb->prefix . 'ffc_recruitment_notice_adjutancy',
+	$wpdb->prefix . 'ffc_recruitment_candidate',
+	$wpdb->prefix . 'ffc_recruitment_notice',
+	$wpdb->prefix . 'ffc_recruitment_adjutancy',
 	// Reregistration (children first).
 	$wpdb->prefix . 'ffc_reregistration_submissions',
 	$wpdb->prefix . 'ffc_reregistrations',
@@ -81,6 +88,8 @@ $ffcertificate_options = array(
 	'ffc_columns_dropped_date',
 	'ffc_migration_user_profiles_errors',
 	'ffc_migration_user_profiles_last_run',
+	// Recruitment module (v6.0.0).
+	'ffc_recruitment_settings',
 );
 
 foreach ( $ffcertificate_options as $ffcertificate_option ) {


### PR DESCRIPTION
## Summary

Implements the Recruitment module backend — Brazilian public-tender ("concurso público") candidate queue management. **PR 1 of 3**.

Refs #79

## Sprints (all complete)

- [x] **1.1** — Migrations: 6 idempotent CREATE TABLE statements
- [x] **1.2** — Entities + Repositories with PHPStan row aliases
- [x] **1.3** — Migration idempotency + repository unit tests
- [x] **2** — `CONTEXT_RECRUITMENT_CANDIDATE` + `DocumentFormatter::mask_rf`
- [x] **3** — `CapabilityManager::CONTEXT_RECRUITMENT` + cap/role registration
- [x] **4** — CSV parser + importer + `RecruitmentPcdHasher`
- [x] **5** — Notice & Classification state machines + Promotion service
- [x] **6** — Convocation service (single + bulk + cancel)
- [x] **7** — Centralized §7-bis delete gating service
- [x] **8** — ActivityLog events + sensitive payload protection
- [x] **9.1** — Admin REST controller (full §14 surface, 21 routes)
- [x] **9.2** — Settings registration (`ffc_recruitment_settings`)
- [x] **10** — Email dispatch on call create (multipart, masked PII)

## Architecture summary

**6 tables (InnoDB + utf8mb4)**: `ffc_recruitment_{adjutancy,notice,notice_adjutancy,candidate,classification,call}` with no DB-level FKs (matches plugin convention; integrity enforced at the service layer).

**6 repositories**: each with `@phpstan-type *Row` alias for typed `$wpdb->get_row()` shapes; atomic transition primitives return affected-row counts so callers detect lost races.

**State machines**: `RecruitmentNoticeStateMachine` + `RecruitmentClassificationStateMachine` enforce every §5 transition rule including the reopen-freeze (once `was_reopened=1`, transitions out of `hired`/`not_shown` are permanently blocked).

**Services**: `RecruitmentCsvImporter` (atomic, all-or-nothing CSV import), `RecruitmentCallService` (single + bulk + cancel, all-or-nothing transactions), `RecruitmentDeleteService` (§7-bis gates with typed `blocked_by` reference counts), `RecruitmentPromotionService` (preview → definitive snapshot), `RecruitmentEmailDispatcher` (best-effort send with masked PII), `RecruitmentActivityLogger` (12 stable action codes with auto-encryption via `SensitiveFieldRegistry::contains_sensitive`).

**REST**: `RecruitmentRestController` registers 21 routes under `ffcertificate/v1/recruitment` plus `/me/recruitment`. Cap-gated via `ffc_manage_recruitment` (auto-granted to `administrator` + the new `ffc_recruitment_manager` role). Stable error codes; 409 + `blocked_by` payload on delete-gate failures.

**Settings**: single `ffc_recruitment_settings` option, 7 sub-keys covering email templates + public shortcode tuning.

## Test coverage

- 18 recruitment-specific test classes
- 199 recruitment tests / 590 assertions
- PHPStan level 8 clean (zero new baseline entries)
- PHPCS clean (with two justified `phpcs:ignore` for legitimate local-file reads)
- Full plugin suite green

## Test plan

- [ ] Plugin activates cleanly on a fresh DB; 6 recruitment tables present, all `ENGINE=InnoDB`.
- [ ] Re-activation is idempotent (no duplicate-table errors, role upgraded not overwritten).
- [ ] PHPStan level 8 stays clean.
- [ ] PHPCS clean.
- [ ] PHPUnit suite green.
- [ ] Plugin uninstall drops all 6 tables, recruitment settings option, `ffc_manage_recruitment` cap, and `ffc_recruitment_manager` role.
- [ ] CSV import: happy path, atomic rollback on bad row, BOM handling, header-mismatch rejection.
- [ ] State transitions: every legal + every blocked transition; reopen-freeze rule; race-loss handling.
- [ ] Convocation: in-order, out-of-order, bulk all-or-nothing, cancel.
- [ ] Delete gates: candidate/classification/adjutancy, with `blocked_by` payload.
- [ ] REST endpoints accessible only with `ffc_manage_recruitment` cap.
- [ ] Settings persist + survive uninstall.

## Next PRs

PR 2 (frontend): public shortcode + admin UI + candidate dashboard.
PR 3 (release): docs + bump 5.4.1 → 6.0.0.

https://claude.ai/code/session_01Ewp3idhND7Pbw8nYZiU2AR