### PR TITLE
feat(debug+i18n): per-area debug toggles + role label translation fix + readme refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+
+- **76 legacy `Utils::debug_log()` calls migrated to the per-area `Debug::log_*()` system.** Previously every call fired whenever `WP_DEBUG=true` with no admin toggle — including frontend shortcode renders that polluted production logs. Each call now lands in one of 14 area-specific helpers gated by a checkbox in **Settings → Advanced → Debug**. Five new areas added (`debug_frontend`, `debug_admin`, `debug_self_scheduling`, `debug_audience`, `debug_qrcode`), each defaulting OFF. `Utils::debug_log()` is now a `@deprecated` thin wrapper that delegates to `Debug::AREA_FORM_PROCESSOR` for any third-party callers; new code should use `Debug::log_*()` directly.
+- **FFC role labels now translate correctly on `wp-admin/users.php`.** WordPress stores role labels verbatim in `wp_user_roles` at `add_role()` time, and its built-in `translate_user_role()` resolves them against the **default** WP textdomain — so plugin-provided role names never localized even when the .po file was loaded. New `wp_roles_init` hook (`CapabilityManager::relabel_ffc_roles`) re-applies `__( …, 'ffcertificate' )` to every FFC role's `name` + `role_names` entry on every page load, so `users.php` always shows the operator's locale.
 
 ---
 
@@ -43,6 +46,9 @@ _No unreleased changes._
 ### Fixed
 
 - **Recruitment tables + manager role no longer require deactivate/reactivate** to land on in-place plugin updates. `register_activation_hook` is the only entry-point firing `RecruitmentActivator::create_tables()` and `CapabilityManager::register_recruitment_manager_role()` in 6.0.0–6.1.0; the WordPress "Update plugin" button DOES NOT fire that hook. Effect on the affected cohort: `maybe_migrate()` ran on `plugins_loaded` against tables that didn't exist, silently failing. Fix: hook `create_tables` at `plugins_loaded` priority 9 + role registration at priority 10 (before `maybe_migrate` at priority 11). All three calls are idempotent — each table-create + role-register short-circuits when the artifact already exists.
+- **`_load_textdomain_just_in_time was called incorrectly` notice** (WP 6.7+) emitted by the v6.2.0 role-registration hooks. WP 6.7+ rejects `__()` calls before `init`; the role labels were resolved via `__()` on `plugins_loaded` callbacks. Both `Loader::register_ffc_roles_safe()` and the recruitment-loader's role registration now hook on `init` priority 1 instead of `plugins_loaded`. Non-translated work (`create_tables`, `maybe_migrate`) stays on `plugins_loaded`.
+- **FFC role labels not translatable on `wp-admin/users.php`.** WordPress stores the role label verbatim in the `wp_user_roles` option at `add_role()` time, then displays it via `translate_user_role()` against the **default** WP textdomain — so plugin-provided role labels never translate, even after the `.po` is loaded. New `CapabilityManager::relabel_ffc_roles()` hooks `wp_roles_init` and re-applies `__()` against the plugin's textdomain on every page load. Affects the 11 FFC roles (`ffc_user`, `ffc_recruitment_manager`, plus the 9 added in this release).
+- **Per-area debug toggles for the legacy `Utils::debug_log()` callsites.** 76 calls across 29 files used to fire whenever `WP_DEBUG=true` with no per-area toggle (e.g. `[FFC] Form shortcode rendered` would spam the log on every shortcode render). Migrated to the existing `Debug::log_*()` system with 5 new areas (`AREA_FRONTEND`, `AREA_ADMIN`, `AREA_SELF_SCHEDULING`, `AREA_AUDIENCE`, `AREA_QRCODE`) so each domain has its own toggle in Settings → Advanced → Debug. `Utils::debug_log()` is now `@deprecated` and delegates to `Debug::AREA_FORM_PROCESSOR` for backwards compat. Existing 9 area toggles are unchanged.
 
 ---
 

--- a/includes/admin/class-ffc-admin-submission-edit-page.php
+++ b/includes/admin/class-ffc-admin-submission-edit-page.php
@@ -550,7 +550,7 @@ class AdminSubmissionEditPage {
 			// Validate user exists if linking to a user.
 			if ( null !== $new_user_id && ! get_userdata( $new_user_id ) ) {
 				// Invalid user ID - skip user link update.
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_admin(
 					'Invalid user ID for linking',
 					array(
 						'submission_id' => $id,

--- a/includes/admin/class-ffc-cpt.php
+++ b/includes/admin/class-ffc-cpt.php
@@ -102,7 +102,7 @@ class CPT {
 	 */
 	public function handle_form_duplication(): void {
 		if ( ! \FreeFormCertificate\Core\Utils::current_user_can_manage() ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_admin(
 				'Unauthorized form duplication attempt',
 				array(
 					'user_id' => get_current_user_id(),
@@ -120,7 +120,7 @@ class CPT {
 		$post = get_post( $post_id );
 
 		if ( ! $post || 'ffc_form' !== $post->post_type ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_admin(
 				'Invalid form duplication request',
 				array(
 					'post_id' => $post_id,
@@ -145,7 +145,7 @@ class CPT {
 		$new_post_id = wp_insert_post( $new_post_args, true );
 
 		if ( is_wp_error( $new_post_id ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_admin(
 				'Form duplication failed',
 				array(
 					'error'            => $new_post_id->get_error_message(),
@@ -183,7 +183,7 @@ class CPT {
 			$metadata_copied[] = 'geofence_config';
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_admin(
 			'Form duplicated successfully',
 			array(
 				'original_post_id' => $post_id,

--- a/includes/admin/class-ffc-settings-save-handler.php
+++ b/includes/admin/class-ffc-settings-save-handler.php
@@ -172,6 +172,14 @@ class SettingsSaveHandler {
 				'debug_rest_api',
 				'debug_migrations',
 				'debug_activity_log',
+				// 6.2.0 — added when the legacy `Utils::debug_log()` calls were
+				// migrated to the per-area `Debug` system. Each new area gets
+				// its own toggle in Settings → Advanced → Debug.
+				'debug_frontend',
+				'debug_admin',
+				'debug_self_scheduling',
+				'debug_audience',
+				'debug_qrcode',
 			);
 
 			foreach ( $debug_flags as $flag ) {

--- a/includes/api/class-ffc-appointment-rest-controller.php
+++ b/includes/api/class-ffc-appointment-rest-controller.php
@@ -382,7 +382,7 @@ class AppointmentRestController {
 	 */
 	private function log_rest_error( string $context, \Exception $e ): void {
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_rest_api(
 				"REST API error: {$context}",
 				array(
 					'message' => $e->getMessage(),

--- a/includes/api/class-ffc-calendar-rest-controller.php
+++ b/includes/api/class-ffc-calendar-rest-controller.php
@@ -298,7 +298,7 @@ class CalendarRestController {
 	 */
 	private function log_rest_error( string $context, \Exception $e ): void {
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_rest_api(
 				"REST API error: {$context}",
 				array(
 					'message' => $e->getMessage(),

--- a/includes/api/class-ffc-form-rest-controller.php
+++ b/includes/api/class-ffc-form-rest-controller.php
@@ -574,7 +574,7 @@ class FormRestController {
 	 */
 	private function log_rest_error( string $context, \Exception $e ): void {
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_rest_api(
 				"REST API error: {$context}",
 				array(
 					'message' => $e->getMessage(),

--- a/includes/api/class-ffc-submission-rest-controller.php
+++ b/includes/api/class-ffc-submission-rest-controller.php
@@ -430,7 +430,7 @@ class SubmissionRestController {
 	 */
 	private function log_rest_error( string $context, \Exception $e ): void {
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_rest_api(
 				"REST API error: {$context}",
 				array(
 					'message' => $e->getMessage(),

--- a/includes/api/class-ffc-user-appointments-rest-controller.php
+++ b/includes/api/class-ffc-user-appointments-rest-controller.php
@@ -229,7 +229,7 @@ class UserAppointmentsRestController {
 
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_rest_api(
 					'get_user_appointments error',
 					array(
 						'message' => $e->getMessage(),

--- a/includes/api/class-ffc-user-audience-rest-controller.php
+++ b/includes/api/class-ffc-user-audience-rest-controller.php
@@ -266,7 +266,7 @@ class UserAudienceRestController {
 
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_rest_api(
 					'get_user_audience_bookings error',
 					array(
 						'message' => $e->getMessage(),

--- a/includes/api/class-ffc-user-certificates-rest-controller.php
+++ b/includes/api/class-ffc-user-certificates-rest-controller.php
@@ -172,7 +172,7 @@ class UserCertificatesRestController {
 
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_rest_api(
 					'get_user_certificates error',
 					array(
 						'message' => $e->getMessage(),

--- a/includes/api/class-ffc-user-profile-rest-controller.php
+++ b/includes/api/class-ffc-user-profile-rest-controller.php
@@ -215,7 +215,7 @@ class UserProfileRestController {
 
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_rest_api(
 					'get_user_profile error',
 					array(
 						'message' => $e->getMessage(),
@@ -307,7 +307,7 @@ class UserProfileRestController {
 
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_rest_api(
 					'update_user_profile error',
 					array(
 						'message' => $e->getMessage(),

--- a/includes/audience/class-ffc-audience-loader.php
+++ b/includes/audience/class-ffc-audience-loader.php
@@ -721,7 +721,7 @@ class AudienceLoader {
 			$fields      = json_decode( $fields_json, true );
 
 			if ( ! is_array( $fields ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_audience(
 					'json_decode failed in ajax_save_custom_fields',
 					array(
 						'json_error' => json_last_error_msg(),

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -284,6 +284,13 @@ class Loader {
 		if ( class_exists( '\FreeFormCertificate\UserDashboard\CapabilityManager' ) ) {
 			\FreeFormCertificate\UserDashboard\CapabilityManager::register_role();
 			\FreeFormCertificate\UserDashboard\CapabilityManager::register_module_roles();
+
+			// Re-apply translated labels every time WP loads its roles.
+			// Without this, `users.php` would show the verbatim English
+			// label that was stored in the database at registration time.
+			// See `CapabilityManager::relabel_ffc_roles()` for full
+			// rationale.
+			add_action( 'wp_roles_init', array( '\FreeFormCertificate\UserDashboard\CapabilityManager', 'relabel_ffc_roles' ) );
 		}
 	}
 

--- a/includes/core/class-ffc-ajax-trait.php
+++ b/includes/core/class-ffc-ajax-trait.php
@@ -123,7 +123,7 @@ trait AjaxTrait {
 	 */
 	protected function handle_ajax_exception( \Throwable $e ): void {
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			Utils::debug_log(
+			Debug::log_form(
 				'AJAX error',
 				array(
 					'message' => $e->getMessage(),

--- a/includes/core/class-ffc-debug.php
+++ b/includes/core/class-ffc-debug.php
@@ -23,17 +23,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Debug {
 
 	/**
-	 * Available debug areas
+	 * Available debug areas.
+	 *
+	 * @since 3.1.0
+	 * @since 6.2.0 Added `AREA_FRONTEND`, `AREA_ADMIN`, `AREA_SELF_SCHEDULING`,
+	 *              `AREA_AUDIENCE`, `AREA_QRCODE` to absorb the 76 calls
+	 *              that used to live on the legacy `Utils::debug_log()` —
+	 *              every call is now toggleable per-area in admin Settings
+	 *              instead of firing whenever `WP_DEBUG=true`.
 	 */
-	const AREA_PDF_GENERATOR  = 'debug_pdf_generator';
-	const AREA_EMAIL_HANDLER  = 'debug_email_handler';
-	const AREA_FORM_PROCESSOR = 'debug_form_processor';
-	const AREA_ENCRYPTION     = 'debug_encryption';
-	const AREA_GEOFENCE       = 'debug_geofence';
-	const AREA_USER_MANAGER   = 'debug_user_manager';
-	const AREA_REST_API       = 'debug_rest_api';
-	const AREA_MIGRATIONS     = 'debug_migrations';
-	const AREA_ACTIVITY_LOG   = 'debug_activity_log';
+	const AREA_PDF_GENERATOR   = 'debug_pdf_generator';
+	const AREA_EMAIL_HANDLER   = 'debug_email_handler';
+	const AREA_FORM_PROCESSOR  = 'debug_form_processor';
+	const AREA_ENCRYPTION      = 'debug_encryption';
+	const AREA_GEOFENCE        = 'debug_geofence';
+	const AREA_USER_MANAGER    = 'debug_user_manager';
+	const AREA_REST_API        = 'debug_rest_api';
+	const AREA_MIGRATIONS      = 'debug_migrations';
+	const AREA_ACTIVITY_LOG    = 'debug_activity_log';
+	const AREA_FRONTEND        = 'debug_frontend';
+	const AREA_ADMIN           = 'debug_admin';
+	const AREA_SELF_SCHEDULING = 'debug_self_scheduling';
+	const AREA_AUDIENCE        = 'debug_audience';
+	const AREA_QRCODE          = 'debug_qrcode';
 
 	/**
 	 * Check if debug is enabled for a specific area
@@ -42,6 +54,15 @@ class Debug {
 	 * @return bool True if debug is enabled for this area
 	 */
 	public static function is_enabled( string $area ): bool {
+		// Defensive: in unit-test contexts where WP isn't fully loaded
+		// (e.g. Brain Monkey tests that exercise code paths now reaching
+		// `Debug::log_*()` after the 6.2.0 legacy migration), `get_option`
+		// may not exist. Fail-closed (debug disabled) rather than fatal —
+		// matches the pre-6.2.0 behaviour of `Utils::debug_log()` which
+		// short-circuited on a missing `WP_DEBUG` constant too.
+		if ( ! function_exists( 'get_option' ) ) {
+			return false;
+		}
 		$settings = get_option( 'ffc_settings', array() );
 		return isset( $settings[ $area ] ) && 1 === $settings[ $area ];
 	}
@@ -171,5 +192,65 @@ class Debug {
 	 */
 	public static function log_activity_log( string $message, $data = null ): void {
 		self::log( self::AREA_ACTIVITY_LOG, $message, $data );
+	}
+
+	/**
+	 * Log for Frontend area (shortcodes, public pages).
+	 *
+	 * @since 6.2.0
+	 * @param string $message Message to log.
+	 * @param mixed  $data Optional data to include.
+	 * @return void
+	 */
+	public static function log_frontend( string $message, $data = null ): void {
+		self::log( self::AREA_FRONTEND, $message, $data );
+	}
+
+	/**
+	 * Log for Admin area (admin pages, CPT handlers, submission edits).
+	 *
+	 * @since 6.2.0
+	 * @param string $message Message to log.
+	 * @param mixed  $data Optional data to include.
+	 * @return void
+	 */
+	public static function log_admin( string $message, $data = null ): void {
+		self::log( self::AREA_ADMIN, $message, $data );
+	}
+
+	/**
+	 * Log for Self-Scheduling module.
+	 *
+	 * @since 6.2.0
+	 * @param string $message Message to log.
+	 * @param mixed  $data Optional data to include.
+	 * @return void
+	 */
+	public static function log_self_scheduling( string $message, $data = null ): void {
+		self::log( self::AREA_SELF_SCHEDULING, $message, $data );
+	}
+
+	/**
+	 * Log for Audience module.
+	 *
+	 * @since 6.2.0
+	 * @param string $message Message to log.
+	 * @param mixed  $data Optional data to include.
+	 * @return void
+	 */
+	public static function log_audience( string $message, $data = null ): void {
+		self::log( self::AREA_AUDIENCE, $message, $data );
+	}
+
+	/**
+	 * Log for QR Code generator.
+	 *
+	 * @since 6.2.0
+	 * @param string $message Message to log.
+	 * @param mixed  $data Optional data to include.
+	 * @return void
+	 */
+	public static function log_qrcode( string $message, $data = null ): void {
+		self::log( self::AREA_QRCODE, $message, $data );
 	}
 }

--- a/includes/core/class-ffc-email-helper-trait.php
+++ b/includes/core/class-ffc-email-helper-trait.php
@@ -49,7 +49,7 @@ trait EmailHelperTrait {
 		$sent    = wp_mail( $to, $subject, $body, $headers, $attachments );
 
 		if ( ! $sent && class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			Utils::debug_log(
+			Debug::log_email(
 				'Email send failed',
 				array(
 					'to'      => $to,

--- a/includes/core/class-ffc-encryption.php
+++ b/includes/core/class-ffc-encryption.php
@@ -87,7 +87,7 @@ class Encryption {
 			);
 
 			if ( false === $encrypted ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_encryption(
 					'Encryption failed',
 					array(
 						'value_length' => strlen( $value ),
@@ -103,7 +103,7 @@ class Encryption {
 			return self::V2_PREFIX . base64_encode( $hmac . $iv . $encrypted );
 
 		} catch ( \Exception $e ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_encryption(
 				'Encryption exception',
 				array(
 					'error' => $e->getMessage(),
@@ -161,7 +161,7 @@ class Encryption {
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- benign: decoding our own ciphertext envelope.
 				$data = base64_decode( substr( $encrypted, strlen( self::V2_PREFIX ) ), true );
 				if ( false === $data || strlen( $data ) < self::HMAC_LENGTH + self::IV_LENGTH ) {
-					\FreeFormCertificate\Core\Utils::debug_log( 'v2 decode failed' );
+					\FreeFormCertificate\Core\Debug::log_encryption( 'v2 decode failed' );
 					return null;
 				}
 
@@ -171,7 +171,7 @@ class Encryption {
 
 				$expected_hmac = hash_hmac( self::HMAC_ALGO, $iv . $encrypted_data, self::get_hmac_key(), true );
 				if ( ! hash_equals( $expected_hmac, $hmac ) ) {
-					\FreeFormCertificate\Core\Utils::debug_log( 'v2 HMAC mismatch' );
+					\FreeFormCertificate\Core\Debug::log_encryption( 'v2 HMAC mismatch' );
 					return null;
 				}
 			} else {
@@ -179,7 +179,7 @@ class Encryption {
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- benign: decoding our own legacy ciphertext envelope.
 				$data = base64_decode( $encrypted, true );
 				if ( false === $data || strlen( $data ) < self::IV_LENGTH ) {
-					\FreeFormCertificate\Core\Utils::debug_log( 'Base64 decode failed' );
+					\FreeFormCertificate\Core\Debug::log_encryption( 'Base64 decode failed' );
 					return null;
 				}
 				$iv             = substr( $data, 0, self::IV_LENGTH );
@@ -196,14 +196,14 @@ class Encryption {
 			);
 
 			if ( false === $decrypted ) {
-				\FreeFormCertificate\Core\Utils::debug_log( 'Decryption failed' );
+				\FreeFormCertificate\Core\Debug::log_encryption( 'Decryption failed' );
 				return null;
 			}
 
 			return $decrypted;
 
 		} catch ( \Exception $e ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_encryption(
 				'Decryption exception',
 				array(
 					'error' => $e->getMessage(),

--- a/includes/core/class-ffc-utils.php
+++ b/includes/core/class-ffc-utils.php
@@ -485,29 +485,21 @@ class Utils {
 	 * Debug log.
 	 *
 	 * Debug log.
+	 * Legacy debug log helper.
 	 *
-	 * Debug log.
-	 *
-	 * Debug log.
+	 * @deprecated 6.2.0 Use {@see Debug::log_*()} instead. Each subsystem
+	 *             now has a dedicated helper gated by an admin toggle in
+	 *             Settings → Advanced → Debug — see `Debug::AREA_*`.
+	 *             Calls landing here delegate to the catch-all
+	 *             `AREA_FORM_PROCESSOR` for backwards compatibility, but
+	 *             new code should use the area-specific methods directly.
 	 *
 	 * @param string $message Message to log.
 	 * @param mixed  $data Optional data to log.
 	 * @return void
 	 */
 	public static function debug_log( string $message, $data = null ): void {
-		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-			return;
-		}
-
-		$log_message = '[FFC] ' . $message;
-
-		if ( null !== $data ) {
-            // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-			$log_message .= ' | Data: ' . print_r( $data, true );
-		}
-
-        // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-		error_log( $log_message );
+		Debug::log( Debug::AREA_FORM_PROCESSOR, $message, $data );
 	}
 
 	/**

--- a/includes/frontend/class-ffc-shortcodes.php
+++ b/includes/frontend/class-ffc-shortcodes.php
@@ -77,7 +77,7 @@ class Shortcodes {
 	 * @return string HTML output
 	 */
 	private function render_magic_link_preview( string $token ): string {
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_frontend(
 			'Magic link shortcode rendered',
 			array(
 				'token' => substr( $token, 0, 8 ) . '...',
@@ -118,7 +118,7 @@ class Shortcodes {
 			return $this->render_magic_link_preview( $magic_token );
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_frontend(
 			'Verification shortcode rendered',
 			array(
 				'ip'        => \FreeFormCertificate\Core\Utils::get_user_ip(),
@@ -146,7 +146,7 @@ class Shortcodes {
 		$form_id = absint( $atts['id'] );
 
 		if ( ! $form_id || get_post_type( $form_id ) !== 'ffc_form' ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_frontend(
 				'Invalid form shortcode',
 				array(
 					'form_id' => $form_id,
@@ -161,7 +161,7 @@ class Shortcodes {
 		$fields     = get_post_meta( $form_id, '_ffc_form_fields', true );
 
 		if ( empty( $fields ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_frontend(
 				'Form has no fields',
 				array(
 					'form_id' => $form_id,
@@ -170,7 +170,7 @@ class Shortcodes {
 			return '<p>' . esc_html__( 'Form has no fields.', 'ffcertificate' ) . '</p>';
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_frontend(
 			'Form shortcode rendered',
 			array(
 				'form_id'      => $form_id,

--- a/includes/frontend/class-ffc-verification-handler.php
+++ b/includes/frontend/class-ffc-verification-handler.php
@@ -475,7 +475,7 @@ class VerificationHandler {
 	 */
 	public function verify_by_magic_token( string $token ): array {
 		// Debug logging.
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_frontend(
 			'Magic token verification started',
 			array(
 				'token_preview' => substr( $token, 0, 8 ) . '...',
@@ -488,7 +488,7 @@ class VerificationHandler {
 		$user_ip    = \FreeFormCertificate\Core\Utils::get_user_ip();
 		$rate_check = \FreeFormCertificate\Security\RateLimiter::check_verification( $user_ip );
 		if ( ! $rate_check['allowed'] ) {
-			\FreeFormCertificate\Core\Utils::debug_log( 'Magic token rate limited' );
+			\FreeFormCertificate\Core\Debug::log_frontend( 'Magic token rate limited' );
 			return array(
 				'found'       => false,
 				'submission'  => null,
@@ -499,7 +499,7 @@ class VerificationHandler {
 		}
 
 		if ( ! \FreeFormCertificate\Generators\MagicLinkHelper::is_valid_token( $token ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log( 'Magic token invalid format' );
+			\FreeFormCertificate\Core\Debug::log_frontend( 'Magic token invalid format' );
 			return array(
 				'found'       => false,
 				'submission'  => null,
@@ -512,7 +512,7 @@ class VerificationHandler {
 		// Get submission by token.
 		$submission = $this->submission_handler()->get_submission_by_token( $token );
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_frontend(
 			'Magic token lookup result',
 			array(
 				'found'         => ! empty( $submission ),

--- a/includes/generators/class-ffc-pdf-generator.php
+++ b/includes/generators/class-ffc-pdf-generator.php
@@ -132,7 +132,7 @@ class PdfGenerator {
 		$filename = apply_filters( 'ffcertificate_certificate_filename', $filename, $form_title, $auth_code, $submission_id );
 
 		// Log generation.
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_pdf(
 			'PDF data generated',
 			array(
 				'submission_id' => $submission_id,
@@ -353,7 +353,7 @@ class PdfGenerator {
 		// Determine target URL (magic link or verification page).
 		$target_url = $this->get_qr_code_target_url( $data );
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_pdf(
 			'QR Code placeholder processing',
 			array(
 				'target_url'        => $target_url,
@@ -372,7 +372,7 @@ class PdfGenerator {
 				$placeholder = $matches[0];
 				$result      = $qr_generator->parse_and_generate( $placeholder, $target_url, $submission_id );
 
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_pdf(
 					'QR Code placeholder replaced',
 					array(
 						'placeholder'   => $placeholder,
@@ -670,7 +670,7 @@ class PdfGenerator {
 		$filename = $this->generate_filename( $form_title, $auth_code );
 
 		// Log generation.
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_pdf(
 			'PDF data generated from form',
 			array(
 				'form_id'      => $form_id,

--- a/includes/generators/class-ffc-qrcode-generator.php
+++ b/includes/generators/class-ffc-qrcode-generator.php
@@ -95,7 +95,7 @@ class QRCodeGenerator {
 		// Parse parameters from placeholder.
 		$params = $this->parse_placeholder_params( $placeholder );
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_qrcode(
 			'QR Code generation requested',
 			array(
 				'submission_id' => $submission_id,
@@ -108,7 +108,7 @@ class QRCodeGenerator {
 		if ( $submission_id > 0 && $this->is_cache_enabled() ) {
 			$cached = $this->get_from_cache( $submission_id );
 			if ( $cached ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_qrcode(
 					'QR Code served from cache',
 					array(
 						'submission_id' => $submission_id,
@@ -132,7 +132,7 @@ class QRCodeGenerator {
 		$qr_base64 = $this->generate( $url, $params );
 
 		if ( empty( $qr_base64 ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'QR Code generation failed',
 				array(
 					'url'           => substr( $url, 0, 50 ) . '...',
@@ -145,7 +145,7 @@ class QRCodeGenerator {
 		// Cache if enabled.
 		if ( $submission_id > 0 && $this->is_cache_enabled() ) {
 			$this->save_to_cache( $submission_id, $qr_base64 );
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'QR Code cached',
 				array(
 					'submission_id' => $submission_id,
@@ -236,7 +236,7 @@ class QRCodeGenerator {
 
 		// Validate URL.
 		if ( empty( $url ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log( 'QR Code: empty URL provided' );
+			\FreeFormCertificate\Core\Debug::log_qrcode( 'QR Code: empty URL provided' );
 			return '';
 		}
 
@@ -247,7 +247,7 @@ class QRCodeGenerator {
 				: tempnam( sys_get_temp_dir(), 'ffc_qr_' );
 
 			if ( ! $temp_file ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_qrcode(
 					'QR Code: temp file creation failed',
 					array(
 						'sys_tmp_dir' => sys_get_temp_dir(),
@@ -279,7 +279,7 @@ class QRCodeGenerator {
 				// Clean up.
 				wp_delete_file( $temp_file );
 
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_qrcode(
 					'QR Code generated successfully',
 					array(
 						'url_length'    => strlen( $url ),
@@ -296,7 +296,7 @@ class QRCodeGenerator {
 				wp_delete_file( $temp_file );
 			}
 
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'QR Code: temp file empty or missing after generation',
 				array(
 					'temp_file' => $temp_file,
@@ -307,7 +307,7 @@ class QRCodeGenerator {
 			return '';
 
 		} catch ( \Exception $e ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'QR Code generation exception',
 				array(
 					'error' => $e->getMessage(),
@@ -316,7 +316,7 @@ class QRCodeGenerator {
 			);
 			return '';
 		} catch ( \Throwable $e ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'QR Code generation fatal error',
 				array(
 					'error' => $e->getMessage(),
@@ -467,7 +467,7 @@ class QRCodeGenerator {
 			return false;
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_qrcode(
 			'Clearing QR cache',
 			array(
 				'submission_id' => $submission_id,
@@ -493,7 +493,7 @@ class QRCodeGenerator {
 			$cleared = (int) $result;
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_qrcode(
 			'QR cache cleared',
 			array(
 				'cleared_count' => $cleared,
@@ -525,7 +525,7 @@ class QRCodeGenerator {
 		);
 
 		if ( ! $submission || empty( $submission['magic_token'] ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'Magic QR: No token found',
 				array(
 					'submission_id' => $submission_id,
@@ -537,7 +537,7 @@ class QRCodeGenerator {
 		$magic_link = \FreeFormCertificate\Generators\MagicLinkHelper::generate_magic_link( $submission['magic_token'] );
 
 		if ( empty( $magic_link ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_qrcode(
 				'Magic QR: Link generation failed',
 				array(
 					'submission_id' => $submission_id,
@@ -547,7 +547,7 @@ class QRCodeGenerator {
 			return '';
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_qrcode(
 			'Magic QR: Generating for submission',
 			array(
 				'submission_id' => $submission_id,

--- a/includes/migrations/class-ffc-migration-status-calculator.php
+++ b/includes/migrations/class-ffc-migration-status-calculator.php
@@ -152,7 +152,7 @@ class MigrationStatusCalculator {
 		} catch ( \Throwable $e ) {
 			$this->strategy_errors[ $migration_key ] = $e->getMessage();
 			if ( class_exists( '\\FreeFormCertificate\\Core\\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_migrations(
 					'Failed to initialize migration strategy',
 					array(
 						'key'   => $migration_key,

--- a/includes/repositories/ffc-abstract-repository.php
+++ b/includes/repositories/ffc-abstract-repository.php
@@ -448,7 +448,7 @@ abstract class AbstractRepository {
 		}
 
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_form(
 				"Database {$operation} failed",
 				array(
 					'table' => $this->table,

--- a/includes/self-scheduling/class-ffc-self-scheduling-admin.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-admin.php
@@ -66,7 +66,7 @@ class SelfSchedulingAdmin {
 				$error = error_get_last();
 				if ( $error && in_array( $error['type'], array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR ), true ) ) {
 					if ( class_exists( '\\FreeFormCertificate\\Core\\Utils', false ) ) {
-						\FreeFormCertificate\Core\Utils::debug_log( 'Appointments page FATAL error (shutdown)', $error );
+						\FreeFormCertificate\Core\Debug::log_self_scheduling( 'Appointments page FATAL error (shutdown)', $error );
 					}
 				}
 			}
@@ -80,7 +80,7 @@ class SelfSchedulingAdmin {
 				. esc_html( $e->getMessage() )
 				. ' <em>(' . esc_html( basename( $e->getFile() ) ) . ':' . esc_html( (string) $e->getLine() ) . ')</em>'
 				. '</p></div></div>';
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Appointments page error',
 				array(
 					'error' => $e->getMessage(),

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
@@ -139,7 +139,7 @@ class AppointmentAjaxHandler {
 				}
 			} catch ( \Throwable $e ) {
 				if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-					\FreeFormCertificate\Core\Utils::debug_log(
+					\FreeFormCertificate\Core\Debug::log_self_scheduling(
 						'Appointment PDF generation error',
 						array(
 							'message' => $e->getMessage(),
@@ -182,7 +182,7 @@ class AppointmentAjaxHandler {
 			wp_send_json_success( $response );
 		} catch ( \Exception $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_self_scheduling(
 					'Appointment AJAX error',
 					array(
 						'message' => $e->getMessage(),
@@ -273,7 +273,7 @@ class AppointmentAjaxHandler {
 
 		} catch ( \Throwable $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_self_scheduling(
 					'Cancellation AJAX error',
 					array(
 						'message' => $e->getMessage(),
@@ -348,7 +348,7 @@ class AppointmentAjaxHandler {
 
 		} catch ( \Throwable $e ) {
 			if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_self_scheduling(
 					'Admin appointments AJAX error',
 					array(
 						'message' => $e->getMessage(),

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
@@ -228,7 +228,7 @@ class AppointmentCsvExporter {
 	 * @return void
 	 */
 	public function export_csv( $calendar_ids = null, array $statuses = array(), ?string $start_date = null, ?string $end_date = null ): void {
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_self_scheduling(
 			'Appointment CSV export started',
 			array(
 				'calendar_ids' => $calendar_ids,
@@ -407,7 +407,7 @@ class AppointmentCsvExporter {
 			$this->export_csv( $calendar_ids, $statuses, $start_date, $end_date );
 
 		} catch ( \Exception $e ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Appointment CSV export exception',
 				array(
 					'error' => $e->getMessage(),

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
@@ -513,7 +513,7 @@ class AppointmentHandler {
 					$data['user_id'] = $user_id;
 
 					if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-						\FreeFormCertificate\Core\Utils::debug_log(
+						\FreeFormCertificate\Core\Debug::log_self_scheduling(
 							'User created/linked for appointment',
 							array(
 								'user_id'    => $user_id,
@@ -525,7 +525,7 @@ class AppointmentHandler {
 				}
 			} catch ( \Exception $e ) {
 				if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-					\FreeFormCertificate\Core\Utils::debug_log(
+					\FreeFormCertificate\Core\Debug::log_self_scheduling(
 						'Failed to create user for appointment',
 						array(
 							'email' => $data['email'],

--- a/includes/self-scheduling/class-ffc-self-scheduling-cleanup-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-cleanup-handler.php
@@ -160,7 +160,7 @@ class SelfSchedulingCleanupHandler {
 		}
 
 		// Log the action.
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_self_scheduling(
 			'Appointments cleaned up',
 			array(
 				'calendar_id'    => $calendar_id,

--- a/includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-cpt.php
@@ -144,7 +144,7 @@ class SelfSchedulingCPT {
 	 */
 	public function handle_calendar_duplication(): void {
 		if ( ! \FreeFormCertificate\Core\Utils::current_user_can_admin_or( 'ffc_manage_self_scheduling' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Unauthorized calendar duplication attempt',
 				array(
 					'user_id' => get_current_user_id(),
@@ -162,7 +162,7 @@ class SelfSchedulingCPT {
 		$post = get_post( $post_id );
 
 		if ( ! $post || 'ffc_self_scheduling' !== $post->post_type ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Invalid calendar duplication request',
 				array(
 					'post_id' => $post_id,
@@ -187,7 +187,7 @@ class SelfSchedulingCPT {
 		$new_post_id = wp_insert_post( $new_post_args, true );
 
 		if ( is_wp_error( $new_post_id ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Calendar duplication failed',
 				array(
 					'error'            => $new_post_id->get_error_message(),
@@ -219,7 +219,7 @@ class SelfSchedulingCPT {
 			$metadata_copied[] = 'email_config';
 		}
 
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_self_scheduling(
 			'Calendar duplicated successfully',
 			array(
 				'original_post_id' => $post_id,
@@ -371,7 +371,7 @@ class SelfSchedulingCPT {
 			// Delete calendar record.
 			$this->calendar_repo()->delete( $calendar_id );
 
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Calendar data cleaned up',
 				array(
 					'post_id'                => $post_id,
@@ -502,7 +502,7 @@ class SelfSchedulingCPT {
 
 		// Log notification.
 		if ( class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-			\FreeFormCertificate\Core\Utils::debug_log(
+			\FreeFormCertificate\Core\Debug::log_self_scheduling(
 				'Calendar deletion notification sent',
 				array(
 					'appointment_id' => $appointment['id'],

--- a/includes/self-scheduling/views/appointments-list.php
+++ b/includes/self-scheduling/views/appointments-list.php
@@ -587,7 +587,7 @@ if ( $ffc_self_scheduling_appointment_id > 0 ) {
 			echo '<p><a href="' . esc_url( $ffcertificate_appointments_url ) . '" class="button">' . esc_html__( 'Back to List', 'ffcertificate' ) . '</a></p>';
 			echo '</div>';
 			if ( class_exists( '\\FreeFormCertificate\\Core\\Utils' ) ) {
-				\FreeFormCertificate\Core\Utils::debug_log(
+				\FreeFormCertificate\Core\Debug::log_self_scheduling(
 					'Appointment view error',
 					array(
 						'id'    => $ffc_self_scheduling_appointment_id,

--- a/includes/settings/views/ffc-tab-advanced.php
+++ b/includes/settings/views/ffc-tab-advanced.php
@@ -260,6 +260,81 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 						</p>
 					</td>
 				</tr>
+
+				<tr>
+					<th scope="row">
+						<label for="debug_frontend"><?php esc_html_e( 'Frontend', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<label>
+							<input type="checkbox" name="ffc_settings[debug_frontend]" id="debug_frontend" value="1" <?php checked( $ffcertificate_get_option( 'debug_frontend' ), 1 ); ?>>
+							<?php esc_html_e( 'Enable debug logging for frontend shortcodes + verification', 'ffcertificate' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Logs `[ffc_form]`, `[ffc_verification]`, and `[ffc_magic_link]` shortcode renders + the public verification flow.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row">
+						<label for="debug_admin"><?php esc_html_e( 'Admin', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<label>
+							<input type="checkbox" name="ffc_settings[debug_admin]" id="debug_admin" value="1" <?php checked( $ffcertificate_get_option( 'debug_admin' ), 1 ); ?>>
+							<?php esc_html_e( 'Enable debug logging for admin pages', 'ffcertificate' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Logs admin submission edits, CPT handlers, and admin-side actions.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row">
+						<label for="debug_self_scheduling"><?php esc_html_e( 'Self-Scheduling', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<label>
+							<input type="checkbox" name="ffc_settings[debug_self_scheduling]" id="debug_self_scheduling" value="1" <?php checked( $ffcertificate_get_option( 'debug_self_scheduling' ), 1 ); ?>>
+							<?php esc_html_e( 'Enable debug logging for the self-scheduling module', 'ffcertificate' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Logs appointment booking, cancellation, cleanup, CSV export, and admin/CPT operations.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row">
+						<label for="debug_audience"><?php esc_html_e( 'Audience', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<label>
+							<input type="checkbox" name="ffc_settings[debug_audience]" id="debug_audience" value="1" <?php checked( $ffcertificate_get_option( 'debug_audience' ), 1 ); ?>>
+							<?php esc_html_e( 'Enable debug logging for the audience module', 'ffcertificate' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Logs audience admin actions and user-audience join/leave operations.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row">
+						<label for="debug_qrcode"><?php esc_html_e( 'QR Code', 'ffcertificate' ); ?></label>
+					</th>
+					<td>
+						<label>
+							<input type="checkbox" name="ffc_settings[debug_qrcode]" id="debug_qrcode" value="1" <?php checked( $ffcertificate_get_option( 'debug_qrcode' ), 1 ); ?>>
+							<?php esc_html_e( 'Enable debug logging for QR code generation', 'ffcertificate' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Logs QR-code asset resolution, cache hits, and URL composition.', 'ffcertificate' ); ?>
+						</p>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 </div>

--- a/includes/settings/views/ffc-tab-migrations.php
+++ b/includes/settings/views/ffc-tab-migrations.php
@@ -25,7 +25,7 @@ try {
 } catch ( \Throwable $e ) {
 	$ffcertificate_init_error = $e->getMessage();
 	if ( class_exists( '\\FreeFormCertificate\\Core\\Utils' ) ) {
-		\FreeFormCertificate\Core\Utils::debug_log(
+		\FreeFormCertificate\Core\Debug::log_migrations(
 			'Migration tab initialization failed',
 			array(
 				'error' => $e->getMessage(),

--- a/includes/submissions/class-ffc-form-cache.php
+++ b/includes/submissions/class-ffc-form-cache.php
@@ -51,13 +51,13 @@ class FormCache {
 				wp_cache_set( $cache_key, $config, self::CACHE_GROUP, self::get_expiration() );
 
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					\FreeFormCertificate\Core\Utils::debug_log( 'Form config cache MISS', array( 'form_id' => $form_id ) );
+					\FreeFormCertificate\Core\Debug::log_form( 'Form config cache MISS', array( 'form_id' => $form_id ) );
 				}
 			} else {
 				return false;
 			}
 		} elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				\FreeFormCertificate\Core\Utils::debug_log( 'Form config cache HIT', array( 'form_id' => $form_id ) );
+				\FreeFormCertificate\Core\Debug::log_form( 'Form config cache HIT', array( 'form_id' => $form_id ) );
 		}
 
 		return $config;

--- a/includes/user-dashboard/class-ffc-capability-manager.php
+++ b/includes/user-dashboard/class-ffc-capability-manager.php
@@ -814,4 +814,47 @@ class CapabilityManager {
 			remove_role( $slug );
 		}
 	}
+
+	/**
+	 * Re-translate FFC role labels at every page load.
+	 *
+	 * WordPress stores role labels verbatim in the `wp_user_roles` option
+	 * at the moment of `add_role()`. If translations weren't loaded yet,
+	 * the English string gets frozen in the database. On subsequent loads,
+	 * `users.php` displays role names via WP's `translate_user_role()`
+	 * helper — but that helper resolves the label against the **default**
+	 * WP textdomain, not the plugin's textdomain. So plugin-provided role
+	 * labels never translate, even after the .po file is loaded.
+	 *
+	 * Hooking `wp_roles_init` (since WP 4.7) lets us mutate the in-memory
+	 * `WP_Roles::$roles` + `WP_Roles::$role_names` arrays after they're
+	 * loaded. We re-resolve every FFC role's label through `__()` against
+	 * the plugin's textdomain, so users.php always shows the user's locale.
+	 *
+	 * Hooked from `Loader::register_ffc_roles_safe()` (init:1) AFTER the
+	 * role registrations themselves, so the freshly-registered labels also
+	 * get re-translated on the very first page load post-upgrade.
+	 *
+	 * @since 6.2.0
+	 * @param \WP_Roles $wp_roles Roles instance.
+	 * @return void
+	 */
+	public static function relabel_ffc_roles( \WP_Roles $wp_roles ): void {
+		$labels = array(
+			'ffc_user'                     => __( 'FFC User', 'ffcertificate' ),
+			self::RECRUITMENT_MANAGER_ROLE => __( 'Recruitment Manager', 'ffcertificate' ),
+		);
+		foreach ( self::module_roles_definition() as $slug => $def ) {
+			$labels[ $slug ] = $def['label'];
+		}
+
+		foreach ( $labels as $slug => $label ) {
+			if ( isset( $wp_roles->roles[ $slug ] ) ) {
+				$wp_roles->roles[ $slug ]['name'] = $label;
+			}
+			if ( isset( $wp_roles->role_names[ $slug ] ) ) {
+				$wp_roles->role_names[ $slug ] = $label;
+			}
+		}
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -175,91 +175,58 @@ In the certificate layout editor, use these dynamic tags:
 
 == Changelog ==
 
-= 5.4.1 (2026-04-24) =
+= 6.2.0 (2026-05-04) =
 
-Certificate HTML editor gains CodeMirror syntax highlighting with distinct coloring for HTML tags and `{{placeholder}}` tokens, plus a three-option `Code Editor Theme` setting (Auto / Light / Dark, dark by default on fresh installs) with a VS-Code-Dark+-inspired palette; the email body moves to a lightweight visual editor (`wp_editor()` teeny); the global TinyMCE placeholder-protection filter is scoped to the plugin's post type so it no longer touches unrelated admin screens; a new per-calendar admin-bypass toggle replaces the hardcoded all-or-nothing bypass for self-scheduling; and the `[ffc_verification]` result card header stops rendering with the admin preview modal's dark slate background.
+**Capabilities + roles overhaul + admin UX scoping + upgrade safety + per-area debug toggles + role i18n fix.**
 
-* Feat: **CodeMirror integration for the certificate HTML editor** — `ffc_pdf_layout` now renders through WordPress's built-in CodeMirror (`wp_enqueue_code_editor`), giving tags, attributes and strings distinct colors and line numbers. A custom overlay paints `{{placeholder}}` tokens in a separate color so variables stand out from markup. The underlying `<textarea>` is preserved and its value is synced on every change, so form submission and saved HTML remain byte-for-byte identical to the previous plain-textarea path; certificate templates and PDF generation are not affected.
-* Feat: **Syntax Highlighting profile notice** — when the user has disabled "Syntax Highlighting" in their WordPress profile, `wp_enqueue_code_editor()` returns false; a small inline description appears below the editor linking to `profile.php#syntax_highlighting` and recommending that the option be enabled for maximum plugin compatibility. The textarea continues to work as before.
-* Feat: **Email body upgraded to `wp_editor()` teeny** — the `email_body` field moves from a plain textarea to a minimal-toolbar visual editor (bold, italic, underline, lists, link/unlink, undo/redo). Media buttons stay disabled. Placeholders such as `{{auth_code}}` and `{{name}}` are preserved thanks to the `tiny_mce_before_init` protection still in place.
-* Feat: **Per-calendar admin-bypass toggle for self-scheduling** — a new `Admin Bypass` checkbox in the Booking Rules metabox of each `ffc_self_scheduling` calendar decides whether users with `manage_options` / `ffc_scheduling_bypass` skip that specific calendar's booking restrictions (advance-booking window, past-date guard, blocked dates, working hours, daily/interval limits, cancellation allowance/deadline). Slot capacity is always enforced. Replaces the previous hardcoded all-or-nothing bypass. Calendars saved before 5.4.1 default to the historical on-state so behavior is preserved without a migration.
-* Feat: **Code Editor Theme setting** — new select on the Advanced settings tab (`Auto` / `Light` / `Dark`) controlling the appearance of the Certificate HTML editor. `Auto` mirrors the plugin's admin Dark Mode preference; fresh installs default to `Dark`. Dark theme ships with a VS-Code-Dark+-inspired palette (background #1e1e1e, blue tags, orange strings, green comments) and keeps `{{placeholder}}` tokens legible with a gold-on-dark overlay. Light theme uses WordPress's default CodeMirror styling with zero extra payload.
-* Change: **TinyMCE placeholder filter scoped to `ffc_form`** — `Admin::configure_tinymce_placeholders()` is no longer attached to `tiny_mce_before_init` globally from the constructor. A new `maybe_register_tinymce_placeholder_filter()` method registers the filter on `admin_head` only when `get_current_screen()->post_type === 'ffc_form'`, eliminating side effects on Classic Editor posts and third-party plugin screens.
-* Change: **Email body sanitization hardened** — save handler now runs `email_body` through `wp_kses_post()` (the canonical WordPress post-content allowlist) instead of the generic plugin allowlist, aligning with its new authoring surface.
-* Change: **CSS placeholder block refactored** — the orphan `.mce-content-body .ffc-placeholder` selector (unreachable while no `wp_editor()` existed) is removed in favor of a single `.ffc-placeholder` rule plus new CodeMirror-specific styles (`.ffc-code-editor-wrapper .CodeMirror`, `.cm-ffc-placeholder-token`, `.ffc-code-editor-notice`).
-* Change: **`CalendarRepository::userHasSchedulingBypass()` accepts a calendar context** — the method now takes an optional calendar post ID and consults `_ffc_self_scheduling_config['admin_bypass']`. Callers that pass null (audience/REST admin read paths) keep the historical capability-only semantics unchanged; booking and cancellation flows pass the calendar id so the toggle takes effect.
-* Fix: **`[ffc_verification]` result card header showed a black bar instead of the blue gradient** — a later `.ffc-preview-header` rule intended only for the admin preview modal (`#ffc-preview-modal`) was unscoped and overrode the verification card's blue gradient + centered title, also forcing `display: flex; justify-content: space-between` which visually separated the badge from the appointment status label. All five affected modal-only selectors are now scoped to `#ffc-preview-modal`, restoring the intended header on certificate, appointment and reregistration verification results.
-* Security (MEDIUM): `wp_kses_post()` applied to `email_body` in the form editor save handler — scripts, forms, and other disallowed tags are stripped on save of the now-rich email template.
-* Test: new unit tests covering `maybe_register_tinymce_placeholder_filter()` across three screen states (ffc_form, other post type, null screen), plus four new tests in `CalendarRepositoryTest` for the per-calendar `admin_bypass` consumption path (toggle off, toggle on, legacy calendar without the key, unprivileged user with any setting).
-* Chore: new JS module `assets/js/ffc-admin-code-editor.js` (+ minified build) initializes CodeMirror, adds the placeholder overlay, keeps the textarea in sync on change and on submit, and degrades gracefully when the code editor is unavailable.
+* Feat: 14 granular admin capabilities (cross-module + per-domain recruitment) replace blanket `manage_options` gates so site owners can delegate scoped roles without giving full WP admin.
+* Feat: 9 new roles bundle the new caps — Certificate Manager, Self-Scheduling Manager, Audience Manager, Reregistration Manager, FFC Operator, plus a 4-tier recruitment ladder (Auditor → Operator → Manager → Admin).
+* Feat: `AdminMenuVisibility` defense-in-depth UX layer hides core WP menus, blocks direct-URL access (redirect to role's landing page), and prunes the top admin bar per FFC role.
+* Feat: 5 new debug areas (Frontend, Admin, Self-Scheduling, Audience, QR Code) with per-area toggles in **Settings → Advanced → Debug**. The 76 legacy `Utils::debug_log()` calls migrated to `Debug::log_*()`; `Utils::debug_log()` is now `@deprecated`. Frontend shortcode renders + other internal events no longer pollute production logs.
+* Fix: FFC role labels now translate correctly on `wp-admin/users.php`. New `wp_roles_init` hook re-applies `__()` against the plugin's textdomain on every page load (WordPress's built-in `translate_user_role()` resolves against the **default** WP textdomain, so plugin role names never localized).
+* Fix: 3 legacy non-namespaced certificate caps (`view_own_certificates`, `download_own_certificates`, `view_certificate_history`) renamed to the consistent `ffc_*` namespace with a one-time idempotent migration.
+* Fix: Pre-existing in-place-upgrade bug — recruitment tables left un-created when bypassing reactivation. `RecruitmentActivator::create_tables()` + role registrations now run on `plugins_loaded` (idempotent self-heal).
 
-= 5.4.0 (2026-04-23) =
+= 6.1.0 (2026-05-02) =
 
-Encryption and privacy hardening across the user-data surface, the accumulated security audit (Tier 1 + Tier 2), CSV download intermediate screen, a performance pass for admin submissions at scale, and the `UserProfileService` refactor consolidating profile reads and writes through a single entry point.
+**Recruitment admin UX parity + dashboard integration + Preliminary list visual axis.** Closes #90.
 
-* Feat: **Centralized sensitive-field policy** via `FreeFormCertificate\Core\SensitiveFieldRegistry` — single declarative map replacing three hard-coded lists. Consumed by `SubmissionHandler` and `AppointmentRepository`.
-* Feat: **`UserProfileFieldMap`** — per-field descriptor declaring storage layer (`wp_users`, `ffc_user_profiles`, `wp_usermeta`), sensitivity, hashability, and optional mirror targets (e.g. `display_name` → `wp_users.display_name`).
-* Feat: **`ViewPolicy` enum** (`FULL`, `MASKED`, `HASHED_ONLY`) declaring how sensitive fields are rendered on read. The service audits but does not elevate privileges; callers validate capability.
-* Feat: **`UserProfileService::read()` / `::write()`** — single entry point consolidating profile reads and writes across the three storage layers with transparent encryption, hashing, and mirror syncing. `FULL` reads that touch sensitive fields emit a metadata-only audit entry. `write()` accepts `$extra_descriptors` for dynamic reregistration keys outside the static map; overrides are per-call and cleared via try/finally.
-* Feat: **`email_hash_rehash` migration** — batched, idempotent, cursor-based. Rewrites legacy unsalted `email_hash` values in `wp_ffc_submissions` and `wp_ffc_self_scheduling_appointments`.
-* Feat: **`activity_log_clear_plaintext` migration** — NULLs the `context` plaintext column on activity log rows that already hold a ciphertext, closing the dual-storage leak on historical data.
-* Feat: **CSV download intermediate screen** — info screen showing form restrictions, dates, geolocation, quiz, and quota between hash validation and download. Download button only enabled after the form has ended; certificate preview available before the collection period begins.
-* Feat: **Public CSV sync-export row cap** — new `public_csv_sync_max_rows` setting (Advanced tab, default 2000, range 100–10000).
-* Change: **Activity log encryption gate** switched from a hard-coded action whitelist to payload inspection via `SensitiveFieldRegistry::contains_sensitive()`. Actions carrying sensitive fields (including nested payloads) are encrypted automatically; actions with trivial payloads are no longer wrapped in a meaningless ciphertext.
-* Change: **`ActivityLog::log()`** no longer dual-stores `context` plaintext alongside its ciphertext. Sensitive rows NULL the plaintext column; reads decrypt transparently via `ActivityLogQuery::resolve_context()`.
-* Change: **`UserManager::update_profile()` and `::update_extended_profile()`** are now thin facades over `UserProfileService::write()`. Legacy inline encrypt/hash paths are gone. Behavior improvement: clearing a sensitive field now also deletes the sibling `*_hash` meta row.
-* Change: **`Encryption::decrypt()`** split into a public wrapper and a private helper; emits a `decrypt_failure` WARNING to `ActivityLog` whenever a non-empty ciphertext resolves to null.
-* Change: Residual `class_exists ? Encryption::hash : hash('sha256')` fallbacks removed from `SelfSchedulingAppointmentHandler` and `SubmissionRepository::hash()`.
-* Change: Encryption envelope produces authenticated **v2 ciphertexts** (encrypt-then-MAC, HMAC-SHA256); legacy v1 ciphertexts remain decryptable.
-* Perf: `SubmissionRepository::countByStatus()` cached in a 5-minute transient; composite index `(form_id, status, submission_date)` on `ffc_submissions`; activity log cleanup admin_init fallback; `findPaginated()` search optimizations.
-* Fix: **Email hash divergence** between `wp_ffc_submissions` and `wp_ffc_self_scheduling_appointments` — same email produced different hashes, breaking cross-entity lookups. Unified on `Encryption::hash`.
-* Fix: **`AppointmentRepository::findByCpfRf`** never matched its own writes (raw SHA-256 read vs salted write).
-* Fix: **`UserCleanup::handle_email_change`** reindexed submission `email_hash` with raw SHA-256, overwriting correct salted hashes on every email change.
-* Fix: **`SecurityService::verify_simple_captcha`** rejected valid answer `0` (`empty('0')` is true in PHP). `hash_equals()` used for timing-safe comparison.
-* Fix: **`json_decode(null)` deprecation** in `SubmissionRestController::decrypt_submission_data` (PHP 8.1+).
-* Fix: Activity log disabled-notice link pointed to `Settings > General`; toggle lives in `Settings > Advanced`.
-* Security (CRITICAL / LGPD): cross-table hash consistency — dedup and reconciliation between submissions, appointments and user profile now works reliably.
-* Security (HIGH / LGPD): activity log no longer dual-stores PII plaintext alongside ciphertext.
-* Security (MEDIUM / LGPD): decrypt failures auditable — HMAC mismatch, key-rotation breakage and corruption stop being silent.
-* Security (HIGH): column-name SQL injection hardening in `AbstractRepository::build_where_clause()` via `%i` placeholder and allowlist.
-* Security (HIGH): timing-safe token comparison via `hash_equals()` in appointment receipt handler; escape user-supplied values in audience email templates.
-* Security (MEDIUM): `SubmissionRestController` admin endpoints restricted to `manage_options`; `UserProfileRestController` sanitizes user input; `AudienceRepository` replaces inline `IN()` interpolation with parameterized placeholders.
-* Security (MEDIUM / XSS): escape output in `SubmissionsList`, frontend field renderer, PDF layout `{{form_title}}` substitution, and admin-configured email bodies.
-* Security (MEDIUM / transport): `IpGeolocation` HTTPS opt-in; `RateLimiter` only trusts `REMOTE_ADDR` unless `ffc_trust_forwarded_headers` is enabled; magic-link QR codes generated locally.
-* Security (MEDIUM / path traversal): validate receipt template path; allowlist reregistration email templates; move ICS temp files out of public uploads.
-* Security (LOW): remove `$e->getMessage()` from client-facing error responses; `Admin::redirect_with_msg()` builds target from `page`/`post_type`; various minor output-escaping fixes.
-* Security (privacy): hash PII identifiers before logging (`RateLimiter`, `IpGeolocation`) for LGPD compliance.
-* Docs: `SECURITY.md` supported-versions table updated to `5.4.x`. `CONTRIBUTING.md` Branches section no longer mandates the `claude/*` prefix for human contributors; Releasing section documents the `[Unreleased] → [X.Y.Z]` workflow.
-* Test: **3234 → 3485 tests** (+251) with **8783 assertions** — new suites for `SensitiveFieldRegistry`, `SensitiveFieldPolicyTest`, `DecryptFailureLoggingTest`, `UserProfileFieldMapTest`, `UserProfileServiceTest`, `CustomFieldValidator`, `Autoloader`, `UserContextTrait`, `MigrationDynamicReregFields`, `ReregistrationStandardFieldsSeeder`, `AbstractRepository`, `Geofence`, `FormListColumns`, and new coverage for `UserManager::update_extended_profile` / `get_extended_profile`.
-* Chore: WPCS **1232 → 0 errors** across 161 files; PHPStan level 7 **3 → 0 errors**.
+* Feat: Recruitment admin moves from inline `<table>` placeholders to full `WP_List_Table` listings (sort, search, paginate, bulk actions, row actions) for Notices / Adjutancies / Candidates / Reasons.
+* Feat: Dedicated edit screens for notices (5 sections incl. transitions, attach/detach, CSV import, classifications) + candidates (general, sensitive data, classification + call history, hard-delete) + reasons.
+* Feat: Notice ↔ adjutancy attach UI + REST — fixes a `recruitment_notice_has_no_adjutancies` 400 that blocked CSV imports on fresh installs.
+* Feat: Preliminary visual statuses (Empty / Denied / Granted / Appeal denied / Appeal granted) + global Reasons catalog without touching the §5.2 state machine. Schema migration v5 + v6 (adds `preview_status`, `preview_reason_id`, `time_points`, `hab_emebs`).
+* Feat: Per-adjutancy + per-status configurable badge colors via `<input type="color">`.
+* Feat: Public shortcode polish — adjutancy filter (functional now; was silently ignored), name search (`?q=`), subscription-type filter (PCD/GERAL), persistent filter UI, BR-format dates (DD-MM-YYYY) + 2-decimal scores, semicolon CSV delimiter auto-detection.
+* Feat: Out-of-order call confirm + reason prompt (single + bulk); 12h public-shortcode cache TTL with admin-write invalidation; CSV import activity indicator.
+* Change: Notice status `active` → `definitive` (schema migrations v2 + v3 cover both upgrade cohorts).
+* Perf: Public shortcode candidate-fetch — N round-trips → 1 via `RecruitmentCandidateRepository::get_by_ids()`. 30–50% cold-cache improvement.
 
-= 5.3.0 (2026-04-17) =
+= 6.0.0 (2026-05-01) =
 
-Full-page cache compatibility, per-form captcha isolation, and CI pipeline improvements.
+**Recruitment module — Brazilian public-tender ("concurso público") candidate queue management.** PHPStan level 7 → 8 (no baseline).
 
-* Feat: **Full-page cache compatibility** — forms and calendars now work correctly with LiteSpeed Cache, WP Rocket, W3 Total Cache, and WP Super Cache. Business-hours restricted calendars send no-cache headers to prevent stale content; audience shortcodes prevent cross-user cache leakage for logged-in users.
-* Feat: **Dynamic Fragments geofence refresh** — AJAX endpoint returns fresh geofence configs per form so cached pages always show up-to-date availability windows.
-* Feat: **Automatic cache purge on save** — saving a form or calendar automatically purges cached pages that embed it (LiteSpeed, WP Rocket, W3TC, WP Super Cache).
-* Feat: **CSV Download Page URL setting** — new field on General settings tab.
-* Feat: **Search forms by ID** — admin forms list now supports searching by numeric post ID.
-* Fix: **Same captcha on all forms** — multiple forms on a cached page now each get a unique math captcha.
-* Refactor: **CustomFieldValidator extraction** from CustomFieldRepository for single-responsibility.
-* Refactor: Expanded in-plugin Documentation tab with additional sections.
-* CI: Remove duplicate push triggers, extract composite action, add Dependabot auto-merge, promote PHPCS to gating, promote PHPStan to level 7.
-* Chore: Auto-fix ~83k PHPCS violations, annotate 223 false positives, Phase 3 mechanical fixes.
+* Feat: New `[ffc_recruitment_queue]` public shortcode + candidate-self `[ffc_recruitment_my_calls]` dashboard section + wp-admin "Recrutamento" submenu.
+* Feat: 21-route admin REST surface under `ffcertificate/v1/recruitment` (notices, classifications, candidates, adjutancies, calls, /me/recruitment).
+* Feat: `ffc_manage_recruitment` capability + dedicated `ffc_recruitment_manager` role for delegation without giving `manage_options`.
+* Feat: Atomic CSV importer (single-transaction wipe + reinsert with rollback on any validation error).
+* Feat: Two state machines — Notice (draft → preliminary → active → closed) + Classification (empty → called → accepted → hired/not_shown) with §5.1 reopen-freeze rule that locks `hired`/`not_shown` once a notice has been reopened.
+* Feat: Convocation service (single + bulk + cancel with append-only call history); email dispatch on call create with masked PII placeholders.
+* Feat: Centralized §7-bis delete gating (candidate hard-delete only when zero classifications; classification individual delete only when `empty` + draft/preliminary).
+* Feat: Submissions admin "Move to form…" bulk action with identifier-based conflict detection.
+* Change: PHPStan bumped from level 7 (231-entry baseline) to **level 8 with zero errors and no baseline**. ~70 production call sites + ~80 test references migrated away from `Utils::*` deprecated shims.
 
 For the complete changelog history, see [CHANGELOG.md](CHANGELOG.md).
 
 == Upgrade Notice ==
 
-= 5.4.1 =
-Certificate HTML editor now uses CodeMirror with VS-Code-style syntax highlighting (Auto/Light/Dark theme, dark by default). Email body upgraded to a lightweight visual editor with `wp_kses_post()` hardening. Per-calendar admin-bypass toggle for self-scheduling replaces the previous all-or-nothing bypass. Fixed dark-header bug on `[ffc_verification]` result cards. No database changes. No breaking changes.
+= 6.2.0 =
+Capabilities + roles overhaul: 14 new granular admin caps replace blanket `manage_options` gates, 9 new roles bundle the caps for delegation. Defense-in-depth admin UX layer hides core WP menus + blocks direct-URL access per role. 5 new debug-area toggles in **Settings → Advanced → Debug**. Fixes role translation on `wp-admin/users.php`. Fixes pre-existing in-place-upgrade bug that left recruitment tables un-created. 3 legacy certificate caps renamed to `ffc_*` namespace with one-time idempotent migration. No data loss; backup recommended.
 
-= 5.4.0 =
-Encryption and privacy hardening across the user-data surface (centralized sensitive-field policy, payload-driven activity log encryption, auditable decrypt failures). Tier 1 + Tier 2 security audit applied. CSV download intermediate screen and performance pass for admin submissions at scale. Migration `email_hash_rehash` runs automatically. Backup recommended.
+= 6.1.0 =
+Recruitment admin UX parity (full WP_List_Table backing, edit screens) + dashboard integration + Preliminary list visual axis. Schema migrations v2–v6 run automatically (notice status `active` → `definitive` rename + new columns for preview status / time points / hab_emebs + `ffc_recruitment_reason` table). Backup recommended before upgrade.
 
-= 5.3.0 =
-Full-page cache compatibility (LiteSpeed, WP Rocket, W3 Total Cache, WP Super Cache). Per-form captcha isolation. CI pipeline improvements. No database changes. No breaking changes.
+= 6.0.0 =
+NEW Recruitment module — Brazilian public-tender candidate queue management. 21 admin REST routes, atomic CSV importer, two state machines, convocation service, dedicated `ffc_recruitment_manager` role. PHPStan level 7 → 8 with zero baseline. 6 new InnoDB tables created on activation. Backup recommended.
 
 For older releases, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/tests/Unit/DebugTest.php
+++ b/tests/Unit/DebugTest.php
@@ -177,6 +177,10 @@ class DebugTest extends TestCase {
         $areas = array_filter( $constants, function ( $k ) {
             return str_starts_with( $k, 'AREA_' );
         }, ARRAY_FILTER_USE_KEY );
-        $this->assertCount( 9, $areas );
+        // 9 pre-6.2.0 areas + 5 added in 6.2.0 (FRONTEND, ADMIN,
+        // SELF_SCHEDULING, AUDIENCE, QRCODE) when the legacy
+        // `Utils::debug_log()` callsites were migrated to the per-area
+        // `Debug` system.
+        $this->assertCount( 14, $areas );
     }
 }

--- a/tests/Unit/EncryptionTest.php
+++ b/tests/Unit/EncryptionTest.php
@@ -33,6 +33,11 @@ class EncryptionTest extends TestCase {
         if ( ! defined( 'AUTH_KEY' ) ) {
             define( 'AUTH_KEY', 'test-auth-key-1234567890abcdef' );
         }
+
+        // 6.2.0: Encryption error paths now log via `Debug::log_encryption()`,
+        // which reads `ffc_settings` to gate per-area. Stub get_option so the
+        // gate is reached without exploding.
+        Functions\when( 'get_option' )->justReturn( array() );
     }
 
     protected function tearDown(): void {

--- a/tests/Unit/FrontendShortcodesTest.php
+++ b/tests/Unit/FrontendShortcodesTest.php
@@ -41,6 +41,10 @@ class FrontendShortcodesTest extends TestCase {
         Functions\when( 'wp_unslash' )->returnArg();
         Functions\when( 'wp_rand' )->alias( function ( int $min = 0, int $max = 0 ) { return random_int( $min, $max ); } );
         Functions\when( 'wp_hash' )->alias( function ( $data ) { return hash( 'sha256', $data ); } );
+        // 6.2.0: every legacy `Utils::debug_log()` call became `Debug::log_*()`,
+        // which reads `ffc_settings` to gate per-area. Stub get_option so the
+        // gate is reached without exploding.
+        Functions\when( 'get_option' )->justReturn( array() );
 
         if ( ! defined( 'ABSPATH' ) ) {
             define( 'ABSPATH', '/tmp/' );

--- a/tests/Unit/SubmissionRepositoryTest.php
+++ b/tests/Unit/SubmissionRepositoryTest.php
@@ -42,6 +42,11 @@ class SubmissionRepositoryTest extends TestCase {
         Functions\when( 'set_transient' )->justReturn( true );
         Functions\when( 'delete_transient' )->justReturn( true );
 
+        // 6.2.0: Repository error paths log via `Debug::log_form()`, which
+        // reads `ffc_settings` to gate per-area. Stub get_option so the gate
+        // is reached without exploding.
+        Functions\when( 'get_option' )->justReturn( array() );
+
         $this->repo = new SubmissionRepository();
     }
 


### PR DESCRIPTION
## Summary

Two unrelated 6.2.x patches + a readme refresh, all in one PR:

### 1. Per-area debug toggles (Option B from the audit)

The legacy `Utils::debug_log()` only checked `WP_DEBUG` — once on, every internal call fired with no admin toggle. The modern `Debug::log_*()` system already had 9 area toggles, but 76 callsites across 29 files still used the old helper. Notable side-effect: frontend shortcode renders ("[FFC] Form shortcode rendered") were polluting production logs.

What ships:

- **5 new `Debug` areas** (`AREA_FRONTEND`, `AREA_ADMIN`, `AREA_SELF_SCHEDULING`, `AREA_AUDIENCE`, `AREA_QRCODE`) with matching helpers.
- **76 callsites migrated** to the appropriate `Debug::log_*()` helper.
- **5 new checkboxes in Settings → Advanced → Debug**, all defaulting OFF; sanitizer accepts them.
- **`Utils::debug_log()` is now `@deprecated 6.2.0`** — thin wrapper delegating to `Debug::log( AREA_FORM_PROCESSOR, … )` for any third-party callers.

### 2. Role label translation fix on `wp-admin/users.php`

WordPress stores role labels verbatim in `wp_user_roles` at `add_role()` time. Its built-in `translate_user_role()` resolves them against the **default** WP textdomain — so plugin-provided role names never localize even when the .po file is loaded.

Fix: new `CapabilityManager::relabel_ffc_roles()` hooked on `wp_roles_init`. Re-applies `__( $label, 'ffcertificate' )` to every FFC role's `name` + `role_names` entry on every page load, so `users.php` always shows the operator's locale. Covers `ffc_user`, `ffc_recruitment_manager`, plus the 8 new 6.2.0 module-manager / recruitment-tier roles.

### 3. readme.txt refresh

Per request: **only the last 3 versions** in the Changelog + Upgrade Notice sections (6.2.0, 6.1.0, 6.0.0). Removed the outdated 5.4.1 / 5.4.0 / 5.3.0 blocks. Full history still in `CHANGELOG.md`.

## Test plan

- [x] `vendor/bin/phpunit` — 3772 tests / 9594 assertions, all green
- [x] `vendor/bin/phpstan analyze` — no errors
- [x] `vendor/bin/phpcs` (WPCS) — clean on changed files
- [ ] Manual: `WP_DEBUG=true`, all debug toggles OFF — confirm `[FFC] Form shortcode rendered` no longer appears in `debug.log` on a public page render.
- [ ] Manual: enable Frontend toggle in Settings → Advanced — confirm logs reappear.
- [ ] Manual: install pt-BR translation, visit `wp-admin/users.php` — confirm "FFC Recruitment Manager" / "FFC User" / etc. show in pt-BR.

https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbRaUURDyTcYFD9hAkpAhn)_