### PR TITLE
[Perf] idx_created + audience-booking FOR UPDATE + chunked CSV + cron cleanup (closes #144, v6.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.5.0] (2026-05-10)
+
+**Performance and stability (#144).** Three real implementations + three "already done in earlier releases" honest no-ops + one deferred-as-follow-up. Minor bump because the migration adds indexes on existing tables and changes the `create()` invariant on audience bookings (now atomic).
+
+### Added
+
+- **`Activator::maybe_add_perf_indexes()` (#144 S1).** Adds `KEY idx_created (created_at)` to `ffc_recruitment_candidate`, `ffc_recruitment_notice`, and `ffc_reregistration_submissions` on installs that didn't have them. Idempotent — gated on `ffc_perf_indexes_db_version` keyed to `FFC_VERSION`. Hooked from `Loader::init_plugin()` so existing installs pick up the indexes on next page load. The audit also asked about `idx_updated` / other tables; investigation showed `ffc_activity_log`, `ffc_rate_limit_logs`, `ffc_device_signals` already declare `idx_created`, and tables like `ffc_user_profiles` have no query orders/filters on `created_at` — adding indexes there would be pure write overhead, so left alone.
+- **`ReregistrationSubmissionRepository::stream_for_export()` (#144 S5).** Generator yielding rows in 500-row chunks, used by `ReregistrationCsvExporter` instead of materialising the full result set. Bounded memory for 50k+ row exports.
+- **Cron `cleanup_stale_export_jobs()` (#144 S6).** Hooked into the existing `ffcertificate_daily_cleanup_hook`, walks `_transient_ffc_csv_export_*` and `_transient_ffc_public_csv_*` rows in `wp_options`, unlinks the temp CSV files referenced in the payload, deletes the transient. Reclaims disk space + DB rows from CSV exports the user abandoned mid-flight.
+
+### Changed
+
+- **`AudienceBookingRepository::create()` is now atomic (#144 S2).** Conflict-check + insert run inside a `START TRANSACTION ... COMMIT` block, with a `SELECT ... FOR UPDATE` on the conflict predicate. Before this commit, two concurrent requests for the same `(environment, date, time)` slot could both pass the conflict check (no row existed yet) and both insert. The `idx_env_date_status` index already declared on the table gives InnoDB the row + gap locks needed to block concurrent inserts in the locked range. Mirrors the pattern at `SelfSchedulingAppointmentHandler::create_or_update():140`.
+
+### Honest no-ops (audit findings already implemented)
+
+- **#144 S4 — N+1 in admin user columns:** already batch-loaded since v4.9.7 (`load_certificate_counts`, `load_appointment_counts`, `load_recruitment_notice_counts`). Three GROUP BY queries per page render, regardless of user count.
+- **#144 S7 — Activity log pagination:** already implemented; `class-ffc-admin-activity-log-page.php` uses `$per_page = 50` (smaller than the requested LIMIT 100) and `$total_pages` for navigation. Export path keeps the full dump (`limit => 999999`).
+- **#144 S8 — Conditional asset enqueue:** every public-frontend `wp_enqueue_scripts` hook in the plugin already gates on `has_shortcode()` against the rendered post content (or enqueues from inside the shortcode's `render()`). No unconditional enqueue exists.
+
+### Deferred to follow-up
+
+- **#144 S3 — Async ficha generation via Action Scheduler:** the work requires bundling Action Scheduler (~150 LOC + two custom tables + a new admin page) which is a wider surface than this PR's scope. Tracked as #148.
+
+---
+
 ## [6.4.1] (2026-05-10)
 
 **REST API lockdown (#139).** Plugs a config-blob leak in the public REST surface and adds a circuit-breaker on the public booking calendars. `GET /wp-json/ffc/v1/forms` and `GET /wp-json/ffc/v1/forms/{id}` previously carried `permission_callback => '__return_true'` and returned the full `_ffc_form_config` blob — which on a typical install contains `allowed_users_list`, `denied_users_list`, `validation_code`, `generated_codes_list`, `geo_areas`, `geo_ip_area_location_ids`, `email_body`, `email_subject`. Anyone with the public REST URL could enumerate every form's gating policy.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.4.1
+ * Version:            6.5.0
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.4.1' );                // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.5.0' );                // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/admin/class-ffc-csv-exporter.php
+++ b/includes/admin/class-ffc-csv-exporter.php
@@ -358,6 +358,67 @@ class CsvExporter {
 		exit;
 	}
 
+	/**
+	 * Daily cleanup: remove temp CSV files + transient option rows
+	 * left behind by exports the user abandoned mid-stream (closed
+	 * the browser before clicking the download link, lost network,
+	 * etc.). Walks both `_transient_ffc_csv_export_*` (admin) and
+	 * `_transient_ffc_public_csv_*` (front-end) prefixes; for each
+	 * row whose `_transient_timeout_*` is past, unlinks the temp
+	 * file referenced in the payload and deletes the option pair.
+	 *
+	 * Hooked from {@see Loader::define_admin_hooks()} to
+	 * `ffcertificate_daily_cleanup_hook` (existing daily cron).
+	 *
+	 * @since 6.5.0
+	 * @return int Number of stale jobs reclaimed.
+	 */
+	public static function cleanup_stale_export_jobs(): int {
+		global $wpdb;
+
+		$prefixes = array(
+			'_transient_timeout_ffc_csv_export_',
+			'_transient_timeout_ffc_public_csv_',
+		);
+
+		$now      = time();
+		$reclaimed = 0;
+
+		foreach ( $prefixes as $timeout_prefix ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+					$wpdb->esc_like( $timeout_prefix ) . '%'
+				)
+			);
+			if ( empty( $rows ) ) {
+				continue;
+			}
+			foreach ( $rows as $row ) {
+				$expires_at = (int) $row->option_value;
+				if ( $expires_at > $now ) {
+					continue; // Still within TTL — leave it.
+				}
+
+				$transient_key = (string) preg_replace( '/^_transient_timeout_/', '', $row->option_name );
+
+				// Read the payload BEFORE deleting so we can unlink
+				// the temp file the abandoned job left on disk.
+				$job = get_option( '_transient_' . $transient_key );
+				if ( is_array( $job ) && ! empty( $job['file'] ) && file_exists( $job['file'] ) ) {
+                    // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+					unlink( $job['file'] );
+				}
+
+				delete_transient( $transient_key );
+				++$reclaimed;
+			}
+		}
+
+		return $reclaimed;
+	}
+
 	// ──────────────────────────────────────────────────────────────.
 	// Legacy entry point (kept for backwards compat)
 	// ──────────────────────────────────────────────────────────────.

--- a/includes/admin/class-ffc-csv-exporter.php
+++ b/includes/admin/class-ffc-csv-exporter.php
@@ -381,7 +381,7 @@ class CsvExporter {
 			'_transient_timeout_ffc_public_csv_',
 		);
 
-		$now      = time();
+		$now       = time();
 		$reclaimed = 0;
 
 		foreach ( $prefixes as $timeout_prefix ) {

--- a/includes/audience/class-ffc-audience-booking-repository.php
+++ b/includes/audience/class-ffc-audience-booking-repository.php
@@ -362,6 +362,30 @@ class AudienceBookingRepository {
 			return false;
 		}
 
+		// Race protection: conflict-check + insert run inside a single
+		// transaction so two concurrent requests for the same slot can't
+		// both pass the check and both insert. Mirrors the pattern at
+		// `SelfSchedulingAppointmentHandler::create_or_update():140`.
+		// `idx_env_date_status (environment_id, booking_date, status)`
+		// (declared on the table) lets InnoDB take row + gap locks on the
+		// matched range so the second transaction blocks until the first
+		// commits. The REST layer still calls `get_conflicts()` first for
+		// a friendly error, but this is the authoritative check.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'START TRANSACTION' );
+
+		$conflicts = self::get_conflicts_for_update(
+			(int) $data['environment_id'],
+			(string) $data['booking_date'],
+			(string) $data['start_time'],
+			(string) $data['end_time']
+		);
+		if ( ! empty( $conflicts ) ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query( 'ROLLBACK' );
+			return false;
+		}
+
 		$result = $wpdb->insert(
 			$table,
 			array(
@@ -379,10 +403,15 @@ class AudienceBookingRepository {
 		);
 
 		if ( ! $result ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
-		$booking_id = $wpdb->insert_id;
+		$booking_id = (int) $wpdb->insert_id;
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'COMMIT' );
 
 		// Add audience associations if provided.
 		if ( isset( $data['audience_ids'] ) && is_array( $data['audience_ids'] ) ) {
@@ -399,6 +428,52 @@ class AudienceBookingRepository {
 		}
 
 		return $booking_id;
+	}
+
+	/**
+	 * Conflict-check used by {@see self::create()} inside a transaction.
+	 * Identical predicate to {@see self::get_conflicts()} but with the
+	 * `FOR UPDATE` row + gap lock that prevents concurrent inserts in
+	 * the same `(environment_id, booking_date)` range from completing
+	 * until the holding transaction commits. Must run inside a
+	 * `START TRANSACTION ... COMMIT` block.
+	 *
+	 * @since 6.5.0
+	 * @param int    $environment_id Environment ID.
+	 * @param string $date           Booking date (Y-m-d).
+	 * @param string $start_time     Start time (H:i).
+	 * @param string $end_time       End time (H:i).
+	 * @return array<int, mixed>
+	 */
+	private static function get_conflicts_for_update( int $environment_id, string $date, string $start_time, string $end_time ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id FROM %i
+                WHERE environment_id = %d
+                AND booking_date = %s
+                AND status = 'active'
+                AND (
+                    (start_time < %s AND end_time > %s) OR
+                    (start_time >= %s AND start_time < %s) OR
+                    (end_time > %s AND end_time <= %s)
+                )
+                FOR UPDATE",
+				$table,
+				$environment_id,
+				$date,
+				$end_time,
+				$start_time,
+				$start_time,
+				$end_time,
+				$start_time,
+				$end_time
+			)
+		);
+		return is_array( $results ) ? $results : array();
 	}
 
 	/**

--- a/includes/class-ffc-activator.php
+++ b/includes/class-ffc-activator.php
@@ -154,6 +154,55 @@ class Activator {
 	}
 
 	/**
+	 * Idempotently add `idx_created` indexes to FFC custom tables that
+	 * order/filter on `created_at` but did not declare the index in
+	 * their CREATE TABLE statement. Runs once per `FFC_VERSION`.
+	 *
+	 * Concrete benefit:
+	 *   - `ffc_recruitment_candidate.created_at`: every admin candidate
+	 *     listing and every adjutancy-keyed search runs `ORDER BY created_at
+	 *     DESC` — without an index this is a full-table sort on the
+	 *     entire candidate roster.
+	 *   - `ffc_recruitment_notice.created_at`: smaller table, but the
+	 *     notice list page runs `ORDER BY created_at DESC` on every render.
+	 *   - `ffc_reregistration_submissions.created_at`: secondary sort
+	 *     after `r.start_date DESC` in the submissions list join.
+	 *
+	 * Tables intentionally NOT touched by this migration:
+	 *   - `ffc_activity_log`, `ffc_rate_limit_logs`, `ffc_device_signals`
+	 *     already declare `idx_created` in their CREATE TABLE.
+	 *   - `ffc_user_profiles`, `ffc_custom_fields`, `ffc_audience_*`,
+	 *     `ffc_audiences` have `created_at` columns but no query
+	 *     orders/filters on them — adding an index there would be pure
+	 *     write overhead.
+	 *
+	 * @since 6.5.0
+	 * @return void
+	 */
+	public static function maybe_add_perf_indexes(): void {
+		$stored = get_option( 'ffc_perf_indexes_db_version', '' );
+
+		if ( FFC_VERSION === $stored ) {
+			return;
+		}
+
+		global $wpdb;
+		$tables_with_idx_created = array(
+			$wpdb->prefix . 'ffc_recruitment_candidate',
+			$wpdb->prefix . 'ffc_recruitment_notice',
+			$wpdb->prefix . 'ffc_reregistration_submissions',
+		);
+
+		foreach ( $tables_with_idx_created as $table ) {
+			if ( self::table_exists( $table ) ) {
+				self::add_index_if_missing( $table, 'idx_created', '(created_at)' );
+			}
+		}
+
+		update_option( 'ffc_perf_indexes_db_version', FFC_VERSION, true );
+	}
+
+	/**
 	 * Add columns.
 	 */
 	private static function add_columns(): void {
@@ -581,7 +630,8 @@ class Activator {
             PRIMARY KEY (id),
             UNIQUE KEY idx_reregistration_user (reregistration_id, user_id),
             KEY idx_user_id (user_id),
-            KEY idx_status (status)
+            KEY idx_status (status),
+            KEY idx_created (created_at)
         ) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -169,6 +169,11 @@ class Loader {
 		// Ensure submissions table schema is current (runs add_columns on version change).
 		\FreeFormCertificate\Activator::maybe_add_columns();
 
+		// 6.5.0: idx_created on candidate / notice / reregistration_submissions
+		// for ORDER BY created_at queries (issue #144 S1). Idempotent — gated
+		// on FFC_VERSION so the ALTER TABLE runs once per release.
+		\FreeFormCertificate\Activator::maybe_add_perf_indexes();
+
 		// Ensure rate-limit tables (incl. ffc_device_signals added in 6.3.0) exist
 		// even after in-place plugin updates that bypass register_activation_hook.
 		if ( class_exists( '\FreeFormCertificate\Security\RateLimitActivator' ) ) {

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -436,9 +436,15 @@ class Loader {
 		);
 		// 6.5.0: scrub stale CSV-export temp files + transient rows
 		// left behind by users who abandoned an export mid-flight (#144 S6).
+		// Wrapped in a void closure because cleanup_stale_export_jobs()
+		// returns an int (count of reclaimed jobs) — useful for logging
+		// or programmatic invocation, but action callbacks must return
+		// void per PHPStan's `return.void` rule.
 		add_action(
 			'ffcertificate_daily_cleanup_hook',
-			array( \FreeFormCertificate\Admin\CsvExporter::class, 'cleanup_stale_export_jobs' )
+			static function (): void {
+				\FreeFormCertificate\Admin\CsvExporter::cleanup_stale_export_jobs();
+			}
 		);
 		add_action( 'ffcertificate_reregistration_expire_hook', array( ReregistrationRepository::class, 'expire_overdue' ) );
 		add_action( 'ffcertificate_reregistration_expire_hook', array( ReregistrationEmailHandler::class, 'run_automated_reminders' ) );

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -434,6 +434,12 @@ class Loader {
 				$this->submission_handler->run_data_cleanup();
 			}
 		);
+		// 6.5.0: scrub stale CSV-export temp files + transient rows
+		// left behind by users who abandoned an export mid-flight (#144 S6).
+		add_action(
+			'ffcertificate_daily_cleanup_hook',
+			array( \FreeFormCertificate\Admin\CsvExporter::class, 'cleanup_stale_export_jobs' )
+		);
 		add_action( 'ffcertificate_reregistration_expire_hook', array( ReregistrationRepository::class, 'expire_overdue' ) );
 		add_action( 'ffcertificate_reregistration_expire_hook', array( ReregistrationEmailHandler::class, 'run_automated_reminders' ) );
 	}

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -355,7 +355,8 @@ class RecruitmentActivator {
             updated_at datetime NOT NULL,
             PRIMARY KEY (id),
             UNIQUE KEY uq_code (code),
-            KEY idx_status (status)
+            KEY idx_status (status),
+            KEY idx_created (created_at)
         ) ENGINE=InnoDB {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -442,7 +443,8 @@ class RecruitmentActivator {
             UNIQUE KEY uq_cpf_hash (cpf_hash),
             UNIQUE KEY uq_rf_hash (rf_hash),
             KEY idx_email_hash (email_hash),
-            KEY idx_user_id (user_id)
+            KEY idx_user_id (user_id),
+            KEY idx_created (created_at)
         ) ENGINE=InnoDB {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/reregistration/class-ffc-reregistration-csv-exporter.php
+++ b/includes/reregistration/class-ffc-reregistration-csv-exporter.php
@@ -48,7 +48,10 @@ class ReregistrationCsvExporter {
 			return;
 		}
 
-		$submissions = ReregistrationSubmissionRepository::get_for_export( $id );
+		// Stream submissions in chunks of 500 so a 50k-row reregistration
+		// stays memory-bounded. The generator pipes straight into the
+		// CSV writer below without materialising the full result set.
+		$submissions = ReregistrationSubmissionRepository::stream_for_export( $id );
 		$fields      = self::get_custom_fields_for_reregistration( $rereg );
 
 		// Build CSV.

--- a/includes/reregistration/class-ffc-reregistration-submission-repository.php
+++ b/includes/reregistration/class-ffc-reregistration-submission-repository.php
@@ -609,7 +609,7 @@ class ReregistrationSubmissionRepository {
 	 * @param int                  $reregistration_id Reregistration ID.
 	 * @param array<string, mixed> $filters           Filters (status, search, orderby, order).
 	 * @param int                  $chunk_size        Rows per database round-trip.
-	 * @return \Generator<int, object>
+	 * @return \Generator<int, ReregistrationSubmissionRow>
 	 */
 	public static function stream_for_export( int $reregistration_id, array $filters = array(), int $chunk_size = 500 ): \Generator {
 		$offset = 0;

--- a/includes/reregistration/class-ffc-reregistration-submission-repository.php
+++ b/includes/reregistration/class-ffc-reregistration-submission-repository.php
@@ -601,6 +601,36 @@ class ReregistrationSubmissionRepository {
 	}
 
 	/**
+	 * Stream submissions for CSV export in chunks of $chunk_size rows
+	 * to keep memory bounded for large reregistrations. Yields rows
+	 * one at a time so the caller can pipe into `Csv::writer->rows()`.
+	 *
+	 * @since 6.5.0
+	 * @param int                  $reregistration_id Reregistration ID.
+	 * @param array<string, mixed> $filters           Filters (status, search, orderby, order).
+	 * @param int                  $chunk_size        Rows per database round-trip.
+	 * @return \Generator<int, object>
+	 */
+	public static function stream_for_export( int $reregistration_id, array $filters = array(), int $chunk_size = 500 ): \Generator {
+		$offset = 0;
+		while ( true ) {
+			$filters['limit']  = $chunk_size;
+			$filters['offset'] = $offset;
+			$rows              = self::get_by_reregistration( $reregistration_id, $filters );
+			if ( empty( $rows ) ) {
+				return;
+			}
+			foreach ( $rows as $row ) {
+				yield $row;
+			}
+			if ( count( $rows ) < $chunk_size ) {
+				return;
+			}
+			$offset += $chunk_size;
+		}
+	}
+
+	/**
 	 * Create pending submissions for all affected users of a reregistration.
 	 *
 	 * Skips users who already have a submission for this reregistration.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.4.1
+Stable tag: 6.5.0
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/AudienceBookingRepositoryTest.php
+++ b/tests/Unit/AudienceBookingRepositoryTest.php
@@ -58,6 +58,15 @@ class AudienceBookingRepositoryTest extends TestCase {
         $this->wpdb->shouldReceive('prepare')->andReturnUsing(function() {
             return func_get_args()[0];
         })->byDefault();
+
+        // 6.5.0: create() now wraps conflict-check + insert in a
+        // START TRANSACTION ... COMMIT block (#144 S2). Default the
+        // transaction primitives + the inner FOR UPDATE select to
+        // no-op success so existing create() tests keep passing
+        // without per-test ceremony. Tests exercising the conflict
+        // path can override.
+        $this->wpdb->shouldReceive('query')->byDefault();
+        $this->wpdb->shouldReceive('get_results')->andReturn([])->byDefault();
     }
 
     protected function tearDown(): void {
@@ -613,6 +622,49 @@ class AudienceBookingRepositoryTest extends TestCase {
         ]);
 
         $this->assertFalse($result);
+    }
+
+    public function test_create_aborts_when_for_update_finds_conflict(): void {
+        // Override the default no-conflict get_results stub: simulate
+        // the SELECT ... FOR UPDATE returning an existing booking, so
+        // create() must roll back without inserting.
+        $this->wpdb->shouldReceive('get_results')->once()->andReturn(array(
+            (object) array( 'id' => 99 ),
+        ));
+        $this->wpdb->shouldNotReceive('insert');
+
+        $result = AudienceBookingRepository::create([
+            'environment_id' => 5,
+            'booking_date' => '2026-03-15',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'description' => 'Concurrent attempt',
+        ]);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_create_runs_inside_a_transaction(): void {
+        $this->wpdb->insert_id = 12;
+        $this->wpdb->shouldReceive('insert')->once()->andReturn(1);
+
+        $captured_queries = array();
+        $this->wpdb->shouldReceive('query')->andReturnUsing(function ($sql) use (&$captured_queries) {
+            $captured_queries[] = (string) $sql;
+            return 1;
+        });
+
+        AudienceBookingRepository::create([
+            'environment_id' => 5,
+            'booking_date' => '2026-03-15',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'description' => 'Booked safely',
+        ]);
+
+        $this->assertContains('START TRANSACTION', $captured_queries);
+        $this->assertContains('COMMIT', $captured_queries);
+        $this->assertNotContains('ROLLBACK', $captured_queries);
     }
 
     public function test_create_uses_defaults(): void {


### PR DESCRIPTION
Closes #144. Spawned #148 for the deferred S3.

## Sprints

| # | Commit | Status |
|---|---|---|
| **S1** | `d5c8e1d` | ✅ `idx_created` on candidate / notice / reregistration_submissions |
| **S2** | `4a5a217` | ✅ `START TRANSACTION` + `FOR UPDATE` in `AudienceBookingRepository::create()` |
| **S3** | (deferred) | ⏭️ Action Scheduler async ficha — moved to **#148** |
| **S4** | (no-op) | ✅ N+1 already eliminated in v4.9.7 batch GROUP BY |
| **S5** | `c5fdafb` | ✅ `stream_for_export()` generator on reregistration CSV (500-row chunks) |
| **S6** | `72bb30c` | ✅ daily cron `cleanup_stale_export_jobs()` for transients + temp files |
| **S7** | (no-op) | ✅ activity log already paginated (`$per_page = 50`) |
| **S8** | (no-op) | ✅ frontend enqueues already gated on `has_shortcode()` |
| **rel** | `c50ac73` | ✅ bump 6.4.1 → 6.5.0 + CHANGELOG + static-analysis fixups |

## Honest deltas vs the original audit

- **3 of the 8 "sprints" were stale audit findings.** S4 was implemented in v4.9.7 (batch GROUP BY caches in `AdminUserColumns`). S7 was already done (`$per_page = 50`, smaller than the issue's "LIMIT 100" target). S8 was already done (every public-frontend enqueue gates on `has_shortcode()` — `class-ffc-frontend.php:104`, `class-ffc-audience-loader.php:260`, `class-ffc-self-scheduling-shortcode.php:60`, etc.). All three documented in the CHANGELOG with pointers to the existing implementations.
- **S1 narrowed from "all custom tables" to 3 targets.** The audit listed `ffc_user_profiles, ffc_audience_*, ffc_reregistrations, ffc_recruitment_*`. Investigation showed `ffc_activity_log`, `ffc_rate_limit_logs`, `ffc_device_signals` already declare `idx_created`; `ffc_user_profiles` / `ffc_audience_*` / `ffc_audiences` have `created_at` columns but no query orders/filters on them. Indexing those would be pure write overhead. Real targets: `ffc_recruitment_candidate` (admin listing's `ORDER BY created_at DESC`), `ffc_recruitment_notice`, `ffc_reregistration_submissions`. `idx_updated` not added anywhere — no callsite orders on `updated_at`.
- **S5 scope narrowed to reregistration only.** `PublicCsvExporter` and admin `CsvExporter` already use cursor pagination (50 rows/batch). `SelfSchedulingAppointmentCsvExporter` does dynamic-column discovery via `get_dynamic_columns($rows)` — it must see all rows before writing the header, so a clean streaming conversion needs a two-pass query (one for keys, one for rows). Deferred from this PR; reregistration converts cleanly because the column set is fixed.
- **S2 implementation is real.** Confirmed race condition: `get_conflicts()` in REST + `create()` in repository ran as two non-transactional steps. Fix wraps both inside `START TRANSACTION ... COMMIT` with `SELECT ... FOR UPDATE` on the conflict predicate. The existing `idx_env_date_status (environment_id, booking_date, status)` index gives InnoDB the row + gap locks needed to block concurrent inserts.
- **S3 spun off to #148.** Action Scheduler bundling is ~150 LOC + two custom tables + a new admin page + cron discipline operators need to learn. Wider surface than this PR deserves; tracked separately.

## Verification

- [x] **PHPUnit:** new + existing tests green (95 audience booking, 81 reregistration submission/repo, full suite.)
- [x] **PHPStan:** 0 errors.
- [x] **WPCS:** clean on all 7 touched files.
- [x] **Migration idempotent:** `maybe_add_perf_indexes()` keys on `ffc_perf_indexes_db_version` against `FFC_VERSION`. `add_index_if_missing()` already short-circuits when the index exists.

## Test plan for reviewer

- [ ] Activate the plugin on an install that's been running pre-6.5.0; verify `SHOW INDEX FROM wp_ffc_recruitment_candidate;` lists `idx_created`.
- [ ] Concurrent booking test: open two terminals, fire two `POST /wp-json/ffc/v1/calendars/{id}/appointments` for the same slot simultaneously — exactly one should succeed, the other gets a conflict response.
- [ ] Re-run with `EXPLAIN SELECT * FROM wp_ffc_recruitment_candidate ORDER BY created_at DESC LIMIT 50;` → key column shows `idx_created`.
- [ ] Run a 10k+ row reregistration CSV export — observe memory profile in Query Monitor / xdebug; should stay flat (~32MB) instead of climbing.
- [ ] Wait for / fake `ffcertificate_daily_cleanup_hook` invocation; verify abandoned export temp files in `wp-content/uploads/` get unlinked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SphzDGfdHo63qBK7XMkWcF)_