### PR TITLE
fix: persist toggle-off + explicit "none" CPF mode in form editor groups 7/8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Form editor: groups 7 (Public CSV Download) and 8 (Device Fingerprint Limit) silently failed to save when the geofence config (group 6) had validation errors.** `FormEditorSaveHandler::save_form_data()` returned early after surfacing the geofence error transient, aborting the rest of the save pipeline. The validation error still surfaces via the transient, but the geofence meta is now simply skipped while CSV-download and device-limit sections continue to persist their changes.
+- **Form editor: turning the Public CSV Download (group 7) or Device Fingerprint Limit (group 8) toggle OFF did not persist.** The browser strips unchecked checkboxes from the POST and the admin JS also disables every sub-field on uncheck, so the entire `ffc_csv_public` / `ffc_device_limit` array vanished from `$_POST` and the save handler's `isset()` guard skipped the block — leaving `_ffc_csv_public_enabled` / `_ffc_device_limit_enabled` stuck at `'1'`. Each metabox now emits a hidden `[present]=1` marker outside the `<table>` (out of reach of both the sub-field disable JS and the globally-off disable), so the array is always submitted and the save handler always sees the user's intent to disable.
+- **Form editor: explicitly choosing "No — only Form ID + Hash" for the public CSV CPF gate silently reverted to "Audit".** `FormEditorSaveHandler::save_form_data()` unconditionally coerced `'none' → 'audit'` on every save, masking the user's choice. Coercion now only applies on the very first enable transition (toggle flipping `0 → 1` while the dropdown is at the default `'none'`); on later saves the user's explicit selection sticks.
 
 ---
 

--- a/includes/admin/class-ffc-form-editor-metabox-renderer.php
+++ b/includes/admin/class-ffc-form-editor-metabox-renderer.php
@@ -888,6 +888,7 @@ class FormEditorMetaboxRenderer {
 			<?php esc_html_e( 'Allow a person without WordPress access to download the submissions CSV for this form by providing the Form ID + a hash on a public page that contains the [ffc_csv_download] shortcode.', 'ffcertificate' ); ?>
 		</p>
 
+		<input type="hidden" name="ffc_csv_public[present]" value="1">
 		<table class="form-table ffc-csv-public-table<?php echo $sub_disabled ? ' ffc-csv-public-disabled' : ''; ?>">
 			<tr>
 				<th scope="row">
@@ -1176,6 +1177,7 @@ class FormEditorMetaboxRenderer {
 			</p>
 		<?php endif; ?>
 
+		<input type="hidden" name="ffc_device_limit[present]" value="1">
 		<table class="<?php echo esc_attr( implode( ' ', $table_classes ) ); ?>">
 			<tr>
 				<th scope="row">

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -180,7 +180,8 @@ class FormEditorSaveHandler {
             // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Each key sanitized individually.
 			$public_raw = wp_unslash( $_POST['ffc_csv_public'] );
 
-			$enabled = ! empty( $public_raw['enabled'] ) ? '1' : '0';
+			$previous_enabled = (string) get_post_meta( $post_id, '_ffc_csv_public_enabled', true );
+			$enabled          = ! empty( $public_raw['enabled'] ) ? '1' : '0';
 			update_post_meta( $post_id, '_ffc_csv_public_enabled', $enabled );
 
 			// When the master toggle is off, the sub-fields are rendered
@@ -219,15 +220,18 @@ class FormEditorSaveHandler {
 					update_post_meta( $post_id, '_ffc_csv_public_count', 0 );
 				}
 
-				// CPF gate mode for the public download. When the persisted
-				// mode is empty/'none', default to 'audit' so newly-enabled
-				// public downloads always log who pulled them.
+				// CPF gate mode for the public download. On the very first
+				// enable transition (toggle just flipped 0→1) and the user
+				// left the dropdown at the 'none' default, upgrade to 'audit'
+				// so newly-enabled public downloads always log who pulled
+				// them. On subsequent saves, respect the user's explicit
+				// choice — including 'none' if they actively pick it.
 				$valid_modes = array( 'none', 'audit', 'participants', 'owner', 'whitelist' );
 				$mode_raw    = isset( $public_raw['cpf_mode'] ) ? sanitize_key( (string) $public_raw['cpf_mode'] ) : 'none';
 				if ( ! in_array( $mode_raw, $valid_modes, true ) ) {
 					$mode_raw = 'none';
 				}
-				if ( 'none' === $mode_raw ) {
+				if ( '1' !== $previous_enabled && 'none' === $mode_raw ) {
 					$mode_raw = 'audit';
 				}
 				update_post_meta( $post_id, '_ffc_csv_public_cpf_mode', $mode_raw );


### PR DESCRIPTION
## Summary

Follow-up to #152 — the user reported two further save bugs in the certificate form editor's metaboxes 7 (Public CSV Download) and 8 (Device Fingerprint Limit):

> Quando as opções (7 e/ou 8) estão marcadas e eu salvo, tudo corre bem; mas quando estão habilitadas e eu desmarco (desabilito), isso não é salvo. Em 7 também não salva quando eu mudo o modo de auditoria para outro modo.

### Bug 1 — Toggle-off doesn't persist

When the master toggle is initially ON and the user unchecks it:

- The unchecked checkbox is stripped from the POST by the browser.
- `assets/js/ffc-admin.js:461,478` additionally disables every `.ffc-csv-public-sub :input` / `.ffc-device-limit-sub :input` on change, so all sub-fields are also stripped.
- For the device-limit table, `assets/js/ffc-admin.js:482` disables **every** input in the table when the global subsystem is off.
- Result: `$_POST['ffc_csv_public']` / `$_POST['ffc_device_limit']` is entirely absent, and the wrapping `if ( isset(...) )` in `FormEditorSaveHandler::save_form_data()` skips the block — `_ffc_csv_public_enabled` / `_ffc_device_limit_enabled` stays at `'1'`.

**Fix:** emit a hidden `[present]=1` marker **outside** each metabox's `<table>` (so neither the sub-field disable handler nor the device-table globally-off disable touches it). The array is now always submitted and the handler reliably writes `enabled='0'` on uncheck.

### Bug 2 — Explicit "none" CPF mode reverts to "audit"

`save-handler` lines 229-231 force-coerced `'none' → 'audit'` on **every** save, masking the user's explicit choice. The intent (auto-upgrade on first enable so newly-enabled downloads always log who pulls them) is preserved by gating the coercion on the previous `_ffc_csv_public_enabled` value: only when the toggle just transitioned `0 → 1` does `'none'` become `'audit'`. On all subsequent saves the user's explicit selection sticks.

## Test plan

- [x] `vendor/bin/phpunit` — full suite, 3870 tests / 9810 assertions, 0 failures.
- [x] `vendor/bin/phpunit --filter FormEditorSaveHandlerTest` — 24/24 pass.
- [ ] Manual: enable group 7, save, then uncheck and save → `_ffc_csv_public_enabled` becomes `'0'` and the metabox renders disabled on reload.
- [ ] Manual: enable group 8, save, then uncheck and save → `_ffc_device_limit_enabled` becomes `'0'`.
- [ ] Manual: with group 7 already enabled, change CPF mode dropdown from "Audit" to "No — only Form ID + Hash" and save → `_ffc_csv_public_cpf_mode` persists as `'none'` (and reload reflects "No"). 
- [ ] Manual: enable group 7 for the first time leaving the dropdown on the default → mode is auto-upgraded to `'audit'` (preserves original intent).

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_