### PR TITLE
[Sec] REST lockdown — auth gate /forms config leak + rate-limit calendars (closes #139, v6.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.4.1] (2026-05-10)
+
+**REST API lockdown (#139).** Plugs a config-blob leak in the public REST surface and adds a circuit-breaker on the public booking calendars. `GET /wp-json/ffc/v1/forms` and `GET /wp-json/ffc/v1/forms/{id}` previously carried `permission_callback => '__return_true'` and returned the full `_ffc_form_config` blob — which on a typical install contains `allowed_users_list`, `denied_users_list`, `validation_code`, `generated_codes_list`, `geo_areas`, `geo_ip_area_location_ids`, `email_body`, `email_subject`. Anyone with the public REST URL could enumerate every form's gating policy.
+
+### Added
+
+- **`ffc_read_forms_api` capability.** New admin-level capability granted to the `administrator` role automatically via `Loader::ensure_admin_capabilities()` (runs once per `FFC_VERSION` change). External integrators authenticate with WordPress Application Passwords (HTTP Basic, since WP 5.6); the linked user must hold the cap.
+- **Documentation tab section "19. REST API Authentication".** Distinguishes public-by-design endpoints (form submission, certificate verification, booking calendars) from authenticated endpoints. Includes a curl example using Application Passwords + the new capability.
+
+### Changed
+
+- **`GET /forms` / `GET /forms/{id}` now require `ffc_read_forms_api`.** Permission callback delegates to `current_user_can()`. Trimmed payload: only `id`, `title`, `status`, `date`, `modified`, `link` — the `_ffc_form_config` blob, `fields` array, and `background` are gone. Integrators that need form structure use the public-by-design `GET /forms/{id}/schema` endpoint.
+- **`limit` parameter on `GET /forms` clamped at 100.** Out-of-range or non-numeric values coerce to the default of 100. Pagination is a follow-up.
+- **Calendar GET routes carry an IP-keyed rate-limit circuit breaker.** `GET /calendars`, `GET /calendars/{id}`, and `GET /calendars/{id}/slots` now reject requests from IPs that have already tripped the rate-limit pool (typically populated by failed/abusive submit/verify hits from the same address). Returns HTTP 429 with `wait_seconds`.
+
+### Documented
+
+- **Public-by-design routes carry an explicit `phpcs:ignore` comment + per-route block docblock.** `GET /forms/{id}/schema`, `POST /forms/{id}/submit`, `POST /verify`, `POST /calendars/{id}/appointments`, and the three calendar GETs each describe the public flow they serve and the secondary defences in play (rate-limit pool, geofence, hash_equals on tokens, CPF/RF validation). Future contributors see the rationale without having to chase the audit trail.
+
+### Security
+
+- No CVE assigned. Pre-6.4.1 the `_ffc_form_config` blob was readable by any anonymous caller via `GET /wp-json/ffc/v1/forms`. The blob contains gate-list metadata (allowed/denied user IDs, generated/validation codes, geofence configuration). Sites running pre-6.4.1 should treat their generated/validation codes and gate-list contents as compromised; rotate codes after upgrading if the API was reachable from the public internet.
+
+---
+
 ## [6.4.0] (2026-05-10)
 
 **Unified CSV IO abstraction (#126).** Internal refactor: every CSV the plugin reads or writes now flows through a single pair of primitives — `\FreeFormCertificate\Core\Csv::writer()` / `Csv::reader()` — instead of the eight exporters and two importers each implementing fputcsv/fgetcsv/delimiter detection/BOM handling on their own. No user-facing change for files that already used `;` (the post-6.3.9 default); audience export templates now correctly emit a UTF-8 BOM (previously they were the only files in the plugin that didn't, causing Excel to render accented characters as mojibake until manually fixing encoding). Minor bump because the surface area touched is broad even though behaviour is preserved on every public format.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.4.0
+ * Version:            6.4.1
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.4.0' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.4.1' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/api/class-ffc-appointment-rest-controller.php
+++ b/includes/api/class-ffc-appointment-rest-controller.php
@@ -45,12 +45,24 @@ class AppointmentRestController {
 	 */
 	public function register_routes(): void {
 		// POST /calendars/{id}/appointments - Create appointment.
+		//
+		// Public-by-design — anonymous visitors create bookings here
+		// (the [ffc_self_scheduling] shortcode submits to this route to
+		// reserve a slot). Locking this behind a permission gate would
+		// require every booking visitor to register for a WordPress
+		// account first, defeating the public booking flow. The handler
+		// defends with: required-field validation, calendar visibility
+		// checks (private calendars 403 anonymous callers), slot
+		// availability re-check inside a SELECT ... FOR UPDATE
+		// transaction, email format validation, and the IP-keyed rate-
+		// limit pool. See issue #139.
 		register_rest_route(
 			$this->namespace,
 			'/calendars/(?P<id>\d+)/appointments',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_appointment' ),
+				// phpcs:ignore -- public-by-design: anonymous booking creation; see route docblock above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'id' => array(

--- a/includes/api/class-ffc-calendar-rest-controller.php
+++ b/includes/api/class-ffc-calendar-rest-controller.php
@@ -44,24 +44,34 @@ class CalendarRestController {
 	 * Register routes
 	 */
 	public function register_routes(): void {
-		// GET /calendars - List all active calendars.
+		// GET /calendars, GET /calendars/{id}, GET /calendars/{id}/slots
+		//
+		// All three are public-by-design — the [ffc_self_scheduling]
+		// shortcode hits them anonymously to render the public booking
+		// UI. They cannot move behind a permission gate. Defence is the
+		// IP-keyed rate-limit guard called at the top of every handler
+		// (see CalendarRestController::rate_limit_guard()), which trips
+		// when the IP pool is exhausted by abusive submit/verify hits
+		// from the same address. See issue #139 (S3).
+
 		register_rest_route(
 			$this->namespace,
 			'/calendars',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_calendars' ),
+				// phpcs:ignore -- public-by-design: see register_routes() block comment above and #139.
 				'permission_callback' => '__return_true',
 			)
 		);
 
-		// GET /calendars/{id} - Get calendar details.
 		register_rest_route(
 			$this->namespace,
 			'/calendars/(?P<id>\d+)',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_calendar' ),
+				// phpcs:ignore -- public-by-design: see register_routes() block comment above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'id' => array(
@@ -73,13 +83,13 @@ class CalendarRestController {
 			)
 		);
 
-		// GET /calendars/{id}/slots - Get available time slots.
 		register_rest_route(
 			$this->namespace,
 			'/calendars/(?P<id>\d+)/slots',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_calendar_slots' ),
+				// phpcs:ignore -- public-by-design: see register_routes() block comment above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'id'   => array(

--- a/includes/api/class-ffc-calendar-rest-controller.php
+++ b/includes/api/class-ffc-calendar-rest-controller.php
@@ -99,6 +99,42 @@ class CalendarRestController {
 	}
 
 	/**
+	 * Reject the request when the caller's IP has already tripped the
+	 * rate-limit pool (typically populated by failed/abusive form
+	 * submissions from the same IP). Returns null on green light.
+	 *
+	 * Rationale: the calendar GET routes are public-by-design — the
+	 * `[ffc_self_scheduling]` shortcode hits them anonymously to build
+	 * the booking UI. Behind `__return_true` they had no defence at
+	 * all against a scraper polling `/slots` to enumerate the working
+	 * hours of every calendar on a site. This guard is a circuit
+	 * breaker, not a per-read limiter: it shares the IP pool with
+	 * submit/verify, so an actor caught flooding submissions also
+	 * gets blocked from these reads. A per-read pool is a follow-up.
+	 *
+	 * @since 6.4.1
+	 * @return \WP_Error|null `WP_Error` (status 429) when blocked, null when allowed.
+	 */
+	private function rate_limit_guard() {
+		if ( ! class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
+			return null;
+		}
+		$ip       = \FreeFormCertificate\Core\Utils::get_user_ip();
+		$ip_check = \FreeFormCertificate\Security\RateLimiter::check_ip_limit( $ip );
+		if ( ! empty( $ip_check['allowed'] ) ) {
+			return null;
+		}
+		return new \WP_Error(
+			'rate_limit_exceeded',
+			isset( $ip_check['message'] ) ? (string) $ip_check['message'] : __( 'Too many requests. Please try again later.', 'ffcertificate' ),
+			array(
+				'status'       => 429,
+				'wait_seconds' => isset( $ip_check['wait_seconds'] ) ? (int) $ip_check['wait_seconds'] : 60,
+			)
+		);
+	}
+
+	/**
 	 * GET /calendars
 	 * List all active calendars
 	 *
@@ -107,6 +143,11 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendars( $request ) {
+		$blocked = $this->rate_limit_guard();
+		if ( $blocked instanceof \WP_Error ) {
+			return $blocked;
+		}
+
 		try {
 			if ( ! class_exists( '\FreeFormCertificate\Repositories\CalendarRepository' ) ) {
 				return new \WP_Error(
@@ -172,6 +213,11 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendar( $request ) {
+		$blocked = $this->rate_limit_guard();
+		if ( $blocked instanceof \WP_Error ) {
+			return $blocked;
+		}
+
 		try {
 			$calendar_id = $request->get_param( 'id' );
 
@@ -252,6 +298,11 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendar_slots( $request ) {
+		$blocked = $this->rate_limit_guard();
+		if ( $blocked instanceof \WP_Error ) {
+			return $blocked;
+		}
+
 		try {
 			$calendar_id = $request->get_param( 'id' );
 			$date        = $request->get_param( 'date' );

--- a/includes/api/class-ffc-form-rest-controller.php
+++ b/includes/api/class-ffc-form-rest-controller.php
@@ -112,12 +112,22 @@ class FormRestController {
 		);
 
 		// GET /forms/{id}/schema - Lightweight read-only form metadata.
+		//
+		// Public-by-design — the lightweight counterpart to GET /forms/{id}.
+		// Returns only id + title + the fields renderers need (name, label,
+		// type, required, options) and is the documented entry point for
+		// integrators that want to build a custom form UI without holding
+		// `ffc_read_forms_api`. The trim is enforced inside the handler
+		// (see get_form_schema()) and is filterable via
+		// `ffcertificate_rest_form_schema` so projects can add or remove
+		// keys without having to fork the controller. See issue #139.
 		register_rest_route(
 			$this->namespace,
 			'/forms/(?P<id>\d+)/schema',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_form_schema' ),
+				// phpcs:ignore -- public-by-design: serves the curated schema; see route docblock above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'id' => array(
@@ -130,12 +140,24 @@ class FormRestController {
 		);
 
 		// POST /forms/{id}/submit - Submit a form.
+		//
+		// Public-by-design — anonymous visitors submit certificate forms
+		// here (the plugin's primary public flow). Locking this behind a
+		// permission gate would break every "fill in the form to receive
+		// your certificate" deployment. The handler defends with: form
+		// publish-state check, geofence (date/time + IP geolocation), CPF/RF
+		// algorithm validation, email format validation, and three rate-
+		// limit pools (IP, email, CPF) — see submit_form() body. CSRF on
+		// REST endpoints is handled by WordPress's nonce/header model;
+		// origin validation is enforced by the submit form_processor used
+		// by the same flow. See issue #139.
 		register_rest_route(
 			$this->namespace,
 			'/forms/(?P<id>\d+)/submit',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'submit_form' ),
+				// phpcs:ignore -- public-by-design: anonymous submission flow; see route docblock above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'id' => array(

--- a/includes/api/class-ffc-form-rest-controller.php
+++ b/includes/api/class-ffc-form-rest-controller.php
@@ -28,6 +28,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FormRestController {
 
 	/**
+	 * Maximum number of forms returned by `GET /forms` regardless of
+	 * the `limit` query argument. Authenticated callers asking for
+	 * more get clamped silently. Pagination is a follow-up; for now
+	 * 100 is a safe upper bound — large enough that no realistic
+	 * site is artificially constrained, small enough that a misuse
+	 * cannot dump the entire form catalogue in one round trip.
+	 */
+	private const DEFAULT_FORMS_LIMIT = 100;
+
+	/**
 	 * API namespace
 	 *
 	 * @var string
@@ -57,30 +67,40 @@ class FormRestController {
 	 */
 	public function register_routes(): void {
 		// GET /forms - List all published forms.
+		//
+		// Authenticated. External integrators use a WordPress
+		// Application Password (Basic Auth, since WP 5.6) to call
+		// this endpoint; the linked user must hold `ffc_read_forms_api`
+		// (granted to the administrator role automatically; delegable
+		// to other roles via the standard WP cap UI). The previous
+		// `__return_true` permission_callback exposed the
+		// `_ffc_form_config` blob which contains allowed/denied user
+		// lists, generated/validation codes, and geofence config —
+		// see issue #139 for the audit finding.
 		register_rest_route(
 			$this->namespace,
 			'/forms',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_forms' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'permission_read_forms_api' ),
 				'args'                => array(
 					'limit' => array(
-						'default'           => -1,
-						'sanitize_callback' => 'absint',
+						'default'           => self::DEFAULT_FORMS_LIMIT,
+						'sanitize_callback' => array( $this, 'sanitize_limit' ),
 					),
 				),
 			)
 		);
 
-		// GET /forms/{id} - Get single form.
+		// GET /forms/{id} - Get single form. Same auth model as /forms above.
 		register_rest_route(
 			$this->namespace,
 			'/forms/(?P<id>\d+)',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_form' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'permission_read_forms_api' ),
 				'args'                => array(
 					'id' => array(
 						'validate_callback' => function ( $param ) {
@@ -130,6 +150,36 @@ class FormRestController {
 	}
 
 	/**
+	 * Permission callback for the authenticated `/forms` endpoints.
+	 *
+	 * @since 6.4.1
+	 * @return bool
+	 */
+	public function permission_read_forms_api(): bool {
+		return current_user_can( 'ffc_read_forms_api' );
+	}
+
+	/**
+	 * Sanitize and clamp the `limit` query arg on `GET /forms`.
+	 *
+	 * Returns DEFAULT_FORMS_LIMIT for non-positive or non-numeric
+	 * input, including the legacy default of `-1` (which previously
+	 * meant "all forms" — kept working through this clamp so existing
+	 * integrators do not 4xx).
+	 *
+	 * @since 6.4.1
+	 * @param mixed $value Raw query arg.
+	 * @return int Clamped limit, 1..DEFAULT_FORMS_LIMIT.
+	 */
+	public function sanitize_limit( $value ): int {
+		$n = absint( $value );
+		if ( $n <= 0 ) {
+			return self::DEFAULT_FORMS_LIMIT;
+		}
+		return min( $n, self::DEFAULT_FORMS_LIMIT );
+	}
+
+	/**
 	 * GET /forms
 	 * List all published forms
 	 *
@@ -138,7 +188,7 @@ class FormRestController {
 	 */
 	public function get_forms( $request ) {
 		try {
-			$limit = $request->get_param( 'limit' );
+			$limit = (int) $request->get_param( 'limit' );
 
 			if ( ! $this->form_repository ) {
 				return new \WP_Error(
@@ -150,6 +200,12 @@ class FormRestController {
 
 			$forms = $this->form_repository->findPublished( $limit );
 
+			// Trimmed payload: id/title/status/dates/link only. The
+			// previous response embedded the full `_ffc_form_config`
+			// blob (allowed/denied user lists, validation/generated
+			// codes, geofence + IP areas, email body, etc.) — see
+			// issue #139. Integrators that need form structure should
+			// hit `/forms/{id}/schema` (lightweight, public-by-design).
 			$response = array();
 			foreach ( $forms as $form ) {
 				$response[] = array(
@@ -159,7 +215,6 @@ class FormRestController {
 					'date'     => $form->post_date,
 					'modified' => $form->post_modified,
 					'link'     => get_permalink( $form->ID ),
-					'config'   => $this->form_repository->getConfig( $form->ID ),
 				);
 			}
 
@@ -204,19 +259,19 @@ class FormRestController {
 				);
 			}
 
-			if ( ! $this->form_repository ) {
-				return new \WP_Error( 'form_repo_unavailable', __( 'Form repository not available', 'ffcertificate' ), array( 'status' => 500 ) );
-			}
-
+			// Trimmed payload, same rationale as `GET /forms`: drop
+			// the `_ffc_form_config` blob, fields, and background that
+			// the previous unauthenticated response leaked. Integrators
+			// that need form structure use `GET /forms/{id}/schema`
+			// (public-by-design, returns id/title/fields with only the
+			// keys a renderer needs). See issue #139.
 			$response = array(
-				'id'         => $form->ID,
-				'title'      => $form->post_title,
-				'status'     => $form->post_status,
-				'date'       => $form->post_date,
-				'modified'   => $form->post_modified,
-				'config'     => $this->form_repository->getConfig( $form_id ),
-				'fields'     => $this->form_repository->getFields( $form_id ),
-				'background' => $this->form_repository->getBackground( $form_id ),
+				'id'       => $form->ID,
+				'title'    => $form->post_title,
+				'status'   => $form->post_status,
+				'date'     => $form->post_date,
+				'modified' => $form->post_modified,
+				'link'     => get_permalink( $form->ID ),
 			);
 
 			return rest_ensure_response( $response );

--- a/includes/api/class-ffc-submission-rest-controller.php
+++ b/includes/api/class-ffc-submission-rest-controller.php
@@ -103,12 +103,22 @@ class SubmissionRestController {
 		);
 
 		// POST /verify - Verify certificate by auth code.
+		//
+		// Public-by-design — the certificate verification page
+		// (`/validate-certificate/`) lets anyone confirm a cert by typing
+		// in the auth code printed on it. Auth-gating this would defeat
+		// the verification feature's whole point. The handler defends
+		// with: auth-code length validation, hash_equals comparison
+		// (hardened in #140), and the verification-specific rate-limit
+		// pool (RateLimiter::check_verification) which throttles
+		// brute-force attempts before format validation runs. See #139.
 		register_rest_route(
 			$this->namespace,
 			'/verify',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'verify_certificate' ),
+				// phpcs:ignore -- public-by-design: certificate verification flow; see route docblock above and #139.
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'auth_code' => array(

--- a/includes/settings/views/ffc-tab-documentation.php
+++ b/includes/settings/views/ffc-tab-documentation.php
@@ -1358,4 +1358,118 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 </div>
 
+<!-- 19. REST API Authentication Section -->
+<div class="card">
+	<h3 id="rest-api-auth" class="ffc-icon-lock"><?php esc_html_e( '19. REST API Authentication', 'ffcertificate' ); ?></h3>
+
+	<p>
+		<?php esc_html_e( 'External integrations call the FFC REST API under the namespace', 'ffcertificate' ); ?>
+		<code>/wp-json/ffc/v1/</code>.
+		<?php esc_html_e( 'Endpoints fall into two categories:', 'ffcertificate' ); ?>
+	</p>
+
+	<div class="ffc-doc-example">
+		<h4><?php esc_html_e( 'Public-by-design endpoints', 'ffcertificate' ); ?></h4>
+		<p>
+			<?php esc_html_e( 'Anonymous-by-contract because they serve the plugin\'s public flows: the form-submission shortcode, the certificate-verification page, and the booking shortcode. They do not accept authentication and are protected by rate limiting, geofence rules, hash_equals comparisons on tokens, and (for submissions) email + CPF/RF format validation.', 'ffcertificate' ); ?>
+		</p>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Method', 'ffcertificate' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Endpoint', 'ffcertificate' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Purpose', 'ffcertificate' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>GET</code></td>
+					<td><code>/forms/{id}/schema</code></td>
+					<td><?php esc_html_e( 'Lightweight form metadata for renderer integrations.', 'ffcertificate' ); ?></td>
+				</tr>
+				<tr>
+					<td><code>POST</code></td>
+					<td><code>/forms/{id}/submit</code></td>
+					<td><?php esc_html_e( 'Anonymous certificate submission.', 'ffcertificate' ); ?></td>
+				</tr>
+				<tr>
+					<td><code>POST</code></td>
+					<td><code>/verify</code></td>
+					<td><?php esc_html_e( 'Verify a certificate by auth code.', 'ffcertificate' ); ?></td>
+				</tr>
+				<tr>
+					<td><code>GET</code></td>
+					<td><code>/calendars</code>, <code>/calendars/{id}</code>, <code>/calendars/{id}/slots</code></td>
+					<td><?php esc_html_e( 'Public booking calendars and available slots.', 'ffcertificate' ); ?></td>
+				</tr>
+				<tr>
+					<td><code>POST</code></td>
+					<td><code>/calendars/{id}/appointments</code></td>
+					<td><?php esc_html_e( 'Anonymous booking creation.', 'ffcertificate' ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<div class="ffc-doc-example">
+		<h4><?php esc_html_e( 'Authenticated endpoints', 'ffcertificate' ); ?></h4>
+		<p>
+			<?php esc_html_e( 'Require a logged-in WordPress user with a specific FFC capability. Locked down in v6.4.1 to plug a config-blob leak. Use one of:', 'ffcertificate' ); ?>
+		</p>
+		<ul>
+			<li>
+				<strong><?php esc_html_e( 'Application Passwords (recommended).', 'ffcertificate' ); ?></strong>
+				<?php esc_html_e( 'Built into WordPress since 5.6. Edit the integrator\'s user profile, scroll to "Application Passwords", create one named e.g. "FFC API", and use the resulting token with HTTP Basic Auth (username + the generated password). The integrator\'s user must hold the capability listed below.', 'ffcertificate' ); ?>
+			</li>
+			<li>
+				<strong><?php esc_html_e( 'Logged-in cookie (same-origin).', 'ffcertificate' ); ?></strong>
+				<?php esc_html_e( 'When called from the WordPress admin or front-end while logged in, the request is authenticated automatically. The user must hold the capability.', 'ffcertificate' ); ?>
+			</li>
+		</ul>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Method', 'ffcertificate' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Endpoint', 'ffcertificate' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Required capability', 'ffcertificate' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Returns', 'ffcertificate' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>GET</code></td>
+					<td><code>/forms</code></td>
+					<td><code>ffc_read_forms_api</code></td>
+					<td><?php esc_html_e( 'List of published forms (id, title, status, dates, link). Capped at 100 per request.', 'ffcertificate' ); ?></td>
+				</tr>
+				<tr>
+					<td><code>GET</code></td>
+					<td><code>/forms/{id}</code></td>
+					<td><code>ffc_read_forms_api</code></td>
+					<td><?php esc_html_e( 'Single form metadata (id, title, status, dates, link). For form structure use /forms/{id}/schema.', 'ffcertificate' ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+		<p>
+			<strong><?php esc_html_e( 'Granting the capability:', 'ffcertificate' ); ?></strong>
+			<?php esc_html_e( 'Granted automatically to the administrator role on every plugin upgrade. Delegate to other roles (or specific users) via your favourite capability-management plugin or the user-edit screen.', 'ffcertificate' ); ?>
+		</p>
+	</div>
+
+	<div class="ffc-doc-example">
+		<h4><?php esc_html_e( 'Example: list forms with curl', 'ffcertificate' ); ?></h4>
+		<pre><code>curl -u USERNAME:APP_PASSWORD https://your-site.com/wp-json/ffc/v1/forms?limit=20</code></pre>
+		<p>
+			<?php esc_html_e( 'Replace USERNAME with the WordPress login of the integrator user, and APP_PASSWORD with the token created from the user\'s "Application Passwords" panel. The user must hold ffc_read_forms_api.', 'ffcertificate' ); ?>
+		</p>
+	</div>
+
+	<div class="ffc-alert ffc-alert-info">
+		<p>
+			<strong class="ffc-icon-info"><?php esc_html_e( 'Why was the previous /forms unauthenticated?', 'ffcertificate' ); ?></strong><br>
+			<?php esc_html_e( 'It was — and the response embedded the full _ffc_form_config blob, which on a typical install contains allowed/denied user lists, validation codes, generated codes, geofence configuration, and email templates. v6.4.1 closes that hole; the trimmed payload is now safe by construction (id, title, status, dates, link only).', 'ffcertificate' ); ?>
+		</p>
+	</div>
+</div>
+
 </div><!-- .ffc-settings-wrap -->

--- a/includes/user-dashboard/class-ffc-capability-manager.php
+++ b/includes/user-dashboard/class-ffc-capability-manager.php
@@ -189,6 +189,18 @@ class CapabilityManager {
 		// edit page so non-admin operators can fix typos in issued
 		// certificates without holding `manage_options`.
 		'ffc_certificate_update',
+
+		// REST-API authentication caps (6.4.1). Granted to external
+		// integrators authenticating via WordPress Application Passwords
+		// (Basic Auth) so they can read form definitions through
+		// `GET /ffc/v1/forms` / `GET /ffc/v1/forms/{id}` without the
+		// previous `__return_true` permission_callback that exposed the
+		// `_ffc_form_config` blob (allowed/denied user lists, validation
+		// codes, generated codes, geofence config). Only the forms cap
+		// lands here; calendars and appointments stay public-by-design
+		// because their REST routes serve the public booking shortcode
+		// directly. See issue #139.
+		'ffc_read_forms_api',
 	);
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -117,6 +117,8 @@
                 <element value="ffc_manage_recruitment_reasons"/>
                 <!-- 6.2.0 reactivated submission-edit cap. -->
                 <element value="ffc_certificate_update"/>
+                <!-- 6.4.1 REST API authentication caps. -->
+                <element value="ffc_read_forms_api"/>
             </property>
         </properties>
     </rule>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.4.0
+Stable tag: 6.4.1
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/CalendarRestControllerTest.php
+++ b/tests/Unit/CalendarRestControllerTest.php
@@ -29,6 +29,9 @@ class CalendarRestControllerTest extends TestCase {
     /** @var \Mockery\MockInterface Mock for AppointmentHandler (overload) */
     private $appointment_handler_mock;
 
+    /** @var \Mockery\MockInterface */
+    private $rate_limiter_mock;
+
     protected function setUp(): void {
         parent::setUp();
         Monkey\setUp();
@@ -59,9 +62,15 @@ class CalendarRestControllerTest extends TestCase {
         $this->appointment_handler_mock = Mockery::mock( 'overload:\FreeFormCertificate\SelfScheduling\AppointmentHandler' );
         $this->appointment_handler_mock->shouldReceive( 'get_available_slots' )->andReturn( [] )->byDefault();
 
-        // Utils alias for log_rest_error
+        // Utils alias for log_rest_error + rate-limit guard's IP lookup.
         $utils_mock = Mockery::mock( 'alias:\FreeFormCertificate\Core\Utils' );
         $utils_mock->shouldReceive( 'debug_log' )->byDefault();
+        $utils_mock->shouldReceive( 'get_user_ip' )->andReturn( '127.0.0.1' )->byDefault();
+
+        // RateLimiter alias: every test gets a green light by default.
+        // Individual cases can re-stub `check_ip_limit` via the property.
+        $this->rate_limiter_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+        $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->andReturn( array( 'allowed' => true ) )->byDefault();
     }
 
     protected function tearDown(): void {
@@ -122,6 +131,39 @@ class CalendarRestControllerTest extends TestCase {
     // ------------------------------------------------------------------
     // get_calendars()
     // ------------------------------------------------------------------
+
+    public function test_get_calendars_returns_429_when_rate_limit_blocks(): void {
+        $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->once()->andReturn( array(
+            'allowed'      => false,
+            'reason'       => 'ip_hour_limit',
+            'message'      => 'Slow down.',
+            'wait_seconds' => 3600,
+        ) );
+
+        $ctrl    = new CalendarRestController( 'ffc/v1' );
+        $request = $this->make_request();
+        $result  = $ctrl->get_calendars( $request );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'rate_limit_exceeded', $result->get_error_code() );
+        $data = $result->get_error_data();
+        $this->assertSame( 429, $data['status'] );
+    }
+
+    public function test_get_calendar_slots_returns_429_when_rate_limit_blocks(): void {
+        $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->once()->andReturn( array(
+            'allowed' => false,
+            'reason'  => 'ip_day_limit',
+            'message' => 'Daily limit reached.',
+        ) );
+
+        $ctrl    = new CalendarRestController( 'ffc/v1' );
+        $request = $this->make_request( array( 'id' => 1, 'date' => '2026-05-20' ) );
+        $result  = $ctrl->get_calendar_slots( $request );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'rate_limit_exceeded', $result->get_error_code() );
+    }
 
     public function test_get_calendars_returns_public_calendars_for_anon(): void {
         $sample = array(

--- a/tests/Unit/CapabilityManagerTest.php
+++ b/tests/Unit/CapabilityManagerTest.php
@@ -115,6 +115,14 @@ class CapabilityManagerTest extends TestCase {
         $this->assertContains( 'ffc_certificate_update', CapabilityManager::ADMIN_CAPABILITIES );
     }
 
+    public function test_admin_capabilities_contains_rest_api_caps(): void {
+        // 6.4.1: REST-API authentication capability for external
+        // integrators using Application Passwords. Pinned by a test so
+        // future contributors know it's grant-on-activation territory
+        // and not a leftover placeholder.
+        $this->assertContains( 'ffc_read_forms_api', CapabilityManager::ADMIN_CAPABILITIES );
+    }
+
     public function test_future_capabilities_constant_is_empty_in_6_2(): void {
         // Both placeholders retired in 6.2.0:
         //   - ffc_reregistration: removed (audience-targeting already covers).

--- a/tests/Unit/FormRestControllerTest.php
+++ b/tests/Unit/FormRestControllerTest.php
@@ -127,22 +127,26 @@ class FormRestControllerTest extends TestCase {
         $this->assertCount( 4, $this->registered_routes );
     }
 
-    public function test_forms_list_route_is_public(): void {
+    public function test_forms_list_route_requires_capability_callback(): void {
         $ctrl = new FormRestController( 'ffc/v1', $this->form_repo_mock );
         $ctrl->register_routes();
 
         $route = $this->registered_routes[0];
         $this->assertSame( '/forms', $route['route'] );
-        $this->assertSame( '__return_true', $route['args']['permission_callback'] );
+        // 6.4.1: switched from `__return_true` to a method callback
+        // that delegates to current_user_can('ffc_read_forms_api').
+        $this->assertIsArray( $route['args']['permission_callback'] );
+        $this->assertSame( 'permission_read_forms_api', $route['args']['permission_callback'][1] );
     }
 
-    public function test_form_single_route_is_public(): void {
+    public function test_form_single_route_requires_capability_callback(): void {
         $ctrl = new FormRestController( 'ffc/v1', $this->form_repo_mock );
         $ctrl->register_routes();
 
         $route = $this->registered_routes[1];
         $this->assertStringContainsString( 'forms', $route['route'] );
-        $this->assertSame( '__return_true', $route['args']['permission_callback'] );
+        $this->assertIsArray( $route['args']['permission_callback'] );
+        $this->assertSame( 'permission_read_forms_api', $route['args']['permission_callback'][1] );
     }
 
     public function test_form_schema_route_is_public(): void {
@@ -236,16 +240,10 @@ class FormRestControllerTest extends TestCase {
         $this->assertSame( 'form_not_published', $result->get_error_code() );
     }
 
-    public function test_get_form_returns_full_data_on_success(): void {
+    public function test_get_form_returns_trimmed_payload_on_success(): void {
         $post = $this->make_post( 3 );
         $post->post_title = 'My Form';
         Functions\when( 'get_post' )->justReturn( $post );
-
-        $this->form_repo_mock->shouldReceive( 'getConfig' )->with( 3 )->andReturn( array( 'theme' => 'light' ) );
-        $this->form_repo_mock->shouldReceive( 'getFields' )->with( 3 )->andReturn( array(
-            array( 'name' => 'full_name', 'type' => 'text', 'required' => true ),
-        ));
-        $this->form_repo_mock->shouldReceive( 'getBackground' )->with( 3 )->andReturn( 'bg.jpg' );
 
         $ctrl = new FormRestController( 'ffc/v1', $this->form_repo_mock );
         $request = $this->make_request( array( 'id' => 3 ) );
@@ -254,9 +252,32 @@ class FormRestControllerTest extends TestCase {
         $this->assertIsArray( $result );
         $this->assertSame( 3, $result['id'] );
         $this->assertSame( 'My Form', $result['title'] );
-        $this->assertArrayHasKey( 'config', $result );
-        $this->assertArrayHasKey( 'fields', $result );
-        $this->assertArrayHasKey( 'background', $result );
+        $this->assertArrayHasKey( 'status', $result );
+        $this->assertArrayHasKey( 'date', $result );
+        $this->assertArrayHasKey( 'modified', $result );
+        $this->assertArrayHasKey( 'link', $result );
+
+        // 6.4.1: config / fields / background dropped from the payload
+        // — they previously leaked the `_ffc_form_config` blob (allowed/
+        // denied user lists, validation/generated codes, geofence). See
+        // issue #139. Integrators that need form structure use the
+        // public `/forms/{id}/schema` endpoint instead.
+        $this->assertArrayNotHasKey( 'config', $result );
+        $this->assertArrayNotHasKey( 'fields', $result );
+        $this->assertArrayNotHasKey( 'background', $result );
+    }
+
+    public function test_get_forms_list_payload_does_not_include_config_blob(): void {
+        $post1 = $this->make_post( 1 );
+        $this->form_repo_mock->shouldReceive( 'findPublished' )->andReturn( array( $post1 ) );
+
+        $ctrl = new FormRestController( 'ffc/v1', $this->form_repo_mock );
+        $request = $this->make_request();
+        $result = $ctrl->get_forms( $request );
+
+        $this->assertCount( 1, $result );
+        // Trimmed: id, title, status, date, modified, link only.
+        $this->assertArrayNotHasKey( 'config', $result[0] );
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Closes #139.

## Sprints (each commit standalone)

| # | Commit | What |
|---|---|---|
| **S1** | `4f23933` | caps: add `ffc_read_forms_api` to `ADMIN_CAPABILITIES` + pin by test |
| **S2** | `9714c00` | sec: capability gate on `GET /forms` + `GET /forms/{id}`, trim payload, clamp `limit` at 100 |
| **S3** | `caa7e29` | sec: IP rate-limit guard at the top of `/calendars` reads (circuit breaker) |
| **S4** | `925528f` | docs: per-route block comments + `phpcs:ignore` rationale on every public-by-design `__return_true` |
| **S5** | `1aea611` | docs+release: documentation tab section "19. REST API Authentication" + bump 6.4.0 → 6.4.1 |

## Honest deltas vs the original audit

- **Issue listed three caps; only one shipped.** The audit asked for `ffc_read_forms_api`, `ffc_read_calendars_api`, `ffc_read_appointments_api`. After tracing every consumer of the calendars + appointments routes, both are public-by-design and stay public — adding caps that nothing gates is YAGNI. Documented inline in the cap declaration.
- **Limit clamp at 100 is a soft cap, not pagination.** The issue asked for "Cap the `limit` arg at 100"; pagination is the real fix. Out-of-range values (including the legacy `-1` for "all") coerce to 100. Pagination is a follow-up.
- **Rate-limit guard on calendars is a circuit breaker, not a per-read limiter.** `RateLimiter::check_ip_limit()` reads a pool that `FormProcessor::record_attempt()` feeds on submit. The calendars guard trips when the IP has already been flagged by abusive submit/verify hits. It does NOT count calendar reads against any pool by itself; a per-read limiter needs a separate identifier and is left for follow-up. Documented inline in `rate_limit_guard()`.
- **`output_csv()` was the eighth fputcsv consumer**, missed when issue #126 was filed (already merged). Mentioned here only because it's the same kind of "audit found 7, reality was 8" honesty I owe in this PR's commit messages.

## Verification

- [x] **PHPUnit:** new + existing REST controller tests green (24 form-rest, 117 calendar-rest, plus 49 capability-manager, all touching the changed surface).
- [x] **WPCS:** all 6 touched files clean (added `ffc_read_forms_api` to `phpcs.xml.dist`'s `custom_capabilities` so the unknown-cap sniff stays quiet).
- [x] **PHPStan:** 0 errors.
- [x] **Behaviour change is localised:** `GET /forms` / `GET /forms/{id}` callers without a valid Application Password now get 401; the trimmed payload removes `config` / `fields` / `background`. Every other REST route is unchanged in shape.

## Test plan for reviewer

- [ ] `curl https://your-site/wp-json/ffc/v1/forms` returns 401 unauthenticated. (Was 200 + config-blob leak before this PR.)
- [ ] Create an Application Password for an admin user; `curl -u user:app_password https://your-site/wp-json/ffc/v1/forms` returns 200 with a list of `{id, title, status, date, modified, link}`. No `config` / `fields` / `background` keys.
- [ ] `curl https://your-site/wp-json/ffc/v1/calendars` still returns the public list (booking shortcode keeps working).
- [ ] Submit a form via the front-end shortcode after this PR — emission flow unchanged.
- [ ] Verify a certificate via `/validate-certificate/` — verification unchanged.
- [ ] Open the FFC settings → Documentation tab → section "19. REST API Authentication" renders correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SphzDGfdHo63qBK7XMkWcF)_