### PR TITLE
fix: stop email_hash_rehash from re-surfacing as pending after new submissions

### DIFF
--- a/includes/migrations/strategies/class-ffc-email-hash-rehash-migration-strategy.php
+++ b/includes/migrations/strategies/class-ffc-email-hash-rehash-migration-strategy.php
@@ -50,6 +50,19 @@ class EmailHashRehashMigrationStrategy implements MigrationStrategyInterface {
 	private const CURSOR_OPTION_PREFIX = 'ffc_email_hash_rehash_cursor_';
 
 	/**
+	 * Option name for the migration completion flag.
+	 *
+	 * Set once both tables have been walked and pending == 0. Required
+	 * because the cursor-based accounting cannot distinguish "row above
+	 * cursor that was inserted after migration finished" (already correct
+	 * by construction — the buggy write paths are fixed) from "row above
+	 * cursor that still holds a legacy unsalted hash". Without the flag,
+	 * every new submission would falsely re-surface this migration as
+	 * pending.
+	 */
+	private const COMPLETE_OPTION = 'ffc_email_hash_rehash_completed';
+
+	/**
 	 * Submissions table.
 	 *
 	 * @var string
@@ -83,7 +96,21 @@ class EmailHashRehashMigrationStrategy implements MigrationStrategyInterface {
 		$submissions  = $this->count_table_status( $this->submissions_table );
 		$appointments = $this->count_table_status( $this->appointments_table );
 
-		$total    = $submissions['total'] + $appointments['total'];
+		$total = $submissions['total'] + $appointments['total'];
+
+		// Once the migration has been declared complete, treat all rows
+		// (including those inserted afterwards) as migrated. New writes go
+		// through Encryption::hash() so they are correct by construction.
+		if ( $this->is_completed() ) {
+			return array(
+				'total'       => $total,
+				'migrated'    => $total,
+				'pending'     => 0,
+				'percent'     => 100.0,
+				'is_complete' => true,
+			);
+		}
+
 		$migrated = $submissions['migrated'] + $appointments['migrated'];
 		$pending  = $submissions['pending'] + $appointments['pending'];
 		$percent  = ( $total > 0 ) ? ( $migrated / $total ) * 100 : 100;
@@ -108,6 +135,16 @@ class EmailHashRehashMigrationStrategy implements MigrationStrategyInterface {
 	public function execute( string $migration_key, array $migration_config, int $batch_number = 0 ): array {
 		$batch_size = isset( $migration_config['batch_size'] ) ? (int) $migration_config['batch_size'] : 100;
 
+		if ( $this->is_completed() ) {
+			return array(
+				'success'   => true,
+				'processed' => 0,
+				'has_more'  => false,
+				'message'   => __( 'Email hash rehash already completed.', 'ffcertificate' ),
+				'errors'    => array(),
+			);
+		}
+
 		$total_processed = 0;
 		$all_errors      = array();
 
@@ -120,6 +157,14 @@ class EmailHashRehashMigrationStrategy implements MigrationStrategyInterface {
 		}
 
 		$status = $this->calculate_status( $migration_key, $migration_config );
+
+		// Once both tables are fully walked with no errors, latch the
+		// completion flag so future submissions don't re-surface the
+		// migration as pending.
+		if ( 0 === $status['pending'] && empty( $all_errors ) ) {
+			$this->mark_completed();
+			$status['is_complete'] = true;
+		}
 
 		if ( class_exists( '\\FreeFormCertificate\\Core\\ActivityLog' ) ) {
 			\FreeFormCertificate\Core\ActivityLog::log(
@@ -338,6 +383,24 @@ class EmailHashRehashMigrationStrategy implements MigrationStrategyInterface {
 			'processed' => $processed,
 			'errors'    => $errors,
 		);
+	}
+
+	/**
+	 * Whether the migration has already been declared complete.
+	 *
+	 * @return bool
+	 */
+	private function is_completed(): bool {
+		return (bool) get_option( self::COMPLETE_OPTION, false );
+	}
+
+	/**
+	 * Latch the migration as complete.
+	 *
+	 * @return void
+	 */
+	private function mark_completed(): void {
+		update_option( self::COMPLETE_OPTION, true, false );
 	}
 
 	/**


### PR DESCRIPTION
## Sintoma

Em `ffc_form&page=ffc-settings&tab=migrations`, a migração **Recalcular Hashes de Pesquisa de E-mail** voltou a aparecer como pendente após novas submissões — mesmo depois de uma execução bem-sucedida (28/30 mostrando 2 pendentes na captura do usuário).

## Diagnóstico

O hash para **novas submissões está correto**. Verifiquei os caminhos de escrita:

- `SubmissionHandler` (`includes/submissions/class-ffc-submission-handler.php:181`) usa `SensitiveFieldRegistry::encrypt_fields()` → `Encryption::hash()` (com salt).
- `AppointmentRepository::createAppointment` (`includes/repositories/ffc-appointment-repository.php:530`) idem.
- `UserCleanup::handle_email_change` (`includes/user-dashboard/class-ffc-user-cleanup.php:173`) usa `Encryption::hash()` direto.

Todos os três usam o hash com salt — os bugs históricos que motivaram esta migração já foram corrigidos.

O problema é a **contabilidade de status** em `EmailHashRehashMigrationStrategy::count_table_status()`:

```php
migrated = COUNT(*) WHERE id <= cursor
pending  = total - migrated
```

Como o cursor não acompanha `MAX(id)` após nova submissão, qualquer linha nova com `id > cursor` aparece como "pendente". Se o usuário clicar "Executar Migração" novamente, o `process_table` percorre essas linhas, o `hash_equals` confirma que já estão corretas (`continue` idempotente) e o cursor avança — mas a próxima submissão repete o ciclo.

## Correção

Sigo o mesmo padrão das outras migrações neste plugin (`ffc_migration_*_completed`): adiciono um flag latched `ffc_email_hash_rehash_completed`.

- Quando `execute()` termina e o status mostra `pending === 0` sem erros, o flag é gravado.
- `calculate_status()` faz curto-circuito quando o flag está setado e retorna `is_complete = true, pending = 0`, contando todas as linhas atuais como migradas.
- `execute()` também faz curto-circuito quando já completo.

Como os caminhos de escrita já produzem o hash correto por construção, novas linhas após o latch não precisam de migração — exatamente o comportamento esperado.

## Test plan

- [ ] Em ambiente com migração marcada completa via UI, criar nova submissão e abrir aba de migrações → migração deve continuar mostrando 100% completo.
- [ ] Em ambiente com legítimas linhas legacy, executar a migração → deve processar normalmente até `pending === 0` e então marcar como completo.
- [ ] Reabrir aba de migrações após reload → status persistente como completo (option latched).

https://claude.ai/code/session_01Ky9Z6C4Pi4zGPyY9wXuWU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky9Z6C4Pi4zGPyY9wXuWU9)_