### PR TITLE
feat(recruitment): per-adjutancy badge color, persistent filter UI, view-as on convocations tab

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -107,6 +107,38 @@ class RecruitmentActivator {
 			self::migrate_status_final_to_definitive();
 			update_option( $option_key, 3 );
 		}
+
+		if ( $current < 4 ) {
+			self::migrate_add_adjutancy_color();
+			update_option( $option_key, 4 );
+		}
+	}
+
+	/**
+	 * V4 schema migration — add `color` column to `ffc_recruitment_adjutancy`.
+	 *
+	 * Holds a per-adjutancy badge background color rendered by the public
+	 * shortcode (mirrors the existing per-status color knobs in the
+	 * Settings tab). VARCHAR(9) is wide enough for `#RRGGBBAA`.
+	 *
+	 * @return void
+	 */
+	private static function migrate_add_adjutancy_color(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . 'ffc_recruitment_adjutancy';
+
+		if ( ! self::table_exists( $table ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Schema migration; $table is built from $wpdb->prefix.
+		$existing = $wpdb->get_var( "SHOW COLUMNS FROM `{$table}` LIKE 'color'" );
+		if ( null !== $existing && '' !== (string) $existing ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Schema migration.
+		$wpdb->query( "ALTER TABLE `{$table}` ADD COLUMN color VARCHAR(9) NOT NULL DEFAULT '#e9ecef' AFTER name" );
 	}
 
 	/**
@@ -195,6 +227,7 @@ class RecruitmentActivator {
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             slug varchar(64) NOT NULL,
             name varchar(255) NOT NULL,
+            color varchar(9) NOT NULL DEFAULT '#e9ecef',
             created_at datetime NOT NULL,
             updated_at datetime NOT NULL,
             PRIMARY KEY (id),

--- a/includes/recruitment/class-ffc-recruitment-adjutancies-list-table.php
+++ b/includes/recruitment/class-ffc-recruitment-adjutancies-list-table.php
@@ -57,6 +57,7 @@ class RecruitmentAdjutanciesListTable extends \WP_List_Table {
 			'cb'         => '<input type="checkbox" />',
 			'slug'       => __( 'Slug', 'ffcertificate' ),
 			'name'       => __( 'Name', 'ffcertificate' ),
+			'color'      => __( 'Badge color', 'ffcertificate' ),
 			'usage'      => __( 'Notices using', 'ffcertificate' ),
 			'created_at' => __( 'Created at', 'ffcertificate' ),
 		);
@@ -146,6 +147,27 @@ class RecruitmentAdjutanciesListTable extends \WP_List_Table {
 			esc_url( $edit_url ),
 			esc_html( $slug ),
 			$this->row_actions( $actions )
+		);
+	}
+
+	/**
+	 * Color column — inline color picker that PATCHes the row via the
+	 * REST endpoint on change. The picker UX mirrors the per-status
+	 * pickers in the Settings tab so admins get one consistent affordance
+	 * for every "what color is this badge" choice in the module.
+	 *
+	 * @param array<string, mixed> $item Row.
+	 * @return string
+	 */
+	protected function column_color( $item ): string {
+		$id    = (int) $item['id'];
+		$color = (string) ( $item['color'] ?? RecruitmentAdjutancyRepository::DEFAULT_COLOR );
+		return sprintf(
+			'<input type="color" value="%s" data-ffc-adjutancy-id="%d" class="ffc-adjutancy-color-picker" aria-label="%s"> <code class="ffc-adjutancy-color-hex">%s</code>',
+			esc_attr( $color ),
+			$id,
+			esc_attr__( 'Badge color', 'ffcertificate' ),
+			esc_html( $color )
 		);
 	}
 
@@ -275,6 +297,7 @@ class RecruitmentAdjutanciesListTable extends \WP_List_Table {
 					'id'         => (int) $row->id,
 					'slug'       => (string) $row->slug,
 					'name'       => (string) $row->name,
+					'color'      => isset( $row->color ) ? (string) $row->color : RecruitmentAdjutancyRepository::DEFAULT_COLOR,
 					'created_at' => (string) $row->created_at,
 				);
 			},

--- a/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
@@ -30,9 +30,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Database repository for `ffc_recruitment_adjutancy` rows.
  *
- * @phpstan-type AdjutancyRow \stdClass&object{id: numeric-string, slug: string, name: string, created_at: string, updated_at: string}
+ * @phpstan-type AdjutancyRow \stdClass&object{id: numeric-string, slug: string, name: string, color: string, created_at: string, updated_at: string}
  */
 class RecruitmentAdjutancyRepository {
+
+	/** Default badge color used when admins haven't picked one yet. */
+	public const DEFAULT_COLOR = '#e9ecef';
 
 	use \FreeFormCertificate\Core\StaticRepositoryTrait;
 
@@ -149,11 +152,13 @@ class RecruitmentAdjutancyRepository {
 	 * Caller is responsible for slug normalization. Returns `false` on
 	 * insert failure (e.g. duplicate slug rejected by the UNIQUE constraint).
 	 *
-	 * @param string $slug Unique slug.
-	 * @param string $name Display name.
+	 * @param string $slug  Unique slug.
+	 * @param string $name  Display name.
+	 * @param string $color Optional badge background color (#RGB / #RRGGBB / #RRGGBBAA);
+	 *                      falls back to {@see self::DEFAULT_COLOR} on empty input.
 	 * @return int|false New adjutancy ID or false on failure.
 	 */
-	public static function create( string $slug, string $name ) {
+	public static function create( string $slug, string $name, string $color = '' ) {
 		$wpdb  = self::db();
 		$table = self::get_table_name();
 
@@ -165,10 +170,11 @@ class RecruitmentAdjutancyRepository {
 			array(
 				'slug'       => $slug,
 				'name'       => $name,
+				'color'      => self::normalize_color( $color ),
 				'created_at' => $now,
 				'updated_at' => $now,
 			),
-			array( '%s', '%s', '%s', '%s' )
+			array( '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		if ( ! $result ) {
@@ -179,13 +185,35 @@ class RecruitmentAdjutancyRepository {
 	}
 
 	/**
+	 * Normalize a color string into the canonical lowercase hex form.
+	 *
+	 * Accepts `#RGB`, `#RRGGBB`, or `#RRGGBBAA`; anything else falls back
+	 * to {@see self::DEFAULT_COLOR}. Mirrors the validator on
+	 * {@see RecruitmentSettings::sanitize_color()} so the per-adjutancy
+	 * picker and the per-status picker enforce identical input rules.
+	 *
+	 * @param string $value Raw value.
+	 * @return string
+	 */
+	public static function normalize_color( string $value ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return self::DEFAULT_COLOR;
+		}
+		if ( 1 === preg_match( '/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $value ) ) {
+			return strtolower( $value );
+		}
+		return self::DEFAULT_COLOR;
+	}
+
+	/**
 	 * Update name and/or slug on an existing adjutancy.
 	 *
-	 * Only `slug` and `name` are accepted; any other key in `$data` is
-	 * silently ignored. `updated_at` is refreshed automatically.
+	 * Only `slug`, `name`, and `color` are accepted; any other key in `$data`
+	 * is silently ignored. `updated_at` is refreshed automatically.
 	 *
 	 * @param int                  $id   Adjutancy ID.
-	 * @param array<string, mixed> $data Subset of {slug, name}.
+	 * @param array<string, mixed> $data Subset of {slug, name, color}.
 	 * @return bool True on successful update (zero or more rows affected).
 	 */
 	public static function update( int $id, array $data ): bool {
@@ -203,6 +231,11 @@ class RecruitmentAdjutancyRepository {
 		if ( isset( $data['name'] ) && is_string( $data['name'] ) ) {
 			$update['name'] = $data['name'];
 			$format[]       = '%s';
+		}
+
+		if ( isset( $data['color'] ) && is_string( $data['color'] ) ) {
+			$update['color'] = self::normalize_color( $data['color'] );
+			$format[]        = '%s';
 		}
 
 		if ( empty( $update ) ) {

--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -351,6 +351,47 @@ final class RecruitmentAdminPage {
 		echo '</form>';
 
 		self::render_create_adjutancy_form();
+		self::render_adjutancy_color_picker_script();
+	}
+
+	/**
+	 * Inline JS that turns each adjutancy color picker (rendered by
+	 * {@see RecruitmentAdjutanciesListTable::column_color()}) into an
+	 * auto-PATCHing control.
+	 *
+	 * Listening at `change` instead of `input` so the request fires once
+	 * the user commits a color rather than firing on every drag step
+	 * across the picker. The hex label next to the picker is updated in
+	 * place so admins get instant feedback without a page reload.
+	 *
+	 * @return void
+	 */
+	private static function render_adjutancy_color_picker_script(): void {
+		$nonce    = wp_create_nonce( 'wp_rest' );
+		$base_url = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/adjutancies/' ) );
+
+		echo '<script>'
+			. '(function(){'
+			. 'document.querySelectorAll(".ffc-adjutancy-color-picker").forEach(function(input){'
+			. 'input.addEventListener("change",function(){'
+			. 'var id=parseInt(input.getAttribute("data-ffc-adjutancy-id"),10);'
+			. 'if(!id){return;}'
+			. 'var fd=new FormData();fd.append("color",input.value);'
+			. 'fetch(' . wp_json_encode( $base_url ) . '+id,{'
+			. 'method:"POST",'
+			. 'headers:{"X-WP-Nonce":' . wp_json_encode( $nonce ) . ',"X-HTTP-Method-Override":"PATCH"},'
+			. 'body:fd'
+			. '}).then(function(r){return r.json();}).then(function(d){'
+			. 'if(d&&d.color){'
+			. 'input.value=d.color;'
+			. 'var hex=input.parentNode.querySelector(".ffc-adjutancy-color-hex");'
+			. 'if(hex){hex.textContent=d.color;}'
+			. '}else{alert(JSON.stringify(d));}'
+			. '});'
+			. '});'
+			. '});'
+			. '})();'
+			. '</script>';
 	}
 
 	/**
@@ -507,6 +548,8 @@ final class RecruitmentAdminPage {
 	private static function render_create_adjutancy_form(): void {
 		$nonce = wp_create_nonce( 'wp_rest' );
 
+		$default_color = RecruitmentAdjutancyRepository::DEFAULT_COLOR;
+
 		echo '<h3>' . esc_html__( 'Create new adjutancy', 'ffcertificate' ) . '</h3>';
 		echo '<form id="ffc-create-adjutancy" method="post" onsubmit="return ffcRecruitmentCreateAdjutancy(this);">';
 		echo '<table class="form-table"><tbody>';
@@ -514,6 +557,10 @@ final class RecruitmentAdminPage {
 		echo '<td><input id="ffc-adj-slug" name="slug" type="text" class="regular-text" required></td></tr>';
 		echo '<tr><th><label for="ffc-adj-name">' . esc_html__( 'Name', 'ffcertificate' ) . '</label></th>';
 		echo '<td><input id="ffc-adj-name" name="name" type="text" class="regular-text" required></td></tr>';
+		echo '<tr><th><label for="ffc-adj-color">' . esc_html__( 'Badge color', 'ffcertificate' ) . '</label></th>';
+		echo '<td><input id="ffc-adj-color" name="color" type="color" value="' . esc_attr( $default_color ) . '">';
+		echo '<p class="description">' . esc_html__( 'Background color for this adjutancy badge on the public shortcode. Accepts #RGB / #RRGGBB / #RRGGBBAA. Bad values silently fall back to the default.', 'ffcertificate' ) . '</p>';
+		echo '</td></tr>';
 		echo '</tbody></table>';
 		echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Create', 'ffcertificate' ) . '</button></p>';
 		echo '</form>';

--- a/includes/recruitment/class-ffc-recruitment-dashboard-section.php
+++ b/includes/recruitment/class-ffc-recruitment-dashboard-section.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Recruitment;
 
+use FreeFormCertificate\Shortcodes\DashboardViewMode;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -62,16 +64,41 @@ final class RecruitmentDashboardSection {
 	}
 
 	/**
-	 * Shortcode callback.
+	 * Shortcode callback. Resolves the effective user via the dashboard's
+	 * "view as user" override (admins only, gated by nonce + cap inside
+	 * {@see DashboardViewMode::get_view_as_user_id()}) so the section
+	 * renders the impersonated user's classifications instead of the
+	 * admin's own when an admin is in view-as mode.
 	 *
+	 * @param array<string|int, mixed>|string $atts Raw shortcode attributes (unused).
 	 * @return string
 	 */
-	public static function render(): string {
+	public static function render( $atts = array() ): string {
+		unset( $atts );
+
 		if ( ! is_user_logged_in() ) {
 			return '';
 		}
 
-		$user_id = get_current_user_id();
+		$view_as = class_exists( DashboardViewMode::class )
+			? DashboardViewMode::get_view_as_user_id()
+			: false;
+		$user_id = $view_as ? (int) $view_as : (int) get_current_user_id();
+
+		return self::render_for_user( $user_id );
+	}
+
+	/**
+	 * In-process render entry point. Used by `DashboardShortcode` so the
+	 * already-resolved (view-as-aware) `$user_id` can be threaded through
+	 * without re-checking nonces/caps a second time. Anyone calling this
+	 * directly is responsible for ensuring the supplied id is the user
+	 * they actually intend to render — the method does not re-validate.
+	 *
+	 * @param int $user_id Effective candidate-side WP user id.
+	 * @return string
+	 */
+	public static function render_for_user( int $user_id ): string {
 		if ( $user_id <= 0 ) {
 			return '';
 		}

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -104,12 +104,17 @@ final class RecruitmentPublicShortcode {
 		);
 
 		$notice_code = trim( (string) $atts['notice'] );
-		$slug_filter = trim( (string) $atts['adjutancy'] );
+		$attr_filter = trim( (string) $atts['adjutancy'] );
+		$slug_filter = $attr_filter;
 
 		// When the shortcode wasn't called with a fixed adjutancy attribute,
 		// honor the per-page filter dropdown (`?adjutancy=foo`). Sanitize
 		// to a sane slug shape so a hostile URL doesn't bleed into the
-		// repository lookup.
+		// repository lookup. The filter UI is suppressed only when the
+		// shortcode itself pinned an adjutancy via attribute — selecting
+		// a value via the dropdown must still leave the dropdown rendered
+		// so visitors can switch back to "All" or pick a different one.
+		$filter_locked = '' !== $attr_filter;
 		if ( '' === $slug_filter ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only filter.
 			$get_filter  = isset( $_GET['adjutancy'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['adjutancy'] ) ) : '';
@@ -130,13 +135,13 @@ final class RecruitmentPublicShortcode {
 		$page_top    = max( 1, (int) ( $_GET['page_top'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_bottom = max( 1, (int) ( $_GET['page_bottom'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		$cache_key = self::cache_key( $notice_code, $slug_filter, $page_top, $page_bottom );
+		$cache_key = self::cache_key( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked );
 		$cached    = get_transient( $cache_key );
 		if ( is_string( $cached ) ) {
 			return $cached;
 		}
 
-		$html = self::wrap_output( self::render_uncached( $notice_code, $slug_filter, $page_top, $page_bottom ) );
+		$html = self::wrap_output( self::render_uncached( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked ) );
 
 		$settings = RecruitmentSettings::all();
 		$ttl      = (int) $settings['public_cache_seconds'];
@@ -183,13 +188,17 @@ final class RecruitmentPublicShortcode {
 	 * Split out so tests / direct callers can bypass caching without
 	 * messing with transients.
 	 *
-	 * @param string $notice_code  User-supplied notice code.
-	 * @param string $slug_filter  User-supplied adjutancy slug filter (may be empty).
-	 * @param int    $page_top     1-indexed page for the "Não chamados" section.
-	 * @param int    $page_bottom  1-indexed page for the "Chamados" section.
+	 * @param string $notice_code   User-supplied notice code.
+	 * @param string $slug_filter   User-supplied adjutancy slug filter (may be empty).
+	 * @param int    $page_top      1-indexed page for the "Não chamados" section.
+	 * @param int    $page_bottom   1-indexed page for the "Chamados" section.
+	 * @param bool   $filter_locked True when the shortcode was called with a fixed
+	 *                              `adjutancy=` attribute — the filter UI is then
+	 *                              suppressed so callers who pinned the adjutancy
+	 *                              cannot be re-routed by URL tampering.
 	 * @return string
 	 */
-	public static function render_uncached( string $notice_code, string $slug_filter, int $page_top, int $page_bottom ): string {
+	public static function render_uncached( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false ): string {
 		$notice = RecruitmentNoticeRepository::get_by_code( $notice_code );
 		if ( null === $notice ) {
 			return self::msg( __( 'Notice not found.', 'ffcertificate' ), 'error' );
@@ -248,9 +257,13 @@ final class RecruitmentPublicShortcode {
 		$settings  = RecruitmentSettings::all();
 		$page_size = (int) $settings['public_default_page_size'];
 
-		$adjutancy_filter_html = '' === $slug_filter
-			? self::render_adjutancy_filter( (int) $notice->id )
-			: '';
+		// Render the filter dropdown unless the shortcode itself pinned an
+		// adjutancy via attribute. Keeping the dropdown rendered when a URL
+		// filter is active is intentional: visitors must always be able to
+		// switch back to "All" or to a different adjutancy from the same UI.
+		$adjutancy_filter_html = $filter_locked
+			? ''
+			: self::render_adjutancy_filter( (int) $notice->id );
 
 		$top_section    = self::render_section(
 			__( 'Not yet called', 'ffcertificate' ),
@@ -382,7 +395,7 @@ final class RecruitmentPublicShortcode {
 		}
 		if ( $columns['adjutancy'] ) {
 			$adjutancy = RecruitmentAdjutancyRepository::get_by_id( (int) $row->adjutancy_id );
-			$html     .= '<td>' . esc_html( null === $adjutancy ? '' : (string) $adjutancy->name ) . '</td>';
+			$html     .= '<td>' . self::render_adjutancy_badge( $adjutancy ) . '</td>';
 		}
 		if ( $columns['cpf_masked'] ) {
 			$plain = self::decrypt_field( $candidate->cpf_encrypted );
@@ -616,6 +629,33 @@ final class RecruitmentPublicShortcode {
 	}
 
 	/**
+	 * Render an adjutancy as a colored "tag" badge. The color comes from
+	 * the per-adjutancy `color` column (configured in the Recruitment ›
+	 * Adjutancies admin tab); rows missing the column fall back to the
+	 * neutral default. Mirrors {@see self::render_status_badge()} so the
+	 * two badge types share visual treatment.
+	 *
+	 * @param object|null $adjutancy Adjutancy row (AdjutancyRow) or null.
+	 * @phpstan-param (\stdClass&object{name?: mixed, color?: mixed})|null $adjutancy
+	 * @return string Already-escaped HTML; empty string when adjutancy is null.
+	 */
+	private static function render_adjutancy_badge( ?object $adjutancy ): string {
+		if ( null === $adjutancy ) {
+			return '';
+		}
+		$color_raw = $adjutancy->color ?? '';
+		$color     = is_string( $color_raw ) && '' !== $color_raw
+			? $color_raw
+			: RecruitmentAdjutancyRepository::DEFAULT_COLOR;
+		$name      = $adjutancy->name ?? '';
+		return sprintf(
+			'<span class="ffc-recruitment-adjutancy-badge" style="background:%s;color:#333;padding:3px 10px;border-radius:12px;font-size:12px;font-weight:500;display:inline-block;">%s</span>',
+			esc_attr( $color ),
+			esc_html( is_string( $name ) ? $name : '' )
+		);
+	}
+
+	/**
 	 * Render the status as a colored "tag" badge. Colors come from the
 	 * recruitment Settings page (admins can override per-deployment); the
 	 * defaults are the soft palette the user requested:
@@ -706,11 +746,13 @@ final class RecruitmentPublicShortcode {
 	 * @param string $slug_filter   Adjutancy slug filter ('' when no filter).
 	 * @param int    $page_top      Página da seção "Não chamados".
 	 * @param int    $page_bottom   Página da seção "Chamados".
+	 * @param bool   $filter_locked Whether the shortcode pinned the adjutancy
+	 *                              via attribute (filter UI is suppressed).
 	 * @return string Transient key (under WP's 172-char limit).
 	 */
-	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom ): string {
+	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false ): string {
 		return self::CACHE_PREFIX . md5(
-			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom
+			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom . '|' . ( $filter_locked ? '1' : '0' )
 		);
 	}
 

--- a/includes/recruitment/class-ffc-recruitment-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-rest-controller.php
@@ -265,14 +265,19 @@ final class RecruitmentRestController {
 					'callback'            => array( $this, 'create_adjutancy' ),
 					'permission_callback' => array( $this, 'check_admin_cap' ),
 					'args'                => array(
-						'slug' => array(
+						'slug'  => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_title',
 						),
-						'name' => array(
+						'name'  => array(
 							'type'              => 'string',
 							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'color' => array(
+							'type'              => 'string',
+							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
@@ -757,7 +762,8 @@ final class RecruitmentRestController {
 	public function create_adjutancy( \WP_REST_Request $request ) {
 		$id = RecruitmentAdjutancyRepository::create(
 			(string) $request->get_param( 'slug' ),
-			(string) $request->get_param( 'name' )
+			(string) $request->get_param( 'name' ),
+			(string) ( $request->get_param( 'color' ) ?? '' )
 		);
 		if ( false === $id ) {
 			return new \WP_Error(
@@ -777,7 +783,7 @@ final class RecruitmentRestController {
 	 */
 	public function update_adjutancy( \WP_REST_Request $request ) {
 		$id   = (int) $request->get_param( 'id' );
-		$data = array_intersect_key( $request->get_params(), array_flip( array( 'slug', 'name' ) ) );
+		$data = array_intersect_key( $request->get_params(), array_flip( array( 'slug', 'name', 'color' ) ) );
 		$ok   = RecruitmentAdjutancyRepository::update( $id, $data );
 		if ( ! $ok ) {
 			return new \WP_Error(

--- a/includes/shortcodes/class-ffc-dashboard-shortcode.php
+++ b/includes/shortcodes/class-ffc-dashboard-shortcode.php
@@ -126,7 +126,10 @@ class DashboardShortcode {
 		// the repository layer.
 		$recruitment_html = '';
 		if ( class_exists( '\FreeFormCertificate\Recruitment\RecruitmentDashboardSection' ) ) {
-			$recruitment_html = \FreeFormCertificate\Recruitment\RecruitmentDashboardSection::render();
+			// Pass the already-resolved (view-as-aware) $user_id explicitly
+			// so the recruitment section renders for the impersonated user
+			// when an admin is in view-as mode — not the admin's own row.
+			$recruitment_html = \FreeFormCertificate\Recruitment\RecruitmentDashboardSection::render_for_user( (int) $user_id );
 		}
 		$can_view_recruitment = '' !== $recruitment_html;
 

--- a/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
+++ b/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
@@ -114,11 +114,12 @@ class RecruitmentRecruitmentAdjutancyRepositoryTest extends TestCase {
 					function ( $data ) {
 						return 'matematica' === $data['slug']
 							&& 'Matemática' === $data['name']
+							&& '#e9ecef' === $data['color']
 							&& '2026-05-01 10:00:00' === $data['created_at']
 							&& '2026-05-01 10:00:00' === $data['updated_at'];
 					}
 				),
-				array( '%s', '%s', '%s', '%s' )
+				array( '%s', '%s', '%s', '%s', '%s' )
 			)
 			->andReturn( 1 );
 


### PR DESCRIPTION
## Summary

Three related fixes for the recruitment module that surfaced together:

- **Public shortcode filter persistence.** `[ffc_recruitment_queue notice="..."]` now keeps the adjutancy filter dropdown rendered after a filter is applied (`?adjutancy=portugues`) so visitors can switch back to "All" or pick a different adjutancy. The dropdown is suppressed only when the shortcode itself pinned an adjutancy via attribute (`adjutancy="..."`), in which case URL tampering must not be able to override the pin.
- **Per-adjutancy badge color** (parity with the existing per-status color picker on the Settings tab). Schema migration v4 adds a `color` column to `ffc_recruitment_adjutancy`; the create form ships a color input, the list table exposes an inline picker that PATCHes via the existing REST endpoint, and the public shortcode renders the adjutancy column as a colored badge using the per-adjutancy color.
- **View-as bug on the user dashboard "Convocações" tab.** `RecruitmentDashboardSection::render()` was calling `get_current_user_id()` directly, so admins in view-as mode kept seeing their own classifications instead of the impersonated user's. The dashboard shortcode now threads its already-resolved (view-as-aware) user id explicitly via a new `render_for_user( int $user_id )` entry point, and the standalone `[ffc_recruitment_my_calls]` shortcode now also checks `DashboardViewMode::get_view_as_user_id()` before falling back to the current user.

## Test plan

- [x] `vendor/bin/phpunit` — 3726 tests, 9462 assertions, all passing
- [x] `vendor/bin/phpstan analyze` — no errors
- [ ] Manual: render `[ffc_recruitment_queue notice="EDITAL-X"]` on a notice with 2+ adjutancies; apply `?adjutancy=...`; confirm the dropdown stays visible and "All" clears the filter.
- [ ] Manual: render the same shortcode with a fixed `adjutancy="..."` attribute; confirm the dropdown is suppressed.
- [ ] Manual: in `Recruitment › Adjutancies`, set a color on an adjutancy and confirm it shows on the public shortcode's adjutancy column.
- [ ] Manual: as admin, use view-as mode on the user dashboard and confirm the "Convocações" tab shows the impersonated user's classifications.

https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn)_