### PR TITLE
fix(roles): defer __()-using role registrations to init:1 to silence WP 6.7 notice

### DIFF
--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -172,15 +172,16 @@ class Loader {
 		// In-place plugin updates (drop new files via `wp-admin/plugins.php`'s
 		// "Update" button) DO NOT fire `register_activation_hook`. Re-register
 		// the canonical FFC role + the 6.2.0 module-manager / recruitment-tier
-		// roles here so they survive upgrades that bumped the role catalog
-		// without a full deactivate/reactivate cycle. Both calls are idempotent
-		// — `register_role()` short-circuits to an upgrade path when the role
-		// already exists; `register_module_roles()` only adds caps it finds
-		// missing.
-		if ( class_exists( '\FreeFormCertificate\UserDashboard\CapabilityManager' ) ) {
-			\FreeFormCertificate\UserDashboard\CapabilityManager::register_role();
-			\FreeFormCertificate\UserDashboard\CapabilityManager::register_module_roles();
-		}
+		// roles so they survive upgrades that bumped the role catalog without
+		// a full deactivate/reactivate cycle.
+		//
+		// Hooked on `init` priority 1 (NOT `plugins_loaded`) because
+		// `register_role()` / `register_module_roles()` call `__()` for the
+		// translated role labels, and WordPress 6.7+ emits a "translation
+		// loading … too early" notice when text-domain translations are
+		// resolved before `init` fires. Running at `init:1` is still very
+		// early but after WP loads the textdomain.
+		add_action( 'init', array( $this, 'register_ffc_roles_safe' ), 1 );
 
 		if ( class_exists( '\FreeFormCertificate\SelfScheduling\SelfSchedulingActivator' ) ) {
 			\FreeFormCertificate\SelfScheduling\SelfSchedulingActivator::maybe_migrate();
@@ -264,6 +265,26 @@ class Loader {
 		$this->ensure_legacy_caps_renamed();
 		$this->define_admin_hooks();
 		$this->init_rest_api();
+	}
+
+	/**
+	 * Register the FFC user-side role + the 6.2.0 module-manager /
+	 * recruitment-tier roles. Hooked on `init` priority 1 from
+	 * `init_plugin()` because the role labels are translated via
+	 * `__( …, 'ffcertificate' )` and WP 6.7+ emits a notice when
+	 * translation lookups happen before the `init` hook fires.
+	 *
+	 * Idempotent: existing roles are upgraded with any newly
+	 * introduced caps; manually granted caps are preserved.
+	 *
+	 * @since 6.2.0
+	 * @return void
+	 */
+	public function register_ffc_roles_safe(): void {
+		if ( class_exists( '\FreeFormCertificate\UserDashboard\CapabilityManager' ) ) {
+			\FreeFormCertificate\UserDashboard\CapabilityManager::register_role();
+			\FreeFormCertificate\UserDashboard\CapabilityManager::register_module_roles();
+		}
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-loader.php
+++ b/includes/recruitment/class-ffc-recruitment-loader.php
@@ -54,26 +54,28 @@ final class RecruitmentLoader {
 		//
 		// In-place plugin updates (replacing files via `wp-admin/plugins.php`'s
 		// "Update" button or by overwriting the directory) DO NOT fire the
-		// `register_activation_hook` callback. Without the two hooks below,
+		// `register_activation_hook` callback. Without the hooks below,
 		// installs upgrading from a pre-recruitment release (≤ 5.4.x) onto a
 		// recruitment-bearing release (≥ 6.0.0) end up with a fully-loaded
 		// recruitment module that has no tables and no manager role.
 		//
-		// Both `create_tables()` and `register_recruitment_manager_role()`
-		// are idempotent — each individual table-create + role-register
-		// short-circuits when the artifact already exists. Safe to call on
-		// every `plugins_loaded` of every page load.
+		// `create_tables()` and `maybe_migrate()` stay on `plugins_loaded`
+		// (they don't touch translated strings). The recruitment-manager
+		// role registration uses `__( …, 'ffcertificate' )` for the role
+		// label and so MUST run on `init` (priority 1, very early but after
+		// WP loads the textdomain) — calling `__()` on `plugins_loaded`
+		// triggers the WP 6.7+ "translation loading … too early" notice.
 		add_action( 'plugins_loaded', array( RecruitmentActivator::class, 'create_tables' ), 9 );
+		add_action( 'plugins_loaded', array( RecruitmentActivator::class, 'maybe_migrate' ), 11 );
 		add_action(
-			'plugins_loaded',
+			'init',
 			static function (): void {
 				if ( class_exists( '\FreeFormCertificate\UserDashboard\CapabilityManager' ) ) {
 					\FreeFormCertificate\UserDashboard\CapabilityManager::register_recruitment_manager_role();
 				}
 			},
-			10
+			1
 		);
-		add_action( 'plugins_loaded', array( RecruitmentActivator::class, 'maybe_migrate' ), 11 );
 	}
 
 	/**

--- a/tests/Unit/RecruitmentLoaderTest.php
+++ b/tests/Unit/RecruitmentLoaderTest.php
@@ -35,15 +35,23 @@ class RecruitmentLoaderTest extends TestCase {
 		parent::tearDown();
 	}
 
-	public function test_plugins_loaded_hooks_fire_in_priority_order_9_10_11(): void {
+	public function test_plugins_loaded_hooks_create_tables_and_maybe_migrate(): void {
 		// Capture every add_action call so we can pin the safety-net set
-		// (create_tables@9, role@10, maybe_migrate@11) without coupling to
-		// brain/monkey's expectation argument-matching quirks.
+		// (create_tables@plugins_loaded:9, maybe_migrate@plugins_loaded:11,
+		// role@init:1) without coupling to brain/monkey's expectation
+		// argument-matching quirks.
 		$plugins_loaded = array();
+		$init_hooks     = array();
 		Functions\when( 'add_action' )->alias(
-			static function ( $hook, $cb, $priority = 10, $accepted = 1 ) use ( &$plugins_loaded ): bool {
+			static function ( $hook, $cb, $priority = 10, $accepted = 1 ) use ( &$plugins_loaded, &$init_hooks ): bool {
 				if ( 'plugins_loaded' === $hook ) {
 					$plugins_loaded[] = array(
+						'priority' => $priority,
+						'callback' => $cb,
+					);
+				}
+				if ( 'init' === $hook ) {
+					$init_hooks[] = array(
 						'priority' => $priority,
 						'callback' => $cb,
 					);
@@ -54,22 +62,21 @@ class RecruitmentLoaderTest extends TestCase {
 
 		( new RecruitmentLoader() )->init();
 
-		$priorities = array_column( $plugins_loaded, 'priority' );
+		$plugins_loaded_priorities = array_column( $plugins_loaded, 'priority' );
+		$this->assertContains( 9, $plugins_loaded_priorities, 'create_tables must hook plugins_loaded:9' );
+		$this->assertContains( 11, $plugins_loaded_priorities, 'maybe_migrate must hook plugins_loaded:11' );
 
-		// All three priority slots are occupied.
-		$this->assertContains( 9, $priorities, 'create_tables must hook at priority 9' );
-		$this->assertContains( 10, $priorities, 'role self-heal must hook at priority 10' );
-		$this->assertContains( 11, $priorities, 'maybe_migrate must hook at priority 11' );
-
-		// Verify create_tables + maybe_migrate are wired to the right callables
-		// (the role registration is a closure so we just verify a closure is
-		// hooked at priority 10).
 		$by_priority = array();
 		foreach ( $plugins_loaded as $entry ) {
 			$by_priority[ $entry['priority'] ] = $entry['callback'];
 		}
 		$this->assertSame( array( RecruitmentActivator::class, 'create_tables' ), $by_priority[9] );
 		$this->assertSame( array( RecruitmentActivator::class, 'maybe_migrate' ), $by_priority[11] );
-		$this->assertInstanceOf( \Closure::class, $by_priority[10] );
+
+		// Role self-heal moved to init:1 in 6.2.x — the role label uses __()
+		// so it can't run on plugins_loaded without tripping WP 6.7+'s
+		// "translation loading … too early" notice.
+		$init_priorities = array_column( $init_hooks, 'priority' );
+		$this->assertContains( 1, $init_priorities, 'role self-heal must hook init:1' );
 	}
 }


### PR DESCRIPTION
## Summary

Hot-fix for the WP 6.7+ "translation loading … too early" notice that started appearing in production after PR #109 (v6.2.0) merged.

## Root cause

PR #109 hooked three role-registration callbacks on `plugins_loaded` so in-place plugin updates would self-heal without needing a deactivate/reactivate cycle:

- `CapabilityManager::register_role()` → uses `__( 'FFC User', 'ffcertificate' )`
- `CapabilityManager::register_module_roles()` → uses `__()` for 8 role labels
- `CapabilityManager::register_recruitment_manager_role()` → uses `__( 'Recruitment Manager', 'ffcertificate' )`

WordPress 6.7+ emits a `_load_textdomain_just_in_time` notice whenever a textdomain is resolved before the `init` hook fires, and `plugins_loaded` is squarely *before* `init`. The notice fired on every page load.

## Fix

The three role-registration callbacks move from `plugins_loaded` to `init` priority 1 — still very early in WP boot, but after WP loads the textdomain so `__()` is safe to call.

The non-translated recruitment work stays on `plugins_loaded`:
- `RecruitmentActivator::create_tables()` at priority 9 (no `__()` calls)
- `RecruitmentActivator::maybe_migrate()` at priority 11 (no `__()` calls)

`RecruitmentLoaderTest` was pinning the old `plugins_loaded:9/10/11` priority arrangement; updated to assert `plugins_loaded:9` + `plugins_loaded:11` (create_tables + maybe_migrate) AND `init:1` (role self-heal).

## Test plan

- [x] `vendor/bin/phpunit` — 3772 tests / 9594 assertions, all green
- [x] `vendor/bin/phpstan analyze` — no errors
- [x] `vendor/bin/phpcs` (WPCS) — clean on changed files
- [ ] Manual: deploy to the affected install, reload an admin page, confirm the notice disappears from `debug.log`.

https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn)_