### PR TITLE
feat(recruitment): username pattern + public shortcode polish + candidate user link/unlink + submenus + close-notice confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 - **`DashboardShortcode::render`** gained a `$can_view_recruitment` branch. The section's HTML is rendered once via `RecruitmentDashboardSection::render()` (which already encodes the visibility gate by returning empty string when the user has no classifications) and reused as both the gate signal and the tab body — no extra repository round-trip.
 - New "My Calls" tab appears between the existing Reregistration and Profile tabs when the gate passes. Active by default for users whose only ffc-related data is recruitment classifications (i.e. they have no certificates, appointments, audience, or reregistrations).
+- **`UserCreator::generate_username` prefers the email prefix** (everything before `@`) over name-based slugs. Aligns the recruitment promotion path with the legacy `ffc_form` submission path on a single canonical username convention. Existing usernames are unaffected; only NEW user creations from this commit forward follow the new logic.
+
+### Added
+
+- **`adjutancy` column** in `public_columns_config` (default on). Renders the adjutancy name resolved from `adjutancy_id` on the public shortcode listing. Operators can disable it per-notice via the `public_columns_config` JSON.
+- **Public shortcode adjutancy filter** now functional. The dropdown's `?adjutancy=…` GET submission was being silently ignored; `render()` now reads `$_GET['adjutancy']` whenever the shortcode wasn't called with an explicit `adjutancy=` attribute. The filter dropdown also marks the active option `selected` and preserves every other GET param via hidden inputs so paging state survives a filter change.
+- **Public shortcode formats** — date renders as `DD-MM-YYYY` (BR convention), time as `HH:MM` (no seconds), score as 2-decimal (`53.00` instead of `53.0000`).
+- **Status badges as colored tags** with operator-configurable colors. The recruitment Settings tab gained a "Status badge colors" section with four `<input type="color">` swatches (defaults: soft yellow `#fff3cd` for empty, soft purple `#e9d8fd` for called/accepted, soft green `#d4edda` for hired, soft red `#f8d7da` for not_shown). Stored under four new `ffc_recruitment_settings` sub-keys (`status_color_empty`, `status_color_called`, `status_color_hired`, `status_color_not_shown`) with strict `#RGB` / `#RRGGBB` / `#RRGGBBAA` validation.
+- **Manual link / unlink WP user** on the candidate edit screen's Sensitive data section. Operator can now (a) detach a candidate from a wrongly-promoted wp_user without touching the wp_user account, and (b) attach the candidate to any existing wp_user resolved by numeric ID, login, or email. Routed through two admin-post handlers gated by the same per-candidate nonce; lookups via `WP_User::get_user_by` (`get_user_by('id'|'email'|'login')`). Three new flash keys: `link-user-ok`, `link-user-not-found`, `unlink-user-ok`.
+- **wp-admin submenus under "Recruitment"** — the top-level item now expands into Notices / Adjutancies / Candidates / Settings, each linking to the corresponding `?tab=…`. The auto-generated duplicate first submenu is replaced via the `$submenu` global so no duplicate appears.
+- **Close-notice confirmation** — clicking "Close" on the Status section now fires a `confirm()` prompt naming the side-effects (calls history goes read-only, public shortcode displays the "Notice closed." banner, reopen requires a reason and locks hired/not_shown permanently). Mirrors the existing draft → preliminary confirm pattern.
+
+### Note
+
+- **Why no "Trash" / soft-delete on Notices and Adjutancies tabs** (asked by the user): per §7-bis of the original plan, the recruitment domain deliberately ships **hard-delete only** with referential gates instead of a trash bin:
+  - **Notices** — `RecruitmentNoticeRepository::delete()` removes the row directly. There is no "Trash". Deletion of a notice that already has classifications would orphan them, so the typical operator path is to `closed` the notice instead (preserves history, hides the listing).
+  - **Adjutancies** — `RecruitmentDeleteService::delete_adjutancy()` rejects with a 409 envelope when the adjutancy is referenced by `notice_adjutancy` or `classification` rows; otherwise hard-deletes. Same "no Trash" choice.
+  - **Candidates** — gated per §7-bis (zero classifications + reason); also hard-delete only.
+  This matches the rest of the plugin's hard-delete-with-gates convention (cf. existing repositories) and avoids the "is this row safe to revive?" ambiguity a Trash bin would introduce.
 
 ---
 

--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -415,6 +415,25 @@ final class RecruitmentAdminPage {
 
 		echo '</tbody></table>';
 
+		echo '<h3>' . esc_html__( 'Status badge colors', 'ffcertificate' ) . '</h3>';
+		echo '<p class="description">' . esc_html__( 'Background color used for each classification status pill on the public shortcode. Accepts #RGB / #RRGGBB / #RRGGBBAA. Bad values silently fall back to defaults.', 'ffcertificate' ) . '</p>';
+		echo '<table class="form-table"><tbody>';
+
+		$status_color_rows = array(
+			'status_color_empty'     => __( 'Waiting (empty)', 'ffcertificate' ),
+			'status_color_called'    => __( 'Called / Accepted', 'ffcertificate' ),
+			'status_color_hired'     => __( 'Hired', 'ffcertificate' ),
+			'status_color_not_shown' => __( 'Did not show up', 'ffcertificate' ),
+		);
+		foreach ( $status_color_rows as $field => $label ) {
+			echo '<tr><th><label for="ffc-rs-' . esc_attr( $field ) . '">' . esc_html( $label ) . '</label></th><td>';
+			echo '<input id="ffc-rs-' . esc_attr( $field ) . '" type="color" name="' . esc_attr( $opt ) . '[' . esc_attr( $field ) . ']" value="' . esc_attr( (string) $settings[ $field ] ) . '">';
+			echo ' <code style="margin-left:.5em;">' . esc_html( (string) $settings[ $field ] ) . '</code>';
+			echo '</td></tr>';
+		}
+
+		echo '</tbody></table>';
+
 		submit_button();
 		echo '</form>';
 	}

--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -219,6 +219,9 @@ final class RecruitmentAdminPage {
 			'transition-invalid-target'   => array( 'error', __( 'Status transition rejected: the target status was missing or unrecognized.', 'ffcertificate' ) ),
 			'deleted'                     => array( 'success', __( 'Candidate deleted.', 'ffcertificate' ) ),
 			'delete-blocked'              => array( 'error', __( 'Delete blocked: candidate still has classifications. Remove them first or leave the candidate row in place.', 'ffcertificate' ) ),
+			'link-user-ok'                => array( 'success', __( 'Candidate linked to the WP user.', 'ffcertificate' ) ),
+			'link-user-not-found'         => array( 'error', __( 'No WP user found for that lookup. Try the numeric ID, exact login, or full email.', 'ffcertificate' ) ),
+			'unlink-user-ok'              => array( 'success', __( 'Candidate unlinked from the WP user. The wp_user account was not deleted.', 'ffcertificate' ) ),
 			'rank-mandatory'              => array( 'error', __( 'public_columns_config rejected: `rank` cannot be set to false (mandatory column).', 'ffcertificate' ) ),
 			'name-mandatory'              => array( 'error', __( 'public_columns_config rejected: `name` cannot be set to false (mandatory column).', 'ffcertificate' ) ),
 		);

--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -65,6 +65,32 @@ final class RecruitmentAdminPage {
 			'dashicons-groups',
 			28
 		);
+
+		// WP auto-creates a duplicate "Recruitment" first submenu when
+		// add_menu_page also registers a callback. Replace that auto-row
+		// with explicit per-tab submenus below — same parent page, but
+		// each link carries `&tab=…` so the existing render_page()
+		// dispatcher lands on the right section.
+		global $submenu;
+		if ( isset( $submenu[ self::PAGE_SLUG ] ) ) {
+			$submenu[ self::PAGE_SLUG ] = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Replacing the auto-generated duplicate row is the canonical pattern.
+		}
+		$tabs = array(
+			'notices'     => __( 'Notices', 'ffcertificate' ),
+			'adjutancies' => __( 'Adjutancies', 'ffcertificate' ),
+			'candidates'  => __( 'Candidates', 'ffcertificate' ),
+			'settings'    => __( 'Settings', 'ffcertificate' ),
+		);
+		foreach ( $tabs as $tab => $label ) {
+			add_submenu_page(
+				self::PAGE_SLUG,
+				$label,
+				$label,
+				self::CAP,
+				'notices' === $tab ? self::PAGE_SLUG : self::PAGE_SLUG . '&tab=' . $tab,
+				array( self::class, 'render_page' )
+			);
+		}
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
@@ -60,6 +60,8 @@ final class RecruitmentCandidateEditPage {
 	public static function register(): void {
 		add_action( 'admin_post_ffc_recruitment_save_candidate', array( self::class, 'handle_save' ), 10 );
 		add_action( 'admin_post_ffc_recruitment_delete_candidate', array( self::class, 'handle_delete' ), 10 );
+		add_action( 'admin_post_ffc_recruitment_link_candidate_user', array( self::class, 'handle_link_user' ), 10 );
+		add_action( 'admin_post_ffc_recruitment_unlink_candidate_user', array( self::class, 'handle_unlink_user' ), 10 );
 	}
 
 	/**
@@ -170,7 +172,8 @@ final class RecruitmentCandidateEditPage {
 
 		echo '<tr><th>' . esc_html__( 'Linked WP user', 'ffcertificate' ) . '</th>';
 		echo '<td>';
-		$user_id = null === $candidate->user_id ? 0 : (int) $candidate->user_id;
+		$user_id      = null === $candidate->user_id ? 0 : (int) $candidate->user_id;
+		$nonce_action = 'ffc_recruitment_link_candidate_user_' . (int) $candidate->id;
 		if ( $user_id > 0 ) {
 			$user = get_userdata( $user_id );
 			if ( false !== $user ) {
@@ -178,9 +181,32 @@ final class RecruitmentCandidateEditPage {
 			} else {
 				echo '<code>#' . esc_html( (string) $user_id ) . '</code> <em>(' . esc_html__( 'orphaned reference', 'ffcertificate' ) . ')</em>';
 			}
+			// Unlink form — clears the user_id without touching the wp_user.
+			echo ' <form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" style="display:inline;margin-left:.5em;" onsubmit="return confirm(\'' . esc_js( __( 'Unlink the candidate from this WP user? The wp_user account is preserved.', 'ffcertificate' ) ) . '\');">';
+			echo '<input type="hidden" name="action" value="ffc_recruitment_unlink_candidate_user">';
+			echo '<input type="hidden" name="candidate_id" value="' . esc_attr( (string) $candidate->id ) . '">';
+			wp_nonce_field( $nonce_action );
+			echo '<button type="submit" class="button button-link-delete">' . esc_html__( 'Unlink', 'ffcertificate' ) . '</button>';
+			echo '</form>';
 		} else {
 			echo '<em>' . esc_html__( '(not promoted yet)', 'ffcertificate' ) . '</em>';
 		}
+		echo '</td></tr>';
+
+		// Link form — operator picks any wp_user by ID/login/email and the
+		// candidate's user_id is set to it. Same admin-post handler routes
+		// both link + relink (no separate "force" mode — the operator
+		// already saw the current state in the row above).
+		echo '<tr><th>' . esc_html__( 'Link manually to WP user', 'ffcertificate' ) . '</th>';
+		echo '<td>';
+		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" style="display:inline;">';
+		echo '<input type="hidden" name="action" value="ffc_recruitment_link_candidate_user">';
+		echo '<input type="hidden" name="candidate_id" value="' . esc_attr( (string) $candidate->id ) . '">';
+		wp_nonce_field( $nonce_action );
+		echo '<input type="text" name="user_lookup" placeholder="' . esc_attr__( 'WP user ID, login, or email', 'ffcertificate' ) . '" class="regular-text" required> ';
+		echo '<button type="submit" class="button button-secondary">' . esc_html__( 'Link', 'ffcertificate' ) . '</button>';
+		echo '<p class="description">' . esc_html__( 'Resolved via WP_User lookup (numeric → ID, contains @ → email, otherwise login). Does NOT create users; only links existing ones.', 'ffcertificate' ) . '</p>';
+		echo '</form>';
 		echo '</td></tr>';
 
 		echo '</tbody></table>';
@@ -427,6 +453,82 @@ final class RecruitmentCandidateEditPage {
 		}
 
 		self::redirect_with_notice( $id, 'delete-blocked' );
+	}
+
+	/**
+	 * Admin-post handler — link candidate to an existing WP user
+	 * resolved by id, login, or email. Does NOT create new users; only
+	 * sets the candidate.user_id pointer.
+	 *
+	 * @return void
+	 */
+	public static function handle_link_user(): void {
+		if ( ! current_user_can( self::CAP ) ) {
+			wp_die( esc_html__( 'Access denied.', 'ffcertificate' ) );
+		}
+		$id = isset( $_POST['candidate_id'] ) ? absint( wp_unslash( (string) $_POST['candidate_id'] ) ) : 0;
+		check_admin_referer( 'ffc_recruitment_link_candidate_user_' . $id );
+
+		if ( $id <= 0 ) {
+			wp_safe_redirect( self::back_url() );
+			exit;
+		}
+
+		$lookup = isset( $_POST['user_lookup'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['user_lookup'] ) ) : '';
+		$lookup = trim( $lookup );
+
+		$user = self::resolve_user( $lookup );
+		if ( null === $user ) {
+			self::redirect_with_notice( $id, 'link-user-not-found' );
+		}
+
+		RecruitmentCandidateRepository::set_user_id( $id, (int) $user->ID );
+		self::redirect_with_notice( $id, 'link-user-ok' );
+	}
+
+	/**
+	 * Admin-post handler — clear the candidate.user_id pointer. The
+	 * linked wp_user account is preserved untouched.
+	 *
+	 * @return void
+	 */
+	public static function handle_unlink_user(): void {
+		if ( ! current_user_can( self::CAP ) ) {
+			wp_die( esc_html__( 'Access denied.', 'ffcertificate' ) );
+		}
+		$id = isset( $_POST['candidate_id'] ) ? absint( wp_unslash( (string) $_POST['candidate_id'] ) ) : 0;
+		check_admin_referer( 'ffc_recruitment_link_candidate_user_' . $id );
+
+		if ( $id > 0 ) {
+			RecruitmentCandidateRepository::set_user_id( $id, null );
+		}
+		self::redirect_with_notice( $id, 'unlink-user-ok' );
+	}
+
+	/**
+	 * Resolve a free-text lookup string into a `WP_User` or null.
+	 *
+	 * Strategy: numeric → ID, contains `@` → email, otherwise login.
+	 * Returning null lets the caller surface a "not found" flash.
+	 *
+	 * @param string $lookup Free-text input.
+	 * @return \WP_User|null
+	 */
+	private static function resolve_user( string $lookup ): ?\WP_User {
+		if ( '' === $lookup ) {
+			return null;
+		}
+
+		$candidate = null;
+		if ( ctype_digit( $lookup ) ) {
+			$candidate = get_user_by( 'id', (int) $lookup );
+		} elseif ( false !== strpos( $lookup, '@' ) ) {
+			$candidate = get_user_by( 'email', $lookup );
+		} else {
+			$candidate = get_user_by( 'login', $lookup );
+		}
+
+		return $candidate instanceof \WP_User ? $candidate : null;
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
@@ -299,12 +299,17 @@ final class RecruitmentNoticeEditPage {
 
 			// Per-target confirm prompts. draft → preliminary publishes
 			// the candidate list to the public shortcode, so we surface
-			// that side-effect explicitly.
+			// that side-effect explicitly. Closing a notice is also
+			// destructive for the operator (calls history goes read-only,
+			// no more status changes), so we surface that too.
 			echo '<script>'
 				. 'function ffcRecruitmentConfirmTransition(form){'
 				. 'var t=form.target_status?form.target_status.value:(document.activeElement&&document.activeElement.name==="target_status"?document.activeElement.value:"");'
 				. 'if(t==="preliminary"){'
 				. 'return confirm("' . esc_js( __( 'Moving the notice to `preliminary` publishes the imported candidate list on the public shortcode. Continue?', 'ffcertificate' ) ) . '");'
+				. '}'
+				. 'if(t==="closed"){'
+				. 'return confirm("' . esc_js( __( 'Closing the notice freezes its calls history (no new calls, no status changes, no cancellations). The public shortcode will display the "Notice closed." banner above the list. To reopen later, you will need to provide a reason and the hired/not_shown classifications will become permanently locked. Continue?', 'ffcertificate' ) ) . '");'
 				. '}'
 				. 'return true;}'
 				. '</script>';

--- a/includes/recruitment/class-ffc-recruitment-notice-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-repository.php
@@ -49,7 +49,7 @@ class RecruitmentNoticeRepository {
 	 *
 	 * @var string
 	 */
-	public const DEFAULT_PUBLIC_COLUMNS_CONFIG = '{"rank":true,"name":true,"status":true,"pcd_badge":true,"date_to_assume":true,"time_to_assume":true,"score":false,"cpf_masked":false,"rf_masked":false,"email_masked":false}';
+	public const DEFAULT_PUBLIC_COLUMNS_CONFIG = '{"rank":true,"name":true,"adjutancy":true,"status":true,"pcd_badge":true,"date_to_assume":true,"time_to_assume":true,"score":false,"cpf_masked":false,"rf_masked":false,"email_masked":false}';
 
 	/**
 	 * Cache group for this repository.

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -106,6 +106,16 @@ final class RecruitmentPublicShortcode {
 		$notice_code = trim( (string) $atts['notice'] );
 		$slug_filter = trim( (string) $atts['adjutancy'] );
 
+		// When the shortcode wasn't called with a fixed adjutancy attribute,
+		// honor the per-page filter dropdown (`?adjutancy=foo`). Sanitize
+		// to a sane slug shape so a hostile URL doesn't bleed into the
+		// repository lookup.
+		if ( '' === $slug_filter ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only filter.
+			$get_filter  = isset( $_GET['adjutancy'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['adjutancy'] ) ) : '';
+			$slug_filter = trim( $get_filter );
+		}
+
 		if ( '' === $notice_code ) {
 			return self::wrap_output( self::msg( __( 'Notice attribute is required.', 'ffcertificate' ), 'error' ) );
 		}
@@ -307,6 +317,9 @@ final class RecruitmentPublicShortcode {
 		if ( $columns['name'] ) {
 			$html .= '<th>' . esc_html__( 'Name', 'ffcertificate' ) . '</th>';
 		}
+		if ( $columns['adjutancy'] ) {
+			$html .= '<th>' . esc_html__( 'Adjutancy', 'ffcertificate' ) . '</th>';
+		}
 		if ( $columns['cpf_masked'] ) {
 			$html .= '<th>CPF</th>';
 		}
@@ -367,6 +380,10 @@ final class RecruitmentPublicShortcode {
 		if ( $columns['name'] ) {
 			$html .= '<td>' . esc_html( (string) $candidate->name ) . '</td>';
 		}
+		if ( $columns['adjutancy'] ) {
+			$adjutancy = RecruitmentAdjutancyRepository::get_by_id( (int) $row->adjutancy_id );
+			$html     .= '<td>' . esc_html( null === $adjutancy ? '' : (string) $adjutancy->name ) . '</td>';
+		}
 		if ( $columns['cpf_masked'] ) {
 			$plain = self::decrypt_field( $candidate->cpf_encrypted );
 			$html .= '<td>' . esc_html( null === $plain ? '' : DocumentFormatter::mask_cpf( $plain ) ) . '</td>';
@@ -380,10 +397,12 @@ final class RecruitmentPublicShortcode {
 			$html .= '<td>' . esc_html( null === $plain ? '' : DocumentFormatter::mask_email( $plain ) ) . '</td>';
 		}
 		if ( $columns['score'] ) {
-			$html .= '<td>' . esc_html( (string) $row->score ) . '</td>';
+			// §3.5 score is DECIMAL(10,4); operator-facing surface
+			// truncates to 2 decimals for readability (53.00 vs 53.0000).
+			$html .= '<td>' . esc_html( number_format( (float) $row->score, 2, '.', '' ) ) . '</td>';
 		}
 		if ( $columns['status'] ) {
-			$html .= '<td>' . esc_html( self::status_label( (string) $row->status ) ) . '</td>';
+			$html .= '<td>' . self::render_status_badge( (string) $row->status ) . '</td>';
 		}
 		if ( $columns['pcd_badge'] ) {
 			$is_pcd = RecruitmentPcdHasher::verify( (string) $candidate->pcd_hash, (int) $candidate->id );
@@ -392,10 +411,12 @@ final class RecruitmentPublicShortcode {
 		if ( $show_date && ( $columns['date_to_assume'] || $columns['time_to_assume'] ) ) {
 			$call = RecruitmentCallRepository::get_active_for_classification( (int) $row->id );
 			if ( $columns['date_to_assume'] ) {
-				$html .= '<td>' . esc_html( null === $call ? '' : (string) $call->date_to_assume ) . '</td>';
+				$date  = null === $call ? '' : self::format_date_br( (string) $call->date_to_assume );
+				$html .= '<td>' . esc_html( $date ) . '</td>';
 			}
 			if ( $columns['time_to_assume'] ) {
-				$html .= '<td>' . esc_html( null === $call ? '' : (string) $call->time_to_assume ) . '</td>';
+				$time  = null === $call ? '' : self::format_time_hm( (string) $call->time_to_assume );
+				$html .= '<td>' . esc_html( $time ) . '</td>';
 			}
 		} else {
 			if ( $show_date && $columns['date_to_assume'] ) {
@@ -434,12 +455,26 @@ final class RecruitmentPublicShortcode {
 			static fn( $a, $b ) => strcasecmp( (string) $a->name, (string) $b->name )
 		);
 
-		$html  = '<form class="ffc-recruitment-adjutancy-filter" method="get">';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display state.
+		$selected = isset( $_GET['adjutancy'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['adjutancy'] ) ) : '';
+
+		$html = '<form class="ffc-recruitment-adjutancy-filter" method="get">';
+		// Preserve every other GET param (notice, page_top, page_bottom)
+		// so submitting the dropdown doesn't drop them.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only re-emission of caller's params.
+		foreach ( (array) $_GET as $key => $value ) {
+			$key_str = (string) $key;
+			if ( 'adjutancy' === $key_str ) {
+				continue;
+			}
+			$html .= '<input type="hidden" name="' . esc_attr( $key_str ) . '" value="' . esc_attr( wp_unslash( (string) $value ) ) . '">';
+		}
 		$html .= '<label>' . esc_html__( 'Filter by adjutancy:', 'ffcertificate' ) . ' ';
 		$html .= '<select name="adjutancy" onchange="this.form.submit()">';
 		$html .= '<option value="">' . esc_html__( 'All', 'ffcertificate' ) . '</option>';
 		foreach ( $adjutancies as $a ) {
-			$html .= '<option value="' . esc_attr( (string) $a->slug ) . '">' . esc_html( (string) $a->name ) . '</option>';
+			$is_selected = (string) $a->slug === $selected ? ' selected' : '';
+			$html       .= '<option value="' . esc_attr( (string) $a->slug ) . '"' . $is_selected . '>' . esc_html( (string) $a->name ) . '</option>';
 		}
 		$html .= '</select></label></form>';
 
@@ -502,7 +537,7 @@ final class RecruitmentPublicShortcode {
 		$merged = array_merge( $default, $decoded );
 
 		$out = array();
-		foreach ( array( 'rank', 'name', 'status', 'pcd_badge', 'date_to_assume', 'time_to_assume', 'score', 'cpf_masked', 'rf_masked', 'email_masked' ) as $key ) {
+		foreach ( array( 'rank', 'name', 'adjutancy', 'status', 'pcd_badge', 'date_to_assume', 'time_to_assume', 'score', 'cpf_masked', 'rf_masked', 'email_masked' ) as $key ) {
 			$out[ $key ] = ! empty( $merged[ $key ] );
 		}
 
@@ -578,6 +613,75 @@ final class RecruitmentPublicShortcode {
 			'hired'     => __( 'Hired', 'ffcertificate' ),
 		);
 		return $map[ $status ] ?? $status;
+	}
+
+	/**
+	 * Render the status as a colored "tag" badge. Colors come from the
+	 * recruitment Settings page (admins can override per-deployment); the
+	 * defaults are the soft palette the user requested:
+	 *
+	 *   Empty → soft yellow.
+	 *   Called / accepted → soft purple.
+	 *   Not_shown → soft red.
+	 *   Hired → soft green.
+	 *
+	 * Inline `style` is used (not a CSS variable) because each notice
+	 * could in theory render under a host theme without the recruitment
+	 * public CSS — keeping the color in the markup guarantees the badge
+	 * renders correctly even there.
+	 *
+	 * @param string $status Classification status enum value.
+	 * @return string Already-escaped HTML.
+	 */
+	private static function render_status_badge( string $status ): string {
+		$settings = RecruitmentSettings::all();
+		$colors   = array(
+			'empty'     => (string) $settings['status_color_empty'],
+			'called'    => (string) $settings['status_color_called'],
+			'accepted'  => (string) $settings['status_color_called'],
+			'hired'     => (string) $settings['status_color_hired'],
+			'not_shown' => (string) $settings['status_color_not_shown'],
+		);
+		$bg       = $colors[ $status ] ?? '#e9ecef';
+		$label    = self::status_label( $status );
+		return sprintf(
+			'<span class="ffc-recruitment-status-badge ffc-recruitment-status-%s" style="background:%s;color:#333;padding:3px 10px;border-radius:12px;font-size:12px;font-weight:500;display:inline-block;">%s</span>',
+			esc_attr( $status ),
+			esc_attr( $bg ),
+			esc_html( $label )
+		);
+	}
+
+	/**
+	 * Format a `Y-m-d` date string as `d-m-Y` per the user request.
+	 *
+	 * Falls back to the original input when parsing fails (defensive —
+	 * the database stores dates in ISO already, so the strtotime path
+	 * should always succeed for non-empty input).
+	 *
+	 * @param string $iso ISO date.
+	 * @return string
+	 */
+	private static function format_date_br( string $iso ): string {
+		if ( '' === $iso ) {
+			return '';
+		}
+		$ts = strtotime( $iso );
+		return false === $ts ? $iso : gmdate( 'd-m-Y', $ts );
+	}
+
+	/**
+	 * Format a `H:i:s` time string as `H:i` per the user request.
+	 *
+	 * @param string $time DB time.
+	 * @return string
+	 */
+	private static function format_time_hm( string $time ): string {
+		if ( '' === $time ) {
+			return '';
+		}
+		// Strip seconds if present.
+		return substr( $time, 0, 5 );
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-settings.php
+++ b/includes/recruitment/class-ffc-recruitment-settings.php
@@ -53,6 +53,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  *   public_cache_seconds:        int,
  *   public_rate_limit_per_minute: int,
  *   public_default_page_size:    int,
+ *   status_color_empty:          string,
+ *   status_color_called:         string,
+ *   status_color_hired:          string,
+ *   status_color_not_shown:      string,
  * }
  */
 final class RecruitmentSettings {
@@ -107,6 +111,13 @@ final class RecruitmentSettings {
 			'public_cache_seconds'         => 60,
 			'public_rate_limit_per_minute' => 30,
 			'public_default_page_size'     => 50,
+			// Status-badge colors on the public shortcode. Each value is
+			// an HTML color (#RRGGBB or named); validated on save so a
+			// hostile string can't bleed into the stored option.
+			'status_color_empty'           => '#fff3cd',
+			'status_color_called'          => '#e9d8fd',
+			'status_color_hired'           => '#d4edda',
+			'status_color_not_shown'       => '#f8d7da',
 		);
 	}
 
@@ -182,7 +193,36 @@ final class RecruitmentSettings {
 		$out['public_rate_limit_per_minute'] = self::clamp_int( $value['public_rate_limit_per_minute'] ?? null, 0, 6000, $defaults['public_rate_limit_per_minute'] );
 		$out['public_default_page_size']     = self::clamp_int( $value['public_default_page_size'] ?? null, 1, 1000, $defaults['public_default_page_size'] );
 
+		$out['status_color_empty']     = self::sanitize_color( $value['status_color_empty'] ?? null, $defaults['status_color_empty'] );
+		$out['status_color_called']    = self::sanitize_color( $value['status_color_called'] ?? null, $defaults['status_color_called'] );
+		$out['status_color_hired']     = self::sanitize_color( $value['status_color_hired'] ?? null, $defaults['status_color_hired'] );
+		$out['status_color_not_shown'] = self::sanitize_color( $value['status_color_not_shown'] ?? null, $defaults['status_color_not_shown'] );
+
 		return $out;
+	}
+
+	/**
+	 * Sanitize a color string. Accepts #RGB, #RRGGBB, or #RRGGBBAA;
+	 * anything else falls back to the default. Sufficient for the
+	 * status-badge palette use case (the public shortcode renders the
+	 * value directly into a `style="background:..."` attribute).
+	 *
+	 * @param mixed  $value         Raw value.
+	 * @param string $default Fallback when input is unusable.
+	 * @return string
+	 */
+	private static function sanitize_color( $value, string $default ): string {
+		if ( ! is_string( $value ) ) {
+			return $default;
+		}
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return $default;
+		}
+		if ( 1 === preg_match( '/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $value ) ) {
+			return strtolower( $value );
+		}
+		return $default;
 	}
 
 	/**
@@ -226,6 +266,10 @@ final class RecruitmentSettings {
 			'public_cache_seconds'         => is_int( $value['public_cache_seconds'] ?? null ) ? $value['public_cache_seconds'] : $defaults['public_cache_seconds'],
 			'public_rate_limit_per_minute' => is_int( $value['public_rate_limit_per_minute'] ?? null ) ? $value['public_rate_limit_per_minute'] : $defaults['public_rate_limit_per_minute'],
 			'public_default_page_size'     => is_int( $value['public_default_page_size'] ?? null ) ? $value['public_default_page_size'] : $defaults['public_default_page_size'],
+			'status_color_empty'           => is_string( $value['status_color_empty'] ?? null ) ? $value['status_color_empty'] : $defaults['status_color_empty'],
+			'status_color_called'          => is_string( $value['status_color_called'] ?? null ) ? $value['status_color_called'] : $defaults['status_color_called'],
+			'status_color_hired'           => is_string( $value['status_color_hired'] ?? null ) ? $value['status_color_hired'] : $defaults['status_color_hired'],
+			'status_color_not_shown'       => is_string( $value['status_color_not_shown'] ?? null ) ? $value['status_color_not_shown'] : $defaults['status_color_not_shown'],
 		);
 	}
 

--- a/includes/user-dashboard/class-ffc-user-creator.php
+++ b/includes/user-dashboard/class-ffc-user-creator.php
@@ -258,6 +258,39 @@ class UserCreator {
 	 * @return string Unique username
 	 */
 	public static function generate_username( string $email, array $submission_data = array() ): string {
+		// 1. Prefer the email prefix (everything before `@`) per the
+		// plugin-wide convention — keeps usernames stable, predictable
+		// for the operator, and consistent across the recruitment CSV
+		// import path and the legacy ffc_form submission path.
+		$email_prefix = '';
+		if ( '' !== $email ) {
+			$at_pos = strpos( $email, '@' );
+			if ( false !== $at_pos && $at_pos > 0 ) {
+				$email_prefix = strtolower( trim( substr( $email, 0, $at_pos ) ) );
+			}
+		}
+
+		if ( '' !== $email_prefix ) {
+			$slug = sanitize_user( remove_accents( $email_prefix ), true );
+			$slug = preg_replace( '/[^a-z0-9._-]/', '', $slug ) ?? '';
+			$slug = preg_replace( '/[-_.]+/', '.', $slug ) ?? '';
+			$slug = trim( $slug, '.' );
+
+			if ( strlen( $slug ) >= 3 ) {
+				if ( ! username_exists( $slug ) ) {
+					return $slug;
+				}
+				for ( $i = 2; $i <= 99; $i++ ) {
+					$candidate = $slug . '.' . $i;
+					if ( ! username_exists( $candidate ) ) {
+						return $candidate;
+					}
+				}
+			}
+		}
+
+		// 2. Fallback to a name-based slug from submission data — covers
+		// the (rare) case of an empty / unusable email.
 		$possible_names = array( 'nome_completo', 'nome', 'name', 'full_name', 'ffc_nome' );
 		$name           = '';
 
@@ -288,6 +321,7 @@ class UserCreator {
 			}
 		}
 
+		// 3. Last resort: random.
 		do {
 			$username = 'ffc_' . wp_generate_password( 8, false, false );
 		} while ( username_exists( $username ) );

--- a/tests/Unit/UserCreatorTest.php
+++ b/tests/Unit/UserCreatorTest.php
@@ -57,7 +57,7 @@ class UserCreatorTest extends TestCase {
     // generate_username() — public, easy to test in isolation
     // ------------------------------------------------------------------
 
-    public function test_generate_username_from_nome_completo(): void {
+    public function test_generate_username_from_email_prefix(): void {
         Functions\when( 'sanitize_user' )->returnArg();
         Functions\when( 'remove_accents' )->returnArg();
         Functions\when( 'username_exists' )->justReturn( false );
@@ -67,30 +67,30 @@ class UserCreatorTest extends TestCase {
             array( 'nome_completo' => 'Alice Silva' )
         );
 
-        // Space is removed by preg_replace('/[^a-z0-9._-]/', '')
-        $this->assertSame( 'alicesilva', $username );
+        // Email prefix wins over name per the plugin-wide convention.
+        $this->assertSame( 'alice', $username );
     }
 
-    public function test_generate_username_from_nome_field(): void {
+    public function test_generate_username_falls_back_to_name_when_email_is_empty(): void {
         Functions\when( 'sanitize_user' )->returnArg();
         Functions\when( 'remove_accents' )->returnArg();
         Functions\when( 'username_exists' )->justReturn( false );
 
         $username = UserCreator::generate_username(
-            'bob@example.com',
+            '',
             array( 'nome' => 'Bob Santos' )
         );
 
         $this->assertSame( 'bobsantos', $username );
     }
 
-    public function test_generate_username_from_name_field(): void {
+    public function test_generate_username_falls_back_to_name_when_email_prefix_too_short(): void {
         Functions\when( 'sanitize_user' )->returnArg();
         Functions\when( 'remove_accents' )->returnArg();
         Functions\when( 'username_exists' )->justReturn( false );
 
         $username = UserCreator::generate_username(
-            'carol@example.com',
+            'a@example.com',
             array( 'name' => 'Carol Oliveira' )
         );
 
@@ -108,15 +108,15 @@ class UserCreatorTest extends TestCase {
         } );
 
         $username = UserCreator::generate_username(
-            'dave@example.com',
+            'dave.costa@example.com',
             array( 'nome_completo' => 'Dave Costa' )
         );
 
-        // 'davecosta' taken (call 1), 'davecosta.2' taken (call 2), 'davecosta.3' OK (call 3)
-        $this->assertSame( 'davecosta.3', $username );
+        // 'dave.costa' taken (call 1), 'dave.costa.2' taken (call 2), 'dave.costa.3' OK (call 3).
+        $this->assertSame( 'dave.costa.3', $username );
     }
 
-    public function test_generate_username_falls_back_to_random_when_name_too_short(): void {
+    public function test_generate_username_falls_back_to_random_when_email_and_name_too_short(): void {
         Functions\when( 'sanitize_user' )->returnArg();
         Functions\when( 'remove_accents' )->returnArg();
         Functions\when( 'username_exists' )->justReturn( false );
@@ -130,13 +130,13 @@ class UserCreatorTest extends TestCase {
         $this->assertStringStartsWith( 'ffc_', $username );
     }
 
-    public function test_generate_username_falls_back_to_random_when_no_name(): void {
+    public function test_generate_username_falls_back_to_random_when_no_data(): void {
         Functions\when( 'sanitize_user' )->returnArg();
         Functions\when( 'remove_accents' )->returnArg();
         Functions\when( 'username_exists' )->justReturn( false );
         Functions\when( 'wp_generate_password' )->justReturn( 'xyz78901' );
 
-        $username = UserCreator::generate_username( 'test@example.com', array() );
+        $username = UserCreator::generate_username( '', array() );
 
         $this->assertStringStartsWith( 'ffc_', $username );
         $this->assertSame( 'ffc_xyz78901', $username );
@@ -144,15 +144,20 @@ class UserCreatorTest extends TestCase {
 
     public function test_generate_username_strips_special_characters(): void {
         Functions\when( 'sanitize_user' )->returnArg();
-        Functions\when( 'remove_accents' )->alias( function( $s ) { return 'joao silva'; } );
+        Functions\when( 'remove_accents' )->alias( function( $s ) { return $s; } );
         Functions\when( 'username_exists' )->justReturn( false );
 
+        // Email prefix already lacks accents, so this just confirms the
+        // non-alphanumeric strip on the prefix path.
         $username = UserCreator::generate_username(
-            'joao@example.com',
-            array( 'nome_completo' => 'João Silva' )
+            'joão.silva@example.com',
+            array()
         );
 
-        $this->assertSame( 'joaosilva', $username );
+        // Accents removed by remove_accents stub (no-op here); the
+        // [^a-z0-9._-] strip removes the accented chars in input.
+        // Accent stripped by the regex (`ã` outside [a-z0-9._-] → dropped).
+        $this->assertSame( 'joo.silva', $username );
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Six user-reported items, all rolled into the 6.1.0 release narrative (no version bump). Five commits, one per sprint plus the CHANGELOG.

## Items addressed

### 1. Username pattern — email prefix

`UserCreator::generate_username()` now prefers the email prefix (everything before `@`) over the legacy name-slug fallback. Aligns the recruitment promotion path with the legacy `ffc_form` submission path. Existing usernames untouched; only NEW user creations from this commit forward follow the new logic.

### 2. No "Trash" on Notices / Adjutancies — explained, no code change

Per §7-bis of the original plan: the recruitment domain ships **hard-delete with referential gates** instead of a trash bin. Notices delete directly, adjutancies are gate-protected (rejects with 409 when referenced), candidates need zero-classifications + reason. Documented in the CHANGELOG so the rationale is preserved.

### 3. Public shortcode (5 fixes)

- 3.1 Adjutancy filter now functional — `render()` reads `$_GET['adjutancy']` when no explicit attr is set.
- 3.2 New `adjutancy` column in `public_columns_config` (default on).
- 3.3 Date as DD-MM-YYYY, time as HH:MM.
- 3.4 Score formatted to 2 decimals.
- 3.5 Status badges as colored tags (operator-configurable in Settings — 4 new color sub-keys with `<input type="color">` UI).

### 4. Candidate edit — manual WP-user link/unlink

Sensitive data section gains:
- "Unlink" button next to the linked-WP-user row (clears `candidate.user_id` without touching the wp_user).
- "Link manually to WP user" form below (free-text input resolved by ID / login / email; does NOT create users).

Both routes share the same per-candidate nonce. Three new flash keys: `link-user-ok`, `link-user-not-found`, `unlink-user-ok`.

### 5. wp-admin submenus

The top-level "Recruitment" item now expands into Notices / Adjutancies / Candidates / Settings via the `$submenu` global. Each submenu links to the corresponding `?tab=…` so the existing render dispatcher handles them transparently.

### 6. Close-notice confirmation

`ffcRecruitmentConfirmTransition()` gained a `closed` branch: confirm prompt names the side-effects (calls history goes read-only, public banner, reopen-freeze).

## Commits

1. `50b66e9` — Sprint 1: username from email prefix
2. `fc43b31` — Sprint 2: filter fix + adjutancy column + formats + colored status badges
3. `f9164d8` — Sprint 3: candidate WP-user link/unlink
4. `ad73964` — Sprint 4: wp-admin submenus + close-notice confirmation
5. `3930502` — CHANGELOG roll-up

## Version

No bump — continues the 6.1.0 narrative. CHANGELOG entries under `[Unreleased]`.

## Test plan

- [x] `composer ci` green: PHPStan level 8 zero baseline, WPCS clean, PHPUnit **3726 tests / 9462 assertions / 0 failures**.
- [ ] CI green on this PR.
- [ ] Promote a recruitment candidate via CSV import: the resulting wp_user has `user_login = email-prefix` (e.g. `alice` for `alice@example.com`).
- [ ] On the public shortcode: dropdown filter survives reloads, adjutancy column renders, score shows `100.25` not `100.2500`, date shows `15-05-2026`, time shows `08:30`, status pills are color-coded per the Settings palette.
- [ ] Candidate edit screen — Unlink and Link buttons round-trip through the admin-post handlers.
- [ ] wp-admin sidebar — Recruitment expands into 4 submenu items, each landing on the right tab.
- [ ] Click "Close" on a notice: confirm() prompt fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ewp3idhND7Pbw8nYZiU2AR)_