### PR TITLE
feat(recruitment + admin): friendly REST error messages + Notices column / sortable user columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- **Recruitment notices column on the wp-admin users list.** `Notices` shows the distinct count of recruitment notices each user appears in as a candidate (joined via `candidate.user_id → classification.notice_id`). Same batch-load pattern as the existing Certificates / Appointments columns — one GROUP BY query warms a per-request user_id → count map.
+- **Sortable wp-admin user columns: Name, Certificates, Appointments, Notices.** Pre-existing Username / Email already sortable; this widens the set so operators can rank users by activity. The count columns sort at SQL level via a new `pre_user_query` hook that injects a `LEFT JOIN` over a derived count table per orderby key. `COALESCE(cnt, 0)` guarantees zero-row users sort as 0 instead of landing at the bottom on NULL ordering vagaries.
+
+### Changed
+
+- **Recruitment REST error responses now carry user-facing messages.** Failure envelopes that previously surfaced the literal stable code (e.g. operators saw "Error: recruitment_notice_has_no_adjutancies" verbatim in the CSV import dialog) now translate every code through a new `RecruitmentErrorMessages` static map. The stable code stays in `error.code` and `error.data.errors[]` so REST clients and tests are unaffected; new `error.data.messages[]` carries the translated form for every error in the envelope, suitable for multi-error toast rendering. Unknown codes pass through verbatim — deliberate so a newly-added code stays visible rather than being silently masked.
 
 ---
 

--- a/includes/admin/class-ffc-admin-user-columns.php
+++ b/includes/admin/class-ffc-admin-user-columns.php
@@ -38,6 +38,22 @@ class AdminUserColumns {
 	private static ?bool $appointments_table_exists = null;
 
 	/**
+	 * Cached flag for recruitment classification table existence
+	 *
+	 * @since 6.2.0
+	 * @var bool|null
+	 */
+	private static ?bool $recruitment_table_exists = null;
+
+	/**
+	 * Batch-cached recruitment notice counts (user_id => count of distinct notices)
+	 *
+	 * @since 6.2.0
+	 * @var array<int, int>|null
+	 */
+	private static ?array $recruitment_counts_cache = null;
+
+	/**
 	 * Cached dashboard URL for user actions column
 	 *
 	 * @since 4.6.13
@@ -69,6 +85,11 @@ class AdminUserColumns {
 		add_filter( 'manage_users_columns', array( __CLASS__, 'add_custom_columns' ) );
 		add_filter( 'manage_users_custom_column', array( __CLASS__, 'render_custom_column' ), 10, 3 );
 
+		// Mark our value columns + the built-in display name as sortable.
+		add_filter( 'manage_users_sortable_columns', array( __CLASS__, 'register_sortable_columns' ) );
+		// SQL-level sort by count requires rewriting WP_User_Query mid-flight.
+		add_action( 'pre_user_query', array( __CLASS__, 'apply_sort_to_user_query' ) );
+
 		// Enqueue styles for the column.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_styles' ) );
 	}
@@ -89,11 +110,30 @@ class AdminUserColumns {
 			if ( 'posts' === $key ) {
 				$new_columns['ffc_certificates'] = __( 'Certificates', 'ffcertificate' );
 				$new_columns['ffc_appointments'] = __( 'Appointments', 'ffcertificate' );
+				$new_columns['ffc_notices']      = __( 'Notices', 'ffcertificate' );
 				$new_columns['ffc_user_actions'] = __( 'User Actions', 'ffcertificate' );
 			}
 		}
 
 		return $new_columns;
+	}
+
+	/**
+	 * Register the columns that should advertise themselves as sortable.
+	 *
+	 * `name` is the built-in display-name column WP already renders but
+	 * doesn't mark sortable on its own. The three count columns are SQL-
+	 * sorted via {@see self::apply_sort_to_user_query()}.
+	 *
+	 * @param array<string, string|array<int, mixed>> $sortable Existing sortable columns.
+	 * @return array<string, string|array<int, mixed>>
+	 */
+	public static function register_sortable_columns( array $sortable ): array {
+		$sortable['name']             = 'display_name';
+		$sortable['ffc_certificates'] = 'ffc_certificates';
+		$sortable['ffc_appointments'] = 'ffc_appointments';
+		$sortable['ffc_notices']      = 'ffc_notices';
+		return $sortable;
 	}
 
 	/**
@@ -111,6 +151,9 @@ class AdminUserColumns {
 
 			case 'ffc_appointments':
 				return self::render_appointments_count( $user_id );
+
+			case 'ffc_notices':
+				return self::render_notices_count( $user_id );
 
 			case 'ffc_user_actions':
 				return self::render_user_actions( $user_id );
@@ -157,6 +200,30 @@ class AdminUserColumns {
 			'<strong>%d</strong> %s',
 			$count,
 			_n( 'appointment', 'appointments', $count, 'ffcertificate' )
+		);
+	}
+
+	/**
+	 * Render recruitment notices count.
+	 *
+	 * Counts the distinct notices in which the user appears as a candidate
+	 * (i.e. has at least one classification row joined via candidate.user_id).
+	 *
+	 * @since 6.2.0
+	 * @param int $user_id User ID.
+	 * @return string Column HTML
+	 */
+	private static function render_notices_count( int $user_id ): string {
+		$count = self::get_user_notice_count( $user_id );
+
+		if ( 0 === $count ) {
+			return '<span class="ffc-empty-value">—</span>';
+		}
+
+		return sprintf(
+			'<strong>%d</strong> %s',
+			$count,
+			_n( 'notice', 'notices', $count, 'ffcertificate' )
 		);
 	}
 
@@ -227,6 +294,21 @@ class AdminUserColumns {
 	}
 
 	/**
+	 * Get distinct-notice count for user (batch-loaded).
+	 *
+	 * @since 6.2.0
+	 * @param int $user_id User ID.
+	 * @return int
+	 */
+	private static function get_user_notice_count( int $user_id ): int {
+		if ( null === self::$recruitment_counts_cache ) {
+			self::load_recruitment_notice_counts();
+		}
+
+		return self::$recruitment_counts_cache[ $user_id ] ?? 0;
+	}
+
+	/**
 	 * Load certificate counts for all users in a single batch query
 	 *
 	 * @since 4.9.7
@@ -287,6 +369,110 @@ class AdminUserColumns {
 				self::$appointment_counts_cache[ (int) $row['user_id'] ] = (int) $row['cnt'];
 			}
 		}
+	}
+
+	/**
+	 * Load recruitment-notice counts for all users in a single batch query.
+	 *
+	 * Counts distinct notices the user appears in as a candidate, joining
+	 * `candidate.user_id` against the classifications table.
+	 *
+	 * @since 6.2.0
+	 * @return void
+	 */
+	private static function load_recruitment_notice_counts(): void {
+		global $wpdb;
+		$candidates_table      = $wpdb->prefix . 'ffc_recruitment_candidate';
+		$classifications_table = $wpdb->prefix . 'ffc_recruitment_classification';
+
+		if ( null === self::$recruitment_table_exists ) {
+			self::$recruitment_table_exists = self::table_exists( $classifications_table );
+		}
+
+		self::$recruitment_counts_cache = array();
+		if ( ! self::$recruitment_table_exists ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt
+				FROM %i AS cl
+				INNER JOIN %i AS c ON c.id = cl.candidate_id
+				WHERE c.user_id IS NOT NULL
+				GROUP BY c.user_id',
+				$classifications_table,
+				$candidates_table
+			),
+			ARRAY_A
+		);
+
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				self::$recruitment_counts_cache[ (int) $row['user_id'] ] = (int) $row['cnt'];
+			}
+		}
+	}
+
+	/**
+	 * Inject ORDER BY into WP_User_Query when one of our value columns is
+	 * the active sort.
+	 *
+	 * For the count columns we can't use the default `meta_key` pattern (no
+	 * usermeta involved), so we rewrite `query_orderby` to reference a
+	 * left-joined derived table aggregated by user_id. The JOIN is added
+	 * to `query_from` only when the relevant orderby is selected, keeping
+	 * normal user-list queries unaffected.
+	 *
+	 * @since 6.2.0
+	 * @param \WP_User_Query $query Query mid-build.
+	 * @return void
+	 */
+	public static function apply_sort_to_user_query( \WP_User_Query $query ): void {
+		$orderby = isset( $query->query_vars['orderby'] ) ? (string) $query->query_vars['orderby'] : '';
+		if ( ! in_array( $orderby, array( 'ffc_certificates', 'ffc_appointments', 'ffc_notices' ), true ) ) {
+			return;
+		}
+
+		global $wpdb;
+		$order = isset( $query->query_vars['order'] ) && 'ASC' === strtoupper( (string) $query->query_vars['order'] )
+			? 'ASC'
+			: 'DESC';
+
+		switch ( $orderby ) {
+			case 'ffc_certificates':
+				$table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
+				$alias  = 'ffc_cert_counts';
+				$select = "(SELECT user_id, COUNT(*) AS cnt FROM {$table} WHERE user_id IS NOT NULL AND status != 'trash' GROUP BY user_id)";
+				break;
+
+			case 'ffc_appointments':
+				$appts_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
+				if ( ! self::table_exists( $appts_table ) ) {
+					return;
+				}
+				$alias  = 'ffc_appt_counts';
+				$select = "(SELECT user_id, COUNT(*) AS cnt FROM {$appts_table} WHERE user_id IS NOT NULL AND status != 'cancelled' GROUP BY user_id)";
+				break;
+
+			case 'ffc_notices':
+			default:
+				$candidates      = $wpdb->prefix . 'ffc_recruitment_candidate';
+				$classifications = $wpdb->prefix . 'ffc_recruitment_classification';
+				if ( ! self::table_exists( $classifications ) ) {
+					return;
+				}
+				$alias  = 'ffc_notice_counts';
+				$select = "(SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt FROM {$classifications} AS cl INNER JOIN {$candidates} AS c ON c.id = cl.candidate_id WHERE c.user_id IS NOT NULL GROUP BY c.user_id)";
+				break;
+		}
+
+		$query->query_from .= " LEFT JOIN {$select} AS {$alias} ON {$alias}.user_id = {$wpdb->users}.ID";
+		// COALESCE so users with zero rows sort as 0 rather than getting
+		// dropped to the bottom by NULL ordering vagaries between MySQL
+		// versions.
+		$query->query_orderby = "ORDER BY COALESCE({$alias}.cnt, 0) {$order}, {$wpdb->users}.user_login ASC";
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-error-messages.php
+++ b/includes/recruitment/class-ffc-recruitment-error-messages.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Recruitment error-code → user-facing message translator.
+ *
+ * The recruitment service layer returns failure envelopes whose `errors` arrays
+ * contain stable machine-readable codes (e.g. `recruitment_notice_has_no_adjutancies`,
+ * `recruitment_csv_missing_cpf_or_rf`). Those codes are stable identifiers used
+ * by REST clients, tests, and activity logs — but they're not suitable as user-
+ * visible strings.
+ *
+ * This class maps each known code to a translated, user-friendly message. The
+ * REST controller's `wp_error_from_envelope()` calls {@see self::translate()}
+ * so the API response carries a readable message in the `message` slot while
+ * the original code stays in the `code` slot + `errors[]` data array for
+ * tooling and tests.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since 6.2.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Recruitment error-code translator.
+ */
+final class RecruitmentErrorMessages {
+
+	/**
+	 * Translate a single error code (or a `line=N: code` / `code: suffix`
+	 * variant emitted by the CSV importer) into a user-facing message.
+	 *
+	 * The line-prefix format is preserved so operators can locate the
+	 * offending row; the code segment is replaced with its translation
+	 * when one is registered.
+	 *
+	 * Unknown codes pass through unchanged so we never silently swallow
+	 * a new error category.
+	 *
+	 * @param string $raw Error code or composite (e.g. "line=3: recruitment_csv_missing_score").
+	 * @return string Translated message.
+	 */
+	public static function translate( string $raw ): string {
+		$line   = 0;
+		$rest   = $raw;
+		$suffix = '';
+
+		// Pull out a leading `line=N: ` so we can re-prefix the human form.
+		if ( 1 === preg_match( '/^line=(\d+):\s*(.+)$/', $rest, $m ) ) {
+			$line = (int) $m[1];
+			$rest = (string) $m[2];
+		}
+
+		// Pull out a trailing `: suffix` (e.g. adjutancy slug, missing-headers list).
+		$colon = strpos( $rest, ': ' );
+		if ( false !== $colon ) {
+			$suffix = (string) substr( $rest, $colon + 2 );
+			$rest   = (string) substr( $rest, 0, $colon );
+		}
+
+		$map     = self::map();
+		$message = $map[ $rest ] ?? $rest;
+
+		if ( '' !== $suffix && isset( $map[ $rest ] ) ) {
+			$message .= ' (' . $suffix . ')';
+		} elseif ( '' !== $suffix ) {
+			// Unknown code — keep the raw form so debugging info isn't lost.
+			$message = $rest . ': ' . $suffix;
+		}
+
+		if ( $line > 0 ) {
+			/* translators: 1: 1-based line number, 2: error message. */
+			$message = sprintf( __( 'Line %1$d: %2$s', 'ffcertificate' ), $line, $message );
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Translate a list of codes, preserving order + duplicates.
+	 *
+	 * @param array<int, string> $codes Error codes / composites.
+	 * @return array<int, string>
+	 */
+	public static function translate_all( array $codes ): array {
+		return array_map( array( __CLASS__, 'translate' ), $codes );
+	}
+
+	/**
+	 * Static map of stable error codes to translated user-facing strings.
+	 *
+	 * Keep this catalog grouped by subsystem so it's easy to extend when
+	 * a new code lands. Codes not listed here pass through verbatim — that
+	 * makes "missing message" obvious in the UI rather than silently
+	 * masking it as a generic failure.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function map(): array {
+		return array(
+			// Generic.
+			'recruitment_error'                            => __( 'An unexpected error occurred. Please try again.', 'ffcertificate' ),
+
+			// Notices.
+			'recruitment_notice_not_found'                 => __( 'Notice not found.', 'ffcertificate' ),
+			'recruitment_notice_create_failed'             => __( 'Could not create the notice. Please try again.', 'ffcertificate' ),
+			'recruitment_notice_update_failed'             => __( 'Could not update the notice. Please try again.', 'ffcertificate' ),
+			'recruitment_notice_has_no_adjutancies'        => __( 'This notice has no adjutancies linked. Add at least one adjutancy in the Adjutancies tab before importing a CSV.', 'ffcertificate' ),
+			'recruitment_notice_adjutancy_attach_failed'   => __( 'Could not link the adjutancy to the notice. Please try again.', 'ffcertificate' ),
+			'recruitment_notice_status_changed'            => __( 'Notice status changed.', 'ffcertificate' ),
+
+			// Notice state machine.
+			'recruitment_invalid_state_for_preview_import' => __( 'CSV imports for the preliminary list are only allowed while the notice is in `draft` or `preliminary`.', 'ffcertificate' ),
+			'recruitment_definitive_to_preliminary_blocked_by_calls' => __( 'Cannot move back to preliminary: at least one call has already been issued. Cancel pending calls before reverting.', 'ffcertificate' ),
+			'recruitment_state_locked'                     => __( 'This action is not allowed in the notice\'s current state.', 'ffcertificate' ),
+			'recruitment_state_terminal_hired'             => __( 'This candidate has already been hired and cannot be modified.', 'ffcertificate' ),
+			'recruitment_transition_race_lost'             => __( 'Another operator changed this notice\'s status moments ago. Reload to see the current state.', 'ffcertificate' ),
+			'recruitment_transition_reason_required'       => __( 'A reason is required for this status transition.', 'ffcertificate' ),
+			'recruitment_reopen_freeze_active'             => __( 'This notice is in a post-reopen freeze and the affected fields are temporarily locked.', 'ffcertificate' ),
+
+			// Adjutancies.
+			'recruitment_adjutancy_not_found'              => __( 'Adjutancy not found.', 'ffcertificate' ),
+			'recruitment_adjutancy_create_failed'          => __( 'Could not create the adjutancy. Please try again.', 'ffcertificate' ),
+			'recruitment_adjutancy_update_failed'          => __( 'Could not update the adjutancy. Please try again.', 'ffcertificate' ),
+			'recruitment_adjutancy_delete_failed'          => __( 'Could not delete the adjutancy. Please try again.', 'ffcertificate' ),
+			'recruitment_adjutancy_in_use'                 => __( 'This adjutancy is in use by one or more notices and cannot be deleted.', 'ffcertificate' ),
+
+			// Candidates.
+			'recruitment_candidate_not_found'              => __( 'Candidate not found.', 'ffcertificate' ),
+			'recruitment_candidate_upsert_failed'          => __( 'Could not save candidate data. Please try again.', 'ffcertificate' ),
+			'recruitment_candidate_update_failed'          => __( 'Could not update the candidate. Please try again.', 'ffcertificate' ),
+			'recruitment_candidate_update_no_writable_fields' => __( 'No writable fields were supplied for this candidate update.', 'ffcertificate' ),
+			'recruitment_candidate_delete_failed'          => __( 'Could not delete the candidate. Please try again.', 'ffcertificate' ),
+			'recruitment_candidate_has_classifications'    => __( 'This candidate has classifications attached and cannot be deleted directly. Remove the classifications first.', 'ffcertificate' ),
+			'recruitment_candidate_list_requires_filter'   => __( 'A filter (notice / adjutancy / search) is required to list candidates.', 'ffcertificate' ),
+
+			// Classifications.
+			'recruitment_classification_not_found'         => __( 'Classification entry not found.', 'ffcertificate' ),
+			'recruitment_classification_insert_failed'     => __( 'Could not save the classification entry. Please try again.', 'ffcertificate' ),
+			'recruitment_classification_delete_failed'     => __( 'Could not remove the classification entry. Please try again.', 'ffcertificate' ),
+			'recruitment_classification_delete_requires_draft_or_preliminary' => __( 'Classifications can only be removed while the notice is in draft or preliminary status.', 'ffcertificate' ),
+			'recruitment_classification_not_empty'         => __( 'Cannot complete the action: classifications already exist for this notice.', 'ffcertificate' ),
+			'recruitment_classification_not_empty_for_delete' => __( 'Cannot delete this notice: it still has classifications attached.', 'ffcertificate' ),
+
+			// Calls.
+			'recruitment_call_not_found'                   => __( 'Call entry not found.', 'ffcertificate' ),
+			'recruitment_call_insert_failed'               => __( 'Could not register the call. Please try again.', 'ffcertificate' ),
+			'recruitment_call_already_cancelled'           => __( 'This call has already been cancelled.', 'ffcertificate' ),
+			'recruitment_call_cancel_race_lost'            => __( 'Another operator updated this call moments ago. Reload to see the current state.', 'ffcertificate' ),
+			'recruitment_cancel_only_from_called_or_accepted' => __( 'Only calls in `called` or `accepted` state can be cancelled.', 'ffcertificate' ),
+			'recruitment_cancel_reason_required'           => __( 'A reason is required to cancel this call.', 'ffcertificate' ),
+			'recruitment_out_of_order_requires_reason'     => __( 'Calling out of rank order requires a reason.', 'ffcertificate' ),
+			'recruitment_bulk_call_empty_id_list'          => __( 'Select at least one classification to call in bulk.', 'ffcertificate' ),
+
+			// Preview status / reasons.
+			'recruitment_preview_status_invalid'           => __( 'Invalid preliminary status.', 'ffcertificate' ),
+			'recruitment_preview_status_only_on_preview_list' => __( 'Preliminary status can only be set on the preliminary list.', 'ffcertificate' ),
+			'recruitment_preview_status_update_failed'     => __( 'Could not update the preliminary status. Please try again.', 'ffcertificate' ),
+			'recruitment_preview_reason_required'          => __( 'A reason is required for this preliminary status.', 'ffcertificate' ),
+			'recruitment_preview_reason_not_found'         => __( 'Selected preliminary reason no longer exists.', 'ffcertificate' ),
+			'recruitment_preview_reason_status_mismatch'   => __( 'The selected reason does not apply to this preliminary status.', 'ffcertificate' ),
+
+			// Reasons catalog.
+			'recruitment_reason_create_failed'             => __( 'Could not create the reason. Please try again.', 'ffcertificate' ),
+			'recruitment_reason_update_failed'             => __( 'Could not update the reason. Please try again.', 'ffcertificate' ),
+			'recruitment_reason_delete_failed'             => __( 'Could not delete the reason. Please try again.', 'ffcertificate' ),
+			'recruitment_reason_in_use'                    => __( 'This reason is referenced by existing classifications and cannot be deleted.', 'ffcertificate' ),
+
+			// Promotion (preview → definitive).
+			'recruitment_promotion_requires_preliminary_state' => __( 'Promotion to definitive is only allowed while the notice is in `preliminary` status.', 'ffcertificate' ),
+			'recruitment_promotion_no_preview_rows'        => __( 'There are no preliminary rows to promote.', 'ffcertificate' ),
+			'recruitment_promotion_copy_failed'            => __( 'Could not copy preliminary rows into the definitive list. Please try again.', 'ffcertificate' ),
+
+			// CSV import — file-level.
+			'recruitment_csv_file_missing'                 => __( 'No CSV file was uploaded.', 'ffcertificate' ),
+			'recruitment_csv_file_unreadable'              => __( 'Could not read the uploaded CSV file.', 'ffcertificate' ),
+			'recruitment_csv_empty'                        => __( 'The CSV file is empty.', 'ffcertificate' ),
+			'recruitment_csv_unparseable'                  => __( 'The CSV file could not be parsed. Make sure it is UTF-8 with comma or semicolon delimiters.', 'ffcertificate' ),
+			'recruitment_csv_missing_headers'              => __( 'The CSV is missing required header columns.', 'ffcertificate' ),
+
+			// CSV import — per-row validation.
+			'recruitment_csv_missing_cpf_or_rf'            => __( 'At least one of CPF or RF is required.', 'ffcertificate' ),
+			'recruitment_csv_cpf_must_be_digits_only'      => __( 'CPF must contain digits only.', 'ffcertificate' ),
+			'recruitment_csv_rf_must_be_digits_only'       => __( 'RF must contain digits only.', 'ffcertificate' ),
+			'recruitment_csv_missing_score'                => __( 'Score is required.', 'ffcertificate' ),
+			'recruitment_csv_score_uses_comma_decimal'     => __( 'Score uses a comma decimal — replace with a dot (e.g. 12.5).', 'ffcertificate' ),
+			'recruitment_csv_score_invalid_format'         => __( 'Score format is invalid (numeric value expected).', 'ffcertificate' ),
+			'recruitment_csv_rank_invalid'                 => __( 'Rank must be a positive integer.', 'ffcertificate' ),
+			'recruitment_csv_time_points_uses_comma_decimal' => __( 'Time points uses a comma decimal — replace with a dot.', 'ffcertificate' ),
+			'recruitment_csv_time_points_invalid_format'   => __( 'Time points format is invalid (numeric value expected).', 'ffcertificate' ),
+			'recruitment_csv_missing_adjutancy'            => __( 'Adjutancy is required.', 'ffcertificate' ),
+			'recruitment_csv_adjutancy_not_in_notice'      => __( 'Adjutancy is not linked to this notice.', 'ffcertificate' ),
+		);
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-rest-controller.php
@@ -572,7 +572,7 @@ final class RecruitmentRestController {
 
 		$notice = RecruitmentNoticeRepository::get_by_id( $id );
 		if ( null === $notice ) {
-			return new \WP_Error( 'recruitment_notice_not_found', '', array( 'status' => 404 ) );
+			return new \WP_Error( 'recruitment_notice_not_found', RecruitmentErrorMessages::translate( 'recruitment_notice_not_found' ), array( 'status' => 404 ) );
 		}
 
 		return new \WP_REST_Response( $notice, 200 );
@@ -807,7 +807,7 @@ final class RecruitmentRestController {
 
 		$cls = RecruitmentClassificationRepository::get_by_id( $id );
 		if ( null === $cls ) {
-			return new \WP_Error( 'recruitment_classification_not_found', '', array( 'status' => 404 ) );
+			return new \WP_Error( 'recruitment_classification_not_found', RecruitmentErrorMessages::translate( 'recruitment_classification_not_found' ), array( 'status' => 404 ) );
 		}
 		if ( 'preview' !== (string) $cls->list_type ) {
 			return new \WP_Error( 'recruitment_preview_status_only_on_preview_list', __( 'Preliminary status can only be set on classifications in the preview list.', 'ffcertificate' ), array( 'status' => 409 ) );
@@ -815,7 +815,7 @@ final class RecruitmentRestController {
 
 		$valid_statuses = array( 'empty', 'denied', 'granted', 'appeal_denied', 'appeal_granted' );
 		if ( ! in_array( $preview_status, $valid_statuses, true ) ) {
-			return new \WP_Error( 'recruitment_preview_status_invalid', '', array( 'status' => 400 ) );
+			return new \WP_Error( 'recruitment_preview_status_invalid', RecruitmentErrorMessages::translate( 'recruitment_preview_status_invalid' ), array( 'status' => 400 ) );
 		}
 
 		// 'empty' clears any pre-existing reason — operators reset by
@@ -836,7 +836,7 @@ final class RecruitmentRestController {
 		if ( $reason_id > 0 ) {
 			$reason = RecruitmentReasonRepository::get_by_id( $reason_id );
 			if ( null === $reason ) {
-				return new \WP_Error( 'recruitment_preview_reason_not_found', '', array( 'status' => 404 ) );
+				return new \WP_Error( 'recruitment_preview_reason_not_found', RecruitmentErrorMessages::translate( 'recruitment_preview_reason_not_found' ), array( 'status' => 404 ) );
 			}
 			$applies = RecruitmentReasonRepository::decode_applies_to( (string) ( $reason->applies_to ?? '' ) );
 			if ( ! in_array( $preview_status, $applies, true ) ) {
@@ -846,7 +846,7 @@ final class RecruitmentRestController {
 
 		$ok = RecruitmentClassificationRepository::set_preview_status( $id, $preview_status, $reason_id > 0 ? $reason_id : null );
 		if ( ! $ok ) {
-			return new \WP_Error( 'recruitment_preview_status_update_failed', '', array( 'status' => 400 ) );
+			return new \WP_Error( 'recruitment_preview_status_update_failed', RecruitmentErrorMessages::translate( 'recruitment_preview_status_update_failed' ), array( 'status' => 400 ) );
 		}
 
 		return new \WP_REST_Response( RecruitmentClassificationRepository::get_by_id( $id ), 200 );
@@ -1357,13 +1357,15 @@ final class RecruitmentRestController {
 	 * @return \WP_Error
 	 */
 	private function wp_error_from_envelope( array $errors, int $status ): \WP_Error {
-		$code = $errors[0] ?? 'recruitment_error';
+		$code    = $errors[0] ?? 'recruitment_error';
+		$message = RecruitmentErrorMessages::translate( $code );
 		return new \WP_Error(
 			$code,
-			$code,
+			$message,
 			array(
-				'status' => $status,
-				'errors' => $errors,
+				'status'   => $status,
+				'errors'   => $errors,
+				'messages' => RecruitmentErrorMessages::translate_all( $errors ),
 			)
 		);
 	}
@@ -1377,14 +1379,16 @@ final class RecruitmentRestController {
 	 * @return \WP_Error
 	 */
 	private function wp_error_from_envelope_with_blocked( array $envelope, int $status ): \WP_Error {
-		$first = $envelope['errors'][0] ?? 'recruitment_error';
-		$data  = array(
-			'status' => $status,
-			'errors' => $envelope['errors'],
+		$first   = $envelope['errors'][0] ?? 'recruitment_error';
+		$message = RecruitmentErrorMessages::translate( $first );
+		$data    = array(
+			'status'   => $status,
+			'errors'   => $envelope['errors'],
+			'messages' => RecruitmentErrorMessages::translate_all( $envelope['errors'] ),
 		);
 		if ( isset( $envelope['blocked_by'] ) ) {
 			$data['blocked_by'] = $envelope['blocked_by'];
 		}
-		return new \WP_Error( $first, $first, $data );
+		return new \WP_Error( $first, $message, $data );
 	}
 }

--- a/tests/Unit/AdminUserColumnsTest.php
+++ b/tests/Unit/AdminUserColumnsTest.php
@@ -10,6 +10,17 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use FreeFormCertificate\Admin\AdminUserColumns;
 
+// Local stub — kept in this file (rather than bootstrap.php) so it doesn't
+// race with `Mockery::mock( 'overload:\WP_User_Query' )` that other tests
+// use. Each AdminUserColumnsTest method runs in a separate process, so the
+// stub gets a fresh definition every time without leaking globally. eval()
+// keeps the class in the global namespace despite the test file's own
+// namespace declaration above.
+if ( ! class_exists( '\WP_User_Query', false ) ) {
+    // phpcs:ignore Squiz.PHP.Eval.Discouraged -- Test-only inline stub; safer than splitting into a separate file that AdminAjaxTest's overload mock would conflict with.
+    eval( 'class WP_User_Query { public $query_from = ""; public $query_where = ""; public $query_orderby = ""; public $query_vars = array(); }' );
+}
+
 /**
  * Tests for AdminUserColumns: custom user list columns for certificates,
  * appointments, and user actions (login-as-user link).
@@ -85,7 +96,7 @@ class AdminUserColumnsTest extends TestCase {
      */
     private function resetStaticCaches(): void {
         $ref = new \ReflectionClass( AdminUserColumns::class );
-        foreach ( array( 'appointments_table_exists', 'dashboard_url_cache', 'certificate_counts_cache', 'appointment_counts_cache' ) as $prop ) {
+        foreach ( array( 'appointments_table_exists', 'dashboard_url_cache', 'certificate_counts_cache', 'appointment_counts_cache', 'recruitment_table_exists', 'recruitment_counts_cache' ) as $prop ) {
             $p = $ref->getProperty( $prop );
             $p->setAccessible( true );
             $p->setValue( null, null );
@@ -104,6 +115,14 @@ class AdminUserColumnsTest extends TestCase {
         Functions\expect( 'add_filter' )
             ->once()
             ->with( 'manage_users_custom_column', array( AdminUserColumns::class, 'render_custom_column' ), 10, 3 );
+
+        Functions\expect( 'add_filter' )
+            ->once()
+            ->with( 'manage_users_sortable_columns', array( AdminUserColumns::class, 'register_sortable_columns' ) );
+
+        Functions\expect( 'add_action' )
+            ->once()
+            ->with( 'pre_user_query', array( AdminUserColumns::class, 'apply_sort_to_user_query' ) );
 
         Functions\expect( 'add_action' )
             ->once()
@@ -131,7 +150,8 @@ class AdminUserColumnsTest extends TestCase {
         $posts_index = array_search( 'posts', $keys, true );
         $this->assertSame( 'ffc_certificates', $keys[ $posts_index + 1 ] );
         $this->assertSame( 'ffc_appointments', $keys[ $posts_index + 2 ] );
-        $this->assertSame( 'ffc_user_actions', $keys[ $posts_index + 3 ] );
+        $this->assertSame( 'ffc_notices', $keys[ $posts_index + 3 ] );
+        $this->assertSame( 'ffc_user_actions', $keys[ $posts_index + 4 ] );
     }
 
     public function test_add_custom_columns_preserves_existing(): void {
@@ -153,10 +173,11 @@ class AdminUserColumnsTest extends TestCase {
         // New columns added
         $this->assertArrayHasKey( 'ffc_certificates', $result );
         $this->assertArrayHasKey( 'ffc_appointments', $result );
+        $this->assertArrayHasKey( 'ffc_notices', $result );
         $this->assertArrayHasKey( 'ffc_user_actions', $result );
 
-        // Total count: 4 original + 3 new
-        $this->assertCount( 7, $result );
+        // Total count: 4 original + 4 new
+        $this->assertCount( 8, $result );
     }
 
     // ==================================================================
@@ -253,6 +274,110 @@ class AdminUserColumnsTest extends TestCase {
         $output = AdminUserColumns::render_custom_column( 'original_output', 'unknown_col', 42 );
 
         $this->assertSame( 'original_output', $output );
+    }
+
+    // ==================================================================
+    // render_custom_column() — recruitment notices
+    // ==================================================================
+
+    public function test_render_notices_column_zero_count(): void {
+        // table_exists check: classification table missing → zero
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();
+
+        $output = AdminUserColumns::render_custom_column( '', 'ffc_notices', 42 );
+
+        $this->assertStringContainsString( 'ffc-empty-value', $output );
+    }
+
+    public function test_render_notices_column_with_count(): void {
+        // table_exists returns table name — table present
+        $this->wpdb->shouldReceive( 'get_var' )
+            ->andReturn( 'wp_ffc_recruitment_classification' )
+            ->byDefault();
+
+        $this->wpdb->shouldReceive( 'get_results' )
+            ->andReturn( array(
+                array( 'user_id' => '42', 'cnt' => '4' ),
+            ) );
+
+        $output = AdminUserColumns::render_custom_column( '', 'ffc_notices', 42 );
+
+        $this->assertStringContainsString( '<strong>4</strong>', $output );
+        $this->assertStringContainsString( 'notices', $output );
+    }
+
+    // ==================================================================
+    // register_sortable_columns()
+    // ==================================================================
+
+    public function test_register_sortable_columns_adds_name_and_value_columns(): void {
+        $sortable = array( 'username' => 'login', 'email' => 'email' );
+        $result   = AdminUserColumns::register_sortable_columns( $sortable );
+
+        $this->assertSame( 'display_name', $result['name'] );
+        $this->assertSame( 'ffc_certificates', $result['ffc_certificates'] );
+        $this->assertSame( 'ffc_appointments', $result['ffc_appointments'] );
+        $this->assertSame( 'ffc_notices', $result['ffc_notices'] );
+        // Pre-existing entries preserved.
+        $this->assertSame( 'login', $result['username'] );
+        $this->assertSame( 'email', $result['email'] );
+    }
+
+    // ==================================================================
+    // apply_sort_to_user_query()
+    // ==================================================================
+
+    public function test_apply_sort_to_user_query_skips_unknown_orderby(): void {
+        global $wpdb;
+        $wpdb->users = 'wp_users';
+
+        $query                = new \WP_User_Query();
+        $query->query_vars    = array( 'orderby' => 'login', 'order' => 'ASC' );
+        $query->query_from    = 'FROM wp_users';
+        $query->query_orderby = 'ORDER BY user_login ASC';
+
+        AdminUserColumns::apply_sort_to_user_query( $query );
+
+        // Untouched: query_from + query_orderby unchanged for non-FFC orderby.
+        $this->assertSame( 'FROM wp_users', $query->query_from );
+        $this->assertSame( 'ORDER BY user_login ASC', $query->query_orderby );
+    }
+
+    public function test_apply_sort_to_user_query_mutates_query_when_sorting_by_certificates(): void {
+        global $wpdb;
+        $wpdb->users = 'wp_users';
+
+        $query                = new \WP_User_Query();
+        $query->query_vars    = array( 'orderby' => 'ffc_certificates', 'order' => 'DESC' );
+        $query->query_from    = 'FROM wp_users';
+        $query->query_orderby = '';
+
+        AdminUserColumns::apply_sort_to_user_query( $query );
+
+        $this->assertStringContainsString( 'LEFT JOIN', $query->query_from );
+        $this->assertStringContainsString( 'ffc_cert_counts', $query->query_from );
+        $this->assertStringContainsString( 'ORDER BY COALESCE', $query->query_orderby );
+        $this->assertStringContainsString( 'DESC', $query->query_orderby );
+    }
+
+    public function test_apply_sort_to_user_query_mutates_query_when_sorting_by_notices(): void {
+        global $wpdb;
+        $wpdb->users = 'wp_users';
+
+        // table_exists returns the table name → exists
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( 'wp_ffc_recruitment_classification' )->byDefault();
+
+        $query                = new \WP_User_Query();
+        $query->query_vars    = array( 'orderby' => 'ffc_notices', 'order' => 'ASC' );
+        $query->query_from    = 'FROM wp_users';
+        $query->query_orderby = '';
+
+        AdminUserColumns::apply_sort_to_user_query( $query );
+
+        $this->assertStringContainsString( 'ffc_notice_counts', $query->query_from );
+        $this->assertStringContainsString( 'COUNT(DISTINCT cl.notice_id)', $query->query_from );
+        $this->assertStringContainsString( 'ASC', $query->query_orderby );
     }
 
     // ==================================================================

--- a/tests/Unit/RecruitmentErrorMessagesTest.php
+++ b/tests/Unit/RecruitmentErrorMessagesTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentErrorMessages;
+
+/**
+ * Tests for RecruitmentErrorMessages — covers the code → user-facing
+ * message mapping plus the `line=N: ` and `code: suffix` decompositions
+ * emitted by the CSV importer + REST controller.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentErrorMessages
+ */
+class RecruitmentErrorMessagesTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_attr__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_known_code_translates_to_friendly_message(): void {
+		$msg = RecruitmentErrorMessages::translate( 'recruitment_notice_has_no_adjutancies' );
+
+		// Friendly message — not the raw code.
+		$this->assertNotSame( 'recruitment_notice_has_no_adjutancies', $msg );
+		$this->assertStringContainsStringIgnoringCase( 'adjutancies', $msg );
+	}
+
+	public function test_unknown_code_passes_through_verbatim(): void {
+		$this->assertSame( 'recruitment_brand_new_unmapped_code', RecruitmentErrorMessages::translate( 'recruitment_brand_new_unmapped_code' ) );
+	}
+
+	public function test_line_prefix_is_preserved_and_message_translated(): void {
+		$msg = RecruitmentErrorMessages::translate( 'line=42: recruitment_csv_missing_score' );
+
+		$this->assertStringContainsString( '42', $msg );
+		$this->assertStringContainsStringIgnoringCase( 'score', $msg );
+		$this->assertStringNotContainsString( 'recruitment_csv_missing_score', $msg );
+	}
+
+	public function test_suffix_is_appended_in_parens_for_known_codes(): void {
+		$msg = RecruitmentErrorMessages::translate( 'recruitment_csv_adjutancy_not_in_notice: my-slug' );
+
+		$this->assertStringContainsString( '(my-slug)', $msg );
+		$this->assertStringNotContainsString( 'recruitment_csv_adjutancy_not_in_notice', $msg );
+	}
+
+	public function test_suffix_passes_through_for_unknown_codes(): void {
+		$msg = RecruitmentErrorMessages::translate( 'recruitment_unknown_code: some-detail' );
+		$this->assertSame( 'recruitment_unknown_code: some-detail', $msg );
+	}
+
+	public function test_translate_all_preserves_order(): void {
+		$out = RecruitmentErrorMessages::translate_all(
+			array(
+				'recruitment_csv_empty',
+				'recruitment_brand_new',
+				'recruitment_notice_not_found',
+			)
+		);
+
+		$this->assertCount( 3, $out );
+		$this->assertNotSame( 'recruitment_csv_empty', $out[0] );
+		$this->assertSame( 'recruitment_brand_new', $out[1] );
+		$this->assertNotSame( 'recruitment_notice_not_found', $out[2] );
+	}
+}


### PR DESCRIPTION
## Summary

Three-item punchlist: items 1 and 2 are implemented as separate commits on this branch; item 3 is an audit-only report (findings + proposed actions, no code changes — listed below for review).

### Item 1 — Friendly REST error messages (commit `2b297d8`)

Operators were seeing the literal stable code (e.g. `Error: recruitment_notice_has_no_adjutancies`) verbatim in admin UIs because `RecruitmentRestController::wp_error_from_envelope()` was dropping the code into both the `code` and `message` slots of `\WP_Error`.

- New `RecruitmentErrorMessages::translate( $code_or_composite )` static map covering 60+ recruitment_* codes.
- First-class handling of two CSV-importer composites: `line=N: code` becomes `Line N: <translated>`; `code: suffix` becomes `<translated> (suffix)`.
- New `translate_all()` for surfacing every error in a bulk-import failure response. Translated list ships in `error.data.messages[]` so the JS can render multi-error toasts; raw codes still ship in `error.data.errors[]` for tooling.
- Five inline `\WP_Error` sites in the controller that were emitting empty messages now also delegate to the translator.
- Unknown codes pass through verbatim — deliberate so a newly-added code stays visible rather than being silently masked.
- Backward-compatible: `error.code` and `error.data.errors[]` are unchanged. Six new unit tests.

### Item 2 — Notices column + sortable user columns (commit `cde9088`)

- New `ffc_notices` column on the wp-admin users list. Counts the distinct notices each user appears in as a candidate (joined via `candidate.user_id → classification.notice_id`). Same batch-load + zero-fallback pattern as the existing Certificates / Appointments columns.
- `manage_users_sortable_columns` now registers four sortable keys: `name` → built-in `display_name`, plus the three count columns.
- New `pre_user_query` hook injects a `LEFT JOIN (SELECT user_id, COUNT(...) GROUP BY user_id) AS alias` derived-table into `query_from` and rewrites `query_orderby` to `COALESCE(alias.cnt, 0)` so users with zero rows sort as 0 instead of landing at the bottom on NULL ordering vagaries.
- Notices SQL uses `COUNT(DISTINCT cl.notice_id)` so a user with multiple classifications under one notice still counts as 1.
- Both render and sort short-circuit when the recruitment table doesn't exist (fresh installs before the activator runs).
- Seven new unit tests; updated bootstrap stub conflict resolved by defining the `WP_User_Query` test stub locally via `eval()` so it doesn't collide with `Mockery::mock( 'overload:\WP_User_Query' )` in `AdminAjaxTest`.

### Item 3 — Optimization & reuse audit (REPORT ONLY, not in this PR)

Survey of recruitment vs. the rest of the plugin. Nothing in this section is implemented — listing for your review so you can decide which (if any) to greenlight. Each entry has a concrete file path + line number.

| # | Item | File / Line | Effort | Impact |
|---|------|-------------|--------|--------|
| 1 | **Promote `RecruitmentBadgeHtml` to `Core\BadgeHtml`** — 7+ recruitment callsites already delegate to it; scheduling / reregistration / audience modules have inline `style=""` badge patterns that could too. Single dark-mode / accessibility update would propagate plugin-wide. | `includes/recruitment/class-ffc-recruitment-badge-html.php:36-80` | ~1h | **HIGH** |
| 2 | **Extract `normalize_color()` to `Core\ColorValidator`** — two near-identical hex-validators (`#RGB` / `#RRGGBB` / `#RRGGBBAA`) live on the adjutancy and reason repositories; a third path runs through `RecruitmentSettings::sanitize_color()`. ~50 LOC duplicated. | `class-ffc-recruitment-adjutancy-repository.php:200-209` + `class-ffc-recruitment-reason-repository.php:249-258` + `class-ffc-recruitment-settings.php:246-263` | ~1h | MEDIUM |
| 3 | **Batch user-data fetch in candidates list table.** `column_user_id()` calls `get_userdata( $user_id )` per row inside the loop → 20-100 `wp_users` queries per page render. PR #105 already added candidate batch-fetch; this is the same shape for users. | `class-ffc-recruitment-candidates-list-table.php:170` | ~1.5h | MEDIUM |
| 4 | **Privatize `RecruitmentCsvImporter::parse()`** — public static, called only by `import_preview()` / `import_definitive()` internally. Tightens the surface. | `class-ffc-recruitment-csv-importer.php:223` | ~15min | LOW |

Items NOT in the audit list (already aligned or not worth extracting):

- Cache-pattern duplication — already shared via `StaticRepositoryTrait`; recruitment + reregistration both use it.
- CSV import/export pattern — input/output shapes differ fundamentally between recruitment (multi-step validation + transactional rollback) and reregistration (output-only); no clean abstraction.
- WP_List_Table subclasses — recruitment has 4, admin has 1 (Submissions); too domain-specific to share.
- `wp_error_from_envelope` pattern — only recruitment uses the `{success: bool, errors: []}` envelope shape.
- `RecruitmentActivityLogger` — already a thin façade over `Core\ActivityLog`; no duplication.

> Want me to spin item 1 (badge promotion) or item 3 (user batch-fetch) into a follow-up PR? Both are self-contained and unlock cross-module wins.

## Test plan

- [x] `vendor/bin/phpunit` — 3738 tests, 9504 assertions, all passing
- [x] `vendor/bin/phpstan analyze` — no errors
- [x] `vendor/bin/phpcs` (WPCS) — clean on changed files
- [ ] Manual: trigger a CSV import on a notice with zero adjutancies; confirm the dialog shows the friendly Portuguese/English message instead of `recruitment_notice_has_no_adjutancies`.
- [ ] Manual: trigger a CSV with a malformed row (e.g. score uses comma); confirm the per-line error appears as `Line N: Score uses a comma decimal — replace with a dot.`
- [ ] Manual: visit `/wp-admin/users.php`; confirm the new Notices column renders with the expected count + sort arrows on Name / Certificates / Appointments / Notices.
- [ ] Manual: click each sort header; confirm the URL updates to `?orderby=…&order=…` and the rows reorder. Verify zero-row users land in the right position (top for ASC, bottom for DESC).

https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn)_