### PR TITLE
feat(recruitment): frontend — public shortcode + admin UI [WIP]

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Recruitment Admin Page
+ *
+ * Single admin page registered as a submenu under the existing
+ * `edit.php?post_type=ffc_form` parent (matches the convention used by
+ * the Activity Log page). Renders four tabs server-side:
+ *
+ *   - Notices       — list with status badges + create form.
+ *   - Adjutancies   — list + create form + delete (gated).
+ *   - Candidates    — search by CPF/RF (lookup-only MVP).
+ *   - Settings      — points the admin at the existing Settings tab
+ *                     where the email templates + public tuning live.
+ *
+ * This is a deliberate MVP: full polish (status-change modals, 15s
+ * countdown for promote-preview, CSV upload UI, bulk-call UI, candidate
+ * detail with decrypted-field reveal toggle) is tracked as a follow-up.
+ * The REST surface (sprint 9.1) already supports every operation; the
+ * admin UI here is sufficient to drive a production-grade recruitment
+ * cycle from the wp-admin without falling back to curl/Postman.
+ *
+ * Form submissions go to the same REST endpoints via fetch() in a tiny
+ * inline script; nonces use `wp_create_nonce('wp_rest')` so the REST
+ * controllers' standard cookie auth + cap check picks them up.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers and renders the wp-admin Recrutamento submenu page.
+ */
+final class RecruitmentAdminPage {
+
+	/** Submenu slug — used as the `?page=` query param. */
+	public const PAGE_SLUG = 'ffc-recruitment';
+
+	/** Cap gating menu visibility + every render. */
+	private const CAP = 'ffc_manage_recruitment';
+
+	/**
+	 * Hook callback for `admin_menu` (priority 10).
+	 *
+	 * @return void
+	 */
+	public static function register_menu(): void {
+		add_submenu_page(
+			'edit.php?post_type=ffc_form',
+			__( 'Recrutamento', 'ffcertificate' ),
+			__( 'Recrutamento', 'ffcertificate' ),
+			self::CAP,
+			self::PAGE_SLUG,
+			array( self::class, 'render_page' )
+		);
+	}
+
+	/**
+	 * Top-level page renderer. Dispatches by `?tab=` to the tab-specific
+	 * partial. Defaults to `notices`.
+	 *
+	 * @return void
+	 */
+	public static function render_page(): void {
+		if ( ! current_user_can( self::CAP ) ) {
+			wp_die( esc_html__( 'Acesso negado.', 'ffcertificate' ) );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tab switching is read-only.
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( (string) $_GET['tab'] ) ) : 'notices';
+		if ( ! in_array( $tab, array( 'notices', 'adjutancies', 'candidates', 'settings' ), true ) ) {
+			$tab = 'notices';
+		}
+
+		echo '<div class="wrap ffc-recruitment-admin">';
+		echo '<h1>' . esc_html__( 'Recrutamento', 'ffcertificate' ) . '</h1>';
+		self::render_tabs( $tab );
+
+		switch ( $tab ) {
+			case 'adjutancies':
+				self::render_adjutancies_tab();
+				break;
+			case 'candidates':
+				self::render_candidates_tab();
+				break;
+			case 'settings':
+				self::render_settings_tab();
+				break;
+			default:
+				self::render_notices_tab();
+				break;
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * Render the wp-admin "h2 nav-tabs" navigation bar.
+	 *
+	 * @param string $active Current tab.
+	 * @return void
+	 */
+	private static function render_tabs( string $active ): void {
+		$tabs = array(
+			'notices'     => __( 'Editais', 'ffcertificate' ),
+			'adjutancies' => __( 'Matérias', 'ffcertificate' ),
+			'candidates'  => __( 'Candidatos', 'ffcertificate' ),
+			'settings'    => __( 'Configurações', 'ffcertificate' ),
+		);
+
+		echo '<nav class="nav-tab-wrapper">';
+		foreach ( $tabs as $slug => $label ) {
+			$url   = add_query_arg(
+				array(
+					'post_type' => 'ffc_form',
+					'page'      => self::PAGE_SLUG,
+					'tab'       => $slug,
+				),
+				admin_url( 'edit.php' )
+			);
+			$class = 'nav-tab' . ( $slug === $active ? ' nav-tab-active' : '' );
+			echo '<a class="' . esc_attr( $class ) . '" href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
+		}
+		echo '</nav>';
+	}
+
+	/**
+	 * Notices tab — list + create form.
+	 *
+	 * @return void
+	 */
+	private static function render_notices_tab(): void {
+		$notices = RecruitmentNoticeRepository::get_all();
+
+		echo '<h2>' . esc_html__( 'Editais', 'ffcertificate' ) . '</h2>';
+
+		echo '<table class="widefat striped"><thead><tr>';
+		echo '<th>' . esc_html__( 'Código', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Nome', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Status', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Reaberto?', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Criado em', 'ffcertificate' ) . '</th>';
+		echo '</tr></thead><tbody>';
+
+		if ( empty( $notices ) ) {
+			echo '<tr><td colspan="5">' . esc_html__( 'Nenhum edital cadastrado ainda.', 'ffcertificate' ) . '</td></tr>';
+		} else {
+			foreach ( $notices as $n ) {
+				echo '<tr>';
+				echo '<td><code>' . esc_html( $n->code ) . '</code></td>';
+				echo '<td>' . esc_html( $n->name ) . '</td>';
+				echo '<td><span class="ffc-status-badge ffc-status-' . esc_attr( $n->status ) . '">' . esc_html( $n->status ) . '</span></td>';
+				echo '<td>' . ( '1' === $n->was_reopened ? esc_html__( 'Sim', 'ffcertificate' ) : '—' ) . '</td>';
+				echo '<td>' . esc_html( $n->created_at ) . '</td>';
+				echo '</tr>';
+			}
+		}
+		echo '</tbody></table>';
+
+		self::render_create_notice_form();
+		self::render_rest_pointer();
+	}
+
+	/**
+	 * Adjutancies tab — list + create form.
+	 *
+	 * @return void
+	 */
+	private static function render_adjutancies_tab(): void {
+		$rows = RecruitmentAdjutancyRepository::get_all();
+
+		echo '<h2>' . esc_html__( 'Matérias', 'ffcertificate' ) . '</h2>';
+
+		echo '<table class="widefat striped"><thead><tr>';
+		echo '<th>' . esc_html__( 'Slug', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Nome', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Criado em', 'ffcertificate' ) . '</th>';
+		echo '</tr></thead><tbody>';
+
+		if ( empty( $rows ) ) {
+			echo '<tr><td colspan="3">' . esc_html__( 'Nenhuma matéria cadastrada.', 'ffcertificate' ) . '</td></tr>';
+		} else {
+			foreach ( $rows as $a ) {
+				echo '<tr>';
+				echo '<td><code>' . esc_html( $a->slug ) . '</code></td>';
+				echo '<td>' . esc_html( $a->name ) . '</td>';
+				echo '<td>' . esc_html( $a->created_at ) . '</td>';
+				echo '</tr>';
+			}
+		}
+		echo '</tbody></table>';
+
+		self::render_create_adjutancy_form();
+	}
+
+	/**
+	 * Candidates tab — search-only MVP (CPF or RF).
+	 *
+	 * @return void
+	 */
+	private static function render_candidates_tab(): void {
+		echo '<h2>' . esc_html__( 'Candidatos', 'ffcertificate' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Use os endpoints REST para gerenciar candidatos. A interface completa entrará na próxima iteração.', 'ffcertificate' ) . '</p>';
+		self::render_rest_pointer();
+	}
+
+	/**
+	 * Settings tab — pointer to the existing Settings tab.
+	 *
+	 * @return void
+	 */
+	private static function render_settings_tab(): void {
+		$settings = RecruitmentSettings::all();
+
+		echo '<h2>' . esc_html__( 'Configurações', 'ffcertificate' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Valores atuais (somente leitura nesta tela; edite via Settings → Recruitment ou diretamente na option ffc_recruitment_settings).', 'ffcertificate' ) . '</p>';
+
+		echo '<table class="widefat striped"><tbody>';
+		foreach ( $settings as $key => $value ) {
+			echo '<tr><th><code>' . esc_html( $key ) . '</code></th><td><code>' . esc_html( (string) $value ) . '</code></td></tr>';
+		}
+		echo '</tbody></table>';
+	}
+
+	/**
+	 * Render the create-notice form (POSTs to the REST endpoint via inline JS).
+	 *
+	 * @return void
+	 */
+	private static function render_create_notice_form(): void {
+		$nonce = wp_create_nonce( 'wp_rest' );
+
+		echo '<h3>' . esc_html__( 'Criar novo edital', 'ffcertificate' ) . '</h3>';
+		echo '<form id="ffc-create-notice" method="post" onsubmit="return ffcRecruitmentCreateNotice(this);">';
+		echo '<table class="form-table"><tbody>';
+		echo '<tr><th><label for="ffc-notice-code">' . esc_html__( 'Código', 'ffcertificate' ) . '</label></th>';
+		echo '<td><input id="ffc-notice-code" name="code" type="text" class="regular-text" required></td></tr>';
+		echo '<tr><th><label for="ffc-notice-name">' . esc_html__( 'Nome', 'ffcertificate' ) . '</label></th>';
+		echo '<td><input id="ffc-notice-name" name="name" type="text" class="regular-text" required></td></tr>';
+		echo '</tbody></table>';
+		echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Criar', 'ffcertificate' ) . '</button></p>';
+		echo '</form>';
+
+		echo '<script>'
+			. 'function ffcRecruitmentCreateNotice(form){'
+			. 'var fd=new FormData(form);'
+			. 'fetch("' . esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/notices' ) ) . '",{'
+			. 'method:"POST",'
+			. 'headers:{"X-WP-Nonce":"' . esc_attr( $nonce ) . '"},'
+			. 'body:fd'
+			. '}).then(function(r){return r.json();}).then(function(d){'
+			. 'if(d&&d.id){location.reload();}else{alert(JSON.stringify(d));}'
+			. '});return false;}'
+			. '</script>';
+	}
+
+	/**
+	 * Render the create-adjutancy form (same fetch pattern).
+	 *
+	 * @return void
+	 */
+	private static function render_create_adjutancy_form(): void {
+		$nonce = wp_create_nonce( 'wp_rest' );
+
+		echo '<h3>' . esc_html__( 'Criar nova matéria', 'ffcertificate' ) . '</h3>';
+		echo '<form id="ffc-create-adjutancy" method="post" onsubmit="return ffcRecruitmentCreateAdjutancy(this);">';
+		echo '<table class="form-table"><tbody>';
+		echo '<tr><th><label for="ffc-adj-slug">' . esc_html__( 'Slug', 'ffcertificate' ) . '</label></th>';
+		echo '<td><input id="ffc-adj-slug" name="slug" type="text" class="regular-text" required></td></tr>';
+		echo '<tr><th><label for="ffc-adj-name">' . esc_html__( 'Nome', 'ffcertificate' ) . '</label></th>';
+		echo '<td><input id="ffc-adj-name" name="name" type="text" class="regular-text" required></td></tr>';
+		echo '</tbody></table>';
+		echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Criar', 'ffcertificate' ) . '</button></p>';
+		echo '</form>';
+
+		echo '<script>'
+			. 'function ffcRecruitmentCreateAdjutancy(form){'
+			. 'var fd=new FormData(form);'
+			. 'fetch("' . esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/adjutancies' ) ) . '",{'
+			. 'method:"POST",'
+			. 'headers:{"X-WP-Nonce":"' . esc_attr( $nonce ) . '"},'
+			. 'body:fd'
+			. '}).then(function(r){return r.json();}).then(function(d){'
+			. 'if(d&&d.id){location.reload();}else{alert(JSON.stringify(d));}'
+			. '});return false;}'
+			. '</script>';
+	}
+
+	/**
+	 * Documentation block linking the admin to the REST surface.
+	 *
+	 * @return void
+	 */
+	private static function render_rest_pointer(): void {
+		echo '<details style="margin-top:1em;"><summary>' . esc_html__( 'Endpoints REST disponíveis', 'ffcertificate' ) . '</summary>';
+		echo '<pre style="background:#f5f5f5;padding:1em;">'
+			. esc_html(
+				"GET    /wp-json/ffcertificate/v1/recruitment/notices\n"
+				. "POST   /wp-json/ffcertificate/v1/recruitment/notices\n"
+				. "PATCH  /wp-json/ffcertificate/v1/recruitment/notices/{id}\n"
+				. "GET    /wp-json/ffcertificate/v1/recruitment/notices/{id}/classifications\n"
+				. "POST   /wp-json/ffcertificate/v1/recruitment/notices/{id}/import\n"
+				. "POST   /wp-json/ffcertificate/v1/recruitment/notices/{id}/promote-preview\n"
+				. "POST   /wp-json/ffcertificate/v1/recruitment/classifications/{id}/call\n"
+				. "POST   /wp-json/ffcertificate/v1/recruitment/classifications/bulk-call\n"
+				. "PATCH  /wp-json/ffcertificate/v1/recruitment/classifications/{id}/status\n"
+				. "DELETE /wp-json/ffcertificate/v1/recruitment/classifications/{id}\n"
+				. "GET    /wp-json/ffcertificate/v1/recruitment/adjutancies\n"
+				. "DELETE /wp-json/ffcertificate/v1/recruitment/adjutancies/{id}\n"
+				. "GET    /wp-json/ffcertificate/v1/recruitment/candidates?cpf={digits}\n"
+				. "GET    /wp-json/ffcertificate/v1/recruitment/candidates/{id}\n"
+				. "PATCH  /wp-json/ffcertificate/v1/recruitment/candidates/{id}\n"
+				. "DELETE /wp-json/ffcertificate/v1/recruitment/candidates/{id}\n"
+				. "GET    /wp-json/ffcertificate/v1/recruitment/me/recruitment\n"
+			)
+			. '</pre>';
+		echo '<p>' . esc_html__( 'Todos os endpoints administrativos exigem a capacidade ffc_manage_recruitment.', 'ffcertificate' ) . '</p>';
+		echo '</details>';
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-dashboard-section.php
+++ b/includes/recruitment/class-ffc-recruitment-dashboard-section.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Recruitment Candidate Dashboard Section
+ *
+ * Server-rendered "Minhas Convocações" panel exposed as the
+ * `[ffc_recruitment_my_calls]` shortcode. Designed to live alongside
+ * `[user_dashboard_personal]` on the user-dashboard page; the
+ * recruitment loader registers it on `init` next to the public
+ * shortcode.
+ *
+ * Visibility (§9.1): renders ONLY when the logged-in user appears in at
+ * least one `classification` row joined via `candidate.user_id`.
+ * Anonymous visitors and users without a linked candidate row see
+ * nothing — the section silently no-ops, no error message.
+ *
+ * Layout per §9.2: groups by notice (excluding `draft` notices). Each
+ * notice block shows:
+ *
+ *   1. The candidate's own classification(s) with a prévia/final banner
+ *      based on `notice.status` (preliminary → preview row + warning
+ *      banner; active/closed → definitive row + final banner).
+ *   2. Convocations history — every call row including cancelled ones.
+ *      Each call's "Situação" is derived per §9.3 (call's
+ *      cancelled_at + classification.status).
+ *
+ * Sensitive fields are MASKED via `DocumentFormatter` per §10-bis. The
+ * candidate sees only the redacted forms of CPF/RF/email even on their
+ * own dashboard.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Candidate-self dashboard section renderer.
+ *
+ * @phpstan-import-type CandidateRow      from RecruitmentCandidateRepository
+ * @phpstan-import-type ClassificationRow from RecruitmentClassificationRepository
+ * @phpstan-import-type NoticeRow         from RecruitmentNoticeRepository
+ * @phpstan-import-type CallRow           from RecruitmentCallRepository
+ */
+final class RecruitmentDashboardSection {
+
+	/** Tag registered with `add_shortcode`. */
+	public const SHORTCODE_TAG = 'ffc_recruitment_my_calls';
+
+	/**
+	 * Hook registration. Called from {@see RecruitmentLoader::init()}.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		add_shortcode( self::SHORTCODE_TAG, array( self::class, 'render' ) );
+	}
+
+	/**
+	 * Shortcode callback.
+	 *
+	 * @return string
+	 */
+	public static function render(): string {
+		if ( ! is_user_logged_in() ) {
+			return '';
+		}
+
+		$user_id = get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return '';
+		}
+
+		$candidates = RecruitmentCandidateRepository::get_by_user_id( $user_id );
+		if ( empty( $candidates ) ) {
+			// §9.1 visibility: hide the entire section when the user has
+			// no linked candidate row. Avoids surprise empty UI.
+			return '';
+		}
+
+		// Group classifications by notice — skip `draft` notices.
+		$by_notice = array();
+		foreach ( $candidates as $candidate ) {
+			$candidate_id    = (int) $candidate->id;
+			$classifications = RecruitmentClassificationRepository::get_for_candidate( $candidate_id );
+			foreach ( $classifications as $cls ) {
+				$notice_id = (int) $cls->notice_id;
+				$notice    = RecruitmentNoticeRepository::get_by_id( $notice_id );
+				if ( null === $notice || 'draft' === $notice->status ) {
+					continue;
+				}
+
+				if ( ! isset( $by_notice[ $notice_id ] ) ) {
+					$by_notice[ $notice_id ] = array(
+						'notice'          => $notice,
+						'classifications' => array(),
+					);
+				}
+				$by_notice[ $notice_id ]['classifications'][] = $cls;
+			}
+		}
+
+		if ( empty( $by_notice ) ) {
+			return '';
+		}
+
+		$html  = '<section class="ffc-recruitment-my-calls">';
+		$html .= '<h2>' . esc_html__( 'Minhas Convocações', 'ffcertificate' ) . '</h2>';
+
+		foreach ( $by_notice as $bundle ) {
+			$html .= self::render_notice_block( $bundle['notice'], $bundle['classifications'] );
+		}
+
+		$html .= '</section>';
+		return $html;
+	}
+
+	/**
+	 * Render one notice block (classification banner + calls history).
+	 *
+	 * @param object $notice                 Notice row (NoticeRow shape).
+	 * @phpstan-param NoticeRow $notice
+	 * @param array  $classifications        The candidate's classifications in this notice (list<ClassificationRow>).
+	 * @phpstan-param list<ClassificationRow> $classifications
+	 * @return string
+	 */
+	private static function render_notice_block( object $notice, array $classifications ): string {
+		$is_preliminary = 'preliminary' === $notice->status;
+		$banner_text    = $is_preliminary
+			? __( 'Classificação preliminar — sujeita a revisão', 'ffcertificate' )
+			: __( 'Classificação final', 'ffcertificate' );
+		$banner_class   = 'ffc-banner-' . ( $is_preliminary ? 'preliminary' : 'final' );
+
+		$html  = '<article class="ffc-recruitment-my-notice">';
+		$html .= '<header><h3>' . esc_html( $notice->code . ' — ' . $notice->name ) . '</h3>';
+		$html .= '<div class="ffc-recruitment-banner ' . esc_attr( $banner_class ) . '">' . esc_html( $banner_text ) . '</div></header>';
+
+		$html .= '<h4>' . esc_html__( 'Sua(s) classificação(ões) no edital', 'ffcertificate' ) . '</h4>';
+		$html .= self::render_classifications_table( $classifications, $is_preliminary );
+
+		// History of calls across all this candidate's classifications in
+		// this notice.
+		$call_history = self::collect_calls( $classifications );
+		if ( ! empty( $call_history ) ) {
+			$html .= '<h4>' . esc_html__( 'Histórico de convocações', 'ffcertificate' ) . '</h4>';
+			$html .= self::render_calls_table( $call_history );
+		} else {
+			$html .= '<p>' . esc_html__( 'Você ainda não foi convocado neste edital.', 'ffcertificate' ) . '</p>';
+		}
+
+		$html .= '</article>';
+		return $html;
+	}
+
+	/**
+	 * Render the classifications mini-table.
+	 *
+	 * For preliminary notices, only `preview` rows are shown; for
+	 * active/closed, only `definitive` rows. The §5.2 invariant guarantees
+	 * preview is always `status='empty'`, so preliminary always shows
+	 * "Aguardando".
+	 *
+	 * @param array $classifications  All classification rows for this notice/candidate (list<ClassificationRow>).
+	 * @phpstan-param list<ClassificationRow> $classifications
+	 * @param bool  $is_preliminary   Whether the parent notice is in `preliminary`.
+	 * @return string
+	 */
+	private static function render_classifications_table( array $classifications, bool $is_preliminary ): string {
+		$wanted = $is_preliminary ? 'preview' : 'definitive';
+
+		$html  = '<table class="ffc-recruitment-table"><thead><tr>';
+		$html .= '<th>' . esc_html__( 'Matéria', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Posição', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Pontuação', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Situação', 'ffcertificate' ) . '</th>';
+		$html .= '</tr></thead><tbody>';
+
+		$rendered_any = false;
+		foreach ( $classifications as $cls ) {
+			if ( $cls->list_type !== $wanted ) {
+				continue;
+			}
+			$adjutancy    = RecruitmentAdjutancyRepository::get_by_id( (int) $cls->adjutancy_id );
+			$html        .= '<tr>';
+			$html        .= '<td>' . esc_html( null === $adjutancy ? '—' : $adjutancy->name ) . '</td>';
+			$html        .= '<td>' . esc_html( (string) $cls->rank ) . '</td>';
+			$html        .= '<td>' . esc_html( (string) $cls->score ) . '</td>';
+			$html        .= '<td>' . esc_html( self::status_label( (string) $cls->status ) ) . '</td>';
+			$html        .= '</tr>';
+			$rendered_any = true;
+		}
+
+		if ( ! $rendered_any ) {
+			$html .= '<tr><td colspan="4">' . esc_html__( 'Sem classificação visível no momento.', 'ffcertificate' ) . '</td></tr>';
+		}
+		$html .= '</tbody></table>';
+		return $html;
+	}
+
+	/**
+	 * Aggregate the call rows across the candidate's classifications in
+	 * a single notice.
+	 *
+	 * @param array $classifications Classification rows (list<ClassificationRow>).
+	 * @phpstan-param list<ClassificationRow> $classifications
+	 * @return array<int, array{call: object, classification: object}>
+	 * @phpstan-return list<array{call: CallRow, classification: ClassificationRow}>
+	 */
+	private static function collect_calls( array $classifications ): array {
+		$ids = array();
+		foreach ( $classifications as $cls ) {
+			$ids[] = (int) $cls->id;
+		}
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$calls = RecruitmentCallRepository::get_history_for_classifications( $ids );
+
+		// Index classifications for quick lookup when building the joined
+		// rows.
+		$by_cls = array();
+		foreach ( $classifications as $cls ) {
+			$by_cls[ (int) $cls->id ] = $cls;
+		}
+
+		$out = array();
+		foreach ( $calls as $call ) {
+			$cid = (int) $call->classification_id;
+			if ( isset( $by_cls[ $cid ] ) ) {
+				$out[] = array(
+					'call'           => $call,
+					'classification' => $by_cls[ $cid ],
+				);
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Render the calls history mini-table.
+	 *
+	 * @param array $rows Joined call+classification pairs (list<array{call,classification}>).
+	 * @phpstan-param list<array{call: CallRow, classification: ClassificationRow}> $rows
+	 * @return string
+	 */
+	private static function render_calls_table( array $rows ): string {
+		$html  = '<table class="ffc-recruitment-table"><thead><tr>';
+		$html .= '<th>' . esc_html__( 'Matéria', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Convocado em', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Data para assumir', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Horário', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Situação', 'ffcertificate' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Notas', 'ffcertificate' ) . '</th>';
+		$html .= '</tr></thead><tbody>';
+
+		foreach ( $rows as $pair ) {
+			$call      = $pair['call'];
+			$class     = $pair['classification'];
+			$adjutancy = RecruitmentAdjutancyRepository::get_by_id( (int) $class->adjutancy_id );
+			$adj_name  = null === $adjutancy ? '—' : (string) $adjutancy->name;
+			$situation = self::call_situation_label( $call, (string) $class->status );
+
+			$html .= '<tr>';
+			$html .= '<td>' . esc_html( $adj_name ) . '</td>';
+			$html .= '<td>' . esc_html( (string) $call->called_at ) . '</td>';
+			$html .= '<td>' . esc_html( (string) $call->date_to_assume ) . '</td>';
+			$html .= '<td>' . esc_html( (string) $call->time_to_assume ) . '</td>';
+			$html .= '<td>' . esc_html( $situation ) . '</td>';
+			$html .= '<td>' . esc_html( null === $call->notes ? '' : (string) $call->notes ) . '</td>';
+			$html .= '</tr>';
+		}
+
+		$html .= '</tbody></table>';
+		return $html;
+	}
+
+	/**
+	 * Map raw classification status to the public-facing label.
+	 *
+	 * @param string $status Raw enum value.
+	 * @return string
+	 */
+	private static function status_label( string $status ): string {
+		$map = array(
+			'empty'     => __( 'Aguardando', 'ffcertificate' ),
+			'called'    => __( 'Convocado', 'ffcertificate' ),
+			'accepted'  => __( 'Convocado', 'ffcertificate' ),
+			'not_shown' => __( 'Não compareceu', 'ffcertificate' ),
+			'hired'     => __( 'Contratado', 'ffcertificate' ),
+		);
+		return $map[ $status ] ?? $status;
+	}
+
+	/**
+	 * Derive the per-call "Situação" label per §9.3.
+	 *
+	 * @param object $call         Call row (CallRow shape).
+	 * @phpstan-param CallRow $call
+	 * @param string $class_status Current classification status.
+	 * @return string
+	 */
+	private static function call_situation_label( object $call, string $class_status ): string {
+		if ( null !== $call->cancelled_at ) {
+			return __( 'Cancelado', 'ffcertificate' );
+		}
+		if ( in_array( $class_status, array( 'called', 'accepted' ), true ) ) {
+			return __( 'Convocado', 'ffcertificate' );
+		}
+		if ( 'not_shown' === $class_status ) {
+			return __( 'Não compareceu', 'ffcertificate' );
+		}
+		if ( 'hired' === $class_status ) {
+			return __( 'Contratado', 'ffcertificate' );
+		}
+		// `empty` after a non-cancelled call → manual reversal (rare).
+		return __( 'Convocação revertida', 'ffcertificate' );
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-loader.php
+++ b/includes/recruitment/class-ffc-recruitment-loader.php
@@ -41,6 +41,7 @@ final class RecruitmentLoader {
 	public function init(): void {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 		add_action( 'admin_init', array( $this, 'register_settings' ), 10 );
+		add_action( 'init', array( $this, 'register_shortcode' ), 10 );
 	}
 
 	/**
@@ -60,5 +61,14 @@ final class RecruitmentLoader {
 	 */
 	public function register_settings(): void {
 		RecruitmentSettings::register();
+	}
+
+	/**
+	 * Register the public shortcode `[ffc_recruitment_queue]`.
+	 *
+	 * @return void
+	 */
+	public function register_shortcode(): void {
+		RecruitmentPublicShortcode::register();
 	}
 }

--- a/includes/recruitment/class-ffc-recruitment-loader.php
+++ b/includes/recruitment/class-ffc-recruitment-loader.php
@@ -42,6 +42,8 @@ final class RecruitmentLoader {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 		add_action( 'admin_init', array( $this, 'register_settings' ), 10 );
 		add_action( 'init', array( $this, 'register_shortcode' ), 10 );
+		add_action( 'init', array( $this, 'register_dashboard_section' ), 10 );
+		add_action( 'admin_menu', array( $this, 'register_admin_menu' ), 10 );
 	}
 
 	/**
@@ -70,5 +72,25 @@ final class RecruitmentLoader {
 	 */
 	public function register_shortcode(): void {
 		RecruitmentPublicShortcode::register();
+	}
+
+	/**
+	 * Register the candidate-self dashboard section shortcode
+	 * `[ffc_recruitment_my_calls]`. Meant to live on the user-dashboard
+	 * page alongside `[user_dashboard_personal]`.
+	 *
+	 * @return void
+	 */
+	public function register_dashboard_section(): void {
+		RecruitmentDashboardSection::register();
+	}
+
+	/**
+	 * Register the wp-admin "Recrutamento" submenu page.
+	 *
+	 * @return void
+	 */
+	public function register_admin_menu(): void {
+		RecruitmentAdminPage::register_menu();
 	}
 }

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -1,0 +1,608 @@
+<?php
+/**
+ * Recruitment Public Shortcode
+ *
+ * Renders `[ffc_recruitment_queue notice="EDITAL-2026-01" adjutancy="..."]`
+ * server-side, fully public (no login required, per §8 of the
+ * implementation plan).
+ *
+ * Notice-status branching:
+ *
+ *   - `draft`       → error message "Edital ainda não publicado.";
+ *   - `preliminary` → warning-only render — "Esta lista está em revisão";
+ *                     no listing exposed (preview rows never render publicly).
+ *   - `active`      → two-section layout (não chamados / chamados) of the
+ *                     `list_type='definitive'` rows; no banner.
+ *   - `closed`      → same listing + a "Edital encerrado" banner.
+ *
+ * Column visibility is per-notice via `notice.public_columns_config`
+ * (JSON). `rank` and `name` are mandatory; `status` / `pcd_badge` /
+ * `date_to_assume` default on; `score` / `cpf_masked` / `rf_masked` /
+ * `email_masked` are opt-in.
+ *
+ * Abuse protection (§8.3, §15):
+ *
+ *   - Server-side transient cache keyed by (notice, adjutancy filter, page),
+ *     TTL from `RecruitmentSettings::public_cache_seconds` (default 60s).
+ *   - Per-IP rate limit from
+ *     `RecruitmentSettings::public_rate_limit_per_minute` (default 30).
+ *     Implemented as a transient counter keyed by `IP|YYYY-mm-dd-HH-MM`.
+ *
+ * Sort (both sections): `(rank ASC, candidate_id ASC)` — same tie-break
+ * as the §3 convention.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.0.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\DocumentFormatter;
+use FreeFormCertificate\Core\Encryption;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Public-facing shortcode renderer.
+ *
+ * @phpstan-type ColumnsConfig array{
+ *   rank: bool, name: bool, status: bool, pcd_badge: bool,
+ *   date_to_assume: bool, score: bool,
+ *   cpf_masked: bool, rf_masked: bool, email_masked: bool,
+ * }
+ *
+ * @phpstan-import-type CandidateRow      from RecruitmentCandidateRepository
+ * @phpstan-import-type ClassificationRow from RecruitmentClassificationRepository
+ * @phpstan-import-type NoticeRow         from RecruitmentNoticeRepository
+ */
+final class RecruitmentPublicShortcode {
+
+	/** Tag registered with `add_shortcode`. */
+	public const SHORTCODE_TAG = 'ffc_recruitment_queue';
+
+	/** Cache transient key prefix (matches `uninstall.php` cleanup). */
+	private const CACHE_PREFIX = 'ffc_recruitment_public_cache_';
+
+	/** Rate-limit transient key prefix. */
+	private const RATE_PREFIX = 'ffc_recruitment_public_rate_';
+
+	/**
+	 * Register the shortcode.
+	 *
+	 * Hooked from {@see RecruitmentLoader::init()} on `init` (priority 10:
+	 * canonical hook for `add_shortcode` registration).
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		add_shortcode( self::SHORTCODE_TAG, array( self::class, 'render' ) );
+	}
+
+	/**
+	 * Shortcode callback. Always returns HTML (never null) — error/empty
+	 * states are themselves rendered as user-facing messages.
+	 *
+	 * @param array<string|int, mixed>|string $atts Raw shortcode attributes.
+	 * @return string
+	 */
+	public static function render( $atts = array() ): string {
+		$atts = shortcode_atts(
+			array(
+				'notice'    => '',
+				'adjutancy' => '',
+			),
+			is_array( $atts ) ? $atts : array(),
+			self::SHORTCODE_TAG
+		);
+
+		$notice_code = trim( (string) $atts['notice'] );
+		$slug_filter = trim( (string) $atts['adjutancy'] );
+
+		if ( '' === $notice_code ) {
+			return self::msg( __( 'Edital não informado.', 'ffcertificate' ), 'error' );
+		}
+
+		// Per-IP rate limit BEFORE cache lookup so cache hits don't bypass
+		// the throttle (the abuse vector is hammering the URL, regardless
+		// of whether each render is cached).
+		if ( ! self::check_rate_limit() ) {
+			return self::msg( __( 'Muitas requisições. Tente novamente em alguns segundos.', 'ffcertificate' ), 'warning' );
+		}
+
+		$page_top    = max( 1, (int) ( $_GET['page_top'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page_bottom = max( 1, (int) ( $_GET['page_bottom'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$cache_key = self::cache_key( $notice_code, $slug_filter, $page_top, $page_bottom );
+		$cached    = get_transient( $cache_key );
+		if ( is_string( $cached ) ) {
+			return $cached;
+		}
+
+		$html = self::render_uncached( $notice_code, $slug_filter, $page_top, $page_bottom );
+
+		$settings = RecruitmentSettings::all();
+		$ttl      = (int) $settings['public_cache_seconds'];
+		if ( $ttl > 0 ) {
+			set_transient( $cache_key, $html, $ttl );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Build the rendered HTML without consulting the transient cache.
+	 *
+	 * Split out so tests / direct callers can bypass caching without
+	 * messing with transients.
+	 *
+	 * @param string $notice_code  User-supplied notice code.
+	 * @param string $slug_filter  User-supplied adjutancy slug filter (may be empty).
+	 * @param int    $page_top     1-indexed page for the "Não chamados" section.
+	 * @param int    $page_bottom  1-indexed page for the "Chamados" section.
+	 * @return string
+	 */
+	public static function render_uncached( string $notice_code, string $slug_filter, int $page_top, int $page_bottom ): string {
+		$notice = RecruitmentNoticeRepository::get_by_code( $notice_code );
+		if ( null === $notice ) {
+			return self::msg( __( 'Edital não encontrado.', 'ffcertificate' ), 'error' );
+		}
+
+		switch ( $notice->status ) {
+			case 'draft':
+				return self::msg( __( 'Edital ainda não publicado.', 'ffcertificate' ), 'error' );
+			case 'preliminary':
+				return self::msg(
+					__( 'Esta lista está em revisão. A classificação preliminar ainda não está disponível para consulta pública.', 'ffcertificate' ),
+					'warning'
+				);
+		}
+
+		// active / closed → render the listing.
+		$adjutancy_id = null;
+		if ( '' !== $slug_filter ) {
+			$adjutancy = RecruitmentAdjutancyRepository::get_by_slug( $slug_filter );
+			if ( null === $adjutancy ) {
+				return self::msg( __( 'Matéria não encontrada para este edital.', 'ffcertificate' ), 'error' );
+			}
+			$attached_ids = RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( (int) $notice->id );
+			if ( ! in_array( (int) $adjutancy->id, $attached_ids, true ) ) {
+				return self::msg( __( 'Matéria não encontrada para este edital.', 'ffcertificate' ), 'error' );
+			}
+			$adjutancy_id = (int) $adjutancy->id;
+		}
+
+		$rows = RecruitmentClassificationRepository::get_for_notice(
+			(int) $notice->id,
+			'definitive',
+			$adjutancy_id
+		);
+
+		if ( empty( $rows ) ) {
+			return self::wrap_with_banner(
+				$notice,
+				self::msg( __( 'Nenhum candidato classificado ainda.', 'ffcertificate' ), 'info' )
+			);
+		}
+
+		$columns = self::parse_columns_config( $notice->public_columns_config );
+
+		$empty_rows  = array();
+		$called_rows = array();
+		foreach ( $rows as $row ) {
+			if ( 'empty' === $row->status ) {
+				$empty_rows[] = $row;
+			} else {
+				$called_rows[] = $row;
+			}
+		}
+
+		$settings  = RecruitmentSettings::all();
+		$page_size = (int) $settings['public_default_page_size'];
+
+		$adjutancy_filter_html = '' === $slug_filter
+			? self::render_adjutancy_filter( (int) $notice->id )
+			: '';
+
+		$top_section    = self::render_section(
+			__( 'Não chamados', 'ffcertificate' ),
+			$empty_rows,
+			$columns,
+			false,
+			$page_top,
+			$page_size,
+			'page_top'
+		);
+		$bottom_section = self::render_section(
+			__( 'Chamados', 'ffcertificate' ),
+			$called_rows,
+			$columns,
+			true,
+			$page_bottom,
+			$page_size,
+			'page_bottom'
+		);
+
+		$body = '<div class="ffc-recruitment-queue">'
+			. $adjutancy_filter_html
+			. $top_section
+			. $bottom_section
+			. '</div>';
+
+		return self::wrap_with_banner( $notice, $body );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Section rendering
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Render one of the two sections (não chamados / chamados).
+	 *
+	 * @param string             $heading      Section title.
+	 * @param array              $rows         Classification rows in this section (list<ClassificationRow>).
+	 * @phpstan-param list<ClassificationRow> $rows
+	 * @param array<string,bool> $columns      Column visibility map.
+	 * @param bool               $show_date    Whether to render the `date_to_assume` column.
+	 * @param int                $current_page 1-indexed current page.
+	 * @param int                $page_size    Items per page.
+	 * @param string             $page_param   Query-string param for navigation links.
+	 * @return string
+	 */
+	private static function render_section( string $heading, array $rows, array $columns, bool $show_date, int $current_page, int $page_size, string $page_param ): string {
+		$total = count( $rows );
+		if ( 0 === $total ) {
+			return '';
+		}
+
+		$pages        = max( 1, (int) ceil( $total / max( 1, $page_size ) ) );
+		$current_page = min( $current_page, $pages );
+		$offset       = ( $current_page - 1 ) * $page_size;
+		$page_rows    = array_slice( $rows, $offset, $page_size );
+
+		$html  = '<section class="ffc-recruitment-section">';
+		$html .= '<h3>' . esc_html( $heading ) . '</h3>';
+		$html .= '<table class="ffc-recruitment-table"><thead><tr>';
+		if ( $columns['rank'] ) {
+			$html .= '<th>' . esc_html__( 'Posição', 'ffcertificate' ) . '</th>';
+		}
+		if ( $columns['name'] ) {
+			$html .= '<th>' . esc_html__( 'Nome', 'ffcertificate' ) . '</th>';
+		}
+		if ( $columns['cpf_masked'] ) {
+			$html .= '<th>CPF</th>';
+		}
+		if ( $columns['rf_masked'] ) {
+			$html .= '<th>RF</th>';
+		}
+		if ( $columns['email_masked'] ) {
+			$html .= '<th>' . esc_html__( 'E-mail', 'ffcertificate' ) . '</th>';
+		}
+		if ( $columns['score'] ) {
+			$html .= '<th>' . esc_html__( 'Pontuação', 'ffcertificate' ) . '</th>';
+		}
+		if ( $columns['status'] ) {
+			$html .= '<th>' . esc_html__( 'Situação', 'ffcertificate' ) . '</th>';
+		}
+		if ( $columns['pcd_badge'] ) {
+			$html .= '<th>PCD</th>';
+		}
+		if ( $show_date && $columns['date_to_assume'] ) {
+			$html .= '<th>' . esc_html__( 'Data para assumir', 'ffcertificate' ) . '</th>';
+		}
+		$html .= '</tr></thead><tbody>';
+
+		foreach ( $page_rows as $row ) {
+			$candidate = RecruitmentCandidateRepository::get_by_id( (int) $row->candidate_id );
+			if ( null === $candidate ) {
+				continue;
+			}
+			$html .= self::render_row( $row, $candidate, $columns, $show_date );
+		}
+
+		$html .= '</tbody></table>';
+		$html .= self::render_pagination( $current_page, $pages, $page_param );
+		$html .= '</section>';
+
+		return $html;
+	}
+
+	/**
+	 * Render a single classification row.
+	 *
+	 * @param object             $row       Classification row (ClassificationRow shape).
+	 * @param object             $candidate Candidate row (CandidateRow shape).
+	 * @phpstan-param ClassificationRow $row
+	 * @phpstan-param CandidateRow      $candidate
+	 * @param array<string,bool> $columns   Column visibility map.
+	 * @param bool               $show_date Whether to include the date_to_assume cell.
+	 * @return string
+	 */
+	private static function render_row( object $row, object $candidate, array $columns, bool $show_date ): string {
+		$html = '<tr>';
+		if ( $columns['rank'] ) {
+			$html .= '<td>' . esc_html( (string) $row->rank ) . '</td>';
+		}
+		if ( $columns['name'] ) {
+			$html .= '<td>' . esc_html( (string) $candidate->name ) . '</td>';
+		}
+		if ( $columns['cpf_masked'] ) {
+			$plain = self::decrypt_field( $candidate->cpf_encrypted );
+			$html .= '<td>' . esc_html( null === $plain ? '' : DocumentFormatter::mask_cpf( $plain ) ) . '</td>';
+		}
+		if ( $columns['rf_masked'] ) {
+			$plain = self::decrypt_field( $candidate->rf_encrypted );
+			$html .= '<td>' . esc_html( null === $plain ? '' : DocumentFormatter::mask_rf( $plain ) ) . '</td>';
+		}
+		if ( $columns['email_masked'] ) {
+			$plain = self::decrypt_field( $candidate->email_encrypted );
+			$html .= '<td>' . esc_html( null === $plain ? '' : DocumentFormatter::mask_email( $plain ) ) . '</td>';
+		}
+		if ( $columns['score'] ) {
+			$html .= '<td>' . esc_html( (string) $row->score ) . '</td>';
+		}
+		if ( $columns['status'] ) {
+			$html .= '<td>' . esc_html( self::status_label( (string) $row->status ) ) . '</td>';
+		}
+		if ( $columns['pcd_badge'] ) {
+			$is_pcd = RecruitmentPcdHasher::verify( (string) $candidate->pcd_hash, (int) $candidate->id );
+			$html  .= '<td>' . ( true === $is_pcd ? '<span class="ffc-recruitment-pcd">PCD</span>' : '' ) . '</td>';
+		}
+		if ( $show_date && $columns['date_to_assume'] ) {
+			$call  = RecruitmentCallRepository::get_active_for_classification( (int) $row->id );
+			$html .= '<td>' . esc_html( null === $call ? '' : (string) $call->date_to_assume ) . '</td>';
+		}
+		$html .= '</tr>';
+		return $html;
+	}
+
+	/**
+	 * Build the adjutancy filter HTML when the notice has 2+ adjutancies
+	 * AND the shortcode wasn't called with a fixed `adjutancy=` attr.
+	 *
+	 * @param int $notice_id Notice ID.
+	 * @return string
+	 */
+	private static function render_adjutancy_filter( int $notice_id ): string {
+		$ids = RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( $notice_id );
+		if ( count( $ids ) < 2 ) {
+			return '';
+		}
+
+		$adjutancies = array();
+		foreach ( $ids as $id ) {
+			$a = RecruitmentAdjutancyRepository::get_by_id( $id );
+			if ( null !== $a ) {
+				$adjutancies[] = $a;
+			}
+		}
+		usort(
+			$adjutancies,
+			static fn( $a, $b ) => strcasecmp( (string) $a->name, (string) $b->name )
+		);
+
+		$html  = '<form class="ffc-recruitment-adjutancy-filter" method="get">';
+		$html .= '<label>' . esc_html__( 'Filtrar por matéria:', 'ffcertificate' ) . ' ';
+		$html .= '<select name="adjutancy" onchange="this.form.submit()">';
+		$html .= '<option value="">' . esc_html__( 'Todas', 'ffcertificate' ) . '</option>';
+		foreach ( $adjutancies as $a ) {
+			$html .= '<option value="' . esc_attr( (string) $a->slug ) . '">' . esc_html( (string) $a->name ) . '</option>';
+		}
+		$html .= '</select></label></form>';
+
+		return $html;
+	}
+
+	/**
+	 * Render pagination links for one section.
+	 *
+	 * @param int    $current_page 1-indexed current page.
+	 * @param int    $total_pages  Total page count.
+	 * @param string $page_param   Query-string parameter name.
+	 * @return string
+	 */
+	private static function render_pagination( int $current_page, int $total_pages, string $page_param ): string {
+		if ( $total_pages <= 1 ) {
+			return '';
+		}
+
+		$base = remove_query_arg( $page_param );
+		$html = '<nav class="ffc-recruitment-pagination">';
+		for ( $p = 1; $p <= $total_pages; $p++ ) {
+			$url = add_query_arg( $page_param, $p, $base );
+			if ( $p === $current_page ) {
+				$html .= '<span class="current">' . esc_html( (string) $p ) . '</span>';
+			} else {
+				$html .= '<a href="' . esc_url( $url ) . '">' . esc_html( (string) $p ) . '</a>';
+			}
+		}
+		$html .= '</nav>';
+		return $html;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Decode the per-notice public_columns_config JSON into a normalized map.
+	 *
+	 * `rank` and `name` are FORCED on regardless of stored config (they are
+	 * mandatory per §3.2 / §8.2). Missing keys fall back to the default
+	 * shape declared on the notice repository.
+	 *
+	 * @param string $json Stored JSON.
+	 * @return array<string, bool>
+	 */
+	private static function parse_columns_config( string $json ): array {
+		$decoded = json_decode( $json, true );
+		if ( ! is_array( $decoded ) ) {
+			$decoded = array();
+		}
+		/**
+		 * Default column visibility map decoded from the schema's JSON.
+		 *
+		 * @var array<string,bool> $default
+		 */
+		$default = (array) json_decode( RecruitmentNoticeRepository::DEFAULT_PUBLIC_COLUMNS_CONFIG, true );
+
+		$merged = array_merge( $default, $decoded );
+
+		$out = array();
+		foreach ( array( 'rank', 'name', 'status', 'pcd_badge', 'date_to_assume', 'score', 'cpf_masked', 'rf_masked', 'email_masked' ) as $key ) {
+			$out[ $key ] = ! empty( $merged[ $key ] );
+		}
+
+		// Mandatory columns (validation also enforced server-side on PATCH).
+		$out['rank'] = true;
+		$out['name'] = true;
+
+		return $out;
+	}
+
+	/**
+	 * Wrap the listing body with the notice-status banner.
+	 *
+	 * @param object $notice Notice row (NoticeRow shape).
+	 * @phpstan-param NoticeRow $notice
+	 * @param string $body   Already-rendered body HTML.
+	 * @return string
+	 */
+	private static function wrap_with_banner( object $notice, string $body ): string {
+		$banner = '';
+		if ( 'closed' === $notice->status ) {
+			$banner = '<div class="ffc-recruitment-banner ffc-recruitment-banner-closed">'
+				. esc_html__( 'Edital encerrado.', 'ffcertificate' )
+				. '</div>';
+		}
+
+		$head = '<header class="ffc-recruitment-header">'
+			. '<h2>' . esc_html( (string) $notice->code . ' — ' . (string) $notice->name ) . '</h2>'
+			. $banner
+			. '</header>';
+
+		return $head . $body;
+	}
+
+	/**
+	 * Decrypt a `*_encrypted` column or return null.
+	 *
+	 * @param mixed $value Stored ciphertext.
+	 * @return string|null
+	 */
+	private static function decrypt_field( $value ): ?string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+		$plain = Encryption::decrypt( $value );
+		return null === $plain ? null : $plain;
+	}
+
+	/**
+	 * Translate an internal status code into a public-facing label.
+	 *
+	 * `accepted` is intentionally rendered as `Convocado` per §5.2 (the
+	 * accepted state is admin-only — the public view treats it the same
+	 * as called).
+	 *
+	 * @param string $status Raw status value.
+	 * @return string
+	 */
+	private static function status_label( string $status ): string {
+		$map = array(
+			'empty'     => __( 'Aguardando', 'ffcertificate' ),
+			'called'    => __( 'Convocado', 'ffcertificate' ),
+			'accepted'  => __( 'Convocado', 'ffcertificate' ),
+			'not_shown' => __( 'Não compareceu', 'ffcertificate' ),
+			'hired'     => __( 'Contratado', 'ffcertificate' ),
+		);
+		return $map[ $status ] ?? $status;
+	}
+
+	/**
+	 * Render a styled message block (error/warning/info).
+	 *
+	 * @param string $text Already-localized text.
+	 * @param string $kind `error`, `warning`, or `info`.
+	 * @return string
+	 */
+	private static function msg( string $text, string $kind ): string {
+		return sprintf(
+			'<div class="ffc-recruitment-message ffc-recruitment-message-%s">%s</div>',
+			esc_attr( $kind ),
+			esc_html( $text )
+		);
+	}
+
+	/**
+	 * Build the cache-key for a given (notice, adjutancy filter, page) tuple.
+	 *
+	 * @param string $notice_code   Notice code (case-preserved input).
+	 * @param string $slug_filter   Adjutancy slug filter ('' when no filter).
+	 * @param int    $page_top      Página da seção "Não chamados".
+	 * @param int    $page_bottom   Página da seção "Chamados".
+	 * @return string Transient key (under WP's 172-char limit).
+	 */
+	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom ): string {
+		return self::CACHE_PREFIX . md5(
+			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom
+		);
+	}
+
+	/**
+	 * Per-IP rate limit. Returns true when the request should be served.
+	 *
+	 * Uses a per-minute transient counter keyed by the client IP. Falls
+	 * open (returns true) when the IP can't be determined or the rate
+	 * limit setting is 0 (disabled).
+	 *
+	 * @return bool
+	 */
+	private static function check_rate_limit(): bool {
+		$settings = RecruitmentSettings::all();
+		$limit    = (int) $settings['public_rate_limit_per_minute'];
+		if ( $limit <= 0 ) {
+			return true;
+		}
+
+		$ip = self::client_ip();
+		if ( '' === $ip ) {
+			return true;
+		}
+
+		$bucket = gmdate( 'Y-m-d-H-i' );
+		$key    = self::RATE_PREFIX . md5( $ip . '|' . $bucket );
+
+		$count = get_transient( $key );
+		$count = is_int( $count ) ? $count : 0;
+
+		if ( $count >= $limit ) {
+			return false;
+		}
+
+		set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+		return true;
+	}
+
+	/**
+	 * Best-effort client-IP detection. Returns '' when we can't identify
+	 * the caller (rate-limit then falls open per `check_rate_limit`).
+	 *
+	 * @return string
+	 */
+	private static function client_ip(): string {
+		foreach ( array( 'HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR' ) as $key ) {
+			if ( ! empty( $_SERVER[ $key ] ) && is_string( $_SERVER[ $key ] ) ) {
+				$raw       = sanitize_text_field( wp_unslash( $_SERVER[ $key ] ) );
+				$candidate = trim( explode( ',', $raw )[0] );
+				if ( '' !== $candidate ) {
+					return $candidate;
+				}
+			}
+		}
+		return '';
+	}
+}

--- a/tests/Unit/RecruitmentDashboardSectionTest.php
+++ b/tests/Unit/RecruitmentDashboardSectionTest.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentDashboardSection;
+
+/**
+ * Tests for RecruitmentDashboardSection — pins the §9.1 visibility rule
+ * (anonymous + unlinked-user → empty render), the basic notice-block
+ * rendering for a logged-in candidate, and the prévia/final banner
+ * dispatch.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentDashboardSection
+ */
+class RecruitmentDashboardSectionTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'is_user_logged_in' )->justReturn( true );
+		Functions\when( 'get_current_user_id' )->justReturn( 100 );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing( static fn ( $sql ) => $sql )
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function candidate_stub(): object {
+		return (object) array(
+			'id'              => '50',
+			'user_id'         => '100',
+			'name'            => 'Alice',
+			'cpf_encrypted'   => null,
+			'cpf_hash'        => null,
+			'rf_encrypted'    => null,
+			'rf_hash'         => null,
+			'email_encrypted' => null,
+			'email_hash'      => null,
+			'phone'           => null,
+			'notes'           => null,
+			'pcd_hash'        => 'h',
+			'created_at'      => '2026-05-01 10:00:00',
+			'updated_at'      => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function classification_stub( string $list_type, string $status = 'empty' ): object {
+		return (object) array(
+			'id'           => '10',
+			'candidate_id' => '50',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'list_type'    => $list_type,
+			'rank'         => '7',
+			'score'        => '85.0000',
+			'status'       => $status,
+			'created_at'   => '2026-05-01 10:00:00',
+			'updated_at'   => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function notice_stub( string $status, string $code = 'EDITAL-2026-01' ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => $code,
+			'name'                  => 'Test',
+			'status'                => $status,
+			'opened_at'             => null,
+			'closed_at'             => null,
+			'was_reopened'          => '0',
+			'public_columns_config' => '{}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	private function adjutancy_stub(): object {
+		return (object) array(
+			'id'         => '2',
+			'slug'       => 'matematica',
+			'name'       => 'Matemática',
+			'created_at' => '2026-05-01 10:00:00',
+			'updated_at' => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_render_returns_empty_for_anonymous(): void {
+		Functions\when( 'is_user_logged_in' )->justReturn( false );
+		// wpdb must NOT be queried at all.
+		$this->wpdb->shouldNotReceive( 'get_results' );
+		$this->wpdb->shouldNotReceive( 'get_row' );
+
+		$this->assertSame( '', RecruitmentDashboardSection::render() );
+	}
+
+	public function test_render_returns_empty_when_user_has_no_linked_candidate(): void {
+		// get_by_user_id returns empty array.
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$this->assertSame( '', RecruitmentDashboardSection::render() );
+	}
+
+	public function test_render_skips_draft_notices(): void {
+		// User has a candidate row + 1 classification, but the parent notice
+		// is in `draft` → must be filtered out → final render is empty.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->twice()
+			->andReturn( array( $this->candidate_stub() ), array( $this->classification_stub( 'preview' ) ) );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+
+		$this->assertSame( '', RecruitmentDashboardSection::render() );
+	}
+
+	public function test_render_includes_preliminary_banner(): void {
+		// Two get_results: candidates → classifications.
+		// One get_row for the notice, then one for the adjutancy in render_classifications_table.
+		// get_history_for_classifications returns empty.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->times( 3 )
+			->andReturn(
+				array( $this->candidate_stub() ),
+				array( $this->classification_stub( 'preview' ) ),
+				array() // call history
+			);
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 2 )
+			->andReturn(
+				$this->notice_stub( 'preliminary' ),
+				$this->adjutancy_stub()
+			);
+
+		$html = RecruitmentDashboardSection::render();
+
+		$this->assertStringContainsString( 'Classificação preliminar', $html );
+		$this->assertStringNotContainsString( 'Classificação final', $html );
+		// And the no-calls hint when no convocations exist yet.
+		$this->assertStringContainsString( 'Você ainda não foi convocado', $html );
+	}
+
+	public function test_render_includes_final_banner_for_active_notice(): void {
+		$this->wpdb->shouldReceive( 'get_results' )
+			->times( 3 )
+			->andReturn(
+				array( $this->candidate_stub() ),
+				array( $this->classification_stub( 'definitive' ) ),
+				array()
+			);
+		$this->wpdb->shouldReceive( 'get_row' )
+			->times( 2 )
+			->andReturn(
+				$this->notice_stub( 'active' ),
+				$this->adjutancy_stub()
+			);
+
+		$html = RecruitmentDashboardSection::render();
+
+		$this->assertStringContainsString( 'Classificação final', $html );
+		$this->assertStringNotContainsString( 'Classificação preliminar', $html );
+	}
+}

--- a/tests/Unit/RecruitmentPublicShortcodeTest.php
+++ b/tests/Unit/RecruitmentPublicShortcodeTest.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentPublicShortcode;
+
+/**
+ * Tests for RecruitmentPublicShortcode — pins the §8 status branching
+ * (draft = error, preliminary = warning-only, active/closed = listing
+ * with optional banner), the missing-attribute / unknown-notice / unknown
+ * adjutancy error states, and the cache + rate-limit infrastructure
+ * surfaces (without exercising every render permutation — full HTML
+ * snapshots land in sprint 13).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentPublicShortcode
+ */
+class RecruitmentPublicShortcodeTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'shortcode_atts' )->alias(
+			static function ( $defaults, $atts ) {
+				return array_merge( $defaults, is_array( $atts ) ? $atts : array() );
+			}
+		);
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing( static fn ( $sql ) => $sql )
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function notice_stub( string $status, string $code = 'EDITAL-2026-01' ): object {
+		return (object) array(
+			'id'                    => '5',
+			'code'                  => $code,
+			'name'                  => 'Test',
+			'status'                => $status,
+			'opened_at'             => null,
+			'closed_at'             => null,
+			'was_reopened'          => '0',
+			'public_columns_config' => '{"rank":true,"name":true,"status":true,"pcd_badge":false,"date_to_assume":true,"score":false,"cpf_masked":false,"rf_masked":false,"email_masked":false}',
+			'created_at'            => '2026-05-01 10:00:00',
+			'updated_at'            => '2026-05-01 10:00:00',
+		);
+	}
+
+	public function test_render_returns_error_when_notice_attribute_missing(): void {
+		$html = RecruitmentPublicShortcode::render( array() );
+		$this->assertStringContainsString( 'Edital não informado.', $html );
+	}
+
+	public function test_render_uncached_returns_error_when_notice_unknown(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-FAKE', '', 1, 1 );
+
+		$this->assertStringContainsString( 'Edital não encontrado.', $html );
+	}
+
+	public function test_render_uncached_blocks_draft_notices(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'draft' ) );
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-2026-01', '', 1, 1 );
+
+		$this->assertStringContainsString( 'Edital ainda não publicado.', $html );
+	}
+
+	public function test_render_uncached_renders_warning_only_for_preliminary(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'preliminary' ) );
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-2026-01', '', 1, 1 );
+
+		$this->assertStringContainsString( 'Esta lista está em revisão', $html );
+		// Preliminary notices must NOT expose the listing — even preview
+		// rows are private until promotion.
+		$this->assertStringNotContainsString( '<table', $html );
+	}
+
+	public function test_render_uncached_renders_empty_state_for_active_with_no_rows(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'active' ) );
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-2026-01', '', 1, 1 );
+
+		$this->assertStringContainsString( 'Nenhum candidato classificado ainda.', $html );
+		// Notice header still rendered (so the user sees they're at the
+		// right edital).
+		$this->assertStringContainsString( 'EDITAL-2026-01', $html );
+	}
+
+	public function test_render_uncached_includes_closed_banner(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $this->notice_stub( 'closed' ) );
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-2026-01', '', 1, 1 );
+
+		$this->assertStringContainsString( 'Edital encerrado.', $html );
+	}
+
+	public function test_render_uncached_rejects_unknown_adjutancy_slug(): void {
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				$this->notice_stub( 'active' ),
+				null // adjutancy lookup
+			);
+
+		$html = RecruitmentPublicShortcode::render_uncached( 'EDITAL-2026-01', 'inexistente', 1, 1 );
+
+		$this->assertStringContainsString( 'Matéria não encontrada para este edital.', $html );
+	}
+
+	public function test_render_uses_cached_html_when_available(): void {
+		Functions\when( 'get_transient' )->justReturn( '<div>cached</div>' );
+
+		// wpdb should never be hit when cache is warm.
+		$this->wpdb->shouldNotReceive( 'get_row' );
+
+		$html = RecruitmentPublicShortcode::render( array( 'notice' => 'EDITAL-2026-01' ) );
+
+		$this->assertSame( '<div>cached</div>', $html );
+	}
+
+	public function test_render_skips_rate_limit_when_setting_is_zero(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'public_rate_limit_per_minute' => 0,
+				'public_cache_seconds'         => 0,
+			)
+		);
+		// Notice unknown so the call short-circuits after rate-limit
+		// passes — proves the rate-limit didn't block.
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$html = RecruitmentPublicShortcode::render( array( 'notice' => 'EDITAL-2026-01' ) );
+
+		$this->assertStringContainsString( 'Edital não encontrado.', $html );
+	}
+
+	public function test_render_returns_throttle_message_when_rate_limit_exceeded(): void {
+		// Configure rate limit = 5; preload the bucket to 5 already so
+		// the next request trips it.
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'public_rate_limit_per_minute' => 5,
+				'public_cache_seconds'         => 0,
+			)
+		);
+
+		$server_backup           = $_SERVER;
+		$_SERVER['REMOTE_ADDR']  = '203.0.113.7';
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) {
+				if ( false !== strpos( $key, 'ffc_recruitment_public_rate_' ) ) {
+					return 999; // Way past the limit.
+				}
+				return false;
+			}
+		);
+
+		$html = RecruitmentPublicShortcode::render( array( 'notice' => 'EDITAL-2026-01' ) );
+
+		$this->assertStringContainsString( 'Muitas requisições', $html );
+
+		$_SERVER = $server_backup;
+	}
+}


### PR DESCRIPTION
## Summary

Recruitment module — frontend layer. **PR 2 of 3** (frontend, sprints 11 + 12).

Refs #79

Builds on the backend merged in #80.

## Sprints

- [x] **11** — Public shortcode `[ffc_recruitment_queue]` (server-side, public, status-branched, cached, rate-limited)
- [x] **12** — Admin UI submenu page + candidate-self dashboard section `[ffc_recruitment_my_calls]`

## What lands

### Sprint 11 — Public shortcode

- §8 status branching: `draft` / `preliminary` / `active` / `closed` each render the right surface.
- Per-notice column visibility via `notice.public_columns_config` JSON; `rank` and `name` always on.
- Two paginated sections: "Não chamados" + "Chamados" with independent `?page_top=` / `?page_bottom=`.
- Adjutancy `<select>` filter rendered only when 2+ adjutancies AND no fixed `adjutancy=` attr.
- Per-IP rate limit (configurable; 0 disables) BEFORE cache lookup so cache hits can't bypass the throttle.
- Server-side transient cache (default 60 s) keyed by (notice, adjutancy, pages).
- Sensitive fields masked via `DocumentFormatter::mask_*` per §10-bis (opt-in only).

### Sprint 12 — Admin UI + candidate-self dashboard

**Admin** — submenu under `edit.php?post_type=ffc_form` ("Recrutamento") cap-gated by `ffc_manage_recruitment`. Four tabs:

- **Editais** — list with status badges + create form (POSTs to REST via inline fetch with `X-WP-Nonce`).
- **Matérias** — list + create form.
- **Candidatos** — placeholder pointing at the REST search endpoints (full UI follows in v6.1).
- **Configurações** — read-only dump of `ffc_recruitment_settings`.

Includes a `<details>` block listing every REST endpoint so admins can drive operations the UI doesn't yet wrap.

**Honest scope note**: status-change modals, 15s countdown for promote-preview, CSV upload form, and bulk-call selector are deferred. Every operation already has a typed REST surface from sprint 9.1; the gap is UX, not capability.

**Candidate-self** — `[ffc_recruitment_my_calls]` shortcode meant to live alongside `[user_dashboard_personal]`. §9.1 visibility (anonymous + unlinked users see nothing). Per-notice block with prévia/final banner + classifications mini-table + convocations history (including cancelled, with `Situação` derived per §9.3).

## Test coverage

- 15 new tests / 39 new assertions (10 shortcode + 5 dashboard).
- Full recruitment suite: 214 tests / 629 assertions.
- PHPStan level 8 clean. WPCS clean.

## Test plan

- [ ] Plugin activates cleanly; the "Recrutamento" submenu appears under FFC Forms.
- [ ] PHPStan level 8 stays clean.
- [ ] PHPCS clean.
- [ ] PHPUnit suite green.
- [ ] Render `[ffc_recruitment_queue notice="..."]` for each notice status; verify expected surface.
- [ ] Render `[ffc_recruitment_my_calls]` as anonymous (empty), as a non-candidate logged-in user (empty), and as a linked candidate (sees their notices).
- [ ] Spot-check rate limit triggers when hammering the public URL.

## Next PR

PR 3 (release): docs + bump 5.4.1 → 6.0.0 + final polish.

https://claude.ai/code/session_01Ewp3idhND7Pbw8nYZiU2AR