### PR TITLE
[Sec] Hygiene cleanup — escape, allowlist alias, redact log PII, hash_equals on tokens

### DIFF
--- a/includes/admin/class-ffc-admin-user-columns.php
+++ b/includes/admin/class-ffc-admin-user-columns.php
@@ -431,7 +431,28 @@ class AdminUserColumns {
 	 */
 	public static function apply_sort_to_user_query( \WP_User_Query $query ): void {
 		$orderby = isset( $query->query_vars['orderby'] ) ? (string) $query->query_vars['orderby'] : '';
-		if ( ! in_array( $orderby, array( 'ffc_certificates', 'ffc_appointments', 'ffc_notices' ), true ) ) {
+
+		// Allowlist of orderby keys this method handles, mapped to the join
+		// alias the synthesised SQL will reference. Both sides are static
+		// identifiers that never come from request input — the mapping is
+		// the canonical contract and must be the only source of $alias.
+		$alias_map = array(
+			'ffc_certificates' => 'ffc_cert_counts',
+			'ffc_appointments' => 'ffc_appt_counts',
+			'ffc_notices'      => 'ffc_notice_counts',
+		);
+
+		if ( ! isset( $alias_map[ $orderby ] ) ) {
+			return;
+		}
+
+		$alias = $alias_map[ $orderby ];
+
+		// Defense-in-depth: even though $alias comes from a static literal
+		// map keyed by an allowlisted $orderby, refuse to interpolate it
+		// into SQL unless it is a plain identifier. Anything that fails
+		// this check is a programming mistake, not user input — bail safe.
+		if ( ! preg_match( '/^[A-Za-z_][A-Za-z0-9_]*$/', $alias ) ) {
 			return;
 		}
 
@@ -443,7 +464,6 @@ class AdminUserColumns {
 		switch ( $orderby ) {
 			case 'ffc_certificates':
 				$table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
-				$alias  = 'ffc_cert_counts';
 				$select = "(SELECT user_id, COUNT(*) AS cnt FROM {$table} WHERE user_id IS NOT NULL AND status != 'trash' GROUP BY user_id)";
 				break;
 
@@ -452,7 +472,6 @@ class AdminUserColumns {
 				if ( ! self::table_exists( $appts_table ) ) {
 					return;
 				}
-				$alias  = 'ffc_appt_counts';
 				$select = "(SELECT user_id, COUNT(*) AS cnt FROM {$appts_table} WHERE user_id IS NOT NULL AND status != 'cancelled' GROUP BY user_id)";
 				break;
 
@@ -463,7 +482,6 @@ class AdminUserColumns {
 				if ( ! self::table_exists( $classifications ) ) {
 					return;
 				}
-				$alias  = 'ffc_notice_counts';
 				$select = "(SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt FROM {$classifications} AS cl INNER JOIN {$candidates} AS c ON c.id = cl.candidate_id WHERE c.user_id IS NOT NULL GROUP BY c.user_id)";
 				break;
 		}

--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -556,7 +556,7 @@ class FormEditorMetaboxRenderer {
 								</label>
 							</fieldset>
 
-							<div class="ffc-geo-source-locations" <?php echo 'locations' !== $geo_area_source ? 'style="display:none;"' : ''; ?>>
+							<div class="<?php echo esc_attr( 'ffc-geo-source-locations' . ( 'locations' !== $geo_area_source ? ' ffc-initially-hidden' : '' ) ); ?>">
 								<select multiple name="ffc_geofence[geo_area_location_ids][]" class="ffc-w100" size="5">
 									<?php foreach ( $all_locations as $loc ) : ?>
 										<option value="<?php echo esc_attr( $loc['id'] ); ?>" <?php echo in_array( $loc['id'], $geo_area_location_ids, true ) ? 'selected' : ''; ?>>
@@ -567,7 +567,7 @@ class FormEditorMetaboxRenderer {
 								<p class="description"><?php esc_html_e( 'Hold Ctrl/Cmd to select multiple locations.', 'ffcertificate' ); ?></p>
 							</div>
 
-							<div class="ffc-geo-source-custom" <?php echo 'custom' !== $geo_area_source ? 'style="display:none;"' : ''; ?>>
+							<div class="<?php echo esc_attr( 'ffc-geo-source-custom' . ( 'custom' !== $geo_area_source ? ' ffc-initially-hidden' : '' ) ); ?>">
 								<textarea name="ffc_geofence[geo_areas]" rows="5" class="ffc-w100" placeholder="-23.5505, -46.6333, 5000&#10;-22.9068, -43.1729, 10000"><?php echo esc_textarea( $geo_areas ); ?></textarea>
 								<p class="description"><?php esc_html_e( 'Format: latitude, longitude, radius(meters) - One per line. Example: -23.5505, -46.6333, 5000', 'ffcertificate' ); ?></p>
 							</div>
@@ -582,7 +582,7 @@ class FormEditorMetaboxRenderer {
 							</label>
 							<p class="description"><?php esc_html_e( 'When unchecked, IP validation uses the same areas as GPS.', 'ffcertificate' ); ?></p>
 
-							<div class="ffc-ip-areas-container" <?php echo '1' !== $geo_ip_areas_permissive ? 'style="display:none;"' : ''; ?>>
+							<div class="<?php echo esc_attr( 'ffc-ip-areas-container' . ( '1' !== $geo_ip_areas_permissive ? ' ffc-initially-hidden' : '' ) ); ?>">
 								<br>
 								<fieldset>
 									<label>
@@ -596,7 +596,7 @@ class FormEditorMetaboxRenderer {
 									</label>
 								</fieldset>
 
-								<div class="ffc-geo-source-locations" <?php echo 'locations' !== $geo_ip_area_source ? 'style="display:none;"' : ''; ?>>
+								<div class="<?php echo esc_attr( 'ffc-geo-source-locations' . ( 'locations' !== $geo_ip_area_source ? ' ffc-initially-hidden' : '' ) ); ?>">
 									<select multiple name="ffc_geofence[geo_ip_area_location_ids][]" class="ffc-w100" size="5">
 										<?php foreach ( $all_locations as $loc ) : ?>
 											<option value="<?php echo esc_attr( $loc['id'] ); ?>" <?php echo in_array( $loc['id'], $geo_ip_area_location_ids, true ) ? 'selected' : ''; ?>>
@@ -607,7 +607,7 @@ class FormEditorMetaboxRenderer {
 									<p class="description"><?php esc_html_e( 'Hold Ctrl/Cmd to select multiple locations.', 'ffcertificate' ); ?></p>
 								</div>
 
-								<div class="ffc-geo-source-custom" <?php echo 'custom' !== $geo_ip_area_source ? 'style="display:none;"' : ''; ?>>
+								<div class="<?php echo esc_attr( 'ffc-geo-source-custom' . ( 'custom' !== $geo_ip_area_source ? ' ffc-initially-hidden' : '' ) ); ?>">
 									<textarea name="ffc_geofence[geo_ip_areas]" rows="5" class="ffc-w100" placeholder="-23.5505, -46.6333, 50000&#10;-22.9068, -43.1729, 100000"><?php echo esc_textarea( $geo_ip_areas ); ?></textarea>
 									<p class="description"><?php esc_html_e( 'IP geolocation is less precise (1-50km). Use larger radius (in meters).', 'ffcertificate' ); ?></p>
 								</div>

--- a/includes/core/class-ffc-debug.php
+++ b/includes/core/class-ffc-debug.php
@@ -19,8 +19,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Debug.
+ *
+ * Logging contract: scalar payloads are written verbatim, but array /
+ * object payloads pass through `redact_sensitive_data()` first so that
+ * known PII and credential keys (email, cpf, rf, cpf_rf, phone, token,
+ * magic_token, auth_code, password, recipient address) are masked
+ * before reaching `error_log`. URL strings containing those values as
+ * query parameters are stripped of the secret. This means callers do
+ * not need to redact at the call site — the central guarantee holds
+ * even when new callers land. Add new sensitive keys to
+ * `SENSITIVE_KEYS` rather than redacting locally.
  */
 class Debug {
+
+	/**
+	 * Map of array keys whose values must be masked before logging.
+	 * Matched case-insensitively against the array key.
+	 *
+	 * Keep this list synchronised with the data shapes the plugin
+	 * passes to `log_*()`. Adding a key here retroactively protects
+	 * every existing caller.
+	 */
+	private const SENSITIVE_KEYS = array(
+		'email',
+		'recipient',
+		'to',
+		'cpf',
+		'rf',
+		'cpf_rf',
+		'phone',
+		'telefone',
+		'password',
+		'pass',
+		'senha',
+		'auth_code',
+		'magic_token',
+		'token',
+		'confirmation_token',
+		'api_key',
+		'secret',
+	);
+
+	/**
+	 * Query parameters whose values are stripped from logged URLs.
+	 */
+	private const SENSITIVE_URL_PARAMS = array(
+		'magic_token',
+		'auth_code',
+		'token',
+		'password',
+		'api_key',
+	);
 
 	/**
 	 * Available debug areas.
@@ -84,8 +133,9 @@ class Debug {
 
 		if ( null !== $data ) {
 			if ( is_array( $data ) || is_object( $data ) ) {
+				$redacted = self::redact_sensitive_data( $data );
                 // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-				$log_message .= ' | Data: ' . print_r( $data, true );
+				$log_message .= ' | Data: ' . print_r( $redacted, true );
 			} else {
 				$log_message .= ' | Data: ' . $data;
 			}
@@ -93,6 +143,92 @@ class Debug {
 
         // phpcs:ignore WordPress.PHP.DevelopmentFunctions
 		error_log( $log_message );
+	}
+
+	/**
+	 * Walk an array/object payload and mask values whose key matches
+	 * `SENSITIVE_KEYS`, or whose value is a URL carrying one of the
+	 * `SENSITIVE_URL_PARAMS`. Recurses through nested arrays.
+	 *
+	 * Masking preserves a hint of the value's shape (length + 2 leading
+	 * + 2 trailing characters) so logs remain useful for "did the field
+	 * get populated at all?" debugging without leaking the contents.
+	 *
+	 * @param mixed $data  Arbitrary scalar / array / object payload.
+	 * @param int   $depth Recursion guard — stops at 6 levels.
+	 * @return mixed The same shape, with sensitive values masked.
+	 */
+	private static function redact_sensitive_data( $data, int $depth = 0 ) {
+		if ( $depth > 6 ) {
+			return '[deep]';
+		}
+
+		if ( is_object( $data ) ) {
+			$data = (array) $data;
+		}
+
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		$out = array();
+		foreach ( $data as $key => $value ) {
+			$key_str = strtolower( (string) $key );
+			if ( is_string( $value ) && in_array( $key_str, self::SENSITIVE_KEYS, true ) ) {
+				$out[ $key ] = self::mask_value( $value );
+			} elseif ( is_string( $value ) && self::url_carries_secret( $value ) ) {
+				$out[ $key ] = self::strip_secret_query( $value );
+			} elseif ( is_array( $value ) || is_object( $value ) ) {
+				$out[ $key ] = self::redact_sensitive_data( $value, $depth + 1 );
+			} else {
+				$out[ $key ] = $value;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Replace the inner characters of a string with asterisks while
+	 * preserving the first 2, last 2, and the original length. Returns
+	 * `***` for short strings whose shape would otherwise reveal too
+	 * much.
+	 */
+	private static function mask_value( string $value ): string {
+		$len = strlen( $value );
+		if ( 0 === $len ) {
+			return '';
+		}
+		if ( $len <= 4 ) {
+			return str_repeat( '*', $len );
+		}
+		return substr( $value, 0, 2 ) . str_repeat( '*', max( 3, $len - 4 ) ) . substr( $value, -2 ) . " (len:{$len})";
+	}
+
+	/**
+	 * Cheap sniff for "this string looks like a URL with one of our
+	 * sensitive query parameters". Avoids invoking `parse_url` for
+	 * every scalar in the log payload.
+	 */
+	private static function url_carries_secret( string $value ): bool {
+		if ( strncasecmp( $value, 'http', 4 ) !== 0 ) {
+			return false;
+		}
+		foreach ( self::SENSITIVE_URL_PARAMS as $param ) {
+			if ( false !== stripos( $value, $param . '=' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Replace the value of any sensitive query parameter in `$url`
+	 * with `[redacted]`. Works on full URLs and bare query strings.
+	 */
+	private static function strip_secret_query( string $url ): string {
+		$pattern = '/([?&])(' . implode( '|', array_map( 'preg_quote', self::SENSITIVE_URL_PARAMS ) ) . ')=[^&#]*/i';
+		$result  = preg_replace( $pattern, '$1$2=[redacted]', $url );
+		return is_string( $result ) ? $result : $url;
 	}
 
 	/**

--- a/includes/core/class-ffc-debug.php
+++ b/includes/core/class-ffc-debug.php
@@ -192,6 +192,9 @@ class Debug {
 	 * preserving the first 2, last 2, and the original length. Returns
 	 * `***` for short strings whose shape would otherwise reveal too
 	 * much.
+	 *
+	 * @param string $value Sensitive scalar to mask.
+	 * @return string Masked representation.
 	 */
 	private static function mask_value( string $value ): string {
 		$len = strlen( $value );
@@ -208,6 +211,9 @@ class Debug {
 	 * Cheap sniff for "this string looks like a URL with one of our
 	 * sensitive query parameters". Avoids invoking `parse_url` for
 	 * every scalar in the log payload.
+	 *
+	 * @param string $value Candidate string.
+	 * @return bool True when the value is an http(s) URL containing a sensitive query parameter.
 	 */
 	private static function url_carries_secret( string $value ): bool {
 		if ( strncasecmp( $value, 'http', 4 ) !== 0 ) {
@@ -224,6 +230,9 @@ class Debug {
 	/**
 	 * Replace the value of any sensitive query parameter in `$url`
 	 * with `[redacted]`. Works on full URLs and bare query strings.
+	 *
+	 * @param string $url URL or query string.
+	 * @return string URL with sensitive parameter values replaced.
 	 */
 	private static function strip_secret_query( string $url ): string {
 		$pattern = '/([?&])(' . implode( '|', array_map( 'preg_quote', self::SENSITIVE_URL_PARAMS ) ) . ')=[^&#]*/i';

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-handler.php
@@ -367,7 +367,7 @@ class AppointmentHandler {
 					__( 'You do not have permission to cancel appointments.', 'ffcertificate' )
 				);
 			}
-		} elseif ( ! empty( $token ) && $appointment['confirmation_token'] === $token ) {
+		} elseif ( ! empty( $token ) && is_string( $appointment['confirmation_token'] ) && hash_equals( (string) $appointment['confirmation_token'], (string) $token ) ) {
 			$can_cancel = true;
 		}
 

--- a/tests/Unit/DebugTest.php
+++ b/tests/Unit/DebugTest.php
@@ -183,4 +183,91 @@ class DebugTest extends TestCase {
         // `Debug` system.
         $this->assertCount( 14, $areas );
     }
+
+    // ==================================================================
+    // PII / credential redaction in array payloads
+    // ==================================================================
+
+    public function test_log_masks_email_value(): void {
+        $this->enable_area( Debug::AREA_EMAIL_HANDLER );
+        Debug::log( Debug::AREA_EMAIL_HANDLER, 'Sent', array( 'email' => 'someone@example.com' ) );
+        $this->assertStringNotContainsString( 'someone@example.com', $this->logged[0] );
+        // Length hint preserved so the field shape is still debuggable.
+        $this->assertStringContainsString( 'len:19', $this->logged[0] );
+    }
+
+    public function test_log_masks_cpf_and_cpf_rf(): void {
+        $this->enable_area( Debug::AREA_FORM_PROCESSOR );
+        Debug::log( Debug::AREA_FORM_PROCESSOR, 'Doc', array(
+            'cpf'    => '12345678901',
+            'cpf_rf' => '7654321',
+        ) );
+        $this->assertStringNotContainsString( '12345678901', $this->logged[0] );
+        $this->assertStringNotContainsString( '7654321', $this->logged[0] );
+    }
+
+    public function test_log_masks_auth_code_and_magic_token(): void {
+        $this->enable_area( Debug::AREA_PDF_GENERATOR );
+        Debug::log( Debug::AREA_PDF_GENERATOR, 'Generated', array(
+            'auth_code'   => 'ABCDEF123456',
+            'magic_token' => 'tok_supersecret_value_xyz',
+        ) );
+        $this->assertStringNotContainsString( 'ABCDEF123456', $this->logged[0] );
+        $this->assertStringNotContainsString( 'tok_supersecret_value_xyz', $this->logged[0] );
+    }
+
+    public function test_log_strips_magic_token_from_url(): void {
+        $this->enable_area( Debug::AREA_PDF_GENERATOR );
+        Debug::log( Debug::AREA_PDF_GENERATOR, 'Built URL', array(
+            'target_url' => 'https://example.com/valid?magic_token=abc123xyz&foo=bar',
+        ) );
+        $this->assertStringNotContainsString( 'abc123xyz', $this->logged[0] );
+        $this->assertStringContainsString( '[redacted]', $this->logged[0] );
+        $this->assertStringContainsString( 'foo=bar', $this->logged[0] );
+    }
+
+    public function test_log_preserves_non_sensitive_fields(): void {
+        $this->enable_area( Debug::AREA_ADMIN );
+        Debug::log( Debug::AREA_ADMIN, 'Op', array(
+            'submission_id' => 42,
+            'form_id'       => 7,
+            'context'       => 'submission',
+        ) );
+        $this->assertStringContainsString( 'submission_id', $this->logged[0] );
+        $this->assertStringContainsString( '42', $this->logged[0] );
+        $this->assertStringContainsString( 'form_id', $this->logged[0] );
+        $this->assertStringContainsString( 'submission', $this->logged[0] );
+    }
+
+    public function test_log_redacts_recursively(): void {
+        $this->enable_area( Debug::AREA_REST_API );
+        Debug::log( Debug::AREA_REST_API, 'Nested', array(
+            'request' => array(
+                'meta'  => array( 'email' => 'leak@example.com' ),
+                'count' => 3,
+            ),
+        ) );
+        $this->assertStringNotContainsString( 'leak@example.com', $this->logged[0] );
+        $this->assertStringContainsString( 'count', $this->logged[0] );
+        $this->assertStringContainsString( '3', $this->logged[0] );
+    }
+
+    public function test_log_short_value_fully_masked(): void {
+        $this->enable_area( Debug::AREA_FORM_PROCESSOR );
+        Debug::log( Debug::AREA_FORM_PROCESSOR, 'Short', array( 'token' => 'abc' ) );
+        $this->assertStringNotContainsString( '=> abc', $this->logged[0] );
+    }
+
+    public function test_log_keys_are_case_insensitive(): void {
+        $this->enable_area( Debug::AREA_FORM_PROCESSOR );
+        Debug::log( Debug::AREA_FORM_PROCESSOR, 'Mixed', array( 'Email' => 'mixed@example.com' ) );
+        $this->assertStringNotContainsString( 'mixed@example.com', $this->logged[0] );
+    }
+
+    public function test_log_empty_string_preserved_not_masked(): void {
+        $this->enable_area( Debug::AREA_FORM_PROCESSOR );
+        Debug::log( Debug::AREA_FORM_PROCESSOR, 'Empty', array( 'email' => '' ) );
+        // Empty string should remain empty, not get a length hint.
+        $this->assertStringNotContainsString( 'len:0', $this->logged[0] );
+    }
 }


### PR DESCRIPTION
Closes #140.

## Sprints (each commit standalone)

| # | Commit | What |
|---|---|---|
| S1 | `b0b1952` | replace inline-style ternaries with CSS class toggle in metabox renderer |
| S2 | `bf31fe9` | enforce ORDER BY alias allowlist in user-columns query rewriter |
| S3 | `787bcd5` | redact PII and credentials in `Debug::log` array payloads |
| S4 | `2776389` | hash_equals on appointment confirmation_token comparison |

## Honest deltas vs the original audit

- **S1** — wrapping the original `'style="display:none;"'` literal in `esc_attr` would actually break the HTML (escapes the inner quotes). Real fix: drop the inline style, toggle existing `.ffc-initially-hidden` utility class.
- **S2** — auditor claimed `$alias` came from a filter hook; inspection showed it was already constrained to three literals via a switch keyed on an `in_array()`-checked `$orderby`. There was no actual injection vector. Defense-in-depth allowlist + identifier regex added so the contract is now enforceable rather than implicit.
- **S3** — instead of chasing 116 callsites, redaction was centralised inside `Debug::log()`. Six real PII/credential leaks (auth_code, magic_token URL, recipient emails) were neutralised in one place; new callers inherit the protection.
- **S4** — the file the auditor fingered (`class-ffc-public-csv-download.php`) already used `hash_equals`. A real timing-side-channel was found elsewhere though: `appointment-handler.php:370` compared the confirmation token (a bearer credential) with `===`. Fixed.

## Verification

- [x] PHPUnit: 3836 tests, 9751 assertions, all green (includes 9 new redaction tests in `DebugTest`).
- [x] PHPStan: 0 errors.
- [x] No behaviour change in admin geofence metabox UI (jQuery `.show()/.hide()` still drives visibility — `.ffc-initially-hidden` only sets the initial state, identical to the previous inline `style="display:none"`).
- [x] No behaviour change in user list ORDER BY (alias map is the same three literals).

## Test plan for reviewer

- [ ] Open the form editor's geofence metabox: location/custom radio toggling still hides/shows the right panels.
- [ ] On the Users list, click the "Certificates" / "Appointments" / "Notices" sortable column headers — sort still works.
- [ ] Enable any debug area in admin Settings, submit a form / cancel an appointment / generate a PDF, inspect `wp-content/debug.log`: emails masked (`so**********om (len:19)`), magic_token URLs show `[redacted]`.
- [ ] Cancel an appointment via the public link (`?token=...`): legitimate token still works, slightly altered token rejected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SphzDGfdHo63qBK7XMkWcF)_