### PR TITLE
[Refactor] Unified CSV IO — Csv::writer + Csv::reader (closes #126, v6.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+---
+
+## [6.4.0] (2026-05-10)
+
+**Unified CSV IO abstraction (#126).** Internal refactor: every CSV the plugin reads or writes now flows through a single pair of primitives — `\FreeFormCertificate\Core\Csv::writer()` / `Csv::reader()` — instead of the eight exporters and two importers each implementing fputcsv/fgetcsv/delimiter detection/BOM handling on their own. No user-facing change for files that already used `;` (the post-6.3.9 default); audience export templates now correctly emit a UTF-8 BOM (previously they were the only files in the plugin that didn't, causing Excel to render accented characters as mojibake until manually fixing encoding). Minor bump because the surface area touched is broad even though behaviour is preserved on every public format.
+
 ### Added
 
 - **Certificates Dashboard (admin).** New page registered as the first item under the Certificate menu (`edit.php?post_type=ffc_form&page=ffc-certificates-dashboard`). Renders a monthly calendar of every form keyed by its GeoFence start date (with a fallback to the publication date when the form has no GeoFence configured), plus a side list of forms scheduled for the day clicked in the calendar. Day cells get a count chip — green when at least one form on the day is GeoFence-sourced, gray when all are post_date fallbacks. Backed by a new `GET /ffc/v1/certificates/calendar` REST endpoint gated on `edit_others_posts` (Editor + Administrator). Reuses the existing `FFCCalendarCore` JS grid.
+- **Csv / CsvWriter / CsvReader (`includes/core/`).** Public IO primitives (`final class` facade + worker pair). Writer guarantees: BOM emitted exactly once before the first row, `;` delimiter by default, RFC 4180 quoting, optional `skip_bom` flag for append-mode workers picking up after an init writer. Reader guarantees: BOM stripped at byte 0 if present, `,`-vs-`;` auto-detection on the first line (ties → `,` for back-compat), `each(callable)` streams body rows for memory-bounded imports, `header()`/`all()`/`close()` for the convenience cases. 28 PHPUnit cases cover round-trip integrity, BOM contract, all four quoting edge cases, and the resource-vs-string entry points.
+
+### Changed
+
+- **CSV exports migrated to `Csv::writer`.** Eight exporters touched, one per commit: admin submissions (`CsvExporter`), public synchronous + async submissions (`PublicCsvExporter`), self-scheduling appointments (`AppointmentCsvExporter`), recruitment notice template, reregistration submissions (`ReregistrationCsvExporter`), audience admin templates (members + audiences), public-csv-download audit log, admin activity log. Per-exporter mb_convert_encoding and BOM-emission code removed; the writer handles both centrally.
+- **CSV imports migrated to `Csv::reader`.** Two importers (recruitment + audience) drop their per-class `detect_delimiter()` / `peek_delimiter()` / `parse_csv_line()` / `strip_utf8_bom()` helpers (~250 LOC removed). Recruitment importer's previous line-splitter (`preg_split('/\r\n|\n|\r/', $content)` + `str_getcsv` per physical line) is replaced with the reader's `fgetcsv`-based parser, which now correctly handles quoted multi-line cells (was a silent parse failure before).
+- **CsvExportTrait scope narrowed.** `output_csv()` removed (replaced by the new writer); the trait now contains only the JSON-data-shape helpers (extract_dynamic_keys, decode_json_field, build_dynamic_headers, extract_dynamic_values) used by the submission and appointment exporters to flatten encrypted/plaintext `data` columns into dynamic spreadsheet columns.
 
 ### Fixed
 
+- **Audience export templates now emit UTF-8 BOM.** `members-export-*.csv` and `audiences-export-*.csv` were the only CSV files in the plugin without a BOM, so Excel opened them in the wrong encoding by default. The migration to `Csv::writer` standardises BOM emission. Round-trip with the matching importer is unaffected: the importer always tolerated BOM either way.
 - **Audience shortcode modals fall behind the calendar instead of appearing as an overlay.** The day-detail and booking modals in `[ffc_audience]` were rendered outside the `.ffc-shortcode` wrapper that the `ffc-calendar-wrapper` refactor introduced, so the `.ffc-shortcode .ffc-modal` rules (which provide `position: fixed`, the dark backdrop and centred placement) never matched. Modals dropped into normal flow and rendered inline below the calendar. Added `ffc-shortcode` to each modal's class list so the existing scoped CSS applies again — minimal change, no layout or selector-broadening side effects.
 
 ---

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.3.11
+ * Version:            6.4.0
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.3.11' );               // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.4.0' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/admin/class-ffc-admin-activity-log-page.php
+++ b/includes/admin/class-ffc-admin-activity-log-page.php
@@ -22,8 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class AdminActivityLogPage {
 
-	use \FreeFormCertificate\Core\CsvExportTrait;
-
 	/**
 	 * Register admin menu and export handler
 	 */
@@ -122,8 +120,25 @@ class AdminActivityLogPage {
 			);
 		}
 
-		$filename = 'ffc-activity-log-' . gmdate( 'Y-m-d' ) . '.csv';
-		$this->output_csv( $filename, $headers, $rows );
+		$filename      = 'ffc-activity-log-' . gmdate( 'Y-m-d' ) . '.csv';
+		$safe_filename = str_replace( array( "\r", "\n", '"' ), '', $filename );
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename="' . $safe_filename . '"' );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
+		$output = fopen( 'php://output', 'w' );
+		if ( false === $output ) {
+			exit;
+		}
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( $headers );
+		$writer->rows( $rows );
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
+		fclose( $output );
+		exit;
 	}
 
 	/**

--- a/includes/admin/class-ffc-csv-exporter.php
+++ b/includes/admin/class-ffc-csv-exporter.php
@@ -159,16 +159,6 @@ class CsvExporter {
 		$job_id   = wp_generate_uuid4();
 		$tmp_file = $tmp_dir . '/ffc-export-' . $job_id . '.csv';
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-		$fh = fopen( $tmp_file, 'w' );
-		if ( ! $fh ) {
-			wp_send_json_error( __( 'Cannot create temp file.', 'ffcertificate' ) );
-		}
-
-		// BOM + headers.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output.
-		fprintf( $fh, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
-
 		$headers = array_merge(
 			$this->get_fixed_headers( $include_edit_columns ),
 			$this->get_dynamic_headers( $dynamic_keys )
@@ -188,15 +178,13 @@ class CsvExporter {
 		 */
 		$headers = (array) apply_filters( 'ffcertificate_csv_export_headers', $headers, $include_edit_columns, $form_ids );
 
-		$headers = array_map(
-			function ( $h ) {
-				return mb_convert_encoding( (string) $h, 'UTF-8', 'UTF-8' );
-			},
-			$headers
-		);
-		fputcsv( $fh, $headers, ';' );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing handle from fopen() for CSV streaming; WP_Filesystem has no streaming equivalent.
-		fclose( $fh );
+		try {
+			$writer = \FreeFormCertificate\Core\Csv::writer( $tmp_file );
+		} catch ( \RuntimeException $e ) {
+			wp_send_json_error( __( 'Cannot create temp file.', 'ffcertificate' ) );
+		}
+		$writer->row( $headers );
+		$writer->close();
 
 		// Store job state in a transient.
 		$job = array(
@@ -285,23 +273,20 @@ class CsvExporter {
 		 */
 		$batch = apply_filters( 'ffcertificate_csv_export_data', $batch, $job['form_ids'], $job['status'] );
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming append; CsvWriter does not own this handle.
 		$fh = fopen( $job['file'], 'a' );
 		if ( ! $fh ) {
 			wp_send_json_error( __( 'Cannot write to temp file.', 'ffcertificate' ) );
 		}
 
+		// File already contains its BOM from the init handler, so the
+		// append writer suppresses its own BOM emission.
+		$writer = \FreeFormCertificate\Core\Csv::writer( $fh, ';', true );
 		foreach ( $batch as $row ) {
-			$csv_row = $this->format_csv_row( $row, $job['dynamic_keys'], $job['include_edit_columns'] );
-			$csv_row = array_map(
-				function ( $v ) {
-					return mb_convert_encoding( (string) $v, 'UTF-8', 'UTF-8' );
-				},
-				$csv_row
-			);
-			fputcsv( $fh, $csv_row, ';' );
+			$writer->row( $this->format_csv_row( $row, $job['dynamic_keys'], $job['include_edit_columns'] ) );
 		}
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing handle from fopen() for CSV streaming; WP_Filesystem has no streaming equivalent.
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened; CsvWriter does not own borrowed handles.
 		fclose( $fh );
 
 		// Advance cursor.

--- a/includes/audience/class-ffc-audience-admin-import.php
+++ b/includes/audience/class-ffc-audience-admin-import.php
@@ -419,12 +419,13 @@ class AudienceAdminImport {
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
 		$output = fopen( 'php://output', 'w' );
 		if ( false === $output ) {
 			exit;
 		}
-		fputcsv( $output, array( 'email', 'name', 'audience_name' ), ';' );
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( array( 'email', 'name', 'audience_name' ) );
 
 		$seen = array(); // Avoid duplicate rows for same user+audience.
 		foreach ( $audience_ids as $aid ) {
@@ -443,19 +444,18 @@ class AudienceAdminImport {
 					continue;
 				}
 
-				fputcsv(
-					$output,
+				$writer->row(
 					array(
 						$user->user_email,
 						$user->display_name,
 						$audience_name,
-					),
-					';'
+					)
 				);
 			}
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $output );
 		exit;
 	}
@@ -472,41 +472,39 @@ class AudienceAdminImport {
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
 		$output = fopen( 'php://output', 'w' );
 		if ( false === $output ) {
 			exit;
 		}
-		fputcsv( $output, array( 'name', 'color', 'parent' ), ';' );
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( array( 'name', 'color', 'parent' ) );
 
 		// Parents first, then children (same order as import expects).
 		foreach ( $audiences as $audience ) {
-			fputcsv(
-				$output,
+			$writer->row(
 				array(
 					$audience->name,
 					$audience->color ?? '#3788d8',
 					'', // Parents have no parent.
-				),
-				';'
+				)
 			);
 
 			if ( ! empty( $audience->children ) ) {
 				foreach ( $audience->children as $child ) {
-					fputcsv(
-						$output,
+					$writer->row(
 						array(
 							$child->name,
 							$child->color ?? '#3788d8',
 							$audience->name,
-						),
-						';'
+						)
 					);
 				}
 			}
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $output );
 		exit;
 	}

--- a/includes/audience/class-ffc-audience-csv-importer.php
+++ b/includes/audience/class-ffc-audience-csv-importer.php
@@ -52,20 +52,20 @@ class AudienceCsvImporter {
 		}
 
         // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV import; CsvReader does not own this handle.
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
 			$result['errors'][] = __( 'Could not open file.', 'ffcertificate' );
 			return $result;
 		}
 
-		// 6.3.9: auto-detect `,` vs `;` so legacy CSVs and the new
-		// pt-BR-friendly templates both parse correctly.
-		$delimiter = self::peek_delimiter( $handle );
-
-		// Read header row.
-		$header = fgetcsv( $handle, 0, $delimiter );
-		if ( ! $header ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		// Csv::reader auto-detects `,` vs `;` (canonical rule lifted
+		// from the previous self::peek_delimiter() in Sprint 1) and
+		// strips the BOM transparently.
+		$reader = \FreeFormCertificate\Core\Csv::reader( $handle );
+		$header = $reader->header();
+		if ( empty( $header ) ) {
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'Empty file or invalid CSV format.', 'ffcertificate' );
 			return $result;
@@ -88,7 +88,7 @@ class AudienceCsvImporter {
 		$audience_name_col = false !== $audience_name_col ? $audience_name_col : array_search( 'audience', $header, true );
 
 		if ( false === $email_col ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'Required column "email" not found in CSV.', 'ffcertificate' );
 			return $result;
@@ -96,7 +96,7 @@ class AudienceCsvImporter {
 
 		// If no audience_id provided and not in CSV, error.
 		if ( 0 === $audience_id && false === $audience_col && false === $audience_name_col ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'No audience specified. Provide audience_id parameter or include audience_id/audience_name column in CSV.', 'ffcertificate' );
 			return $result;
@@ -104,75 +104,76 @@ class AudienceCsvImporter {
 
 		// Process rows.
 		$row_num = 1;
-		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
-			++$row_num;
+		$reader->each(
+			function ( array $data ) use ( &$row_num, &$result, $email_col, $name_col, $audience_col, $audience_name_col, $audience_id, $create_users ): void {
+				++$row_num;
 
-			// Skip empty rows.
-			if ( empty( array_filter( $data ) ) ) {
-				continue;
-			}
-
-			$email = isset( $data[ $email_col ] ) ? sanitize_email( $data[ $email_col ] ) : '';
-
-			if ( empty( $email ) || ! is_email( $email ) ) {
-				/* translators: %d: row number */
-				$result['errors'][] = sprintf( __( 'Row %d: Invalid email address.', 'ffcertificate' ), $row_num );
-				++$result['skipped'];
-				continue;
-			}
-
-			// Determine audience.
-			$target_audience_id = $audience_id;
-			if ( 0 === $target_audience_id ) {
-				if ( false !== $audience_col && isset( $data[ $audience_col ] ) ) {
-					$target_audience_id = absint( $data[ $audience_col ] );
-				} elseif ( false !== $audience_name_col && isset( $data[ $audience_name_col ] ) ) {
-					$audience_name      = sanitize_text_field( $data[ $audience_name_col ] );
-					$target_audience_id = self::get_audience_id_by_name( $audience_name );
+				// Skip empty rows.
+				if ( empty( array_filter( $data ) ) ) {
+					return;
 				}
-			}
 
-			if ( 0 === $target_audience_id ) {
-				/* translators: %d: row number */
-				$result['errors'][] = sprintf( __( 'Row %d: Could not determine audience.', 'ffcertificate' ), $row_num );
-				++$result['skipped'];
-				continue;
-			}
+				$email = isset( $data[ $email_col ] ) ? sanitize_email( $data[ $email_col ] ) : '';
 
-			// Find or create user.
-			$user = get_user_by( 'email', $email );
-			if ( ! $user ) {
-				if ( $create_users ) {
-					$name    = ( false !== $name_col && isset( $data[ $name_col ] ) ) ? sanitize_text_field( $data[ $name_col ] ) : '';
-					$user_id = self::create_ffc_user( $email, $name );
-					if ( is_wp_error( $user_id ) ) {
-						/* translators: %1$d: row number, %2$s: error message */
-						$result['errors'][] = sprintf( __( 'Row %1$d: Could not create user: %2$s', 'ffcertificate' ), $row_num, $user_id->get_error_message() );
+				if ( empty( $email ) || ! is_email( $email ) ) {
+					/* translators: %d: row number */
+					$result['errors'][] = sprintf( __( 'Row %d: Invalid email address.', 'ffcertificate' ), $row_num );
+					++$result['skipped'];
+					return;
+				}
+
+				// Determine audience.
+				$target_audience_id = $audience_id;
+				if ( 0 === $target_audience_id ) {
+					if ( false !== $audience_col && isset( $data[ $audience_col ] ) ) {
+						$target_audience_id = absint( $data[ $audience_col ] );
+					} elseif ( false !== $audience_name_col && isset( $data[ $audience_name_col ] ) ) {
+						$audience_name      = sanitize_text_field( $data[ $audience_name_col ] );
+						$target_audience_id = self::get_audience_id_by_name( $audience_name );
+					}
+				}
+
+				if ( 0 === $target_audience_id ) {
+					/* translators: %d: row number */
+					$result['errors'][] = sprintf( __( 'Row %d: Could not determine audience.', 'ffcertificate' ), $row_num );
+					++$result['skipped'];
+					return;
+				}
+
+				// Find or create user.
+				$user = get_user_by( 'email', $email );
+				if ( ! $user ) {
+					if ( $create_users ) {
+						$name    = ( false !== $name_col && isset( $data[ $name_col ] ) ) ? sanitize_text_field( $data[ $name_col ] ) : '';
+						$user_id = self::create_ffc_user( $email, $name );
+						if ( is_wp_error( $user_id ) ) {
+							/* translators: %1$d: row number, %2$s: error message */
+							$result['errors'][] = sprintf( __( 'Row %1$d: Could not create user: %2$s', 'ffcertificate' ), $row_num, $user_id->get_error_message() );
+							++$result['skipped'];
+							return;
+						}
+					} else {
+						/* translators: %1$d: row number, %2$s: email address */
+						$result['errors'][] = sprintf( __( 'Row %1$d: User not found: %2$s', 'ffcertificate' ), $row_num, $email );
 						++$result['skipped'];
-						continue;
+						return;
 					}
 				} else {
-					/* translators: %1$d: row number, %2$s: email address */
-					$result['errors'][] = sprintf( __( 'Row %1$d: User not found: %2$s', 'ffcertificate' ), $row_num, $email );
-					++$result['skipped'];
-					continue;
+					$user_id = $user->ID;
 				}
-			} else {
-				$user_id = $user->ID;
-			}
 
-			// Add member to audience.
-			$added = AudienceRepository::add_member( $target_audience_id, $user_id );
-			if ( $added ) {
-				++$result['imported'];
-			} else {
-				// Already a member.
-				++$result['skipped'];
+				// Add member to audience.
+				$added = AudienceRepository::add_member( $target_audience_id, $user_id );
+				if ( $added ) {
+					++$result['imported'];
+				} else {
+					// Already a member.
+					++$result['skipped'];
+				}
 			}
-		}
+		);
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 		fclose( $handle );
 		$result['success'] = true;
 
@@ -198,20 +199,17 @@ class AudienceCsvImporter {
 			return $result;
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV import; CsvReader does not own this handle.
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
 			$result['errors'][] = __( 'Could not open file.', 'ffcertificate' );
 			return $result;
 		}
 
-		// 6.3.9: auto-detect CSV delimiter (`,` or `;`).
-		$delimiter = self::peek_delimiter( $handle );
-
-		// Read header row.
-		$header = fgetcsv( $handle, 0, $delimiter );
-		if ( ! $header ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$reader = \FreeFormCertificate\Core\Csv::reader( $handle );
+		$header = $reader->header();
+		if ( empty( $header ) ) {
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'Empty file or invalid CSV format.', 'ffcertificate' );
 			return $result;
@@ -229,7 +227,7 @@ class AudienceCsvImporter {
 		}
 
 		if ( false === $name_col ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'Required column "name" not found in CSV.', 'ffcertificate' );
 			return $result;
@@ -238,37 +236,38 @@ class AudienceCsvImporter {
 		// First pass: create all parent audiences.
 		$audiences_to_create = array();
 		$row_num             = 1;
-		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
-			++$row_num;
+		$reader->each(
+			static function ( array $data ) use ( &$row_num, &$result, &$audiences_to_create, $name_col, $color_col, $parent_col ): void {
+				++$row_num;
 
-			if ( empty( array_filter( $data ) ) ) {
-				continue;
+				if ( empty( array_filter( $data ) ) ) {
+					return;
+				}
+
+				$name        = isset( $data[ $name_col ] ) ? sanitize_text_field( $data[ $name_col ] ) : '';
+				$color       = ColorValidator::normalize(
+					( false !== $color_col && isset( $data[ $color_col ] ) ) ? $data[ $color_col ] : '',
+					'#3788d8'
+				);
+				$parent_name = ( false !== $parent_col && isset( $data[ $parent_col ] ) ) ? sanitize_text_field( $data[ $parent_col ] ) : '';
+
+				if ( empty( $name ) ) {
+					/* translators: %d: row number */
+					$result['errors'][] = sprintf( __( 'Row %d: Empty name.', 'ffcertificate' ), $row_num );
+					++$result['skipped'];
+					return;
+				}
+
+				$audiences_to_create[] = array(
+					'row'         => $row_num,
+					'name'        => $name,
+					'color'       => $color,
+					'parent_name' => $parent_name,
+				);
 			}
+		);
 
-			$name        = isset( $data[ $name_col ] ) ? sanitize_text_field( $data[ $name_col ] ) : '';
-			$color       = ColorValidator::normalize(
-				( false !== $color_col && isset( $data[ $color_col ] ) ) ? $data[ $color_col ] : '',
-				'#3788d8'
-			);
-			$parent_name = ( false !== $parent_col && isset( $data[ $parent_col ] ) ) ? sanitize_text_field( $data[ $parent_col ] ) : '';
-
-			if ( empty( $name ) ) {
-				/* translators: %d: row number */
-				$result['errors'][] = sprintf( __( 'Row %d: Empty name.', 'ffcertificate' ), $row_num );
-				++$result['skipped'];
-				continue;
-			}
-
-			$audiences_to_create[] = array(
-				'row'         => $row_num,
-				'name'        => $name,
-				'color'       => $color,
-				'parent_name' => $parent_name,
-			);
-		}
-
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 		fclose( $handle );
 
 		// Process in depth order: roots first, then children, then grandchildren.
@@ -439,20 +438,17 @@ class AudienceCsvImporter {
 			return $result;
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV preview; CsvReader does not own this handle.
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
 			$result['errors'][] = __( 'Could not open file.', 'ffcertificate' );
 			return $result;
 		}
 
-		// 6.3.9: auto-detect CSV delimiter (`,` or `;`).
-		$delimiter = self::peek_delimiter( $handle );
-
-		// Read header.
-		$header = fgetcsv( $handle, 0, $delimiter );
-		if ( ! $header ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$reader = \FreeFormCertificate\Core\Csv::reader( $handle );
+		$header = $reader->header();
+		if ( empty( $header ) ) {
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 			fclose( $handle );
 			$result['errors'][] = __( 'Empty file or invalid CSV format.', 'ffcertificate' );
 			return $result;
@@ -470,14 +466,15 @@ class AudienceCsvImporter {
 		}
 
 		// Count rows.
-		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
-		while ( ( $data = fgetcsv( $handle, 0, $delimiter ) ) !== false ) {
-			if ( ! empty( array_filter( $data ) ) ) {
-				++$result['rows'];
+		$reader->each(
+			static function ( array $data ) use ( &$result ): void {
+				if ( ! empty( array_filter( $data ) ) ) {
+					++$result['rows'];
+				}
 			}
-		}
+		);
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 		fclose( $handle );
 
 		$result['valid'] = empty( $result['errors'] );
@@ -514,45 +511,4 @@ class AudienceCsvImporter {
 				"bob@example.com;Bob Johnson;Group B\n";
 	}
 
-	/**
-	 * Peek the first line of a CSV stream to choose between `,` and `;` as
-	 * the field separator, then rewind the handle so the regular
-	 * fgetcsv() loop reads from the start. Mirrors the recruitment
-	 * importer's detect_delimiter(); kept private to this class so the
-	 * surface stays small.
-	 *
-	 * Counts unquoted occurrences of each candidate; ties resolve to `,`
-	 * for backwards compatibility with files that worked pre-detection.
-	 *
-	 * @since 6.3.9
-	 * @param resource $handle Open file handle (read mode, position 0).
-	 * @return string `,` or `;`.
-	 */
-	private static function peek_delimiter( $handle ): string {
-		$first_line = fgets( $handle );
-		rewind( $handle );
-		if ( ! is_string( $first_line ) || '' === $first_line ) {
-			return ',';
-		}
-		$comma     = 0;
-		$semicolon = 0;
-		$in_quotes = false;
-		$length    = strlen( $first_line );
-		for ( $i = 0; $i < $length; $i++ ) {
-			$ch = $first_line[ $i ];
-			if ( '"' === $ch ) {
-				$in_quotes = ! $in_quotes;
-				continue;
-			}
-			if ( $in_quotes ) {
-				continue;
-			}
-			if ( ',' === $ch ) {
-				++$comma;
-			} elseif ( ';' === $ch ) {
-				++$semicolon;
-			}
-		}
-		return $semicolon > $comma ? ';' : ',';
-	}
 }

--- a/includes/audience/class-ffc-audience-csv-importer.php
+++ b/includes/audience/class-ffc-audience-csv-importer.php
@@ -510,5 +510,4 @@ class AudienceCsvImporter {
 				"jane@example.com;Jane Smith;Subgroup A1\n" .
 				"bob@example.com;Bob Johnson;Group B\n";
 	}
-
 }

--- a/includes/core/class-ffc-csv-export-trait.php
+++ b/includes/core/class-ffc-csv-export-trait.php
@@ -1,17 +1,22 @@
 <?php
 /**
- * CSV Export Trait
+ * CsvExportTrait
  *
- * Shared CSV export utilities used across CsvExporter and AppointmentCsvExporter.
+ * JSON-shape helpers used by the submission and appointment CSV
+ * exporters to flatten the encrypted/plaintext `data` blob into
+ * dynamic columns. Pure data shaping — the bytes-to-stream layer
+ * lives in {@see \FreeFormCertificate\Core\CsvWriter} since 6.4.0.
  *
- * Eliminates duplicated code for:
- * - Dynamic column extraction from JSON data
- * - Dynamic header generation (snake_case → Title Case)
- * - CSV output (BOM, UTF-8, semicolon separator, HTTP headers)
- * - Encrypted JSON data decryption with fallback
+ * Three responsibilities, all about turning a row's JSON column
+ * into spreadsheet-friendly columns:
+ *   - extract_dynamic_keys: union of all field keys across rows
+ *   - decode_json_field: encrypted-first decrypt with plaintext fallback
+ *   - build_dynamic_headers: snake_case → Title Case header labels
+ *   - extract_dynamic_values: pluck values for one row in a fixed key order
  *
  * @package FreeFormCertificate\Core
  * @since 4.11.2
+ * @since 6.4.0 output_csv() removed; CSV IO moved to {@see CsvWriter}.
  */
 
 declare(strict_types=1);
@@ -113,59 +118,5 @@ trait CsvExportTrait {
 		}
 
 		return $values;
-	}
-
-	/**
-	 * Output a complete CSV file to php://output.
-	 *
-	 * Handles BOM, UTF-8 encoding, HTTP headers, and row writing.
-	 *
-	 * @param string                              $filename  Download filename (e.g. 'export-2024-01-01.csv').
-	 * @param array<int, string>                  $headers   Column headers.
-	 * @param array<int, array<array-key, mixed>> $rows      Data rows (each is an array of values passed directly to fputcsv).
-	 * @return void Exits after output.
-	 */
-	protected function output_csv( string $filename, array $headers, array $rows ): void {
-		$safe_filename = str_replace( array( "\r", "\n", '"' ), '', $filename );
-		header( 'Content-Type: text/csv; charset=utf-8' );
-		header( 'Content-Disposition: attachment; filename="' . $safe_filename . '"' );
-		header( 'Pragma: no-cache' );
-		header( 'Expires: 0' );
-
-		$output = fopen( 'php://output', 'w' );
-		if ( false === $output ) {
-			exit;
-		}
-
-		// BOM for Excel UTF-8 recognition.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output, not HTML context
-		fprintf( $output, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
-
-		// Convert headers to UTF-8.
-		$headers = array_map(
-			function ( $h ) {
-				return mb_convert_encoding( $h, 'UTF-8', 'UTF-8' );
-			},
-			$headers
-		);
-
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV file output, not HTML context
-		fputcsv( $output, $headers, ';' );
-
-		foreach ( $rows as $row ) {
-			$row = array_map(
-				function ( $v ) {
-					return is_string( $v ) ? mb_convert_encoding( $v, 'UTF-8', 'UTF-8' ) : $v;
-				},
-				$row
-			);
-
-            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV file output, not HTML context
-			fputcsv( $output, $row, ';' );
-		}
-
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing php://output stream for CSV export.
-		fclose( $output );
-		exit;
 	}
 }

--- a/includes/core/class-ffc-csv-reader.php
+++ b/includes/core/class-ffc-csv-reader.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * CsvReader
+ *
+ * Streaming CSV reader with delimiter auto-detection. See {@see Csv}
+ * for the public factory and the IO contract this class implements.
+ *
+ * @package FreeFormCertificate\Core
+ * @since 6.4.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CsvReader.
+ *
+ * Accepts a seekable resource, peeks the first line, and picks `,` or
+ * `;` as the field delimiter based on unquoted occurrence count. Ties
+ * resolve to `,` for backward compatibility with files that worked
+ * pre-detection (the canonical rule lifted from the recruitment
+ * importer's `detect_delimiter()`).
+ *
+ * Body rows are streamed — `each()` calls fgetcsv per row so that 100k+
+ * row imports stay memory-bounded. `all()` is a small-file convenience
+ * built on top of `each()`.
+ */
+final class CsvReader {
+
+	/**
+	 * Underlying file handle. Must be seekable.
+	 *
+	 * @var resource
+	 */
+	private $handle;
+
+	/**
+	 * Detected (or forced) field delimiter for this stream.
+	 *
+	 * @var string
+	 */
+	public string $delimiter;
+
+	/**
+	 * True iff this instance opened the handle (e.g. via
+	 * {@see Csv::reader_from_string()}) and must fclose() it.
+	 *
+	 * @var bool
+	 */
+	private bool $owns_handle;
+
+	/**
+	 * Cached header row after the first call to {@see self::header()}.
+	 *
+	 * @var array<int, string>|null
+	 */
+	private ?array $header = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Skips a UTF-8 BOM at byte 0 if present, then auto-detects the
+	 * delimiter (unless one was forced). After construction the
+	 * handle is positioned at the start of the header line so the
+	 * first {@see self::header()} call returns it intact.
+	 *
+	 * @param resource    $handle          Open readable, seekable handle.
+	 * @param string|null $force_delimiter Skip detection and use this delimiter.
+	 * @param bool        $owns_handle     Whether the reader should fclose on close().
+	 *
+	 * @throws \InvalidArgumentException When $handle is not a resource.
+	 */
+	public function __construct( $handle, ?string $force_delimiter = null, bool $owns_handle = false ) {
+		if ( ! is_resource( $handle ) ) {
+			throw new \InvalidArgumentException( 'CsvReader: handle must be a resource' );
+		}
+		$this->handle      = $handle;
+		$this->owns_handle = $owns_handle;
+		$this->skip_bom_at_start();
+		$this->delimiter = $force_delimiter ?? $this->detect_delimiter_from_first_line();
+	}
+
+	/**
+	 * Read the header row. Idempotent — subsequent calls return the
+	 * cached value without re-reading the stream.
+	 *
+	 * @return array<int, string>
+	 */
+	public function header(): array {
+		if ( null !== $this->header ) {
+			return $this->header;
+		}
+		$row          = fgetcsv( $this->handle, 0, $this->delimiter );
+		$this->header = is_array( $row ) ? self::coerce_cells( $row ) : array();
+		return $this->header;
+	}
+
+	/**
+	 * Stream every body row (everything after the header) through
+	 * the callback. Memory-bounded.
+	 *
+	 * @param callable(array<int, string>): void $cb Invoked once per row.
+	 * @return void
+	 */
+	public function each( callable $cb ): void {
+		if ( null === $this->header ) {
+			$this->header();
+		}
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- canonical fgetcsv() streaming pattern.
+		while ( ( $row = fgetcsv( $this->handle, 0, $this->delimiter ) ) !== false ) {
+			$cb( self::coerce_cells( $row ) );
+		}
+	}
+
+	/**
+	 * Read all body rows into an array. Use only when the file is
+	 * known to be small (config templates, sub-100-row imports).
+	 *
+	 * @return list<array<int, string>>
+	 */
+	public function all(): array {
+		$rows = array();
+		$this->each(
+			static function ( array $row ) use ( &$rows ): void {
+				$rows[] = $row;
+			}
+		);
+		return $rows;
+	}
+
+	/**
+	 * Close the handle iff this reader owns it. Idempotent.
+	 *
+	 * @return void
+	 */
+	public function close(): void {
+		if ( $this->owns_handle && is_resource( $this->handle ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle we created in Csv::reader_from_string().
+			fclose( $this->handle );
+			$this->owns_handle = false;
+		}
+	}
+
+	/**
+	 * Coerce fgetcsv output to a list of strings. fgetcsv returns
+	 * `null` for missing trailing cells on some PHP versions;
+	 * downstream consumers prefer empty strings.
+	 *
+	 * @param array<int, mixed> $row Raw row from fgetcsv.
+	 * @return array<int, string>
+	 */
+	private static function coerce_cells( array $row ): array {
+		return array_map(
+			static function ( $cell ): string {
+				return is_string( $cell ) ? $cell : '';
+			},
+			$row
+		);
+	}
+
+	/**
+	 * Consume a UTF-8 BOM at the current handle position if present.
+	 * If no BOM, rewinds the three peeked bytes so the next read
+	 * sees the actual first byte.
+	 *
+	 * @return void
+	 */
+	private function skip_bom_at_start(): void {
+		$pos    = ftell( $this->handle );
+		$prefix = fread( $this->handle, 3 );
+		if ( false === $prefix || 0 !== strncmp( $prefix, Csv::BOM_UTF8, 3 ) ) {
+			// Not a BOM — restore position so the body keeps byte 0.
+			if ( false !== $pos ) {
+				fseek( $this->handle, $pos );
+			} else {
+				rewind( $this->handle );
+			}
+		}
+		// Else: BOM consumed; leave the handle past it.
+	}
+
+	/**
+	 * Pick `,` vs `;` by counting unquoted occurrences in the first
+	 * line. The canonical rule (semicolon wins iff strictly greater)
+	 * was lifted unchanged from the recruitment / audience importers.
+	 *
+	 * Restores the handle to its pre-peek position so the header
+	 * read sees the line intact.
+	 *
+	 * @return string `,` or `;`.
+	 */
+	private function detect_delimiter_from_first_line(): string {
+		$pos        = ftell( $this->handle );
+		$first_line = fgets( $this->handle );
+		if ( false !== $pos ) {
+			fseek( $this->handle, $pos );
+		} else {
+			rewind( $this->handle );
+		}
+
+		if ( ! is_string( $first_line ) || '' === $first_line ) {
+			return Csv::DELIMITER_LEGACY;
+		}
+
+		$comma     = 0;
+		$semicolon = 0;
+		$in_quotes = false;
+		$length    = strlen( $first_line );
+		for ( $i = 0; $i < $length; $i++ ) {
+			$ch = $first_line[ $i ];
+			if ( '"' === $ch ) {
+				$in_quotes = ! $in_quotes;
+				continue;
+			}
+			if ( $in_quotes ) {
+				continue;
+			}
+			if ( ',' === $ch ) {
+				++$comma;
+			} elseif ( ';' === $ch ) {
+				++$semicolon;
+			}
+		}
+		return $semicolon > $comma ? Csv::DELIMITER_DEFAULT : Csv::DELIMITER_LEGACY;
+	}
+}

--- a/includes/core/class-ffc-csv-reader.php
+++ b/includes/core/class-ffc-csv-reader.php
@@ -104,7 +104,7 @@ final class CsvReader {
 	 * Stream every body row (everything after the header) through
 	 * the callback. Memory-bounded.
 	 *
-	 * @param callable(array<int, string>): void $cb Invoked once per row.
+	 * @param callable $cb Invoked once per row; receives `array<int, string>`.
 	 * @return void
 	 */
 	public function each( callable $cb ): void {
@@ -171,7 +171,8 @@ final class CsvReader {
 	 * @return void
 	 */
 	private function skip_bom_at_start(): void {
-		$pos    = ftell( $this->handle );
+		$pos = ftell( $this->handle );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- streaming CSV reader; WP_Filesystem has no streaming equivalent.
 		$prefix = fread( $this->handle, 3 );
 		if ( false === $prefix || 0 !== strncmp( $prefix, Csv::BOM_UTF8, 3 ) ) {
 			// Not a BOM — restore position so the body keeps byte 0.

--- a/includes/core/class-ffc-csv-reader.php
+++ b/includes/core/class-ffc-csv-reader.php
@@ -57,7 +57,7 @@ final class CsvReader {
 	/**
 	 * Cached header row after the first call to {@see self::header()}.
 	 *
-	 * @var array<int, string>|null
+	 * @var list<string>|null
 	 */
 	private ?array $header = null;
 
@@ -89,7 +89,7 @@ final class CsvReader {
 	 * Read the header row. Idempotent — subsequent calls return the
 	 * cached value without re-reading the stream.
 	 *
-	 * @return array<int, string>
+	 * @return list<string>
 	 */
 	public function header(): array {
 		if ( null !== $this->header ) {
@@ -104,7 +104,7 @@ final class CsvReader {
 	 * Stream every body row (everything after the header) through
 	 * the callback. Memory-bounded.
 	 *
-	 * @param callable $cb Invoked once per row; receives `array<int, string>`.
+	 * @param callable $cb Invoked once per row; receives `list<string>`.
 	 * @return void
 	 */
 	public function each( callable $cb ): void {
@@ -121,13 +121,16 @@ final class CsvReader {
 	 * Read all body rows into an array. Use only when the file is
 	 * known to be small (config templates, sub-100-row imports).
 	 *
-	 * @return list<array<int, string>>
+	 * @return list<list<string>>
 	 */
 	public function all(): array {
 		$rows = array();
 		$this->each(
 			static function ( array $row ) use ( &$rows ): void {
-				$rows[] = $row;
+				// array_values preserves the list invariant for PHPStan;
+				// each() always passes a list-shaped row but the closure
+				// parameter type erases that to plain array.
+				$rows[] = array_values( $row );
 			}
 		);
 		return $rows;
@@ -149,17 +152,22 @@ final class CsvReader {
 	/**
 	 * Coerce fgetcsv output to a list of strings. fgetcsv returns
 	 * `null` for missing trailing cells on some PHP versions;
-	 * downstream consumers prefer empty strings.
+	 * downstream consumers prefer empty strings. fgetcsv emits
+	 * sequential int keys starting at 0 (not associative), so the
+	 * result is a list — preserving that invariant in the type
+	 * annotation lets callers' typed parameters accept it directly.
 	 *
 	 * @param array<int, mixed> $row Raw row from fgetcsv.
-	 * @return array<int, string>
+	 * @return list<string>
 	 */
 	private static function coerce_cells( array $row ): array {
-		return array_map(
-			static function ( $cell ): string {
-				return is_string( $cell ) ? $cell : '';
-			},
-			$row
+		return array_values(
+			array_map(
+				static function ( $cell ): string {
+					return is_string( $cell ) ? $cell : '';
+				},
+				$row
+			)
 		);
 	}
 

--- a/includes/core/class-ffc-csv-writer.php
+++ b/includes/core/class-ffc-csv-writer.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * CsvWriter
+ *
+ * Streaming CSV writer used by every exporter in the plugin. See
+ * {@see Csv} for the public factory and the contract this class
+ * implements.
+ *
+ * @package FreeFormCertificate\Core
+ * @since 6.4.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CsvWriter.
+ *
+ * Guarantees:
+ *   - UTF-8 BOM written exactly once, immediately before the first row.
+ *   - `;` delimiter by default (BR/EU spreadsheet convention).
+ *   - RFC 4180 quoting via fputcsv.
+ *   - String cells force-converted to UTF-8 (no-op for already-valid
+ *     UTF-8) — matches the legacy CsvExportTrait behaviour for the
+ *     migration period; can be loosened later if mb_convert_encoding
+ *     proves a hot spot.
+ *
+ * Lifetime: a writer either OWNS its handle (constructed from a path)
+ * or BORROWS one (constructed from an existing resource). `close()`
+ * fcloses the handle iff owned; calling it on a borrowed handle is a
+ * no-op so the caller can keep writing other content.
+ */
+final class CsvWriter {
+
+	/**
+	 * Underlying file handle.
+	 *
+	 * @var resource
+	 */
+	private $handle;
+
+	/**
+	 * Active field delimiter.
+	 *
+	 * @var string
+	 */
+	private string $delimiter;
+
+	/**
+	 * True iff this instance opened the handle and is responsible
+	 * for fclose()'ing it.
+	 *
+	 * @var bool
+	 */
+	private bool $owns_handle;
+
+	/**
+	 * Set on the first call to {@see self::row()} so the BOM is
+	 * emitted exactly once.
+	 *
+	 * @var bool
+	 */
+	private bool $bom_written = false;
+
+	/**
+	 * True after {@see self::close()} runs. Subsequent writes throw.
+	 *
+	 * @var bool
+	 */
+	private bool $closed = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string|resource $target    Path to open in write mode, or an open writable handle.
+	 * @param string          $delimiter Field delimiter (default: `;`).
+	 *
+	 * @throws \InvalidArgumentException When $target is neither a string nor a resource.
+	 * @throws \RuntimeException         When opening $target as a file fails.
+	 */
+	public function __construct( $target, string $delimiter = Csv::DELIMITER_DEFAULT ) {
+		if ( is_string( $target ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- writing CSV to disk is the documented contract.
+			$handle = fopen( $target, 'w' );
+			if ( false === $handle ) {
+				throw new \RuntimeException( "CsvWriter: cannot open '{$target}' for writing" );
+			}
+			$this->handle      = $handle;
+			$this->owns_handle = true;
+		} elseif ( is_resource( $target ) ) {
+			$this->handle      = $target;
+			$this->owns_handle = false;
+		} else {
+			throw new \InvalidArgumentException( 'CsvWriter: target must be a path or an open resource' );
+		}
+		$this->delimiter = $delimiter;
+	}
+
+	/**
+	 * Write a single row.
+	 *
+	 * @param array<int|string, mixed> $row Cells. Non-string scalars pass through untouched.
+	 *
+	 * @throws \LogicException When called after {@see self::close()}.
+	 * @return void
+	 */
+	public function row( array $row ): void {
+		if ( $this->closed ) {
+			throw new \LogicException( 'CsvWriter: cannot write after close()' );
+		}
+
+		if ( ! $this->bom_written ) {
+			fwrite( $this->handle, Csv::BOM_UTF8 );
+			$this->bom_written = true;
+		}
+
+		$row = array_map(
+			static function ( $cell ) {
+				return is_string( $cell )
+					? mb_convert_encoding( $cell, 'UTF-8', 'UTF-8' )
+					: $cell;
+			},
+			$row
+		);
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv -- canonical CSV writer; fputcsv is the documented WP-allowed exception for actual CSV output.
+		fputcsv( $this->handle, $row, $this->delimiter );
+	}
+
+	/**
+	 * Write many rows in one call.
+	 *
+	 * Accepts any iterable, so generators / lazy producers can stream
+	 * straight through without materialising the full set in memory —
+	 * the streaming-export use case driven by issue #144 S5.
+	 *
+	 * @param iterable<array<int|string, mixed>> $rows Each item is a row array.
+	 * @return void
+	 */
+	public function rows( iterable $rows ): void {
+		foreach ( $rows as $row ) {
+			$this->row( $row );
+		}
+	}
+
+	/**
+	 * Close the underlying handle iff this writer owns it.
+	 *
+	 * Idempotent. Safe to call from a finally block.
+	 *
+	 * @return void
+	 */
+	public function close(): void {
+		if ( $this->closed ) {
+			return;
+		}
+		$this->closed = true;
+		if ( $this->owns_handle && is_resource( $this->handle ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle we opened in the constructor.
+			fclose( $this->handle );
+		}
+	}
+}

--- a/includes/core/class-ffc-csv-writer.php
+++ b/includes/core/class-ffc-csv-writer.php
@@ -79,11 +79,12 @@ final class CsvWriter {
 	 *
 	 * @param string|resource $target    Path to open in write mode, or an open writable handle.
 	 * @param string          $delimiter Field delimiter (default: `;`).
+	 * @param bool            $skip_bom  When true, suppress the BOM emission on the first row. Use when appending to a file that already has its BOM (e.g. batch-export workers picking up after the init writer).
 	 *
 	 * @throws \InvalidArgumentException When $target is neither a string nor a resource.
 	 * @throws \RuntimeException         When opening $target as a file fails.
 	 */
-	public function __construct( $target, string $delimiter = Csv::DELIMITER_DEFAULT ) {
+	public function __construct( $target, string $delimiter = Csv::DELIMITER_DEFAULT, bool $skip_bom = false ) {
 		if ( is_string( $target ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- writing CSV to disk is the documented contract.
 			$handle = fopen( $target, 'w' );
@@ -98,7 +99,8 @@ final class CsvWriter {
 		} else {
 			throw new \InvalidArgumentException( 'CsvWriter: target must be a path or an open resource' );
 		}
-		$this->delimiter = $delimiter;
+		$this->delimiter   = $delimiter;
+		$this->bom_written = $skip_bom;
 	}
 
 	/**

--- a/includes/core/class-ffc-csv-writer.php
+++ b/includes/core/class-ffc-csv-writer.php
@@ -89,7 +89,7 @@ final class CsvWriter {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- writing CSV to disk is the documented contract.
 			$handle = fopen( $target, 'w' );
 			if ( false === $handle ) {
-				throw new \RuntimeException( "CsvWriter: cannot open '{$target}' for writing" );
+				throw new \RuntimeException( esc_html( "CsvWriter: cannot open '{$target}' for writing" ) );
 			}
 			$this->handle      = $handle;
 			$this->owns_handle = true;
@@ -117,6 +117,7 @@ final class CsvWriter {
 		}
 
 		if ( ! $this->bom_written ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- streaming the BOM bytes; WP_Filesystem has no streaming equivalent.
 			fwrite( $this->handle, Csv::BOM_UTF8 );
 			$this->bom_written = true;
 		}

--- a/includes/core/class-ffc-csv.php
+++ b/includes/core/class-ffc-csv.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Csv
+ *
+ * Unified entry point for all CSV reading and writing in the plugin.
+ *
+ * Before this class, eight exporters and two importers each handled
+ * fputcsv/fgetcsv directly. The plugin standardised on `;` as the
+ * field delimiter in 6.3.9 (matching the BR/EU spreadsheet default),
+ * but the IO contract — BOM placement, quoting, delimiter detection —
+ * was still implemented per-call-site. This class consolidates that
+ * contract behind two factory methods so every CSV the plugin emits
+ * or accepts behaves identically.
+ *
+ * @package FreeFormCertificate\Core
+ * @since 6.4.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Csv.
+ *
+ * Static facade. Use {@see self::writer()} / {@see self::reader()} /
+ * {@see self::reader_from_string()} to obtain the worker objects.
+ */
+final class Csv {
+
+	/**
+	 * Default field delimiter — semicolon.
+	 *
+	 * Matches the BR/EU spreadsheet convention where `,` is the
+	 * locale decimal separator. Standardised across the plugin in
+	 * 6.3.9 and codified here.
+	 */
+	public const DELIMITER_DEFAULT = ';';
+
+	/**
+	 * Legacy field delimiter — comma.
+	 *
+	 * Pre-6.3.9 default. Still recognised on import for backward
+	 * compatibility (auto-detected) but no exporter emits it.
+	 */
+	public const DELIMITER_LEGACY = ',';
+
+	/**
+	 * UTF-8 byte order mark, written by every CsvWriter on first row
+	 * so Excel recognises the file as UTF-8 instead of guessing
+	 * (and producing mojibake on accented characters).
+	 */
+	public const BOM_UTF8 = "\xEF\xBB\xBF";
+
+	/**
+	 * Open a writer.
+	 *
+	 * Accepts either a file path (the writer takes ownership and
+	 * fclose()'s on `close()`) or an already-open writable handle
+	 * (caller retains ownership; `close()` is a no-op for the handle).
+	 *
+	 * @param string|resource $target    File path or open writable handle.
+	 * @param string          $delimiter Field delimiter (default: `;`).
+	 * @return CsvWriter
+	 */
+	public static function writer( $target, string $delimiter = self::DELIMITER_DEFAULT ): CsvWriter {
+		return new CsvWriter( $target, $delimiter );
+	}
+
+	/**
+	 * Open a reader on an existing handle.
+	 *
+	 * The handle MUST be seekable and positioned at byte 0 — the
+	 * reader peeks the first line (skipping a BOM if present) to
+	 * pick `,` vs `;`, then rewinds so `header()` / `each()` see the
+	 * stream from the logical start.
+	 *
+	 * @param resource    $handle          Open readable handle.
+	 * @param string|null $force_delimiter Skip auto-detection and use this delimiter.
+	 * @return CsvReader
+	 */
+	public static function reader( $handle, ?string $force_delimiter = null ): CsvReader {
+		return new CsvReader( $handle, $force_delimiter, false );
+	}
+
+	/**
+	 * Open a reader on raw CSV bytes.
+	 *
+	 * Convenience wrapper for callers that already hold the entire
+	 * file in memory (e.g. recruitment CSV upload arrives via
+	 * `file_get_contents`). Internally writes the bytes to a
+	 * `php://memory` stream so the streaming reader handles it
+	 * uniformly. The reader takes ownership of the synthetic stream.
+	 *
+	 * @param string      $content         Raw CSV bytes (BOM tolerated).
+	 * @param string|null $force_delimiter Skip auto-detection.
+	 * @return CsvReader
+	 */
+	public static function reader_from_string( string $content, ?string $force_delimiter = null ): CsvReader {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- in-memory stream, not the filesystem.
+		$handle = fopen( 'php://memory', 'r+' );
+		if ( false === $handle ) {
+			throw new \RuntimeException( 'Csv::reader_from_string: cannot open php://memory' );
+		}
+		fwrite( $handle, $content );
+		rewind( $handle );
+		return new CsvReader( $handle, $force_delimiter, true );
+	}
+}

--- a/includes/core/class-ffc-csv.php
+++ b/includes/core/class-ffc-csv.php
@@ -100,6 +100,8 @@ final class Csv {
 	 * @param string      $content         Raw CSV bytes (BOM tolerated).
 	 * @param string|null $force_delimiter Skip auto-detection.
 	 * @return CsvReader
+	 *
+	 * @throws \RuntimeException When the in-memory stream cannot be opened.
 	 */
 	public static function reader_from_string( string $content, ?string $force_delimiter = null ): CsvReader {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- in-memory stream, not the filesystem.
@@ -107,6 +109,7 @@ final class Csv {
 		if ( false === $handle ) {
 			throw new \RuntimeException( 'Csv::reader_from_string: cannot open php://memory' );
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- writing to in-memory stream, not the filesystem.
 		fwrite( $handle, $content );
 		rewind( $handle );
 		return new CsvReader( $handle, $force_delimiter, true );

--- a/includes/core/class-ffc-csv.php
+++ b/includes/core/class-ffc-csv.php
@@ -65,10 +65,11 @@ final class Csv {
 	 *
 	 * @param string|resource $target    File path or open writable handle.
 	 * @param string          $delimiter Field delimiter (default: `;`).
+	 * @param bool            $skip_bom  Suppress BOM emission. Use only when appending to a file that already contains its BOM.
 	 * @return CsvWriter
 	 */
-	public static function writer( $target, string $delimiter = self::DELIMITER_DEFAULT ): CsvWriter {
-		return new CsvWriter( $target, $delimiter );
+	public static function writer( $target, string $delimiter = self::DELIMITER_DEFAULT, bool $skip_bom = false ): CsvWriter {
+		return new CsvWriter( $target, $delimiter, $skip_bom );
 	}
 
 	/**

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -738,20 +738,18 @@ class PublicCsvDownload {
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
 		$fh = fopen( 'php://output', 'w' );
 		if ( false === $fh ) {
 			wp_die( esc_html__( 'Could not open output stream for CSV export.', 'ffcertificate' ), 500 );
 		}
 
-		// UTF-8 BOM for Excel-friendliness, same convention as PublicCsvExporter.
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
-		fwrite( $fh, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
+		$writer = \FreeFormCertificate\Core\Csv::writer( $fh );
 		if ( ! $encryption_ok ) {
 			// One-line preamble so the admin knows why CPFs come out empty.
-			fputcsv( $fh, array( '# Encryption is not configured on this site; CPF column will be empty for new entries. See plugin docs.' ), ';' );
+			$writer->row( array( '# Encryption is not configured on this site; CPF column will be empty for new entries. See plugin docs.' ) );
 		}
-		fputcsv( $fh, array( 'timestamp_utc', 'ip', 'mode', 'cpf', 'result' ), ';' );
+		$writer->row( array( 'timestamp_utc', 'ip', 'mode', 'cpf', 'result' ) );
 
 		foreach ( $log as $entry ) {
 			if ( ! is_array( $entry ) ) {
@@ -762,9 +760,10 @@ class PublicCsvDownload {
 			$mod = isset( $entry['mode'] ) ? (string) $entry['mode'] : '';
 			$res = isset( $entry['result'] ) ? (string) $entry['result'] : '';
 			$cpf = self::decrypt_log_entry_cpf( $entry );
-			fputcsv( $fh, array( $ts, $ip, $mod, $cpf, $res ), ';' );
+			$writer->row( array( $ts, $ip, $mod, $cpf, $res ) );
 		}
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $fh );
 		exit;
 	}

--- a/includes/frontend/class-ffc-public-csv-exporter.php
+++ b/includes/frontend/class-ffc-public-csv-exporter.php
@@ -159,15 +159,11 @@ class PublicCsvExporter {
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output; CsvWriter receives the borrowed handle.
 		$output = fopen( 'php://output', 'w' );
 		if ( ! $output ) {
 			exit;
 		}
-
-		// BOM for Excel UTF-8 recognition.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output.
-		fprintf( $output, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
 
 		$headers = array_merge(
 			$this->get_fixed_headers( $include_edit_columns ),
@@ -188,13 +184,8 @@ class PublicCsvExporter {
 		 */
 		$headers = (array) apply_filters( 'ffcertificate_csv_export_headers', $headers, $include_edit_columns, $form_ids );
 
-		$headers = array_map(
-			function ( $h ) {
-				return mb_convert_encoding( (string) $h, 'UTF-8', 'UTF-8' );
-			},
-			$headers
-		);
-		fputcsv( $output, $headers, ';' );
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( $headers );
 
 		// Stream rows in batches using cursor pagination.
 		$cursor = PHP_INT_MAX;
@@ -219,14 +210,7 @@ class PublicCsvExporter {
 			$batch = apply_filters( 'ffcertificate_csv_export_data', $batch, $form_ids, $status );
 
 			foreach ( $batch as $row ) {
-				$csv_row = $this->format_csv_row( $row, $dynamic_keys, $include_edit_columns );
-				$csv_row = array_map(
-					function ( $v ) {
-						return mb_convert_encoding( (string) $v, 'UTF-8', 'UTF-8' );
-					},
-					$csv_row
-				);
-				fputcsv( $output, $csv_row, ';' );
+				$writer->row( $this->format_csv_row( $row, $dynamic_keys, $include_edit_columns ) );
 			}
 
 			$last_row = end( $batch );
@@ -234,7 +218,8 @@ class PublicCsvExporter {
 			unset( $batch );
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $output );
 
 		/**
@@ -421,16 +406,6 @@ class PublicCsvExporter {
 		$job_id   = wp_generate_uuid4();
 		$tmp_file = $tmp_dir . '/ffc-public-export-' . $job_id . '.csv';
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-		$fh = fopen( $tmp_file, 'w' );
-		if ( ! $fh ) {
-			wp_send_json_error( array( 'message' => __( 'Cannot create temp file.', 'ffcertificate' ) ) );
-		}
-
-		// BOM + headers.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output.
-		fprintf( $fh, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
-
 		$headers = array_merge(
 			$this->get_fixed_headers( $include_edit_columns ),
 			$this->build_dynamic_headers( $dynamic_keys )
@@ -439,15 +414,13 @@ class PublicCsvExporter {
 		/** This filter is documented in the sync stream path above. */
 		$headers = (array) apply_filters( 'ffcertificate_csv_export_headers', $headers, $include_edit_columns, $form_ids );
 
-		$headers = array_map(
-			function ( $h ) {
-				return mb_convert_encoding( (string) $h, 'UTF-8', 'UTF-8' );
-			},
-			$headers
-		);
-		fputcsv( $fh, $headers, ';' );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		fclose( $fh );
+		try {
+			$writer = \FreeFormCertificate\Core\Csv::writer( $tmp_file );
+		} catch ( \RuntimeException $e ) {
+			wp_send_json_error( array( 'message' => __( 'Cannot create temp file.', 'ffcertificate' ) ) );
+		}
+		$writer->row( $headers );
+		$writer->close();
 
 		$ip_hash     = sha1( \FreeFormCertificate\Core\Utils::get_user_ip() );
 		$nonce_batch = wp_create_nonce( 'ffc_public_csv_batch_' . $job_id );
@@ -543,23 +516,19 @@ class PublicCsvExporter {
 		 */
 		$batch = apply_filters( 'ffcertificate_csv_export_data', $batch, $job['form_ids'], $job['status'] );
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming append; CsvWriter does not own this handle.
 		$fh = fopen( $job['file'], 'a' );
 		if ( ! $fh ) {
 			wp_send_json_error( __( 'Cannot write to temp file.', 'ffcertificate' ) );
 		}
 
+		// File already contains its BOM from the init handler.
+		$writer = \FreeFormCertificate\Core\Csv::writer( $fh, ';', true );
 		foreach ( $batch as $row ) {
-			$csv_row = $this->format_csv_row( $row, $job['dynamic_keys'], $job['include_edit_columns'] );
-			$csv_row = array_map(
-				function ( $v ) {
-					return mb_convert_encoding( (string) $v, 'UTF-8', 'UTF-8' );
-				},
-				$csv_row
-			);
-			fputcsv( $fh, $csv_row, ';' );
+			$writer->row( $this->format_csv_row( $row, $job['dynamic_keys'], $job['include_edit_columns'] ) );
 		}
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the handle this method opened.
 		fclose( $fh );
 
 		$last_row          = end( $batch );

--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -273,7 +273,7 @@ final class RecruitmentCsvImporter {
 					return;
 				}
 
-				$row          = self::build_row( $cells, $index_map );
+				$row          = self::build_row( array_values( $cells ), $index_map );
 				$row['_line'] = $line_number;
 				$rows[]       = $row;
 			}

--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -221,7 +221,6 @@ final class RecruitmentCsvImporter {
 	 * @return array{ok: bool, rows: list<array<string, mixed>>, errors: list<string>}
 	 */
 	public static function parse( string $content ): array {
-		$content = self::strip_utf8_bom( $content );
 		if ( '' === trim( $content ) ) {
 			return array(
 				'ok'     => false,
@@ -230,27 +229,19 @@ final class RecruitmentCsvImporter {
 			);
 		}
 
-		$lines = preg_split( "/\r\n|\n|\r/", $content );
-		if ( ! is_array( $lines ) ) {
-			return array(
-				'ok'     => false,
-				'rows'   => array(),
-				'errors' => array( 'recruitment_csv_unparseable' ),
-			);
-		}
-
-		// Header row. Auto-detect delimiter from the header line: support
-		// both comma and semicolon variants (the latter is the default in
-		// many BR/EU spreadsheet exports). Detection is by occurrence
-		// count on the header — semicolons win iff there are more `;`
-		// than `,` outside of quoted segments.
-		$header_line = (string) array_shift( $lines );
-		$delimiter   = self::detect_delimiter( $header_line );
-		$headers     = self::parse_csv_line( $header_line, $delimiter );
-		$headers     = array_map( 'strtolower', array_map( 'trim', $headers ) );
+		// Csv::reader_from_string() handles BOM stripping and the
+		// `,`-vs-`;` auto-detection (the canonical rule lifted from the
+		// previous self::detect_delimiter()). The reader's fgetcsv-based
+		// parser also handles quoted multi-line fields correctly, which
+		// the previous preg_split('/\r\n|\n|\r/') line-splitter did not —
+		// a quoted cell containing a literal newline would have been
+		// mis-parsed before.
+		$reader  = \FreeFormCertificate\Core\Csv::reader_from_string( $content );
+		$headers = array_map( 'strtolower', array_map( 'trim', $reader->header() ) );
 
 		$missing = array_diff( self::REQUIRED_HEADERS, $headers );
 		if ( ! empty( $missing ) ) {
+			$reader->close();
 			return array(
 				'ok'     => false,
 				'rows'   => array(),
@@ -265,33 +256,29 @@ final class RecruitmentCsvImporter {
 		}
 
 		$rows        = array();
-		$line_number = 1; // 1-based; header was line 1.
-		foreach ( $lines as $line ) {
-			++$line_number;
-			$line = (string) $line;
+		$line_number = 1; // 1-based; header was logical row 1.
+		$reader->each(
+			static function ( array $cells ) use ( &$rows, &$line_number, $index_map ): void {
+				++$line_number;
 
-			if ( '' === trim( $line ) ) {
-				continue; // empty rows skipped per §6.
-			}
-
-			$cells = self::parse_csv_line( $line, $delimiter );
-
-			// Skip rows that are all whitespace after parsing.
-			$any_value = false;
-			foreach ( $cells as $cell ) {
-				if ( '' !== trim( $cell ) ) {
-					$any_value = true;
-					break;
+				// Skip rows that are all whitespace after parsing.
+				$any_value = false;
+				foreach ( $cells as $cell ) {
+					if ( '' !== trim( $cell ) ) {
+						$any_value = true;
+						break;
+					}
 				}
-			}
-			if ( ! $any_value ) {
-				continue;
-			}
+				if ( ! $any_value ) {
+					return;
+				}
 
-			$row          = self::build_row( $cells, $index_map );
-			$row['_line'] = $line_number;
-			$rows[]       = $row;
-		}
+				$row          = self::build_row( $cells, $index_map );
+				$row['_line'] = $line_number;
+				$rows[]       = $row;
+			}
+		);
+		$reader->close();
 
 		return array(
 			'ok'     => true,
@@ -609,75 +596,6 @@ final class RecruitmentCsvImporter {
 		}
 
 		return $map;
-	}
-
-	/**
-	 * Strip a UTF-8 BOM if present.
-	 *
-	 * @param string $content Raw bytes.
-	 * @return string Content with BOM removed.
-	 */
-	private static function strip_utf8_bom( string $content ): string {
-		if ( 0 === strncmp( $content, "\xEF\xBB\xBF", 3 ) ) {
-			return substr( $content, 3 );
-		}
-		return $content;
-	}
-
-	/**
-	 * Parse a single CSV line using `str_getcsv`. The delimiter is detected
-	 * once from the header line (see {@see self::detect_delimiter()}) and
-	 * then forwarded to every subsequent body line so a mixed-quoting file
-	 * still parses consistently.
-	 *
-	 * @param string $line      CSV line.
-	 * @param string $delimiter Field delimiter (`,` or `;`).
-	 * @return list<string>
-	 */
-	private static function parse_csv_line( string $line, string $delimiter = ',' ): array {
-		$cells = str_getcsv( $line, $delimiter );
-		// Coerce nulls (str_getcsv returns null for missing cells in some versions) to empty strings.
-		return array_map(
-			static function ( $cell ): string {
-				return is_string( $cell ) ? $cell : '';
-			},
-			$cells
-		);
-	}
-
-	/**
-	 * Detect the CSV field delimiter by inspecting the header line.
-	 *
-	 * Supports `,` (default) and `;` (common in BR/EU spreadsheet exports
-	 * where comma is the locale decimal separator). Counts occurrences
-	 * outside of double-quoted segments so a quoted comma inside a header
-	 * label doesn't tip the detection. Ties resolve to `,` for backward
-	 * compatibility with files that worked pre-detection.
-	 *
-	 * @param string $header_line The CSV header line.
-	 * @return string `,` or `;`.
-	 */
-	private static function detect_delimiter( string $header_line ): string {
-		$comma_count     = 0;
-		$semicolon_count = 0;
-		$in_quotes       = false;
-		$length          = strlen( $header_line );
-		for ( $i = 0; $i < $length; $i++ ) {
-			$ch = $header_line[ $i ];
-			if ( '"' === $ch ) {
-				$in_quotes = ! $in_quotes;
-				continue;
-			}
-			if ( $in_quotes ) {
-				continue;
-			}
-			if ( ',' === $ch ) {
-				++$comma_count;
-			} elseif ( ';' === $ch ) {
-				++$semicolon_count;
-			}
-		}
-		return $semicolon_count > $comma_count ? ';' : ',';
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page.php
@@ -101,18 +101,15 @@ final class RecruitmentNoticeEditPage {
 			array( 'João Souza', '98765432100', '222222', 'joao@example.com', '11988887777', 'matematica', '2', '78.25', '8.50', '0', '0' ),
 		);
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV to php://output; WP_Filesystem has no streaming equivalent. Same convention as RecruitmentCsvImporter / ReregistrationCsvExporter.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV template to php://output.
 		$out = fopen( 'php://output', 'w' );
 		if ( false === $out ) {
 			exit;
 		}
-		// UTF-8 BOM so Excel opens the file in the right encoding by default.
-		echo "\xEF\xBB\xBF"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- raw byte stream, no HTML context.
-		foreach ( $rows as $row ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv -- streaming to php://output handle.
-			fputcsv( $out, $row, ';' );
-		}
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing handle from fopen() above.
+		$writer = \FreeFormCertificate\Core\Csv::writer( $out );
+		$writer->rows( $rows );
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $out );
 		exit;
 	}

--- a/includes/reregistration/class-ffc-reregistration-csv-exporter.php
+++ b/includes/reregistration/class-ffc-reregistration-csv-exporter.php
@@ -61,14 +61,11 @@ class ReregistrationCsvExporter {
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
 		$output = fopen( 'php://output', 'w' );
 		if ( false === $output ) {
 			exit;
 		}
-		// BOM for Excel UTF-8.
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
-		fwrite( $output, "\xEF\xBB\xBF" );
 
 		// Header row — fixed metadata + all dynamic fields in repository order.
 		$headers = array(
@@ -84,8 +81,8 @@ class ReregistrationCsvExporter {
 			$headers[] = $f->field_label;
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv
-		fputcsv( $output, $headers, ';' );
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( $headers );
 
 		// Data rows.
 		foreach ( $submissions as $sub ) {
@@ -108,11 +105,11 @@ class ReregistrationCsvExporter {
 				$row[] = self::stringify_value( $f, $values[ (string) $f->field_key ] ?? '' );
 			}
 
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fputcsv
-			fputcsv( $output, $row, ';' );
+			$writer->row( $row );
 		}
 
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$writer->close();
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $output );
 		exit;
 	}

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-csv-exporter.php
@@ -263,14 +263,11 @@ class AppointmentCsvExporter {
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- streaming CSV download to php://output.
 		$output = fopen( 'php://output', 'w' );
 		if ( false === $output ) {
 			exit;
 		}
-
-		// BOM for Excel UTF-8 recognition.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV binary output, not HTML context
-		fprintf( $output, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
 
 		// Build headers.
 		$dynamic_keys = $this->get_dynamic_columns( $rows );
@@ -279,34 +276,13 @@ class AppointmentCsvExporter {
 			$this->get_dynamic_headers( $dynamic_keys )
 		);
 
-		// Convert all headers to UTF-8.
-		$headers = array_map(
-			function ( $header ) {
-				return mb_convert_encoding( $header, 'UTF-8', 'UTF-8' );
-			},
-			$headers
-		);
-
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV file output, not HTML context
-		fputcsv( $output, $headers, ';' );
-
-		// Write data rows.
+		$writer = \FreeFormCertificate\Core\Csv::writer( $output );
+		$writer->row( $headers );
 		foreach ( $rows as $row ) {
-			$csv_row = $this->format_csv_row( $row, $dynamic_keys );
-
-			// Convert all row data to UTF-8.
-			$csv_row = array_map(
-				function ( string $value ): string {
-					return mb_convert_encoding( $value, 'UTF-8', 'UTF-8' );
-				},
-				$csv_row
-			);
-
-            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV file output, not HTML context
-			fputcsv( $output, $csv_row, ';' );
+			$writer->row( $this->format_csv_row( $row, $dynamic_keys ) );
 		}
-
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closing php://output stream for CSV export.
+		$writer->close();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closing the php://output handle this method opened.
 		fclose( $output );
 		exit;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.3.11
+Stable tag: 6.4.0
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/CsvTest.php
+++ b/tests/Unit/CsvTest.php
@@ -1,0 +1,329 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Core\Csv;
+use FreeFormCertificate\Core\CsvReader;
+use FreeFormCertificate\Core\CsvWriter;
+
+/**
+ * Tests for Csv / CsvWriter / CsvReader: round-trip integrity, BOM
+ * placement, delimiter auto-detection (including ties), RFC 4180
+ * quoting of cells with delimiters / quotes / newlines, ownership
+ * semantics, and the resource-vs-string reader entrypoints.
+ */
+class CsvTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function tmp_handle() {
+        $handle = fopen( 'php://memory', 'r+' );
+        if ( false === $handle ) {
+            $this->fail( 'Could not open php://memory' );
+        }
+        return $handle;
+    }
+
+    private function dump( $handle ): string {
+        rewind( $handle );
+        return (string) stream_get_contents( $handle );
+    }
+
+    // ==================================================================
+    // Writer — BOM contract
+    // ==================================================================
+
+    public function test_writer_emits_bom_before_first_row(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->row( array( 'a', 'b' ) );
+        $w->close();
+
+        $bytes = $this->dump( $h );
+        $this->assertStringStartsWith( "\xEF\xBB\xBF", $bytes, 'BOM should be the first three bytes' );
+    }
+
+    public function test_writer_emits_bom_only_once(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->row( array( 'h1', 'h2' ) );
+        $w->row( array( 'r1', 'r2' ) );
+        $w->row( array( 'r3', 'r4' ) );
+
+        $bytes      = $this->dump( $h );
+        $bom_count  = substr_count( $bytes, "\xEF\xBB\xBF" );
+        $this->assertSame( 1, $bom_count, 'BOM must appear exactly once' );
+    }
+
+    public function test_writer_no_bom_when_no_rows_written(): void {
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->close();
+
+        $bytes = $this->dump( $h );
+        $this->assertSame( '', $bytes );
+    }
+
+    // ==================================================================
+    // Writer — delimiter
+    // ==================================================================
+
+    public function test_writer_uses_semicolon_by_default(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->row( array( 'a', 'b', 'c' ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "a;b;c\n", $bytes );
+    }
+
+    public function test_writer_respects_custom_delimiter(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h, ',' );
+        $w->row( array( 'a', 'b', 'c' ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "a,b,c\n", $bytes );
+    }
+
+    // ==================================================================
+    // Writer — quoting (RFC 4180)
+    // ==================================================================
+
+    public function test_writer_quotes_cell_with_delimiter(): void {
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->row( array( 'a;b', 'c' ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "\"a;b\";c\n", $bytes );
+    }
+
+    public function test_writer_quotes_cell_with_quote(): void {
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->row( array( 'a"b', 'c' ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "\"a\"\"b\";c\n", $bytes );
+    }
+
+    public function test_writer_quotes_cell_with_newline(): void {
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->row( array( "a\nb", 'c' ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertStringContainsString( "\"a\nb\"", $bytes );
+    }
+
+    // ==================================================================
+    // Writer — rows() iterable
+    // ==================================================================
+
+    public function test_writer_rows_accepts_array(): void {
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->rows( array(
+            array( 'h1', 'h2' ),
+            array( 'a', 'b' ),
+            array( 'c', 'd' ),
+        ) );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "h1;h2\na;b\nc;d\n", $bytes );
+    }
+
+    public function test_writer_rows_accepts_generator(): void {
+        $h   = $this->tmp_handle();
+        $gen = ( static function () {
+            yield array( 'h1', 'h2' );
+            yield array( 'a', 'b' );
+        } )();
+        Csv::writer( $h )->rows( $gen );
+
+        $bytes = ltrim( $this->dump( $h ), "\xEF\xBB\xBF" );
+        $this->assertSame( "h1;h2\na;b\n", $bytes );
+    }
+
+    // ==================================================================
+    // Writer — close() ownership
+    // ==================================================================
+
+    public function test_writer_close_idempotent(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->row( array( 'a' ) );
+        $w->close();
+        $w->close(); // must not throw
+        $this->assertTrue( true );
+    }
+
+    public function test_writer_throws_on_write_after_close(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->close();
+
+        $this->expectException( \LogicException::class );
+        $w->row( array( 'a' ) );
+    }
+
+    public function test_writer_does_not_close_borrowed_handle(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h );
+        $w->row( array( 'a' ) );
+        $w->close();
+        $this->assertTrue( is_resource( $h ), 'Borrowed handle must remain open after writer close' );
+    }
+
+    // ==================================================================
+    // Reader — delimiter auto-detection
+    // ==================================================================
+
+    public function test_reader_detects_semicolon(): void {
+        $r = Csv::reader_from_string( "h1;h2;h3\na;b;c\n" );
+        $this->assertSame( ';', $r->delimiter );
+        $this->assertSame( array( 'h1', 'h2', 'h3' ), $r->header() );
+    }
+
+    public function test_reader_detects_comma(): void {
+        $r = Csv::reader_from_string( "h1,h2,h3\na,b,c\n" );
+        $this->assertSame( ',', $r->delimiter );
+        $this->assertSame( array( 'h1', 'h2', 'h3' ), $r->header() );
+    }
+
+    public function test_reader_tie_resolves_to_comma(): void {
+        // Equal counts of `,` and `;` — rule: comma wins (back-compat).
+        $r = Csv::reader_from_string( "a,b;c,d;e\n" );
+        $this->assertSame( ',', $r->delimiter );
+    }
+
+    public function test_reader_ignores_delimiter_inside_quotes(): void {
+        // Two semicolons total but one is inside quotes; must count one.
+        $r = Csv::reader_from_string( "\"a;b\",c\n" );
+        $this->assertSame( ',', $r->delimiter, 'Quoted ; must not tip detection' );
+    }
+
+    public function test_reader_force_delimiter_overrides_detection(): void {
+        $r = Csv::reader_from_string( "h1;h2\n", ',' );
+        $this->assertSame( ',', $r->delimiter );
+    }
+
+    // ==================================================================
+    // Reader — BOM tolerance
+    // ==================================================================
+
+    public function test_reader_strips_bom_before_detection(): void {
+        $r = Csv::reader_from_string( "\xEF\xBB\xBFh1;h2\na;b\n" );
+        $this->assertSame( ';', $r->delimiter );
+        $this->assertSame( array( 'h1', 'h2' ), $r->header() );
+    }
+
+    public function test_reader_handles_no_bom(): void {
+        $r = Csv::reader_from_string( "h1;h2\na;b\n" );
+        $this->assertSame( array( 'h1', 'h2' ), $r->header() );
+        $this->assertSame( array( array( 'a', 'b' ) ), $r->all() );
+    }
+
+    // ==================================================================
+    // Reader — body iteration
+    // ==================================================================
+
+    public function test_reader_each_streams_body(): void {
+        $r    = Csv::reader_from_string( "h1;h2\nx;1\ny;2\nz;3\n" );
+        $rows = array();
+        $r->each(
+            static function ( array $row ) use ( &$rows ): void {
+                $rows[] = $row;
+            }
+        );
+        $this->assertSame(
+            array(
+                array( 'x', '1' ),
+                array( 'y', '2' ),
+                array( 'z', '3' ),
+            ),
+            $rows
+        );
+    }
+
+    public function test_reader_all_returns_body_only(): void {
+        $r = Csv::reader_from_string( "h1;h2\nx;1\ny;2\n" );
+        $this->assertSame(
+            array(
+                array( 'x', '1' ),
+                array( 'y', '2' ),
+            ),
+            $r->all()
+        );
+    }
+
+    public function test_reader_handles_quoted_delimiter_in_body(): void {
+        $r = Csv::reader_from_string( "h1;h2\n\"a;b\";c\n" );
+        $this->assertSame( array( array( 'a;b', 'c' ) ), $r->all() );
+    }
+
+    public function test_reader_handles_escaped_quote_in_body(): void {
+        $r = Csv::reader_from_string( "h1;h2\n\"a\"\"b\";c\n" );
+        $this->assertSame( array( array( 'a"b', 'c' ) ), $r->all() );
+    }
+
+    // ==================================================================
+    // Round-trip — writer → reader through the same stream
+    // ==================================================================
+
+    public function test_round_trip_preserves_simple_rows(): void {
+        $rows = array(
+            array( 'name', 'email', 'count' ),
+            array( 'Alice', 'a@example.com', '5' ),
+            array( 'Bob', 'b@example.com', '12' ),
+        );
+
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->rows( $rows );
+        rewind( $h );
+        $r = Csv::reader( $h );
+
+        $this->assertSame( ';', $r->delimiter );
+        $this->assertSame( $rows[0], $r->header() );
+        $this->assertSame( array_slice( $rows, 1 ), $r->all() );
+    }
+
+    public function test_round_trip_preserves_special_characters(): void {
+        $rows = array(
+            array( 'col1', 'col2' ),
+            array( 'has;semicolon', 'has"quote' ),
+            array( "has\nnewline", 'plain' ),
+            array( 'unicode: ção', 'plain' ),
+        );
+
+        $h = $this->tmp_handle();
+        Csv::writer( $h )->rows( $rows );
+        rewind( $h );
+        $r = Csv::reader( $h );
+
+        $this->assertSame( $rows[0], $r->header() );
+        $this->assertSame( array_slice( $rows, 1 ), $r->all() );
+    }
+
+    // ==================================================================
+    // Reader_from_string ownership
+    // ==================================================================
+
+    public function test_reader_from_string_close_idempotent(): void {
+        $r = Csv::reader_from_string( "h1;h2\na;b\n" );
+        $r->all();
+        $r->close();
+        $r->close();
+        $this->assertTrue( true );
+    }
+}

--- a/tests/Unit/CsvTest.php
+++ b/tests/Unit/CsvTest.php
@@ -77,6 +77,17 @@ class CsvTest extends TestCase {
         $this->assertSame( '', $bytes );
     }
 
+    public function test_writer_skip_bom_suppresses_emission(): void {
+        $h = $this->tmp_handle();
+        $w = Csv::writer( $h, ';', true );
+        $w->row( array( 'a', 'b' ) );
+        $w->close();
+
+        $bytes = $this->dump( $h );
+        $this->assertStringStartsNotWith( "\xEF\xBB\xBF", $bytes, 'skip_bom must suppress BOM' );
+        $this->assertSame( "a;b\n", $bytes );
+    }
+
     // ==================================================================
     // Writer — delimiter
     // ==================================================================


### PR DESCRIPTION
Closes #126.

## Sprints (each commit standalone)

| # | Commit | What |
|---|---|---|
| **S1** | `1b65dac` | core: add Csv / CsvWriter / CsvReader unified IO primitives + 28 tests |
| **S2a** | `4d76337` | admin csv-exporter → Csv::writer + new skip_bom flag |
| **S2b** | `ed6c922` | frontend public-csv-exporter → Csv::writer (3 callsites) |
| **S2c** | `6b4d27d` | self-scheduling appointment-csv-exporter → Csv::writer |
| **S2d** | `0dc0b4c` | recruitment notice-edit-page CSV template → Csv::writer |
| **S2e** | `aaff7d9` | reregistration-csv-exporter → Csv::writer |
| **S2f** | `5d4382c` | audience-admin-import templates → Csv::writer (BOM fix) |
| **S2g** | `712b861` | frontend public-csv-download audit log → Csv::writer |
| **S3a** | `451e063` | recruitment-csv-importer → Csv::reader (drops 3 helpers) |
| **S3b** | `096c6fd` | audience-csv-importer → Csv::reader (drops peek_delimiter) |
| **S4a** | `1902860` | admin activity-log → Csv::writer; strip output_csv from trait |
| **fix** | `4b8fdd1` | WPCS fixups (esc_html on exception, fwrite/fread phpcs:ignore, callable docblock) |
| **rel** | `7da78fd` | bump 6.3.11 → 6.4.0; CHANGELOG entry |

## Honest deltas vs the original issue

- **Issue scope (#126) listed 7 exporters + 2 importers; reality was 8 + 2.** The activity-log admin page was the eighth exporter, missed when the issue was filed because it consumed the trait's `output_csv()` helper indirectly. Folded into Sprint 4a.
- **Trait removal goal partially met.** #126 said "remove `class-ffc-csv-export-trait.php`". After migration, 4 files still need its JSON-shape helpers (extract_dynamic_keys, decode_json_field, build_dynamic_headers, extract_dynamic_values) — these are about flattening the encrypted/plaintext `data` column into spreadsheet columns, not about CSV IO. `output_csv()` was removed; the helpers stayed. Renaming the trait to `JsonDataColumnTrait` (or similar) is a follow-up, deliberately deferred to keep this PR's blast radius focused on the IO migration.
- **Audience export templates were silently emitting non-BOM CSV.** Two templates (`members-export-*.csv`, `audiences-export-*.csv`) had no UTF-8 BOM, so Excel rendered accented characters as mojibake. The migration to `Csv::writer` fixes this as a side effect — flagged as "Fixed" in the CHANGELOG, treated as a behavioural correction rather than a regression.
- **Recruitment importer's multi-line cells now parse correctly.** The previous `preg_split('/\r\n|\n|\r/', $content)` line-splitter was structurally incapable of handling a quoted cell containing a literal newline; `Csv::reader` uses `fgetcsv` which handles RFC 4180 quoting properly. Treated as a silent fix because the previous behaviour was a parse failure, not a wrong-result.
- **`skip_bom` writer flag added in Sprint 2a.** The admin and public CSV exporters split their work across an init handler + N batch handlers (different processes). The init writes BOM + headers; batches append rows. Without a way to suppress per-batch BOMs, every chunk would re-emit `` and Excel would render garbage. The flag is documented and pinned by a dedicated test.

## Verification

- [x] **PHPUnit:** 28 new Csv tests + full suite green (run prior to push: 3864 tests, 9787 assertions, 0 failures).
- [x] **WPCS:** all 14 touched files clean (`vendor/bin/phpcs --standard=phpcs.xml.dist`).
- [x] **Round-trip integrity:** writer→reader test in `CsvTest::test_round_trip_preserves_special_characters` covers semicolon-in-cell, escaped quote, embedded newline, and unicode (ção).
- [x] **No public format change** for files that already had a BOM (every file except the two audience templates).

## Test plan for reviewer

- [ ] Download a public form's CSV with >100 submissions → opens cleanly in Excel-pt-BR with accented characters intact.
- [ ] Re-import a legacy comma-separated audience CSV → auto-detects, parses, succeeds.
- [ ] Re-import a new semicolon-separated audience CSV → succeeds.
- [ ] Audit-log download from admin Activity Log page → opens cleanly in Excel.
- [ ] Recruitment notice "Download example CSV" → matches the documented column order, opens in Excel.
- [ ] Cancel an appointment via public link → token compare still works (unrelated to this PR but adjacent file touched in #140; verify regression-free).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SphzDGfdHo63qBK7XMkWcF)_