### PR TITLE
fix: persist CSV-download and device-limit metaboxes when geofence is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Form editor: groups 7 (Public CSV Download) and 8 (Device Fingerprint Limit) silently failed to save when the geofence config (group 6) had validation errors.** `FormEditorSaveHandler::save_form_data()` returned early after surfacing the geofence error transient, aborting the rest of the save pipeline. The validation error still surfaces via the transient, but the geofence meta is now simply skipped while CSV-download and device-limit sections continue to persist their changes.
+
 ---
 
 ## [6.5.2] (2026-05-10)

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -163,14 +163,15 @@ class FormEditorSaveHandler {
 				'msg_geo_error'            => sanitize_textarea_field( $geofence['msg_geo_error'] ?? '' ),
 			);
 
-			// Validate geolocation configuration.
+			// Validate geolocation configuration. Surface errors via transient,
+			// but do not abort — independent sections (CSV download, device
+			// fingerprint limit) must still persist their own changes.
 			$validation_errors = $this->validate_geofence_config( $clean_geofence );
 			if ( ! empty( $validation_errors ) ) {
 				set_transient( 'ffc_geofence_error_' . get_current_user_id(), $validation_errors, 45 );
-				return;
+			} else {
+				update_post_meta( $post_id, '_ffc_geofence_config', $clean_geofence );
 			}
-
-			update_post_meta( $post_id, '_ffc_geofence_config', $clean_geofence );
 		}
 
 		// 4. Save Public CSV Download configuration.


### PR DESCRIPTION
## Summary

- Reported: in the certificate form editor, edits to **group 7 (Public CSV Download)** and **group 8 (Device Fingerprint Limit)** were silently discarded on save.
- Root cause: `FormEditorSaveHandler::save_form_data()` (`includes/admin/class-ffc-form-editor-save-handler.php:170`) `return`ed early right after writing the geofence error transient, aborting the rest of the save pipeline. Sections 4 (CSV) and 5 (device limit) never executed whenever the geofence config (group 6) had any validation error — e.g., GPS enabled but no areas defined.
- Fix: keep surfacing the geofence error via the transient, but skip only the geofence `update_post_meta` call instead of returning. The independent CSV-download and device-limit sections now persist normally regardless of geofence validity.

## Test plan

- [x] `vendor/bin/phpunit --filter FormEditorSaveHandlerTest` → 24/24 pass (existing geofence-validation unit tests unaffected).
- [ ] Manual: open a certificate form with an invalid geofence (e.g., GPS toggle ON, no areas), modify a field in group 7 and group 8, click Update, and confirm the values persist while the geofence error notice still appears.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_