### PR TITLE
v6.3.5: fix one-day TZ drift in [ffc_csv_download] info screen body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.3.5] (2026-05-08)
+
+**Bugfix release.** Fixes a one-day drift in the dates rendered on the `[ffc_csv_download]` info screen for any site whose WordPress timezone is west of UTC (e.g. `America/Sao_Paulo` / BRT).
+
+### Fixed
+
+- **`[ffc_csv_download]` info screen showed dates one day earlier** than what the form admin configured (e.g. a form set to start on `12/05/2026` rendered `11/05/2026` in the body, even though the footer status message correctly said "começará em 12/05/2026"). Root cause: `PublicCsvDownload::build_datetime_info()` ran `strtotime( $date_start )` on a bare `Y-m-d` string, which PHP parses as **UTC** midnight. `wp_date()` then formatted that timestamp in the site timezone (e.g. BRT, UTC-3), shifting the day backwards by 3 hours and crossing the midnight boundary. Fixed by anchoring each date with `new DateTimeImmutable( $date, $tz )` before formatting — same approach `Geofence::get_form_start_timestamp()` (which fed the correct footer message) was already using. Two regression tests added to `PublicCsvDownloadTest`: `_keeps_configured_date_when_tz_is_brt` and `_handles_blank_dates`. 3806 unit tests pass (was 3804).
+
+---
+
 ## [6.3.4] (2026-05-07)
 
 **Patch release — UX polish.** Two consistency fixes for the CPF input rendered inside the public CSV download shortcode (`[ffc_csv_download]`): same elegant LGPD consent-box visual that `[ffc_form]` uses, and the same input mask + on-blur validation. Both are pure reuse of helpers that already shipped — no new code paths server-side.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.3.4
+ * Version:            6.3.5
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.3.4' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.3.5' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -945,11 +945,32 @@ class PublicCsvDownload {
 
 		$date_format = get_option( 'date_format' );
 
+		// Anchor each date in the site timezone before formatting. Naive
+		// strtotime() reads "Y-m-d" as PHP-process-local (typically UTC)
+		// midnight, which then drifts to the previous day after wp_date()
+		// converts to a westward TZ like America/Sao_Paulo — manifesting
+		// as "Data de início: 11/05/2026" for a configured 2026-05-12. The
+		// footer status message uses Geofence::get_form_*_timestamp() and
+		// is unaffected; this brings the body in line with the same TZ
+		// anchoring approach.
+		$to_local_ts = static function ( string $date, \DateTimeZone $tz ): ?int {
+			if ( '' === $date ) {
+				return null;
+			}
+			try {
+				return ( new \DateTimeImmutable( $date, $tz ) )->getTimestamp();
+			} catch ( \Exception $e ) {
+				return null;
+			}
+		};
+		$start_ts    = $to_local_ts( $date_start, $tz );
+		$end_ts      = $to_local_ts( $date_end, $tz );
+
 		return array(
 			'has_dates'      => $has_dates,
-			'date_start'     => '' !== $date_start ? wp_date( $date_format, (int) strtotime( $date_start ), $tz ) : null,
+			'date_start'     => null !== $start_ts ? wp_date( $date_format, $start_ts, $tz ) : null,
 			'date_start_raw' => '' !== $date_start ? $date_start : null,
-			'date_end'       => '' !== $date_end ? wp_date( $date_format, (int) strtotime( $date_end ), $tz ) : null,
+			'date_end'       => null !== $end_ts ? wp_date( $date_format, $end_ts, $tz ) : null,
 			'date_end_raw'   => '' !== $date_end ? $date_end : null,
 			'has_times'      => $has_times,
 			'time_start'     => '' !== $time_start ? $time_start : null,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.3.4
+Stable tag: 6.3.5
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/PublicCsvDownloadTest.php
+++ b/tests/Unit/PublicCsvDownloadTest.php
@@ -719,4 +719,65 @@ class PublicCsvDownloadTest extends TestCase {
         $this->assertContains( 'wp_ajax_ffc_public_csv_download', $registered );
         $this->assertContains( 'wp_ajax_nopriv_ffc_public_csv_download', $registered );
     }
+
+    // ==================================================================
+    //  6.3.5 — build_datetime_info() timezone anchoring (regression)
+    // ==================================================================
+
+    /**
+     * Configured 2026-05-12 in America/Sao_Paulo (UTC-3) was being
+     * displayed as 11/05/2026 because strtotime('2026-05-12') reads as
+     * UTC midnight, then wp_date() converts to BRT (-3h) and renders
+     * the previous day. The fix anchors via DateTimeImmutable($date, $tz).
+     */
+    public function test_build_datetime_info_keeps_configured_date_when_tz_is_brt(): void {
+        Functions\when( 'wp_date' )->alias( function ( $format, $timestamp, $tz = null ) {
+            $dt = new \DateTimeImmutable( '@' . $timestamp );
+            if ( $tz instanceof \DateTimeZone ) {
+                $dt = $dt->setTimezone( $tz );
+            }
+            return $dt->format( $format );
+        } );
+        Functions\when( 'get_option' )->alias( function ( $key, $default = '' ) {
+            if ( 'date_format' === $key ) {
+                return 'd/m/Y';
+            }
+            return $default;
+        } );
+
+        $tz = new \DateTimeZone( 'America/Sao_Paulo' );
+
+        $ref = new \ReflectionMethod( PublicCsvDownload::class, 'build_datetime_info' );
+        $ref->setAccessible( true );
+
+        $config = array(
+            'date_start' => '2026-05-12',
+            'date_end'   => '2026-05-12',
+            'time_start' => '17:00:00',
+            'time_end'   => '18:00:00',
+            'time_mode'  => 'daily',
+        );
+
+        $result = $ref->invoke( $this->handler, $config, $tz );
+
+        $this->assertSame( '12/05/2026', $result['date_start'], 'date_start must not drift to 11/05 when site TZ is BRT' );
+        $this->assertSame( '12/05/2026', $result['date_end'], 'date_end must not drift either' );
+        $this->assertSame( '2026-05-12', $result['date_start_raw'] );
+        $this->assertSame( '2026-05-12', $result['date_end_raw'] );
+    }
+
+    public function test_build_datetime_info_handles_blank_dates(): void {
+        $tz = new \DateTimeZone( 'UTC' );
+
+        $ref = new \ReflectionMethod( PublicCsvDownload::class, 'build_datetime_info' );
+        $ref->setAccessible( true );
+
+        $result = $ref->invoke( $this->handler, array(), $tz );
+
+        $this->assertFalse( $result['has_dates'] );
+        $this->assertNull( $result['date_start'] );
+        $this->assertNull( $result['date_end'] );
+        $this->assertNull( $result['date_start_raw'] );
+        $this->assertNull( $result['date_end_raw'] );
+    }
 }


### PR DESCRIPTION
## Summary

Bugfix release **6.3.4 → 6.3.5**.

Forms configured to start on `2026-05-12` in `America/Sao_Paulo` (or any TZ west of UTC) were rendering `11/05/2026` in the body of the `[ffc_csv_download]` info screen — even though the footer status message ("começará em 12/05/2026 17:00") correctly read 12/05.

## Root cause

`PublicCsvDownload::build_datetime_info()` formatted the dates like this:

```php
'date_start' => '' !== $date_start
    ? wp_date( $date_format, (int) strtotime( $date_start ), $tz )
    : null,
```

`strtotime( '2026-05-12' )` parses a bare `Y-m-d` string as PHP-process-local — typically **UTC** midnight. `wp_date()` then formats that UTC timestamp in the site timezone (BRT, UTC-3), which shifts backwards 3 hours, crosses midnight, and renders the previous day.

The footer message used `Geofence::get_form_start_timestamp()` which already does the right thing (`new DateTimeImmutable( $date . ' ' . $time, wp_timezone() )`).

## Fix

`build_datetime_info()` now uses the same TZ-anchoring approach: build the timestamp with `new DateTimeImmutable( $date, $tz )` before handing it to `wp_date()`. Body and footer now agree.

```php
$to_local_ts = static function ( string $date, \DateTimeZone $tz ): ?int {
    if ( '' === $date ) return null;
    try {
        return ( new \DateTimeImmutable( $date, $tz ) )->getTimestamp();
    } catch ( \Exception $e ) {
        return null;
    }
};
$start_ts = $to_local_ts( $date_start, $tz );
$end_ts   = $to_local_ts( $date_end, $tz );

return array(
    'date_start' => null !== $start_ts ? wp_date( $date_format, $start_ts, $tz ) : null,
    'date_end'   => null !== $end_ts   ? wp_date( $date_format, $end_ts, $tz )   : null,
    // ...
);
```

## Tests

Two new regression tests in `PublicCsvDownloadTest`:

- **`test_build_datetime_info_keeps_configured_date_when_tz_is_brt`** — simulates a BRT site (`America/Sao_Paulo`), feeds `date_start = '2026-05-12'`, asserts the formatted output is `12/05/2026` (not `11/05/2026`).
- **`test_build_datetime_info_handles_blank_dates`** — defensive check that empty config produces `null`/`false` fields cleanly.

Both invoke the private method via Reflection so the test surface is minimal.

## Test plan

- [x] PHPUnit: 3806 tests pass locally (was 3804; +2 new).
- [x] PHPStan: clean.
- [x] WPCS: clean.
- [ ] Manual E2E: open `[ffc_csv_download]` on a BRT-configured WP site with a form set to start `12/05/2026 17:00`. Verify (a) "Data de início" reads `12/05/2026`, (b) "Data de término" reads `12/05/2026`, (c) the footer keeps reading "começará em 12/05/2026 17:00" — body and footer now match.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143SjasbkpVUPra6SKgxNuc)_