### PR TITLE
Sprint L: exclude architecturally-untestable JS from coverage (#165)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,10 +33,13 @@ jobs:
     # ffc-geofence-admin.js shipped via #160 (S2 of #161).
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
-      # Ratcheted from 3 → 6 in S4 of #163 after the dashboard-panel tests
-      # brought overall line coverage from 3.78% to 7.37%. Bump again when
-      # a future PR genuinely improves the number.
-      JS_COVERAGE_FLOOR_LINES: '6'
+      # Ratcheted 3 → 6 in S4 of #163 (panel tests pushed coverage to 7.37%),
+      # then 6 → 7 in #165 (architectural exclusions cleaned the denominator,
+      # pushing the same covered LOC to 8.67% over the active surface). The
+      # ~1.7% buffer below the current baseline catches a real regression
+      # without firing on minor flux. Bump again whenever a PR genuinely
+      # improves the number.
+      JS_COVERAGE_FLOOR_LINES: '7'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -19,6 +19,17 @@ export default defineConfig({
 			exclude: [
 				'assets/js/*.min.js',
 				'assets/js/*.min.js.map',
+
+				// Architecturally-excluded from coverage (#165 / Sprint L).
+				// Each entry has a structural reason for not being tested
+				// with the current Vitest + jsdom setup. Revisit if the
+				// underlying dependency stops being the blocker.
+				'assets/js/ffc-admin-migrations.js',     // DB-mutating; manual testing only.
+				'assets/js/ffc-admin-code-editor.js',    // Thin CodeMirror wrapper.
+				'assets/js/ffc-admin-pdf.js',            // Coupled to html2canvas + jsPDF.
+				'assets/js/ffc-pdf-generator.js',        // Coupled to html2canvas + jsPDF.
+				'assets/js/ffc-calendar-frontend.js',    // Built on FullCalendar plugin API.
+				'assets/js/ffc-calendar-admin.js',       // Tiny bridge feeding FullCalendar config.
 			],
 		},
 	},


### PR DESCRIPTION
Closes #165.

## Summary

Sprint L of the JS coverage uplift mapped after #164 merged. Single commit. Removes 6 files from the coverage denominator that won't realistically get unit-test coverage with the current Vitest + jsdom setup — each has a structural reason (third-party-API coupling, DB-mutation, etc.).

## Excluded files

| File | LOC | Reason |
|---|---:|---|
| `ffc-admin-migrations.js` | 91 | DB-mutating; manual-only testing path. |
| `ffc-admin-code-editor.js` | 105 | Thin wrapper around CodeMirror. |
| `ffc-admin-pdf.js` | 464 | Coupled to `html2canvas` + `jsPDF`. |
| `ffc-pdf-generator.js` | 559 | Same coupling. |
| `ffc-calendar-frontend.js` | 719 | Built on FullCalendar's plugin API. |
| `ffc-calendar-admin.js` | 28 | Tiny bridge that feeds config into FullCalendar. |

**Stayed included** (still 0% coverage but visibly in the denominator so the gap remains pressure):
- `ffc-working-hours.js`, `ffc-url-shortener-admin.js`, `ffc-admin-move-submissions.js` — testable with current infra, just not yet prioritised.

## Coverage delta

| | Before (main) | After (this PR) |
|---|---:|---:|
| Files measured | 28 | 22 |
| Total covered LOC | unchanged | unchanged |
| **Overall line coverage** | **7.37%** | **8.67%** |
| Floor (`JS_COVERAGE_FLOOR_LINES`) | 6 | **7** |
| Buffer | 1.37% | 1.67% |

## Test plan

- [x] `npm run test:js:coverage` — line coverage 8.67% over 22 files, gate passes.
- [x] `npm run test:js` — same 42 / 42 OK.
- [x] No PHP / non-JS changes.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_