### PR TITLE
feat(recruitment): frontend + admin polish (filter persistence, search, badge, toggles, OOO prompts, cache)

### DIFF
--- a/assets/css/ffc-recruitment-public.css
+++ b/assets/css/ffc-recruitment-public.css
@@ -46,20 +46,22 @@
     border-bottom: 1px solid var(--ffc-border-light);
     margin-bottom: 16px;
     padding-bottom: 12px;
+    text-align: center;
 }
 
-.ffc-recruitment-queue .ffc-recruitment-header h2 {
-    font-size: 20px;
+.ffc-recruitment-queue .ffc-recruitment-notice-title {
+    font-size: 18px;
     font-weight: 600;
+    margin: 8px 0 0;
 }
 
 .ffc-recruitment-queue .ffc-recruitment-banner {
-    display: inline-block;
-    margin-top: 8px;
+    display: block;
     padding: 6px 12px;
     border-radius: var(--ffc-radius);
-    font-size: 13px;
-    font-weight: 500;
+    font-size: 18px;
+    font-weight: 600;
+    text-align: center;
 }
 
 .ffc-recruitment-queue .ffc-recruitment-banner-preliminary {

--- a/assets/css/ffc-recruitment-public.css
+++ b/assets/css/ffc-recruitment-public.css
@@ -80,6 +80,20 @@
     color: #721c24;
 }
 
+.ffc-recruitment-queue .ffc-recruitment-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin: 12px 0;
+}
+
+.ffc-recruitment-queue .ffc-recruitment-filters label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .ffc-recruitment-queue .ffc-recruitment-section {
     margin-top: 24px;
 }

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -7,7 +7,7 @@
  *
  * Six tables, all prefixed `{$wpdb->prefix}ffc_recruitment_`:
  *
- * - ffc_recruitment_adjutancy           Reusable subject/role definitions (matérias).
+ * - ffc_recruitment_adjutancy           Reusable subject/role definitions (subjects).
  * - ffc_recruitment_notice              The edital lifecycle (draft → preliminary → active → closed).
  * - ffc_recruitment_notice_adjutancy    N:N — which adjutancies belong to which notice.
  * - ffc_recruitment_candidate           Standalone candidate list (linked to wp_users on promotion).
@@ -209,7 +209,7 @@ class RecruitmentActivator {
 	/**
 	 * Create `ffc_recruitment_adjutancy` table.
 	 *
-	 * Reusable subject/role definitions ("matérias"). One row per adjutancy,
+	 * Reusable subject/role definitions ("subjects"). One row per adjutancy,
 	 * shared across notices via the junction table.
 	 *
 	 * @return void

--- a/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-adjutancy-repository.php
@@ -181,6 +181,8 @@ class RecruitmentAdjutancyRepository {
 			return false;
 		}
 
+		do_action( 'ffc_recruitment_public_cache_dirty' );
+
 		return (int) $wpdb->insert_id;
 	}
 
@@ -250,6 +252,10 @@ class RecruitmentAdjutancyRepository {
 
 		static::cache_delete( "id_{$id}" );
 
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
 		return false !== $result;
 	}
 
@@ -271,6 +277,10 @@ class RecruitmentAdjutancyRepository {
 		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 
 		static::cache_delete( "id_{$id}" );
+
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
 
 		return false !== $result;
 	}

--- a/includes/recruitment/class-ffc-recruitment-call-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-call-repository.php
@@ -241,6 +241,8 @@ class RecruitmentCallRepository {
 			return false;
 		}
 
+		do_action( 'ffc_recruitment_public_cache_dirty' );
+
 		return (int) $wpdb->insert_id;
 	}
 
@@ -285,7 +287,12 @@ class RecruitmentCallRepository {
 
 		static::cache_delete( "id_{$id}" );
 
-		return is_int( $affected ) ? $affected : 0;
+		$rows = is_int( $affected ) ? $affected : 0;
+		if ( $rows > 0 ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $rows;
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -278,9 +278,9 @@ class RecruitmentCandidateRepository {
 	 * @return list<CandidateRow>
 	 */
 	public static function get_paginated_for_adjutancy( string $name_search, int $adjutancy_id, int $limit, int $offset ): array {
-		$wpdb       = self::db();
-		$table      = self::get_table_name();
-		$cls_table  = $wpdb->prefix . 'ffc_recruitment_classification';
+		$wpdb      = self::db();
+		$table     = self::get_table_name();
+		$cls_table = $wpdb->prefix . 'ffc_recruitment_classification';
 
 		$limit  = max( 1, min( 200, $limit ) );
 		$offset = max( 0, $offset );
@@ -296,7 +296,7 @@ class RecruitmentCandidateRepository {
 			? array( $table, $cls_table, $adjutancy_id, '%' . $wpdb->esc_like( $name_search ) . '%', $limit, $offset )
 			: array( $table, $cls_table, $adjutancy_id, $limit, $offset );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- $sql is one of two literals selected immediately above; both placeholders match $args.
 		$results = $wpdb->get_results( $wpdb->prepare( $sql, $args ) );
 
 		/**
@@ -327,7 +327,7 @@ class RecruitmentCandidateRepository {
 			? array( $table, $cls_table, $adjutancy_id, '%' . $wpdb->esc_like( $name_search ) . '%' )
 			: array( $table, $cls_table, $adjutancy_id );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- $sql is one of two literals selected immediately above; both placeholders match $args.
 		$total = $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
 
 		return null === $total ? 0 : (int) $total;

--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -265,6 +265,75 @@ class RecruitmentCandidateRepository {
 	}
 
 	/**
+	 * Page of candidates that have at least one classification in the
+	 * supplied adjutancy. Mirrors {@see self::get_paginated()} but
+	 * inner-joins the classification table so the result set is scoped
+	 * to candidates active in that adjutancy. Used by the admin
+	 * Candidates tab's adjutancy filter.
+	 *
+	 * @param string $name_search Optional substring filter on name.
+	 * @param int    $adjutancy_id Adjutancy id (must be > 0).
+	 * @param int    $limit       Page size.
+	 * @param int    $offset      0-indexed offset.
+	 * @return list<CandidateRow>
+	 */
+	public static function get_paginated_for_adjutancy( string $name_search, int $adjutancy_id, int $limit, int $offset ): array {
+		$wpdb       = self::db();
+		$table      = self::get_table_name();
+		$cls_table  = $wpdb->prefix . 'ffc_recruitment_classification';
+
+		$limit  = max( 1, min( 200, $limit ) );
+		$offset = max( 0, $offset );
+
+		// DISTINCT because a candidate can hold several classifications
+		// for the same adjutancy (across notices / list_types) and we
+		// want a single list-table row per candidate.
+		$sql = '' !== $name_search
+			? 'SELECT DISTINCT c.* FROM %i c INNER JOIN %i cls ON cls.candidate_id = c.id WHERE cls.adjutancy_id = %d AND c.name LIKE %s ORDER BY c.created_at DESC LIMIT %d OFFSET %d'
+			: 'SELECT DISTINCT c.* FROM %i c INNER JOIN %i cls ON cls.candidate_id = c.id WHERE cls.adjutancy_id = %d ORDER BY c.created_at DESC LIMIT %d OFFSET %d';
+
+		$args = '' !== $name_search
+			? array( $table, $cls_table, $adjutancy_id, '%' . $wpdb->esc_like( $name_search ) . '%', $limit, $offset )
+			: array( $table, $cls_table, $adjutancy_id, $limit, $offset );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results( $wpdb->prepare( $sql, $args ) );
+
+		/**
+		 * Cast wpdb's mixed return into the typed shape.
+		 *
+		 * @var list<CandidateRow>|null $results
+		 */
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Companion count for {@see self::get_paginated_for_adjutancy()}.
+	 *
+	 * @param string $name_search  Optional substring filter on name.
+	 * @param int    $adjutancy_id Adjutancy id.
+	 * @return int
+	 */
+	public static function count_paginated_for_adjutancy( string $name_search, int $adjutancy_id ): int {
+		$wpdb      = self::db();
+		$table     = self::get_table_name();
+		$cls_table = $wpdb->prefix . 'ffc_recruitment_classification';
+
+		$sql = '' !== $name_search
+			? 'SELECT COUNT(DISTINCT c.id) FROM %i c INNER JOIN %i cls ON cls.candidate_id = c.id WHERE cls.adjutancy_id = %d AND c.name LIKE %s'
+			: 'SELECT COUNT(DISTINCT c.id) FROM %i c INNER JOIN %i cls ON cls.candidate_id = c.id WHERE cls.adjutancy_id = %d';
+
+		$args = '' !== $name_search
+			? array( $table, $cls_table, $adjutancy_id, '%' . $wpdb->esc_like( $name_search ) . '%' )
+			: array( $table, $cls_table, $adjutancy_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$total = $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
+
+		return null === $total ? 0 : (int) $total;
+	}
+
+	/**
 	 * Total candidate count, optionally filtered by `name` substring.
 	 *
 	 * Pairs with {@see self::get_paginated()} to drive the list table

--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -426,6 +426,8 @@ class RecruitmentCandidateRepository {
 			return false;
 		}
 
+		do_action( 'ffc_recruitment_public_cache_dirty' );
+
 		return (int) $wpdb->insert_id;
 	}
 
@@ -482,6 +484,10 @@ class RecruitmentCandidateRepository {
 
 		static::cache_delete( "id_{$id}" );
 
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
 		return false !== $result;
 	}
 
@@ -535,6 +541,10 @@ class RecruitmentCandidateRepository {
 		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 
 		static::cache_delete( "id_{$id}" );
+
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
 
 		return false !== $result;
 	}

--- a/includes/recruitment/class-ffc-recruitment-candidates-list-table.php
+++ b/includes/recruitment/class-ffc-recruitment-candidates-list-table.php
@@ -252,14 +252,21 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$search = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['s'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$adjutancy_id = isset( $_REQUEST['adjutancy_id'] ) ? absint( wp_unslash( (string) $_REQUEST['adjutancy_id'] ) ) : 0;
 
 		$per_page     = $this->get_items_per_page( 'ffc_recruitment_candidates_per_page', self::DEFAULT_PER_PAGE );
 		$per_page     = min( max( 1, $per_page ), self::MAX_PER_PAGE );
 		$current_page = max( 1, $this->get_pagenum() );
 		$offset       = ( $current_page - 1 ) * $per_page;
 
-		$total_items = RecruitmentCandidateRepository::count_paginated( $search );
-		$raw_rows    = RecruitmentCandidateRepository::get_paginated( $search, $per_page, $offset );
+		if ( $adjutancy_id > 0 ) {
+			$total_items = RecruitmentCandidateRepository::count_paginated_for_adjutancy( $search, $adjutancy_id );
+			$raw_rows    = RecruitmentCandidateRepository::get_paginated_for_adjutancy( $search, $adjutancy_id, $per_page, $offset );
+		} else {
+			$total_items = RecruitmentCandidateRepository::count_paginated( $search );
+			$raw_rows    = RecruitmentCandidateRepository::get_paginated( $search, $per_page, $offset );
+		}
 
 		$this->items = array_map( array( self::class, 'convert_row' ), $raw_rows );
 		$this->set_pagination_args(
@@ -288,10 +295,28 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 		$cpf = isset( $_REQUEST['cpf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['cpf'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$rf = isset( $_REQUEST['rf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['rf'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$adjutancy_id = isset( $_REQUEST['adjutancy_id'] ) ? absint( wp_unslash( (string) $_REQUEST['adjutancy_id'] ) ) : 0;
 
 		echo '<div class="alignleft actions">';
 		echo '<input type="text" name="cpf" value="' . esc_attr( $cpf ) . '" placeholder="' . esc_attr__( 'CPF (digits only)', 'ffcertificate' ) . '" size="15">';
 		echo ' <input type="text" name="rf" value="' . esc_attr( $rf ) . '" placeholder="' . esc_attr__( 'RF (digits only)', 'ffcertificate' ) . '" size="10">';
+
+		// Adjutancy dropdown — limits the result set to candidates with at
+		// least one classification in the selected adjutancy. Independent
+		// of the CPF/RF lookup, which short-circuits everything else.
+		$adjutancies = RecruitmentAdjutancyRepository::get_all();
+		if ( ! empty( $adjutancies ) ) {
+			echo ' <select name="adjutancy_id">';
+			echo '<option value="0">' . esc_html__( 'All adjutancies', 'ffcertificate' ) . '</option>';
+			foreach ( $adjutancies as $a ) {
+				$id_int      = (int) $a->id;
+				$is_selected = $id_int === $adjutancy_id ? ' selected' : '';
+				echo '<option value="' . esc_attr( (string) $id_int ) . '"' . esc_attr( $is_selected ) . '>' . esc_html( (string) $a->name ) . '</option>';
+			}
+			echo '</select>';
+		}
+
 		echo ' <input type="submit" class="button" value="' . esc_attr__( 'Filter', 'ffcertificate' ) . '">';
 		echo '</div>';
 	}

--- a/includes/recruitment/class-ffc-recruitment-classification-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-repository.php
@@ -293,6 +293,8 @@ class RecruitmentClassificationRepository {
 			return false;
 		}
 
+		do_action( 'ffc_recruitment_public_cache_dirty' );
+
 		return (int) $wpdb->insert_id;
 	}
 
@@ -332,7 +334,12 @@ class RecruitmentClassificationRepository {
 
 		static::cache_delete( "id_{$id}" );
 
-		return is_int( $affected ) ? $affected : 0;
+		$rows = is_int( $affected ) ? $affected : 0;
+		if ( $rows > 0 ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $rows;
 	}
 
 	/**
@@ -362,7 +369,12 @@ class RecruitmentClassificationRepository {
 			array( '%d', '%s' )
 		);
 
-		return is_int( $result ) ? $result : 0;
+		$rows = is_int( $result ) ? $result : 0;
+		if ( $rows > 0 ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $rows;
 	}
 
 	/**
@@ -383,6 +395,10 @@ class RecruitmentClassificationRepository {
 		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 
 		static::cache_delete( "id_{$id}" );
+
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
 
 		return false !== $result;
 	}

--- a/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-adjutancy-repository.php
@@ -70,7 +70,12 @@ class RecruitmentNoticeAdjutancyRepository {
 			array( '%d', '%d' )
 		);
 
-		return false !== $result && $result > 0;
+		$ok = false !== $result && $result > 0;
+		if ( $ok ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $ok;
 	}
 
 	/**
@@ -99,7 +104,12 @@ class RecruitmentNoticeAdjutancyRepository {
 			array( '%d', '%d' )
 		);
 
-		return false !== $result && $result > 0;
+		$ok = false !== $result && $result > 0;
+		if ( $ok ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $ok;
 	}
 
 	/**
@@ -185,6 +195,11 @@ class RecruitmentNoticeAdjutancyRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk delete; bounded by per-notice cardinality.
 		$result = $wpdb->delete( $table, array( 'notice_id' => $notice_id ), array( '%d' ) );
 
-		return is_int( $result ) ? $result : 0;
+		$rows = is_int( $result ) ? $result : 0;
+		if ( $rows > 0 ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $rows;
 	}
 }

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
@@ -212,15 +212,94 @@ final class RecruitmentNoticeEditPage {
 		echo '<tr><th><label for="ffc-notice-name">' . esc_html__( 'Name', 'ffcertificate' ) . '</label></th>';
 		echo '<td><input id="ffc-notice-name" type="text" class="regular-text" name="name" value="' . esc_attr( (string) $notice->name ) . '" required></td></tr>';
 
-		echo '<tr><th><label for="ffc-notice-pcc">' . esc_html__( 'public_columns_config (JSON)', 'ffcertificate' ) . '</label></th>';
-		echo '<td><textarea id="ffc-notice-pcc" name="public_columns_config" rows="6" class="large-text code">' . esc_textarea( (string) $notice->public_columns_config ) . '</textarea>';
-		echo '<p class="description">' . esc_html__( 'Per-notice column visibility for [ffc_recruitment_queue]. `rank` and `name` are mandatory; setting them to false rejects the save.', 'ffcertificate' ) . '</p></td></tr>';
+		echo '<tr><th>' . esc_html__( 'Public columns', 'ffcertificate' ) . '</th>';
+		echo '<td>' . self::render_columns_toggles( (string) $notice->public_columns_config );
+		echo '<p class="description">' . esc_html__( 'Toggle which columns the public shortcode renders. Rank and Name are mandatory and cannot be turned off.', 'ffcertificate' ) . '</p></td></tr>';
 
 		echo '</tbody></table>';
 		submit_button( __( 'Save general', 'ffcertificate' ) );
 		echo '</form>';
 
 		echo '</div></div>';
+	}
+
+	/**
+	 * Render the public_columns_config field as a grid of on/off
+	 * checkboxes (one per supported column). The mandatory columns
+	 * (rank, name) render as disabled checkboxes pre-checked + a
+	 * hidden input with `value=1` so they always survive the save —
+	 * disabled inputs don't post their value, but a sibling hidden
+	 * field with the same name keeps the boolean true on the server.
+	 *
+	 * Stored as the same JSON shape `parse_columns_config()` already
+	 * consumes, so the public shortcode side needs no change.
+	 *
+	 * @param string $current_json Stored `public_columns_config` JSON.
+	 * @return string
+	 */
+	private static function render_columns_toggles( string $current_json ): string {
+		$labels = self::columns_label_map();
+
+		$decoded = json_decode( $current_json, true );
+		$decoded = is_array( $decoded ) ? $decoded : array();
+		/**
+		 * Defaults from the repository so a brand-new notice with an
+		 * empty/invalid stored config still renders the canonical "on"
+		 * set instead of every checkbox unchecked.
+		 *
+		 * @var array<string,bool> $defaults
+		 */
+		$defaults = (array) json_decode( RecruitmentNoticeRepository::DEFAULT_PUBLIC_COLUMNS_CONFIG, true );
+		$state    = array_merge( $defaults, $decoded );
+
+		$mandatory = array( 'rank', 'name' );
+
+		$html = '<div class="ffc-recruitment-columns-toggles" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:6px 16px;">';
+		foreach ( $labels as $key => $label ) {
+			$is_mandatory = in_array( $key, $mandatory, true );
+			$checked      = $is_mandatory || ! empty( $state[ $key ] );
+			$id_attr      = 'ffc-notice-pcc-' . $key;
+			$html        .= '<label for="' . esc_attr( $id_attr ) . '" style="display:flex;align-items:center;gap:6px;">';
+			if ( $is_mandatory ) {
+				// Disabled checkboxes don't post; a hidden sibling pins
+				// the value=1 so the save handler always sees the
+				// mandatory column as on.
+				$html .= '<input type="hidden" name="public_columns[' . esc_attr( $key ) . ']" value="1">';
+				$html .= '<input id="' . esc_attr( $id_attr ) . '" type="checkbox" checked disabled aria-disabled="true">';
+			} else {
+				$html .= '<input id="' . esc_attr( $id_attr ) . '" type="checkbox" name="public_columns[' . esc_attr( $key ) . ']" value="1"' . ( $checked ? ' checked' : '' ) . '>';
+			}
+			$html .= esc_html( $label );
+			if ( $is_mandatory ) {
+				$html .= ' <em style="color:#646970;font-size:11px;">(' . esc_html__( 'mandatory', 'ffcertificate' ) . ')</em>';
+			}
+			$html .= '</label>';
+		}
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Display labels for every column the public shortcode supports.
+	 * The order here drives the order the toggles render in the grid.
+	 *
+	 * @return array<string,string>
+	 */
+	private static function columns_label_map(): array {
+		return array(
+			'rank'           => __( 'Rank', 'ffcertificate' ),
+			'name'           => __( 'Name', 'ffcertificate' ),
+			'adjutancy'      => __( 'Adjutancy', 'ffcertificate' ),
+			'status'         => __( 'Status', 'ffcertificate' ),
+			'pcd_badge'      => __( 'PCD badge', 'ffcertificate' ),
+			'date_to_assume' => __( 'Date to assume', 'ffcertificate' ),
+			'time_to_assume' => __( 'Time to assume', 'ffcertificate' ),
+			'score'          => __( 'Score', 'ffcertificate' ),
+			'cpf_masked'     => __( 'CPF (masked)', 'ffcertificate' ),
+			'rf_masked'      => __( 'RF (masked)', 'ffcertificate' ),
+			'email_masked'   => __( 'Email (masked)', 'ffcertificate' ),
+		);
 	}
 
 	/**
@@ -842,27 +921,30 @@ final class RecruitmentNoticeEditPage {
 			exit;
 		}
 
-		$name   = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['name'] ) ) : '';
-		$config = isset( $_POST['public_columns_config'] ) ? wp_unslash( (string) $_POST['public_columns_config'] ) : '';
+		$name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['name'] ) ) : '';
 
-		// Validate the public_columns_config JSON. `rank` and `name` are
-		// mandatory true per §3.2 — the repository's update layer doesn't
-		// enforce that, so the UI guard does.
-		$decoded = json_decode( $config, true );
-		if ( is_array( $decoded ) ) {
-			if ( array_key_exists( 'rank', $decoded ) && false === $decoded['rank'] ) {
-				self::redirect_with_notice( $notice_id, 'rank-mandatory' );
-			}
-			if ( array_key_exists( 'name', $decoded ) && false === $decoded['name'] ) {
-				self::redirect_with_notice( $notice_id, 'name-mandatory' );
-			}
+		// Build the JSON config from the checkbox grid. Every key in
+		// columns_label_map() emits an entry; unchecked checkboxes don't
+		// POST so we treat them as `false`, while the mandatory columns
+		// (rank, name) ride on hidden value=1 inputs that always post.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified above via check_admin_referer.
+		$posted = isset( $_POST['public_columns'] ) && is_array( $_POST['public_columns'] )
+			? wp_unslash( $_POST['public_columns'] )
+			: array();
+		$labels = self::columns_label_map();
+		$built  = array();
+		foreach ( array_keys( $labels ) as $key ) {
+			$built[ $key ] = isset( $posted[ $key ] ) && '' !== (string) $posted[ $key ];
 		}
+		$built['rank'] = true;
+		$built['name'] = true;
+		$config        = wp_json_encode( $built );
 
 		RecruitmentNoticeRepository::update(
 			$notice_id,
 			array(
 				'name'                  => $name,
-				'public_columns_config' => $config,
+				'public_columns_config' => is_string( $config ) ? $config : '{}',
 			)
 		);
 

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
@@ -664,7 +664,17 @@ final class RecruitmentNoticeEditPage {
 		foreach ( $rows as $row ) {
 			$candidate_name = $candidates[ (int) $row->candidate_id ] ?? '#' . (int) $row->candidate_id;
 			$adjutancy_slug = $adjutancies[ (int) $row->adjutancy_id ] ?? '#' . (int) $row->adjutancy_id;
-			echo '<tr>';
+			// data-cls-* attributes drive the out-of-order detection in
+			// render_classification_actions_script(): the JS scans all
+			// rows to compute the lowest-rank `empty` row per adjutancy
+			// and flags clicks/bulk-selects that skip ahead of it.
+			printf(
+				'<tr data-cls-id="%d" data-cls-rank="%d" data-cls-adjutancy="%s" data-cls-status="%s">',
+				(int) $row->id,
+				(int) $row->rank,
+				esc_attr( (string) $adjutancy_slug ),
+				esc_attr( (string) $row->status )
+			);
 			if ( $with_actions ) {
 				// Only `empty` rows can be bulk-called (the §5.2
 				// state-machine guard rejects everything else with
@@ -785,13 +795,32 @@ final class RecruitmentNoticeEditPage {
 	 * @return void
 	 */
 	private static function render_classification_actions_script(): void {
-		$nonce        = wp_create_nonce( 'wp_rest' );
-		$call_url     = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/classifications/' ) );
-		$bulk_url     = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/classifications/bulk-call' ) );
-		$bulk_no_sel  = esc_js( __( 'Select at least one row first.', 'ffcertificate' ) );
-		$bulk_no_date = esc_js( __( 'Date and time are required for bulk call.', 'ffcertificate' ) );
+		$nonce              = wp_create_nonce( 'wp_rest' );
+		$call_url           = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/classifications/' ) );
+		$bulk_url           = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/classifications/bulk-call' ) );
+		$bulk_no_sel        = esc_js( __( 'Select at least one row first.', 'ffcertificate' ) );
+		$bulk_no_date       = esc_js( __( 'Date and time are required for bulk call.', 'ffcertificate' ) );
+		$confirm_ooo_single = esc_js( __( 'This call would skip a higher-ranked candidate (out of order). Continue?', 'ffcertificate' ) );
+		$prompt_ooo_reason  = esc_js( __( 'Justification for calling out of order (required):', 'ffcertificate' ) );
+		$confirm_ooo_bulk   = esc_js( __( 'One or more selected rows would skip a higher-ranked candidate (out of order). Continue?', 'ffcertificate' ) );
+		$reason_required    = esc_js( __( 'A justification is required to proceed.', 'ffcertificate' ) );
 
 		echo '<script>'
+			// Compute the lowest-rank `empty` row per adjutancy from the
+			// rendered DOM. Used by both the single-row Call handler and
+			// the bulk-call handler to detect skips before any prompt.
+			. 'function ffcRecruitmentLowestEmpty(){'
+			. 'var rows=document.querySelectorAll("tr[data-cls-id]");'
+			. 'var lowest={};'
+			. 'for(var i=0;i<rows.length;i++){'
+			. 'var tr=rows[i];'
+			. 'if(tr.getAttribute("data-cls-status")!=="empty")continue;'
+			. 'var adj=tr.getAttribute("data-cls-adjutancy");'
+			. 'var rank=parseInt(tr.getAttribute("data-cls-rank"),10);'
+			. 'if(!lowest[adj]||rank<lowest[adj]){lowest[adj]=rank;}'
+			. '}'
+			. 'return lowest;'
+			. '}'
 			// Bulk-call helpers — toggle-all + submit handler.
 			. 'function ffcRecruitmentClsToggleAll(cb){'
 			. 'var boxes=document.querySelectorAll(".ffc-cls-bulk-cb:not([disabled])");'
@@ -805,11 +834,34 @@ final class RecruitmentNoticeEditPage {
 			. 'var ids=[];var boxes=document.querySelectorAll(".ffc-cls-bulk-cb:checked");'
 			. 'for(var i=0;i<boxes.length;i++){ids.push(parseInt(boxes[i].value,10));}'
 			. 'if(ids.length===0){status.textContent="' . esc_attr( $bulk_no_sel ) . '";return;}'
+			// Out-of-order detection: any selected id whose rank > the
+			// lowest-empty-rank in the same adjutancy means the bulk
+			// would skip someone. Build the reasons map upfront if so —
+			// the user supplies one shared justification that we apply
+			// to every selected id (server ignores it for in-order ids).
+			. 'var lowest=ffcRecruitmentLowestEmpty();'
+			. 'var anyOoO=false;'
+			. 'for(var j=0;j<ids.length;j++){'
+			. 'var tr=document.querySelector(\'tr[data-cls-id="\'+ids[j]+\'"]\');'
+			. 'if(!tr)continue;'
+			. 'var rank=parseInt(tr.getAttribute("data-cls-rank"),10);'
+			. 'var adj=tr.getAttribute("data-cls-adjutancy");'
+			. 'if(lowest[adj]&&rank>lowest[adj]){anyOoO=true;break;}'
+			. '}'
+			. 'var reasons={};'
+			. 'if(anyOoO){'
+			. 'if(!confirm("' . esc_attr( $confirm_ooo_bulk ) . '"))return;'
+			. 'var sharedReason=prompt("' . esc_attr( $prompt_ooo_reason ) . '");'
+			. 'if(!sharedReason||!sharedReason.trim()){alert("' . esc_attr( $reason_required ) . '");return;}'
+			. 'for(var k=0;k<ids.length;k++){reasons[String(ids[k])]=sharedReason;}'
+			. '}'
 			. 'status.textContent="…";'
+			. 'var bulkPayload={classification_ids:ids,date_to_assume:date,time_to_assume:time};'
+			. 'if(anyOoO){bulkPayload.out_of_order_reasons=reasons;}'
 			. 'fetch("' . esc_js( $bulk_url ) . '",{'
 			. 'method:"POST",'
 			. 'headers:{"X-WP-Nonce":"' . esc_js( $nonce ) . '","Content-Type":"application/json"},'
-			. 'body:JSON.stringify({classification_ids:ids,date_to_assume:date,time_to_assume:time}),'
+			. 'body:JSON.stringify(bulkPayload),'
 			. 'credentials:"same-origin"'
 			. '}).then(function(r){return r.json().then(function(d){return{status:r.status,body:d};});}).then(function(o){'
 			. 'if(o.status>=200&&o.status<300){location.reload();}'
@@ -824,11 +876,27 @@ final class RecruitmentNoticeEditPage {
 			. 'var base="' . esc_js( $call_url ) . '";'
 			. 'var url,init;'
 			. 'if(action==="call"){'
+			// Out-of-order is detected BEFORE asking date/time so the
+			// admin sees the warning/justification step at the top of
+			// the flow rather than after committing to a schedule.
+			. 'var oooReason="";'
+			. 'var tr=document.querySelector(\'tr[data-cls-id="\'+id+\'"]\');'
+			. 'if(tr){'
+			. 'var rank=parseInt(tr.getAttribute("data-cls-rank"),10);'
+			. 'var adj=tr.getAttribute("data-cls-adjutancy");'
+			. 'var lowest=ffcRecruitmentLowestEmpty();'
+			. 'if(lowest[adj]&&rank>lowest[adj]){'
+			. 'if(!confirm("' . esc_attr( $confirm_ooo_single ) . '"))return;'
+			. 'oooReason=prompt("' . esc_attr( $prompt_ooo_reason ) . '")||"";'
+			. 'if(!oooReason.trim()){alert("' . esc_attr( $reason_required ) . '");return;}'
+			. '}'
+			. '}'
 			. 'var date=prompt("' . esc_js( __( 'Date to assume (YYYY-MM-DD):', 'ffcertificate' ) ) . '");'
 			. 'if(!date)return;'
 			. 'var time=prompt("' . esc_js( __( 'Time to assume (HH:MM):', 'ffcertificate' ) ) . '");'
 			. 'if(!time)return;'
 			. 'var fd=new FormData();fd.append("date_to_assume",date);fd.append("time_to_assume",time);'
+			. 'if(oooReason)fd.append("out_of_order_reason",oooReason);'
 			. 'url=base+id+"/call";init={method:"POST",headers:{"X-WP-Nonce":nonce},body:fd,credentials:"same-origin"};'
 			. '}else if(action==="cancel"){'
 			. 'var reason=prompt("' . esc_js( __( 'Cancellation reason (required):', 'ffcertificate' ) ) . '");'

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
@@ -213,6 +213,7 @@ final class RecruitmentNoticeEditPage {
 		echo '<td><input id="ffc-notice-name" type="text" class="regular-text" name="name" value="' . esc_attr( (string) $notice->name ) . '" required></td></tr>';
 
 		echo '<tr><th>' . esc_html__( 'Public columns', 'ffcertificate' ) . '</th>';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_columns_toggles() returns already-escaped HTML.
 		echo '<td>' . self::render_columns_toggles( (string) $notice->public_columns_config );
 		echo '<p class="description">' . esc_html__( 'Toggle which columns the public shortcode renders. Rank and Name are mandatory and cannot be turned off.', 'ffcertificate' ) . '</p></td></tr>';
 

--- a/includes/recruitment/class-ffc-recruitment-notice-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-repository.php
@@ -211,6 +211,8 @@ class RecruitmentNoticeRepository {
 			return false;
 		}
 
+		do_action( 'ffc_recruitment_public_cache_dirty' );
+
 		return (int) $wpdb->insert_id;
 	}
 
@@ -261,6 +263,10 @@ class RecruitmentNoticeRepository {
 
 		static::cache_delete( "id_{$id}" );
 
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
 		return false !== $result;
 	}
 
@@ -299,7 +305,12 @@ class RecruitmentNoticeRepository {
 
 		static::cache_delete( "id_{$id}" );
 
-		return is_int( $affected ) ? $affected : 0;
+		$rows = is_int( $affected ) ? $affected : 0;
+		if ( $rows > 0 ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
+
+		return $rows;
 	}
 
 	/**
@@ -420,6 +431,10 @@ class RecruitmentNoticeRepository {
 		$result = $wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 
 		static::cache_delete( "id_{$id}" );
+
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+		}
 
 		return false !== $result;
 	}

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -268,7 +268,7 @@ final class RecruitmentPublicShortcode {
 			$needle = function_exists( 'mb_strtolower' )
 				? mb_strtolower( $name_query, 'UTF-8' )
 				: strtolower( $name_query );
-			$rows = array_values(
+			$rows   = array_values(
 				array_filter(
 					$rows,
 					static function ( $row ) use ( $needle ): bool {

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -8,12 +8,12 @@
  *
  * Notice-status branching:
  *
- *   - `draft`       → error message "Edital ainda não publicado.";
- *   - `preliminary` → warning-only render — "Esta lista está em revisão";
+ *   - `draft`       → error message "Notice not yet published.";
+ *   - `preliminary` → warning-only render — "This list is under review";
  *                     no listing exposed (preview rows never render publicly).
- *   - `definitive` → two-section layout (não chamados / chamados) of the
+ *   - `definitive` → two-section layout (waiting / called) of the
  *                     `list_type='definitive'` rows; no banner.
- *   - `closed`      → same listing + a "Edital encerrado" banner.
+ *   - `closed`      → same listing + a "Notice closed" banner.
  *
  * Column visibility is per-notice via `notice.public_columns_config`
  * (JSON). `rank` and `name` are mandatory; `status` / `pcd_badge` /
@@ -190,8 +190,8 @@ final class RecruitmentPublicShortcode {
 	 *
 	 * @param string $notice_code   User-supplied notice code.
 	 * @param string $slug_filter   User-supplied adjutancy slug filter (may be empty).
-	 * @param int    $page_top      1-indexed page for the "Não chamados" section.
-	 * @param int    $page_bottom   1-indexed page for the "Chamados" section.
+	 * @param int    $page_top      1-indexed page for the "Waiting called" section.
+	 * @param int    $page_bottom   1-indexed page for the "Called" section.
 	 * @param bool   $filter_locked True when the shortcode was called with a fixed
 	 *                              `adjutancy=` attribute — the filter UI is then
 	 *                              suppressed so callers who pinned the adjutancy
@@ -266,7 +266,7 @@ final class RecruitmentPublicShortcode {
 			: self::render_adjutancy_filter( (int) $notice->id );
 
 		$top_section    = self::render_section(
-			__( 'Not yet called', 'ffcertificate' ),
+			__( 'Waiting called', 'ffcertificate' ),
 			$empty_rows,
 			$columns,
 			false,
@@ -298,7 +298,7 @@ final class RecruitmentPublicShortcode {
 	// ─────────────────────────────────────────────────────────────────────
 
 	/**
-	 * Render one of the two sections (não chamados / chamados).
+	 * Render one of the two sections (waiting / called).
 	 *
 	 * @param string             $heading      Section title.
 	 * @param array              $rows         Classification rows in this section (list<ClassificationRow>).
@@ -744,8 +744,8 @@ final class RecruitmentPublicShortcode {
 	 *
 	 * @param string $notice_code   Notice code (case-preserved input).
 	 * @param string $slug_filter   Adjutancy slug filter ('' when no filter).
-	 * @param int    $page_top      Página da seção "Não chamados".
-	 * @param int    $page_bottom   Página da seção "Chamados".
+	 * @param int    $page_top      1-indexed page for the "Waiting called" section.
+	 * @param int    $page_bottom   1-indexed page for the "Called" section.
 	 * @param bool   $filter_locked Whether the shortcode pinned the adjutancy
 	 *                              via attribute (filter UI is suppressed).
 	 * @return string Transient key (under WP's 172-char limit).

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -254,6 +254,13 @@ final class RecruitmentPublicShortcode {
 			}
 		}
 
+		// "Called" rows render newest-first (highest rank at the top of
+		// page 1) so the most recently-called candidates land on the
+		// landing page without forcing a paginate-to-end. The repository
+		// returns rows in `(rank ASC, candidate_id ASC)` per §3, so a
+		// straight reverse is sufficient — no resort needed.
+		$called_rows = array_reverse( $called_rows );
+
 		$settings  = RecruitmentSettings::all();
 		$page_size = (int) $settings['public_default_page_size'];
 

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -585,9 +585,14 @@ final class RecruitmentPublicShortcode {
 				. '</div>';
 		}
 
+		// Banner sits above the notice code/name and both lines render at the
+		// same font size + center alignment. The status callout is the more
+		// load-bearing of the two — it answers "is this list final?" — so
+		// elevating it above the edital identifier keeps the most relevant
+		// signal at the top of the page on mobile/narrow viewports.
 		$head = '<header class="ffc-recruitment-header">'
-			. '<h2>' . esc_html( (string) $notice->code . ' — ' . (string) $notice->name ) . '</h2>'
 			. $banner
+			. '<p class="ffc-recruitment-notice-title">' . esc_html( (string) $notice->code . ' — ' . (string) $notice->name ) . '</p>'
 			. '</header>';
 
 		return $head . $body;

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -135,13 +135,17 @@ final class RecruitmentPublicShortcode {
 		$page_top    = max( 1, (int) ( $_GET['page_top'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_bottom = max( 1, (int) ( $_GET['page_bottom'] ?? 1 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		$cache_key = self::cache_key( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only name filter.
+		$name_query = isset( $_GET['q'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['q'] ) ) : '';
+		$name_query = trim( $name_query );
+
+		$cache_key = self::cache_key( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked, $name_query );
 		$cached    = get_transient( $cache_key );
 		if ( is_string( $cached ) ) {
 			return $cached;
 		}
 
-		$html = self::wrap_output( self::render_uncached( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked ) );
+		$html = self::wrap_output( self::render_uncached( $notice_code, $slug_filter, $page_top, $page_bottom, $filter_locked, $name_query ) );
 
 		$settings = RecruitmentSettings::all();
 		$ttl      = (int) $settings['public_cache_seconds'];
@@ -196,9 +200,11 @@ final class RecruitmentPublicShortcode {
 	 *                              `adjutancy=` attribute — the filter UI is then
 	 *                              suppressed so callers who pinned the adjutancy
 	 *                              cannot be re-routed by URL tampering.
+	 * @param string $name_query    Case-insensitive name substring filter (`?q=`);
+	 *                              empty means "no name filter".
 	 * @return string
 	 */
-	public static function render_uncached( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false ): string {
+	public static function render_uncached( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false, string $name_query = '' ): string {
 		$notice = RecruitmentNoticeRepository::get_by_code( $notice_code );
 		if ( null === $notice ) {
 			return self::msg( __( 'Notice not found.', 'ffcertificate' ), 'error' );
@@ -242,6 +248,40 @@ final class RecruitmentPublicShortcode {
 			);
 		}
 
+		// Apply the public name filter (`?q=`) before splitting into
+		// waiting / called sections so pagination counts in each section
+		// reflect only the matching subset. Filtering is case-insensitive
+		// substring match against `candidate.name`; per-row lookups go
+		// through the repository's object-cache so repeating the lookup in
+		// render_row() later is a cache hit rather than a second SELECT.
+		if ( '' !== $name_query ) {
+			$needle = function_exists( 'mb_strtolower' )
+				? mb_strtolower( $name_query, 'UTF-8' )
+				: strtolower( $name_query );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $needle ): bool {
+						$candidate = RecruitmentCandidateRepository::get_by_id( (int) $row->candidate_id );
+						if ( null === $candidate ) {
+							return false;
+						}
+						$name = (string) ( $candidate->name ?? '' );
+						$hay  = function_exists( 'mb_strtolower' )
+							? mb_strtolower( $name, 'UTF-8' )
+							: strtolower( $name );
+						return false !== strpos( $hay, $needle );
+					}
+				)
+			);
+		}
+
+		if ( empty( $rows ) ) {
+			$body = self::render_filters_bar( $notice, $filter_locked, $name_query )
+				. self::msg( __( 'No matches for the current search.', 'ffcertificate' ), 'info' );
+			return self::wrap_with_banner( $notice, $body );
+		}
+
 		$columns = self::parse_columns_config( $notice->public_columns_config );
 
 		$empty_rows  = array();
@@ -264,13 +304,7 @@ final class RecruitmentPublicShortcode {
 		$settings  = RecruitmentSettings::all();
 		$page_size = (int) $settings['public_default_page_size'];
 
-		// Render the filter dropdown unless the shortcode itself pinned an
-		// adjutancy via attribute. Keeping the dropdown rendered when a URL
-		// filter is active is intentional: visitors must always be able to
-		// switch back to "All" or to a different adjutancy from the same UI.
-		$adjutancy_filter_html = $filter_locked
-			? ''
-			: self::render_adjutancy_filter( (int) $notice->id );
+		$filters_bar = self::render_filters_bar( $notice, $filter_locked, $name_query );
 
 		$top_section    = self::render_section(
 			__( 'Waiting called', 'ffcertificate' ),
@@ -292,7 +326,7 @@ final class RecruitmentPublicShortcode {
 		);
 
 		$body = '<div class="ffc-recruitment-queue">'
-			. $adjutancy_filter_html
+			. $filters_bar
 			. $top_section
 			. $bottom_section
 			. '</div>';
@@ -451,13 +485,75 @@ final class RecruitmentPublicShortcode {
 	}
 
 	/**
-	 * Build the adjutancy filter HTML when the notice has 2+ adjutancies
-	 * AND the shortcode wasn't called with a fixed `adjutancy=` attr.
+	 * Render the search/filter bar that sits above the listings.
+	 *
+	 * Combines the adjutancy dropdown (already a no-op when fewer than 2
+	 * adjutancies are attached or when the shortcode pinned the adjutancy
+	 * via attribute) with the name search input. Both controls share a
+	 * single <form> so a name search keeps the active adjutancy filter
+	 * and vice-versa — submitting one preserves the other in the URL.
+	 *
+	 * @param object $notice        Notice row (NoticeRow shape).
+	 * @phpstan-param NoticeRow $notice
+	 * @param bool   $filter_locked Whether the shortcode pinned the adjutancy.
+	 * @param string $name_query    Current `?q=` value (echoed back into the input).
+	 * @return string
+	 */
+	private static function render_filters_bar( object $notice, bool $filter_locked, string $name_query ): string {
+		$adjutancy_html = $filter_locked ? '' : self::render_adjutancy_filter_inputs( (int) $notice->id );
+		$search_html    = self::render_name_search_input( $name_query );
+
+		if ( '' === $adjutancy_html && '' === $search_html ) {
+			return '';
+		}
+
+		// Re-emit every other GET param so submitting either control
+		// doesn't strip notice/page state.
+		$preserved = '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only re-emission of caller's params.
+		foreach ( (array) $_GET as $key => $value ) {
+			$key_str = (string) $key;
+			if ( in_array( $key_str, array( 'adjutancy', 'q' ), true ) ) {
+				continue;
+			}
+			$preserved .= '<input type="hidden" name="' . esc_attr( $key_str ) . '" value="' . esc_attr( wp_unslash( (string) $value ) ) . '">';
+		}
+
+		return '<form class="ffc-recruitment-filters" method="get">'
+			. $preserved
+			. $adjutancy_html
+			. $search_html
+			. '</form>';
+	}
+
+	/**
+	 * Render the name-search input. Always rendered (even when no
+	 * candidates are visible) so visitors can clear or change the
+	 * search from the same control. Submission relies on the wrapping
+	 * <form> from {@see self::render_filters_bar()}.
+	 *
+	 * @param string $name_query Current `?q=` value.
+	 * @return string
+	 */
+	private static function render_name_search_input( string $name_query ): string {
+		$html  = '<label class="ffc-recruitment-name-search">';
+		$html .= esc_html__( 'Search by name:', 'ffcertificate' ) . ' ';
+		$html .= '<input type="search" name="q" value="' . esc_attr( $name_query ) . '" placeholder="' . esc_attr__( 'name…', 'ffcertificate' ) . '">';
+		$html .= ' <button type="submit">' . esc_html__( 'Search', 'ffcertificate' ) . '</button>';
+		$html .= '</label>';
+		return $html;
+	}
+
+	/**
+	 * Build only the adjutancy <label>+<select> portion of the filter
+	 * bar (no wrapping <form> — the caller in
+	 * {@see self::render_filters_bar()} owns the form). Empty string
+	 * when fewer than 2 adjutancies are attached.
 	 *
 	 * @param int $notice_id Notice ID.
 	 * @return string
 	 */
-	private static function render_adjutancy_filter( int $notice_id ): string {
+	private static function render_adjutancy_filter_inputs( int $notice_id ): string {
 		$ids = RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( $notice_id );
 		if ( count( $ids ) < 2 ) {
 			return '';
@@ -478,25 +574,15 @@ final class RecruitmentPublicShortcode {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display state.
 		$selected = isset( $_GET['adjutancy'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['adjutancy'] ) ) : '';
 
-		$html = '<form class="ffc-recruitment-adjutancy-filter" method="get">';
-		// Preserve every other GET param (notice, page_top, page_bottom)
-		// so submitting the dropdown doesn't drop them.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only re-emission of caller's params.
-		foreach ( (array) $_GET as $key => $value ) {
-			$key_str = (string) $key;
-			if ( 'adjutancy' === $key_str ) {
-				continue;
-			}
-			$html .= '<input type="hidden" name="' . esc_attr( $key_str ) . '" value="' . esc_attr( wp_unslash( (string) $value ) ) . '">';
-		}
-		$html .= '<label>' . esc_html__( 'Filter by adjutancy:', 'ffcertificate' ) . ' ';
+		$html  = '<label class="ffc-recruitment-adjutancy-filter">';
+		$html .= esc_html__( 'Filter by adjutancy:', 'ffcertificate' ) . ' ';
 		$html .= '<select name="adjutancy" onchange="this.form.submit()">';
 		$html .= '<option value="">' . esc_html__( 'All', 'ffcertificate' ) . '</option>';
 		foreach ( $adjutancies as $a ) {
 			$is_selected = (string) $a->slug === $selected ? ' selected' : '';
 			$html       .= '<option value="' . esc_attr( (string) $a->slug ) . '"' . $is_selected . '>' . esc_html( (string) $a->name ) . '</option>';
 		}
-		$html .= '</select></label></form>';
+		$html .= '</select></label>';
 
 		return $html;
 	}
@@ -760,11 +846,12 @@ final class RecruitmentPublicShortcode {
 	 * @param int    $page_bottom   1-indexed page for the "Called" section.
 	 * @param bool   $filter_locked Whether the shortcode pinned the adjutancy
 	 *                              via attribute (filter UI is suppressed).
+	 * @param string $name_query    Lowercased name-search filter ('' when none).
 	 * @return string Transient key (under WP's 172-char limit).
 	 */
-	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false ): string {
+	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false, string $name_query = '' ): string {
 		return self::CACHE_PREFIX . md5(
-			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom . '|' . ( $filter_locked ? '1' : '0' )
+			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom . '|' . ( $filter_locked ? '1' : '0' ) . '|' . strtolower( $name_query )
 		);
 	}
 

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode.php
@@ -71,6 +71,15 @@ final class RecruitmentPublicShortcode {
 	private const RATE_PREFIX = 'ffc_recruitment_public_rate_';
 
 	/**
+	 * Versioned cache option. Bumped by {@see self::invalidate_public_cache()}
+	 * on every admin write that affects the public listing; included in
+	 * the cache_key hash so a single increment atomically retires every
+	 * existing transient (the keys simply no longer match anything looked
+	 * up after the bump).
+	 */
+	private const CACHE_VERSION_OPTION = 'ffc_recruitment_public_cache_version';
+
+	/**
 	 * Register the shortcode.
 	 *
 	 * Hooked from {@see RecruitmentLoader::init()} on `init` (priority 10:
@@ -80,6 +89,7 @@ final class RecruitmentPublicShortcode {
 	 */
 	public static function register(): void {
 		add_shortcode( self::SHORTCODE_TAG, array( self::class, 'render' ) );
+		add_action( self::CACHE_DIRTY_ACTION, array( self::class, 'invalidate_public_cache' ) );
 	}
 
 	/**
@@ -850,9 +860,41 @@ final class RecruitmentPublicShortcode {
 	 * @return string Transient key (under WP's 172-char limit).
 	 */
 	private static function cache_key( string $notice_code, string $slug_filter, int $page_top, int $page_bottom, bool $filter_locked = false, string $name_query = '' ): string {
+		$version = (int) get_option( self::CACHE_VERSION_OPTION, 0 );
 		return self::CACHE_PREFIX . md5(
-			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom . '|' . ( $filter_locked ? '1' : '0' ) . '|' . strtolower( $name_query )
+			strtoupper( $notice_code ) . '|' . $slug_filter . '|' . $page_top . '|' . $page_bottom . '|' . ( $filter_locked ? '1' : '0' ) . '|' . strtolower( $name_query ) . '|v' . $version
 		);
+	}
+
+	/**
+	 * Action hook fired by repositories whenever data the public listing
+	 * renders is mutated (notices, classifications, candidates,
+	 * adjutancies, calls, notice↔adjutancy attachments). The shortcode
+	 * subscribes via {@see self::register()} so a single hook firing
+	 * invalidates every cached render without each repository having
+	 * to reach into the shortcode class directly.
+	 */
+	public const CACHE_DIRTY_ACTION = 'ffc_recruitment_public_cache_dirty';
+
+	/**
+	 * Invalidate every cached public-shortcode render in one shot.
+	 *
+	 * Bumps a monotonic version counter folded into {@see self::cache_key()};
+	 * every transient written under the previous version is implicitly
+	 * orphaned (lookups under the new version miss and re-render fresh).
+	 * The orphaned transients still expire under their own TTL — no
+	 * sweep needed.
+	 *
+	 * Wired to {@see self::CACHE_DIRTY_ACTION} from {@see self::register()}.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_public_cache(): void {
+		$current = (int) get_option( self::CACHE_VERSION_OPTION, 0 );
+		// Wrap around at PHP_INT_MAX is theoretical here — even at one
+		// bump per second it would take ~292 billion years to overflow —
+		// but the modulo guards against accidental misconfiguration.
+		update_option( self::CACHE_VERSION_OPTION, ( $current + 1 ) % PHP_INT_MAX, false );
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-settings.php
+++ b/includes/recruitment/class-ffc-recruitment-settings.php
@@ -108,7 +108,12 @@ final class RecruitmentSettings {
 			'email_from_address'           => '',
 			'email_from_name'              => '',
 			'email_body_html'              => self::default_body_template(),
-			'public_cache_seconds'         => 60,
+			// 12h default: the public listing only changes when admins
+			// edit a notice/classification/candidate/adjutancy/call, and
+			// every such write hits the cache invalidator on the public
+			// shortcode — so a long TTL is safe. The Settings tab still
+			// exposes the value for per-deploy overrides.
+			'public_cache_seconds'         => 12 * HOUR_IN_SECONDS,
 			'public_rate_limit_per_minute' => 30,
 			'public_default_page_size'     => 50,
 			// Status-badge colors on the public shortcode. Each value is

--- a/tests/Unit/RecruitmentSettingsTest.php
+++ b/tests/Unit/RecruitmentSettingsTest.php
@@ -54,8 +54,9 @@ class RecruitmentSettingsTest extends TestCase {
 	public function test_defaults_match_plan_documented_values(): void {
 		$defaults = RecruitmentSettings::defaults();
 
-		// Per §15 of the plan.
-		$this->assertSame( 60, $defaults['public_cache_seconds'] );
+		// 12 hours per the v6.1 polish PR (cache invalidation now hooks
+		// every admin write, so the long TTL is safe).
+		$this->assertSame( 12 * HOUR_IN_SECONDS, $defaults['public_cache_seconds'] );
 		$this->assertSame( 30, $defaults['public_rate_limit_per_minute'] );
 		$this->assertSame( 50, $defaults['public_default_page_size'] );
 		$this->assertSame( '', $defaults['email_from_address'] );
@@ -67,7 +68,7 @@ class RecruitmentSettingsTest extends TestCase {
 
 		$all = RecruitmentSettings::all();
 
-		$this->assertSame( 60, $all['public_cache_seconds'] );
+		$this->assertSame( 12 * HOUR_IN_SECONDS, $all['public_cache_seconds'] );
 		$this->assertSame( 30, $all['public_rate_limit_per_minute'] );
 		$this->assertSame( 50, $all['public_default_page_size'] );
 	}
@@ -105,7 +106,7 @@ class RecruitmentSettingsTest extends TestCase {
 
 		$out = RecruitmentSettings::sanitize( array( 'public_cache_seconds' => -5 ) );
 
-		$this->assertSame( 60, $out['public_cache_seconds'], 'Negative input falls back to default per the clamp.' );
+		$this->assertSame( 12 * HOUR_IN_SECONDS, $out['public_cache_seconds'], 'Negative input falls back to default per the clamp.' );
 	}
 
 	public function test_sanitize_caps_oversized_cache_seconds(): void {

--- a/uninstall.php
+++ b/uninstall.php
@@ -90,6 +90,8 @@ $ffcertificate_options = array(
 	'ffc_migration_user_profiles_last_run',
 	// Recruitment module (v6.0.0).
 	'ffc_recruitment_settings',
+	'ffc_recruitment_schema_version',
+	'ffc_recruitment_public_cache_version',
 );
 
 foreach ( $ffcertificate_options as $ffcertificate_option ) {


### PR DESCRIPTION
## Summary

Eight commits, one per discrete change, addressing the recruitment polish punchlist:

### Public shortcode (`[ffc_recruitment_queue]`)

- **i18n sweep + label rename.** "Not yet called" → "Waiting called". Cleared stray pt-BR strings from docstrings (`matérias`, `Edital encerrado`, `não chamados / chamados`) so localizers translate from a single English source.
- **Banner above title (2a).** Status callout (preliminary / final / closed) renders on top, centered, same font size as the edital code/name beneath it.
- **Called list newest-first (2b).** `array_reverse` after splitting; the most recent convocations land on page 1.
- **Name search box (2c).** New `?q=` filter rendered alongside the adjutancy dropdown in a single shared form. Server-side substring filter against `candidate.name`; cache key now factors the query.

### Admin

- **public_columns_config as on/off toggles (3a).** Replaced the raw-JSON textarea on the notice edit page with a checkbox grid. Rank and Name render as disabled+checked with hidden value=1 inputs so the mandatory columns can never be turned off.
- **Adjutancy filter on the Candidates tab (3b).** Dropdown next to the existing CPF/RF inputs; filtering inner-joins through `ffc_recruitment_classification` (DISTINCT on candidate.id collapses cross-notice duplicates).
- **Out-of-order confirm + reason prompt (3c).** Calls that would skip a higher-ranked `empty` candidate now surface a confirmation + justification prompt **before** date/time. Detection runs purely client-side from new `data-cls-*` attributes on each row. Bulk calls get a single confirm + one shared reason that's applied to every selected id.

### Caching

- **12h default TTL + write invalidation (2d).** Bumped `public_cache_seconds` default from 60s to 12h. Every successful write in the notice / classification / candidate / adjutancy / call / notice_adjutancy repositories fires `do_action('ffc_recruitment_public_cache_dirty')`; the shortcode subscribes and bumps a monotonic version counter folded into the cache key, atomically retiring every previous transient. No DELETE-by-prefix scan needed; orphaned transients still expire under their own TTL.

## Test plan

- [x] `vendor/bin/phpunit` — 3726 tests, 9462 assertions, all passing
- [x] `vendor/bin/phpstan analyze` — no errors
- [ ] Manual: apply `?adjutancy=…` then change to `?q=foo` — both controls keep state.
- [ ] Manual: open the notice edit page, toggle a non-mandatory column, save; confirm Rank and Name remain on regardless of POST tampering.
- [ ] Manual: filter Candidates tab by an adjutancy and confirm only candidates with classifications in that adjutancy appear.
- [ ] Manual: click "Call" on a row whose rank is higher than the lowest empty in the same adjutancy; confirm the alert + reason prompt fires before date/time.
- [ ] Manual: bulk-select rows that include a skip; confirm one shared reason prompt and successful submit.
- [ ] Manual: edit any notice/classification/candidate; reload the public page on the same notice and confirm fresh data renders (cache invalidated).

https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn)_