### PR TITLE
v6.3.3: encrypt CPF in audit log + admin CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.3.3] (2026-05-07)
+
+**Patch release — auditable CSV downloads.** The per-form CSV download audit log (introduced in 6.3.0) now stores CPFs **encrypted at-rest** instead of one-way-hashed, and gains a one-click CSV export from the form editor for actual auditability. Reuses the same `Encryption` pipeline that already protects `wp_ffc_submissions`.
+
+### Added
+
+- **CSV export endpoint** for the audit log: `admin-post.php?action=ffc_export_csv_public_download_log&form_id=N&_wpnonce=…`. Streams the `_ffc_csv_public_download_log` post-meta as a UTF-8-BOM CSV (`timestamp_utc, ip, mode, cpf, result`). CPFs are decrypted on the fly via `Encryption::decrypt`. Auth: nonce + `edit_post` on the form + `Utils::current_user_can_admin_or('ffc_manage_settings')`.
+- **"Download audit log (CSV)" button** in the form editor's "Public CSV Download" metabox, plus a live count ("N attempts logged on this form."). Hidden when the log is empty.
+- **Voluntary logging in `mode = 'none'`**: if a user happens to fill the CPF field on a form that doesn't require it (because the shortcode renders the field for safety when the URL has no prefill), and the digits form a valid CPF, the entry is now logged with `result = 'voluntary'`. Junk inputs are silently dropped — they don't compete for the 100-entry cap.
+
+### Changed
+
+- **Audit log schema** — entries now carry `cpf_encrypted` instead of `cpf_hash`. The hash field was write-only since 6.3.0 (no code path read it), so dropping it has no functional impact and matches the pattern the plugin already uses for `wp_ffc_submissions.cpf_encrypted`. Schema flag bumped to `1.3.0` and stored in the new `ffc_csv_public_download_log_format` option.
+- **LGPD disclosure** on the public-download shortcode now states the CPF is "encrypted at rest in the form's audit log" rather than just "logged for audit purposes". Wording also adjusted for the `optional` (no-prefill) variant: "If filled, it will be recorded in the form's audit log even when the form does not require it."
+
+### Removed
+
+- **`cpf_hash` field in audit log entries.** Pre-6.3.3 entries (written by 6.3.0/6.3.1/6.3.2) are wiped on the first `plugins_loaded` after upgrade by the new `PublicCsvDownload::maybe_wipe_legacy_logs()`. Justification: 6.3.0 → 6.3.2 all shipped within the same 24-hour window with effectively zero install base, so a clean wipe avoids carrying `[legacy: hashed only]` placeholders forever in CSV exports. The wipe is idempotent (gated by the `ffc_csv_public_download_log_format` option flag).
+
+### Backwards compatibility
+
+- The validation logic for `whitelist`, `participants`, `owner`, `audit` and `none` modes is **untouched**. Only the audit-log writer changed. The participants-mode hash-lookup against `wp_ffc_submissions.cpf_hash` keeps working exactly as before; that's a separate hash on a different table.
+- Sites running without `Encryption::is_configured()` (i.e. without `SECURE_AUTH_KEY`/`LOGGED_IN_KEY`) still log entries — `cpf_encrypted` falls back to `''`, the export shows `[encryption disabled]`, and the metabox renders a hint to configure encryption.
+- 3804 unit tests pass (was 3799; +5 new in `PublicCsvDownloadTest`).
+
+---
+
 ## [6.3.2] (2026-05-07)
 
 **Patch release — broaden the device fingerprint palette.** Builds on the v6.3.1 thumbmarkjs swap by mapping four additional components into the SQL schema and bumping the fresh-install default `match_threshold` from 5 to 7 to keep the same false-positive ratio against the larger 13-signal palette (was 5/9 ≈ 55%, now 7/13 ≈ 54%). Existing sites keep their persisted threshold; a one-shot dismissable admin notice suggests the bump for sites that still hold the legacy default.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.3.2
+ * Version:            6.3.3
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.3.2' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.3.3' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -1027,6 +1027,69 @@ class FormEditorMetaboxRenderer {
 					</p>
 				</td>
 			</tr>
+
+			<?php
+			$ffc_audit_summary = \FreeFormCertificate\Frontend\PublicCsvDownload::get_audit_log_summary( $post->ID );
+			?>
+			<tr>
+				<th scope="row">
+					<?php esc_html_e( 'Download audit log', 'ffcertificate' ); ?>
+				</th>
+				<td>
+					<p>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %d: number of audit log entries */
+								_n(
+									'%d attempt logged on this form.',
+									'%d attempts logged on this form.',
+									$ffc_audit_summary['count'],
+									'ffcertificate'
+								),
+								$ffc_audit_summary['count']
+							)
+						);
+						?>
+						<?php if ( $ffc_audit_summary['count'] >= \FreeFormCertificate\Frontend\PublicCsvDownload::DOWNLOAD_LOG_MAX ) : ?>
+							<span class="description">
+								<?php
+								echo esc_html(
+									sprintf(
+										/* translators: %d: maximum entries kept in the log */
+										__( 'Limit of %d entries reached — older entries roll off.', 'ffcertificate' ),
+										\FreeFormCertificate\Frontend\PublicCsvDownload::DOWNLOAD_LOG_MAX
+									)
+								);
+								?>
+							</span>
+						<?php endif; ?>
+					</p>
+					<?php if ( null !== $ffc_audit_summary['url'] ) : ?>
+						<p>
+							<a href="<?php echo esc_url( $ffc_audit_summary['url'] ); ?>"
+								class="button"
+								download>
+								<?php esc_html_e( 'Download audit log (CSV)', 'ffcertificate' ); ?>
+							</a>
+						</p>
+						<p class="description">
+							<?php
+							if ( class_exists( '\FreeFormCertificate\Core\Encryption' )
+								&& \FreeFormCertificate\Core\Encryption::is_configured() ) {
+								esc_html_e( 'CPFs are stored encrypted at-rest and decrypted on the fly when you download the CSV. Each entry includes timestamp, IP, gate mode, CPF, and outcome.', 'ffcertificate' );
+							} else {
+								esc_html_e( 'Encryption is not configured on this site. The CPF column will be empty for entries written while encryption is off.', 'ffcertificate' );
+							}
+							?>
+						</p>
+					<?php else : ?>
+						<p class="description">
+							<?php esc_html_e( 'No download attempts have been logged yet.', 'ffcertificate' ); ?>
+						</p>
+					<?php endif; ?>
+				</td>
+			</tr>
 		</table>
 		<?php
 	}

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -175,6 +175,12 @@ class Loader {
 			\FreeFormCertificate\Security\RateLimitActivator::maybe_create_tables();
 		}
 
+		// 6.3.3: wipe pre-encryption CSV-download audit logs once. See the
+		// method's docblock for the install-base reasoning.
+		if ( class_exists( '\FreeFormCertificate\Frontend\PublicCsvDownload' ) ) {
+			\FreeFormCertificate\Frontend\PublicCsvDownload::maybe_wipe_legacy_logs();
+		}
+
 		// In-place plugin updates (drop new files via `wp-admin/plugins.php`'s
 		// "Update" button) DO NOT fire `register_activation_hook`. Re-register
 		// the canonical FFC role + the 6.2.0 module-manager / recruitment-tier

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -53,6 +53,15 @@ class PublicCsvDownload {
 	const FLASH_TRANSIENT_TTL = 60; // Seconds.
 
 	/**
+	 * 6.3.3: schema flag for the audit-log payload. Bumped when the
+	 * structure of {@see META_DOWNLOAD_LOG} entries changes incompatibly.
+	 */
+	const DOWNLOAD_LOG_FORMAT = '1.3.0';
+	const OPTION_LOG_FORMAT   = 'ffc_csv_public_download_log_format';
+	const EXPORT_LOG_ACTION   = 'ffc_export_csv_public_download_log';
+	const EXPORT_LOG_NONCE    = 'ffc_export_csv_public_download_log';
+
+	/**
 	 * Register shortcode + admin-post + AJAX handlers.
 	 */
 	public function register_hooks(): void {
@@ -78,6 +87,9 @@ class PublicCsvDownload {
 		add_action( 'wp_ajax_nopriv_ffc_public_csv_batch', array( $exporter, 'ajax_batch' ) );
 		add_action( 'wp_ajax_ffc_public_csv_download', array( $exporter, 'ajax_download' ) );
 		add_action( 'wp_ajax_nopriv_ffc_public_csv_download', array( $exporter, 'ajax_download' ) );
+
+		// 6.3.3: admin-only audit log export. Logged-in only, no nopriv.
+		add_action( 'admin_post_' . self::EXPORT_LOG_ACTION, array( $this, 'handle_export_log_request' ) );
 	}
 
 	// ──────────────────────────────────────────────────────────────.
@@ -191,9 +203,11 @@ class PublicCsvDownload {
 						<p class="description">
 							<?php
 							if ( 'audit' === $cpf_mode ) {
-								esc_html_e( 'Your CPF is logged for audit purposes but does not gate the download.', 'ffcertificate' );
+								esc_html_e( 'Your CPF is recorded in this form\'s audit log (encrypted at rest) but does not gate the download.', 'ffcertificate' );
+							} elseif ( 'optional' === $cpf_mode ) {
+								esc_html_e( 'Optional. If the form requires a CPF, enter it here. If filled, it will be recorded (encrypted at rest) in the form\'s audit log even when the form does not require it.', 'ffcertificate' );
 							} else {
-								esc_html_e( 'Enter the CPF authorized to download this CSV.', 'ffcertificate' );
+								esc_html_e( 'Enter the CPF authorized to download this CSV. The CPF is encrypted at rest in the form\'s audit log.', 'ffcertificate' );
 							}
 							?>
 						</p>
@@ -509,6 +523,17 @@ class PublicCsvDownload {
 			$mode = 'none';
 		}
 		if ( 'none' === $mode ) {
+			// 6.3.3: even when CPF is not required for this form, if the user
+			// volunteered a syntactically valid one, audit it. Useful when the
+			// shortcode renders the field for safety (no prefill in URL) and a
+			// well-meaning user fills it anyway. Junk input is silently dropped
+			// — we don't want garbage rows competing for DOWNLOAD_LOG_MAX slots.
+			$voluntary_digits = preg_replace( '/\D/', '', $cpf_input );
+			$voluntary_digits = is_string( $voluntary_digits ) ? $voluntary_digits : '';
+			if ( '' !== $voluntary_digits
+				&& \FreeFormCertificate\Core\DocumentFormatter::validate_cpf( $voluntary_digits ) ) {
+				$this->record_download_log_entry( $form_id, 'none', $voluntary_digits, 'voluntary' );
+			}
 			return null;
 		}
 
@@ -593,30 +618,202 @@ class PublicCsvDownload {
 	 * Append an entry to the per-form download audit log.
 	 *
 	 * Stores the latest DOWNLOAD_LOG_MAX rows in a single post meta. CPF
-	 * is hashed (SHA-256 of the digits-only string) so the log is safe
-	 * to display in the admin without exposing raw documents.
+	 * is encrypted at-rest via the plugin's Encryption helper (same pipeline
+	 * that protects ffc_submissions.cpf_encrypted) so the form owner can
+	 * later decrypt and audit who downloaded the CSV. When Encryption is not
+	 * configured on the site, the CPF field falls back to '' and the export
+	 * shows a placeholder — admins can configure encryption to retroactively
+	 * make new entries auditable.
+	 *
+	 * Schema (6.3.3): { ts, ip, mode, cpf_encrypted, result }. Pre-6.3.3
+	 * entries (which used cpf_hash) are wiped on the first plugins_loaded
+	 * after upgrade by maybe_wipe_legacy_logs() — see that method for the
+	 * justification (install base reality + clean break).
 	 *
 	 * @param int    $form_id Form ID.
 	 * @param string $mode    CPF gate mode that was active.
 	 * @param string $digits  Digits-only CPF (may be '' for fail_missing).
 	 * @param string $result  Outcome tag: success | fail_missing |
 	 *                        fail_format | fail_match | fail_unknown_mode |
-	 *                        audit_pass.
+	 *                        audit_pass | voluntary.
 	 */
 	private function record_download_log_entry( int $form_id, string $mode, string $digits, string $result ): void {
+		$cpf_encrypted = '';
+		if ( '' !== $digits
+			&& class_exists( '\FreeFormCertificate\Core\Encryption' )
+			&& \FreeFormCertificate\Core\Encryption::is_configured() ) {
+			$encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $digits );
+			if ( is_string( $encrypted ) ) {
+				$cpf_encrypted = $encrypted;
+			}
+		}
+
 		$existing   = get_post_meta( $form_id, self::META_DOWNLOAD_LOG, true );
 		$existing   = is_array( $existing ) ? $existing : array();
 		$existing[] = array(
-			'ts'       => time(),
-			'ip'       => \FreeFormCertificate\Core\Utils::get_user_ip(),
-			'mode'     => $mode,
-			'cpf_hash' => '' !== $digits ? hash( 'sha256', $digits ) : '',
-			'result'   => $result,
+			'ts'            => time(),
+			'ip'            => \FreeFormCertificate\Core\Utils::get_user_ip(),
+			'mode'          => $mode,
+			'cpf_encrypted' => $cpf_encrypted,
+			'result'        => $result,
 		);
 		if ( count( $existing ) > self::DOWNLOAD_LOG_MAX ) {
 			$existing = array_slice( $existing, -self::DOWNLOAD_LOG_MAX );
 		}
 		update_post_meta( $form_id, self::META_DOWNLOAD_LOG, $existing );
+	}
+
+	/**
+	 * One-shot wipe of pre-6.3.3 audit-log entries.
+	 *
+	 * Pre-6.3.3 entries used a write-only `cpf_hash` field (sha256 of the
+	 * digits) which was never read by any code path — it was kept "just in
+	 * case" we ever needed CPF lookups in the log. The 6.3.3 schema replaces
+	 * that with a reversible `cpf_encrypted` field consumed by the new
+	 * audit-CSV exporter. Mixing the two formats would force the exporter
+	 * to render entire columns of "[legacy: hashed only]" placeholders for
+	 * stale 6.3.0–6.3.2 entries that no human can ever recover. Since
+	 * 6.3.0 → 6.3.2 all shipped within the same 24h window and the install
+	 * base for those releases is effectively zero, the cleanest path is to
+	 * delete the legacy log meta on first plugins_loaded after the upgrade
+	 * and let new entries accumulate fresh.
+	 *
+	 * Idempotent: gated on the {@see OPTION_LOG_FORMAT} option flag. Runs
+	 * exactly once per install no matter how many requests fire it.
+	 */
+	public static function maybe_wipe_legacy_logs(): void {
+		if ( self::DOWNLOAD_LOG_FORMAT === (string) get_option( self::OPTION_LOG_FORMAT, '' ) ) {
+			return;
+		}
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		delete_metadata( 'post', 0, self::META_DOWNLOAD_LOG, '', true );
+		update_option( self::OPTION_LOG_FORMAT, self::DOWNLOAD_LOG_FORMAT, true );
+	}
+
+	/**
+	 * Admin-post handler for the audit-log CSV export. Streams
+	 * `_ffc_csv_public_download_log` for a single form as a CSV download
+	 * with CPFs decrypted on the fly via {@see Encryption::decrypt}.
+	 *
+	 * Auth: nonce + user must satisfy {@see Utils::current_user_can_admin_or}
+	 * with `ffc_manage_settings` AND have `edit_post` on the target form.
+	 *
+	 * @return void Streams CSV and exits; never returns on success.
+	 */
+	public function handle_export_log_request(): void {
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce validated below.
+		$form_id = isset( $_GET['form_id'] ) ? absint( wp_unslash( $_GET['form_id'] ) ) : 0;
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, self::EXPORT_LOG_NONCE . '_' . $form_id ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'ffcertificate' ), 403 );
+		}
+		if ( $form_id <= 0 || get_post_type( $form_id ) !== 'ffc_form' ) {
+			wp_die( esc_html__( 'Form not found.', 'ffcertificate' ), 404 );
+		}
+		if ( ! current_user_can( 'edit_post', $form_id ) ) {
+			wp_die( esc_html__( 'You do not have permission to export this log.', 'ffcertificate' ), 403 );
+		}
+		$can_audit = class_exists( '\FreeFormCertificate\Core\Utils' )
+			? \FreeFormCertificate\Core\Utils::current_user_can_admin_or( 'ffc_manage_settings' )
+			: current_user_can( 'manage_options' );
+		if ( ! $can_audit ) {
+			wp_die( esc_html__( 'You do not have permission to export this log.', 'ffcertificate' ), 403 );
+		}
+
+		$log = get_post_meta( $form_id, self::META_DOWNLOAD_LOG, true );
+		$log = is_array( $log ) ? $log : array();
+
+		$encryption_ok = class_exists( '\FreeFormCertificate\Core\Encryption' )
+			&& \FreeFormCertificate\Core\Encryption::is_configured();
+
+		$filename = 'ffc-csv-download-log-' . $form_id . '-' . gmdate( 'Y-m-d-His' ) . '.csv';
+
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$fh = fopen( 'php://output', 'w' );
+		if ( false === $fh ) {
+			wp_die( esc_html__( 'Could not open output stream for CSV export.', 'ffcertificate' ), 500 );
+		}
+
+		// UTF-8 BOM for Excel-friendliness, same convention as PublicCsvExporter.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		fwrite( $fh, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
+		if ( ! $encryption_ok ) {
+			// One-line preamble so the admin knows why CPFs come out empty.
+			fputcsv( $fh, array( '# Encryption is not configured on this site; CPF column will be empty for new entries. See plugin docs.' ) );
+		}
+		fputcsv( $fh, array( 'timestamp_utc', 'ip', 'mode', 'cpf', 'result' ) );
+
+		foreach ( $log as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$ts  = isset( $entry['ts'] ) ? gmdate( 'Y-m-d H:i:s', (int) $entry['ts'] ) : '';
+			$ip  = isset( $entry['ip'] ) ? (string) $entry['ip'] : '';
+			$mod = isset( $entry['mode'] ) ? (string) $entry['mode'] : '';
+			$res = isset( $entry['result'] ) ? (string) $entry['result'] : '';
+			$cpf = self::decrypt_log_entry_cpf( $entry );
+			fputcsv( $fh, array( $ts, $ip, $mod, $cpf, $res ) );
+		}
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		fclose( $fh );
+		exit;
+	}
+
+	/**
+	 * Decrypt a single log entry's CPF for display in the export.
+	 *
+	 * @param array<string, mixed> $entry Log entry row.
+	 * @return string Formatted CPF, '' when blank, or a marker for failures.
+	 */
+	private static function decrypt_log_entry_cpf( array $entry ): string {
+		$cipher = isset( $entry['cpf_encrypted'] ) ? (string) $entry['cpf_encrypted'] : '';
+		if ( '' === $cipher ) {
+			return '';
+		}
+		if ( ! class_exists( '\FreeFormCertificate\Core\Encryption' )
+			|| ! \FreeFormCertificate\Core\Encryption::is_configured() ) {
+			return '[encryption disabled]';
+		}
+		$plain = \FreeFormCertificate\Core\Encryption::decrypt( $cipher );
+		if ( ! is_string( $plain ) || '' === $plain ) {
+			return '[decrypt failed]';
+		}
+		if ( class_exists( '\FreeFormCertificate\Core\DocumentFormatter' ) ) {
+			return \FreeFormCertificate\Core\DocumentFormatter::format_cpf( $plain );
+		}
+		return $plain;
+	}
+
+	/**
+	 * Public read-only count + URL builder for the metabox button.
+	 *
+	 * @param int $form_id Form ID.
+	 * @return array{count: int, url: string|null}
+	 */
+	public static function get_audit_log_summary( int $form_id ): array {
+		$log   = get_post_meta( $form_id, self::META_DOWNLOAD_LOG, true );
+		$count = is_array( $log ) ? count( $log ) : 0;
+		$url   = null;
+		if ( $count > 0 ) {
+			$url = add_query_arg(
+				array(
+					'action'   => self::EXPORT_LOG_ACTION,
+					'form_id'  => $form_id,
+					'_wpnonce' => wp_create_nonce( self::EXPORT_LOG_NONCE . '_' . $form_id ),
+				),
+				admin_url( 'admin-post.php' )
+			);
+		}
+		return array(
+			'count' => $count,
+			'url'   => $url,
+		);
 	}
 
 	// ──────────────────────────────────────────────────────────────.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.3.2
+Stable tag: 6.3.3
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/PublicCsvDownloadTest.php
+++ b/tests/Unit/PublicCsvDownloadTest.php
@@ -254,7 +254,8 @@ class PublicCsvDownloadTest extends TestCase {
         $this->assertCount( 1, $log );
         $this->assertSame( 'audit', $log[0]['mode'] );
         $this->assertSame( 'audit_pass', $log[0]['result'] );
-        $this->assertNotEmpty( $log[0]['cpf_hash'] );
+        $this->assertArrayHasKey( 'cpf_encrypted', $log[0] );
+        $this->assertArrayNotHasKey( 'cpf_hash', $log[0], 'cpf_hash dropped in 6.3.3' );
     }
 
     public function test_validate_cpf_requirement_blocks_missing_cpf(): void {
@@ -312,7 +313,7 @@ class PublicCsvDownloadTest extends TestCase {
         // Pre-fill DOWNLOAD_LOG_MAX existing entries.
         $existing = array();
         for ( $i = 0; $i < PublicCsvDownload::DOWNLOAD_LOG_MAX; $i++ ) {
-            $existing[] = array( 'ts' => $i, 'ip' => '0.0.0.0', 'mode' => 'audit', 'cpf_hash' => 'h', 'result' => 'audit_pass' );
+            $existing[] = array( 'ts' => $i, 'ip' => '0.0.0.0', 'mode' => 'audit', 'cpf_encrypted' => 'h', 'result' => 'audit_pass' );
         }
         $this->meta_store[ $form_id . ':_ffc_csv_public_download_log' ] = $existing;
 
@@ -321,6 +322,88 @@ class PublicCsvDownloadTest extends TestCase {
         $log = $this->meta_store[ $form_id . ':_ffc_csv_public_download_log' ] ?? array();
         $this->assertCount( PublicCsvDownload::DOWNLOAD_LOG_MAX, $log, 'Log should be capped' );
         $this->assertNotSame( 0, $log[0]['ts'], 'Oldest entry should have been dropped' );
+    }
+
+    // ==================================================================
+    //  6.3.3 — voluntary logging in mode='none' + encrypted CPF + helpers
+    // ==================================================================
+
+    public function test_validate_cpf_requirement_none_mode_logs_voluntary_when_filled_and_valid(): void {
+        $form_id = 42;
+        $this->meta_store[ $form_id . ':_ffc_csv_public_cpf_mode' ] = 'none';
+
+        $result = $this->handler->validate_cpf_requirement( $form_id, '529.982.247-25' );
+
+        $this->assertNull( $result, 'mode=none must never block, even with CPF filled' );
+        $log = $this->meta_store[ $form_id . ':_ffc_csv_public_download_log' ] ?? array();
+        $this->assertCount( 1, $log );
+        $this->assertSame( 'none', $log[0]['mode'] );
+        $this->assertSame( 'voluntary', $log[0]['result'] );
+        $this->assertArrayHasKey( 'cpf_encrypted', $log[0] );
+    }
+
+    public function test_validate_cpf_requirement_none_mode_skips_voluntary_log_for_invalid_format(): void {
+        $form_id = 42;
+        $this->meta_store[ $form_id . ':_ffc_csv_public_cpf_mode' ] = 'none';
+
+        // 11 same digits → checksum invalid; junk drops silently.
+        $result = $this->handler->validate_cpf_requirement( $form_id, '11111111111' );
+
+        $this->assertNull( $result );
+        $this->assertArrayNotHasKey(
+            $form_id . ':_ffc_csv_public_download_log',
+            $this->meta_store,
+            'Invalid voluntary CPFs must not pollute the audit log'
+        );
+    }
+
+    public function test_record_log_entry_uses_cpf_encrypted_field_only(): void {
+        $form_id = 42;
+        $this->meta_store[ $form_id . ':_ffc_csv_public_cpf_mode' ] = 'audit';
+
+        $this->handler->validate_cpf_requirement( $form_id, '529.982.247-25' );
+
+        $log = $this->meta_store[ $form_id . ':_ffc_csv_public_download_log' ] ?? array();
+        $this->assertNotEmpty( $log );
+        $entry = $log[0];
+
+        // 6.3.3 schema: cpf_encrypted only, cpf_hash dropped.
+        $this->assertArrayHasKey( 'cpf_encrypted', $entry );
+        $this->assertArrayNotHasKey( 'cpf_hash', $entry );
+
+        // Encryption is configured in tests/bootstrap.php (SECURE_AUTH_KEY +
+        // LOGGED_IN_KEY constants are seeded), so cpf_encrypted should be a
+        // non-empty string different from the digits themselves.
+        $this->assertIsString( $entry['cpf_encrypted'] );
+        $this->assertNotEmpty( $entry['cpf_encrypted'] );
+        $this->assertNotSame( '52998224725', $entry['cpf_encrypted'] );
+    }
+
+    public function test_get_audit_log_summary_returns_count_and_url_when_log_present(): void {
+        $form_id = 42;
+        $this->meta_store[ $form_id . ':_ffc_csv_public_download_log' ] = array(
+            array( 'ts' => time(), 'ip' => '1.2.3.4', 'mode' => 'audit', 'cpf_encrypted' => 'x', 'result' => 'audit_pass' ),
+            array( 'ts' => time(), 'ip' => '1.2.3.4', 'mode' => 'audit', 'cpf_encrypted' => 'y', 'result' => 'audit_pass' ),
+        );
+        Functions\when( 'wp_create_nonce' )->justReturn( 'n' );
+        Functions\when( 'add_query_arg' )->alias( function ( $args, $url ) {
+            return $url . '?' . http_build_query( $args );
+        } );
+
+        $summary = PublicCsvDownload::get_audit_log_summary( $form_id );
+
+        $this->assertSame( 2, $summary['count'] );
+        $this->assertIsString( $summary['url'] );
+        $this->assertStringContainsString( PublicCsvDownload::EXPORT_LOG_ACTION, $summary['url'] );
+    }
+
+    public function test_get_audit_log_summary_returns_null_url_when_log_empty(): void {
+        $form_id = 42;
+        // No meta seeded.
+        $summary = PublicCsvDownload::get_audit_log_summary( $form_id );
+
+        $this->assertSame( 0, $summary['count'] );
+        $this->assertNull( $summary['url'] );
     }
 
     public function test_register_hooks_registers_shortcode_and_admin_post_actions(): void {


### PR DESCRIPTION
## Summary

Patch release **6.3.2 → 6.3.3**.

The audit log introduced in v6.3.0 was write-only and one-way-hashed — admins could write `_ffc_csv_public_download_log` entries but couldn't actually audit "who downloaded the CSV". This release makes the log **actually auditable** by reusing the same `Encryption` pipeline that already protects `wp_ffc_submissions.cpf_encrypted`, plus a one-click **Download audit log (CSV)** button in the form editor.

## What changes

### Audit log schema

- Field rename / drop: `cpf_hash` (sha256, write-only) → `cpf_encrypted` (AES-256 via plugin's Encryption helper, decrypted on export).
- Schema flag bumped to `'1.3.0'` and stored in the new `ffc_csv_public_download_log_format` option.
- Pre-6.3.3 entries (6.3.0/6.3.1/6.3.2) are wiped on the first `plugins_loaded` after upgrade by `PublicCsvDownload::maybe_wipe_legacy_logs()`. Idempotent (gated by the format option flag). Justification documented in CHANGELOG: 6.3.0 → 6.3.2 all shipped within the same 24h window with effectively zero install base, so a clean wipe is safer than carrying `[legacy: hashed only]` placeholders forever.

### CSV export endpoint

```
admin-post.php?action=ffc_export_csv_public_download_log&form_id=N&_wpnonce=…
```

- Auth: nonce + `edit_post( $form_id )` + `Utils::current_user_can_admin_or('ffc_manage_settings')`.
- Streams BOM-prefixed UTF-8 CSV with columns: `timestamp_utc, ip, mode, cpf, result`.
- CPFs decrypted via `Encryption::decrypt` and formatted via `DocumentFormatter::format_cpf`.
- When Encryption isn't configured, the CSV emits a `# Encryption is not configured ...` preamble and the `cpf` column shows `[encryption disabled]`.
- Decrypt failures show `[decrypt failed]` so a single bad row doesn't abort the whole export.

### Voluntary logging

When `cpf_mode = 'none'` and the user volunteers a syntactically valid CPF (because the shortcode renders the field as `optional` when the URL has no prefill), the entry is now logged with `result = 'voluntary'`. Junk CPFs (invalid format) are silently dropped — they don't compete for the 100-entry cap.

### Metabox button

New row in the **Public CSV Download** metabox: live count ("N attempts logged on this form.") + the download button when N > 0. Help text adapts to whether Encryption is configured.

### LGPD copy

The CPF field's description on the public download shortcode now states the CPF is "encrypted at rest in the form's audit log" instead of just "logged". Also updated the `optional` (no-prefill) variant: "If filled, it will be recorded in the form's audit log even when the form does not require it."

## Backwards compatibility

- **Validation logic for all 5 CPF gate modes (`none`, `audit`, `participants`, `owner`, `whitelist`) is untouched.** Only the audit-log writer changed. Participants-mode hash-lookup against `wp_ffc_submissions.cpf_hash` keeps working — that's a separate hash on a separate table.
- Sites without `Encryption::is_configured()` (no `SECURE_AUTH_KEY`/`LOGGED_IN_KEY`) continue logging entries with empty `cpf_encrypted` field. No fatal, no break.

## File summary

```
includes/frontend/class-ffc-public-csv-download.php       ~  +200 LOC (encrypt + export + wipe + helper + LGPD)
includes/admin/class-ffc-form-editor-metabox-renderer.php ~  +60 LOC (button + count row)
includes/class-ffc-loader.php                             ~  +5 LOC (call maybe_wipe_legacy_logs)
ffcertificate.php                                         ~  Version bump 6.3.3
readme.txt                                                ~  Stable tag 6.3.3
CHANGELOG.md                                              ~  [6.3.3] section
tests/Unit/PublicCsvDownloadTest.php                      ~  +5 tests, +rename hash→encrypted assertions
```

## Test plan

- [x] PHPUnit: 3804 tests pass locally (was 3799; +5 new).
- [x] PHPStan: clean.
- [x] WPCS: clean.
- [x] `npm run build`: nothing minifies (no JS source touched).
- [ ] Manual E2E: 6.3.2 → 6.3.3 in-place upgrade. Verify (a) legacy log entries are wiped on first `plugins_loaded`, (b) admin notice metabox row shows "0 attempts logged" with no button until first download, (c) submitting a CPF with `mode=whitelist` writes `cpf_encrypted`, (d) clicking the export button streams a CSV with plaintext CPFs, (e) submitting a valid CPF on a form with `mode=none` produces a `voluntary` log entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143SjasbkpVUPra6SKgxNuc)_