### PR TITLE
v6.3.9: standardise CSV separator on `;` + audience importer auto-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.3.9] (2026-05-09)
+
+**Consistency release.** Standardises every plugin-emitted CSV on the semicolon (`;`) delimiter, fixing three exporters that were still using the comma default and breaking Excel-pt-BR / WPS / LibreOffice locale opens. Audience importer gains delimiter auto-detection so legacy comma-separated files keep working.
+
+### Changed
+
+- **Three CSV exporters now emit `;` instead of `,`**, matching the rest of the plugin (which already used `;` since 5.x): the public CSV download audit-log exporter (`PublicCsvDownload::handle_export_log_request`, introduced in 6.3.3), the reregistration submissions exporter (`ReregistrationCsvExporter`), and the audience admin import templates (`AudienceAdminImport::export_*_csv`). Now a Brazilian admin double-clicking the `.csv` no longer sees everything crammed into column A.
+- **Audience importer auto-detects `,` vs `;`.** Mirrors the recruitment importer's `detect_delimiter()` strategy: peek the header line, count unquoted occurrences, return whichever wins (ties resolve to `,`). Implemented as a private `peek_delimiter()` static helper that rewinds the file handle so the regular `fgetcsv()` loop runs unchanged. Comma-separated files exported by older versions (or hand-authored elsewhere) continue importing without changes.
+- **Sample CSVs in `AudienceCsvImporter::get_sample_csv()`** updated to use `;` to match the live export templates. Cosmetic only — the importer accepts both.
+
+### Backwards compatibility
+
+- **Existing comma-separated CSV files**: still import correctly via the audience importer's auto-detect (added in this release) and the recruitment importer's pre-existing detection. Nothing breaks.
+- **Custom downstream parsers (admin's external tooling)**: if a site automated parsing of the reregistration or audit-log CSV against the comma format, those scripts need a one-line update to `;`. Documented here.
+
+No PHP/server schema change. PHPUnit + PHPStan + WPCS clean.
+
+---
+
 ## [6.3.8] (2026-05-08)
 
 **UX release — two form-copy fixes.** Shrinks the device fingerprint LGPD disclosure on `[ffc_form]` and corrects the CPF-field labelling in `[ffc_csv_download]`'s `audit` mode where the markup contradicted the server behaviour.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.3.8
+ * Version:            6.3.9
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.3.8' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.3.9' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/audience/class-ffc-audience-admin-import.php
+++ b/includes/audience/class-ffc-audience-admin-import.php
@@ -424,7 +424,7 @@ class AudienceAdminImport {
 		if ( false === $output ) {
 			exit;
 		}
-		fputcsv( $output, array( 'email', 'name', 'audience_name' ) );
+		fputcsv( $output, array( 'email', 'name', 'audience_name' ), ';' );
 
 		$seen = array(); // Avoid duplicate rows for same user+audience.
 		foreach ( $audience_ids as $aid ) {
@@ -449,7 +449,8 @@ class AudienceAdminImport {
 						$user->user_email,
 						$user->display_name,
 						$audience_name,
-					)
+					),
+					';'
 				);
 			}
 		}
@@ -476,7 +477,7 @@ class AudienceAdminImport {
 		if ( false === $output ) {
 			exit;
 		}
-		fputcsv( $output, array( 'name', 'color', 'parent' ) );
+		fputcsv( $output, array( 'name', 'color', 'parent' ), ';' );
 
 		// Parents first, then children (same order as import expects).
 		foreach ( $audiences as $audience ) {
@@ -486,7 +487,8 @@ class AudienceAdminImport {
 					$audience->name,
 					$audience->color ?? '#3788d8',
 					'', // Parents have no parent.
-				)
+				),
+				';'
 			);
 
 			if ( ! empty( $audience->children ) ) {
@@ -497,7 +499,8 @@ class AudienceAdminImport {
 							$child->name,
 							$child->color ?? '#3788d8',
 							$audience->name,
-						)
+						),
+						';'
 					);
 				}
 			}

--- a/includes/audience/class-ffc-audience-csv-importer.php
+++ b/includes/audience/class-ffc-audience-csv-importer.php
@@ -58,8 +58,12 @@ class AudienceCsvImporter {
 			return $result;
 		}
 
+		// 6.3.9: auto-detect `,` vs `;` so legacy CSVs and the new
+		// pt-BR-friendly templates both parse correctly.
+		$delimiter = self::peek_delimiter( $handle );
+
 		// Read header row.
-		$header = fgetcsv( $handle );
+		$header = fgetcsv( $handle, 0, $delimiter );
 		if ( ! $header ) {
             // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $handle );
@@ -101,7 +105,7 @@ class AudienceCsvImporter {
 		// Process rows.
 		$row_num = 1;
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle ) ) !== false ) {
+		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
 			++$row_num;
 
 			// Skip empty rows.
@@ -201,8 +205,11 @@ class AudienceCsvImporter {
 			return $result;
 		}
 
+		// 6.3.9: auto-detect CSV delimiter (`,` or `;`).
+		$delimiter = self::peek_delimiter( $handle );
+
 		// Read header row.
-		$header = fgetcsv( $handle );
+		$header = fgetcsv( $handle, 0, $delimiter );
 		if ( ! $header ) {
             // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $handle );
@@ -232,7 +239,7 @@ class AudienceCsvImporter {
 		$audiences_to_create = array();
 		$row_num             = 1;
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle ) ) !== false ) {
+		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
 			++$row_num;
 
 			if ( empty( array_filter( $data ) ) ) {
@@ -439,8 +446,11 @@ class AudienceCsvImporter {
 			return $result;
 		}
 
+		// 6.3.9: auto-detect CSV delimiter (`,` or `;`).
+		$delimiter = self::peek_delimiter( $handle );
+
 		// Read header.
-		$header = fgetcsv( $handle );
+		$header = fgetcsv( $handle, 0, $delimiter );
 		if ( ! $header ) {
             // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $handle );
@@ -461,7 +471,7 @@ class AudienceCsvImporter {
 
 		// Count rows.
 		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle ) ) !== false ) {
+		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
 			if ( ! empty( array_filter( $data ) ) ) {
 				++$result['rows'];
 			}
@@ -478,24 +488,71 @@ class AudienceCsvImporter {
 	/**
 	 * Generate sample CSV content
 	 *
+	 * Mirrors the live export templates (semicolon-separated since 6.3.9
+	 * for Excel-pt-BR / WPS / LibreOffice locale compatibility). The
+	 * importer auto-detects the delimiter, so existing comma-separated
+	 * files keep working.
+	 *
 	 * @param string $type Type of CSV ('members' or 'audiences').
 	 * @return string CSV content
 	 */
 	public static function get_sample_csv( string $type = 'members' ): string {
 		if ( 'audiences' === $type ) {
-			return "name,color,parent\n" .
-					"Group A,#3788d8,\n" .
-					"Group B,#28a745,\n" .
-					"Subgroup A1,#dc3545,Group A\n" .
-					"Subgroup A2,#ffc107,Group A\n" .
-					"Subgroup B1,#17a2b8,Group B\n" .
-					"Team B1-Alpha,#6f42c1,Subgroup B1\n";
+			return "name;color;parent\n" .
+					"Group A;#3788d8;\n" .
+					"Group B;#28a745;\n" .
+					"Subgroup A1;#dc3545;Group A\n" .
+					"Subgroup A2;#ffc107;Group A\n" .
+					"Subgroup B1;#17a2b8;Group B\n" .
+					"Team B1-Alpha;#6f42c1;Subgroup B1\n";
 		}
 
 		// Default: members.
-		return "email,name,audience_name\n" .
-				"john@example.com,John Doe,Group A\n" .
-				"jane@example.com,Jane Smith,Subgroup A1\n" .
-				"bob@example.com,Bob Johnson,Group B\n";
+		return "email;name;audience_name\n" .
+				"john@example.com;John Doe;Group A\n" .
+				"jane@example.com;Jane Smith;Subgroup A1\n" .
+				"bob@example.com;Bob Johnson;Group B\n";
+	}
+
+	/**
+	 * Peek the first line of a CSV stream to choose between `,` and `;` as
+	 * the field separator, then rewind the handle so the regular
+	 * fgetcsv() loop reads from the start. Mirrors the recruitment
+	 * importer's detect_delimiter(); kept private to this class so the
+	 * surface stays small.
+	 *
+	 * Counts unquoted occurrences of each candidate; ties resolve to `,`
+	 * for backwards compatibility with files that worked pre-detection.
+	 *
+	 * @since 6.3.9
+	 * @param resource $handle Open file handle (read mode, position 0).
+	 * @return string `,` or `;`.
+	 */
+	private static function peek_delimiter( $handle ): string {
+		$first_line = fgets( $handle );
+		rewind( $handle );
+		if ( ! is_string( $first_line ) || '' === $first_line ) {
+			return ',';
+		}
+		$comma     = 0;
+		$semicolon = 0;
+		$in_quotes = false;
+		$length    = strlen( $first_line );
+		for ( $i = 0; $i < $length; $i++ ) {
+			$ch = $first_line[ $i ];
+			if ( '"' === $ch ) {
+				$in_quotes = ! $in_quotes;
+				continue;
+			}
+			if ( $in_quotes ) {
+				continue;
+			}
+			if ( ',' === $ch ) {
+				++$comma;
+			} elseif ( ';' === $ch ) {
+				++$semicolon;
+			}
+		}
+		return $semicolon > $comma ? ';' : ',';
 	}
 }

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -749,9 +749,9 @@ class PublicCsvDownload {
 		fwrite( $fh, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
 		if ( ! $encryption_ok ) {
 			// One-line preamble so the admin knows why CPFs come out empty.
-			fputcsv( $fh, array( '# Encryption is not configured on this site; CPF column will be empty for new entries. See plugin docs.' ) );
+			fputcsv( $fh, array( '# Encryption is not configured on this site; CPF column will be empty for new entries. See plugin docs.' ), ';' );
 		}
-		fputcsv( $fh, array( 'timestamp_utc', 'ip', 'mode', 'cpf', 'result' ) );
+		fputcsv( $fh, array( 'timestamp_utc', 'ip', 'mode', 'cpf', 'result' ), ';' );
 
 		foreach ( $log as $entry ) {
 			if ( ! is_array( $entry ) ) {
@@ -762,7 +762,7 @@ class PublicCsvDownload {
 			$mod = isset( $entry['mode'] ) ? (string) $entry['mode'] : '';
 			$res = isset( $entry['result'] ) ? (string) $entry['result'] : '';
 			$cpf = self::decrypt_log_entry_cpf( $entry );
-			fputcsv( $fh, array( $ts, $ip, $mod, $cpf, $res ) );
+			fputcsv( $fh, array( $ts, $ip, $mod, $cpf, $res ), ';' );
 		}
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $fh );

--- a/includes/reregistration/class-ffc-reregistration-csv-exporter.php
+++ b/includes/reregistration/class-ffc-reregistration-csv-exporter.php
@@ -85,7 +85,7 @@ class ReregistrationCsvExporter {
 		}
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv
-		fputcsv( $output, $headers );
+		fputcsv( $output, $headers, ';' );
 
 		// Data rows.
 		foreach ( $submissions as $sub ) {
@@ -109,7 +109,7 @@ class ReregistrationCsvExporter {
 			}
 
             // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv
-			fputcsv( $output, $row );
+			fputcsv( $output, $row, ';' );
 		}
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.3.8
+Stable tag: 6.3.9
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

Consistency release **6.3.8 → 6.3.9**. **Stacked PR** — bases on `claude/v6-3-8-shorten-fingerprint-disclosure` (PR #124). Diff shown here is v6.3.9 only; will rebase to `main` after #124 merges.

Standardises every plugin-emitted CSV on the semicolon (`;`) delimiter, fixing three exporters that were still using the comma default and breaking Excel-pt-BR / WPS / LibreOffice locale opens. Audience importer gains delimiter auto-detection so legacy comma-separated files keep working.

## Audit before fix

| Exporter | Was | Now |
|---|---|---|
| `class-ffc-csv-exporter.php` (admin – submissions) | `;` | `;` |
| `class-ffc-public-csv-exporter.php` (public form CSV) | `;` | `;` |
| `class-ffc-self-scheduling-appointment-csv-exporter.php` | `;` | `;` |
| `class-ffc-recruitment-notice-edit-page.php` | `;` | `;` |
| `class-ffc-csv-export-trait.php` (shared base) | `;` | `;` |
| **`class-ffc-public-csv-download.php`** (audit log v6.3.3) | **`,`** | **`;`** ✓ |
| **`class-ffc-reregistration-csv-exporter.php`** | **default `,`** | **`;`** ✓ |
| **`class-ffc-audience-admin-import.php`** (import templates) | **default `,`** | **`;`** ✓ |

## Audience importer auto-detect

Existing comma-separated files would now fail to parse if we changed only the export side. Added `AudienceCsvImporter::peek_delimiter()` mirroring the strategy in `RecruitmentCsvImporter::detect_delimiter()`:

1. `fgets()` reads the first line.
2. `rewind()` returns the handle to position 0 so the regular `fgetcsv()` flow runs unchanged.
3. Count unquoted `,` and `;` in the header line; ties resolve to `,` for backwards compat.

All three import paths in the file (members import, audiences import, validate-only pass) now call `peek_delimiter()` once and pass the result to every `fgetcsv()`.

## Sample CSV

`AudienceCsvImporter::get_sample_csv()` now emits `;`-separated samples to match the live export templates. Importer accepts both delimiters, so this is cosmetic — keeps the help-text consistent with what the user will see when they download a real template.

## Backwards compatibility

- **Comma-separated CSVs in the wild**: still import correctly (audience importer's new auto-detect + recruitment importer's pre-existing detection).
- **Custom downstream parsers**: a site that automated parsing of the reregistration or the audit-log CSV against the comma format needs a one-line update. Documented in CHANGELOG under "Backwards compatibility".

## File summary

```
includes/frontend/class-ffc-public-csv-download.php       ~  3× fputcsv with ';'
includes/reregistration/class-ffc-reregistration-csv-exporter.php  ~  2× fputcsv with ';'
includes/audience/class-ffc-audience-admin-import.php     ~  5× fputcsv with ';'
includes/audience/class-ffc-audience-csv-importer.php     ~  +peek_delimiter() + 6× fgetcsv with $delimiter + sample CSV updated
ffcertificate.php                                         ~  Version 6.3.9 + FFC_VERSION
readme.txt                                                ~  Stable tag 6.3.9
CHANGELOG.md                                              ~  [6.3.9] section
```

## Test plan

- [x] PHPUnit (Audience + Reregistration + PublicCsvDownload filter): 829 tests pass.
- [x] PHPStan: clean.
- [x] WPCS: clean (5/5 files).
- [ ] Manual E2E:
  - Download a fresh members template → open in Excel-pt-BR → columns separate correctly.
  - Re-import the same template (now `;`) → audience importer auto-detects and creates members.
  - Re-import a legacy template a user has on disk (still `,`) → auto-detect picks `,`, import succeeds.
  - Download the audit log CSV from a form metabox → opens in Excel-pt-BR with proper columns.

## Stacked PR notes

- **Do not merge before #124.** Once #124 merges to `main`, GitHub auto-rebases this PR's base to `main` and the diff collapses to v6.3.9 only.
- If #124 needs rework, this PR rebases cleanly: the only file touched by both PRs is `ffcertificate.php` (just the version constant) and `CHANGELOG.md` — both are pure-text and merge with no conflicts.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143SjasbkpVUPra6SKgxNuc)_