### PR TITLE
JS coverage easy wins: geofence completo + panels restantes + scripts isolados (#168)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,12 +34,14 @@ jobs:
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
       # Ratcheted 3 → 6 in S4 of #163 (panel tests pushed coverage to 7.37%),
-      # then 6 → 7 in #165 (architectural exclusions cleaned the denominator,
-      # pushing the same covered LOC to 8.67% over the active surface). The
-      # ~1.7% buffer below the current baseline catches a real regression
-      # without firing on minor flux. Bump again whenever a PR genuinely
-      # improves the number.
-      JS_COVERAGE_FLOOR_LINES: '7'
+      # then 6 → 7 in #165 (architectural exclusions cleaned the denominator),
+      # then 7 → 15 in Sprint D of #168 (Sprints A+B+C of #168 added 60+
+      # tests across geofence helpers, remaining panels, and 5 small
+      # scripts, taking overall line coverage to 16.86%). The ~1.8% buffer
+      # below the current baseline catches a real regression without
+      # firing on minor flux. Bump again whenever a PR genuinely improves
+      # the number.
+      JS_COVERAGE_FLOOR_LINES: '15'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/already-submitted-notice.test.js
+++ b/tests/js/already-submitted-notice.test.js
@@ -1,0 +1,93 @@
+// Tests for `assets/js/ffc-already-submitted-notice.js`.
+//
+// The script is a `$(document).ready(...)` IIFE that:
+//   1. Reads localStorage `ffc_submitted_forms` (JSON array of form IDs).
+//   2. Finds the first `form.ffc-submission-form` on the page.
+//   3. If the form's `[name="form_id"]` value is in the list AND the
+//      session-storage dismissal flag isn't set, inserts a friendly
+//      notice above the form wrapper.
+//   4. Dismiss button sets the sessionStorage flag and removes the
+//      notice.
+//
+// Sprint C of #168.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+const STORAGE_KEY = 'ffc_submitted_forms';
+const DISMISS_PREFIX = 'ffc_already_submitted_dismissed_';
+
+beforeEach(() => {
+	window.localStorage.clear();
+	window.sessionStorage.clear();
+});
+
+async function loadOnReady() {
+	loadScript('assets/js/ffc-already-submitted-notice.js');
+	// `$(document).ready(cb)` defers to a microtask in jQuery 4 even when
+	// the document is already complete.
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+function installForm(formId) {
+	document.body.innerHTML = `
+		<div class="ffc-form-wrapper">
+			<form class="ffc-submission-form">
+				<input type="hidden" name="form_id" value="${formId}" />
+			</form>
+		</div>
+	`;
+}
+
+describe('ffc-already-submitted-notice', () => {
+	it('renders no notice when the form ID is not in localStorage', async () => {
+		installForm(7);
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
+		await loadOnReady();
+		expect(document.querySelector('.ffc-already-submitted-notice')).toBeNull();
+	});
+
+	it('renders the notice when the form ID is in localStorage', async () => {
+		installForm(42);
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([42]));
+		await loadOnReady();
+		const notice = document.querySelector('.ffc-already-submitted-notice');
+		expect(notice).not.toBeNull();
+		expect(notice.querySelector('h3')).not.toBeNull();
+		expect(notice.querySelector('.ffc-already-submitted-dismiss')).not.toBeNull();
+	});
+
+	it('does NOT render when the dismissal flag is already set for this form', async () => {
+		installForm(42);
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([42]));
+		window.sessionStorage.setItem(DISMISS_PREFIX + '42', '1');
+		await loadOnReady();
+		expect(document.querySelector('.ffc-already-submitted-notice')).toBeNull();
+	});
+
+	it('dismiss button removes the notice and sets the sessionStorage flag', async () => {
+		installForm(99);
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([99]));
+		await loadOnReady();
+		const dismiss = document.querySelector('.ffc-already-submitted-dismiss');
+		expect(dismiss).not.toBeNull();
+		dismiss.click();
+		expect(document.querySelector('.ffc-already-submitted-notice')).toBeNull();
+		expect(window.sessionStorage.getItem(DISMISS_PREFIX + '99')).toBe('1');
+	});
+
+	it('does nothing when no .ffc-submission-form is on the page', async () => {
+		document.body.innerHTML = '<div>no form here</div>';
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([1]));
+		await loadOnReady();
+		expect(document.querySelector('.ffc-already-submitted-notice')).toBeNull();
+	});
+
+	it('survives malformed JSON in localStorage', async () => {
+		installForm(1);
+		window.localStorage.setItem(STORAGE_KEY, 'not-json{');
+		await loadOnReady();
+		// Should not throw; just renders nothing (since the parsed list
+		// is treated as empty).
+		expect(document.querySelector('.ffc-already-submitted-notice')).toBeNull();
+	});
+});

--- a/tests/js/dashboard-audience-join.test.js
+++ b/tests/js/dashboard-audience-join.test.js
@@ -1,0 +1,149 @@
+// Tests for the joinable-groups sub-panel
+// (assets/js/ffc-user-dashboard-audience-join.js).
+//
+// Not a full panel — exposes only `FFCDashboard.audienceJoin.load()`,
+// which fetches via AJAX and renders into `#ffc-audience-join-section`.
+// We mock `$.ajax` to feed deterministic responses and assert against
+// the rendered DOM.
+//
+// Sprint B of #168.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { installDashboardFixtures, loadDashboardCore, loadPanel } from './dashboard-fixtures.js';
+
+beforeAll(() => {
+	installDashboardFixtures();
+	Object.assign(window.ffcDashboard.strings, {
+		joinGroups: 'Join Groups',
+		joinGroupsDesc: 'Select up to {max} groups.',
+		joinGroup: 'Join',
+		leaveGroup: 'Leave',
+	});
+	window.ffcDashboard.restUrl = 'https://x.test/wp-json/ffc/v1/';
+	window.ffcDashboard.nonce = 'test-nonce';
+
+	// Inject the section the load() target writes into.
+	document.getElementById('ffc-dashboard').insertAdjacentHTML(
+		'beforeend',
+		'<div id="ffc-audience-join-section"></div>'
+	);
+
+	loadDashboardCore();
+	loadPanel('audience-join');
+});
+
+beforeEach(() => {
+	document.getElementById('ffc-audience-join-section').innerHTML = '';
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function mockAjaxSuccess(data) {
+	return vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+		if (opts.success) opts.success(data);
+		return {};
+	});
+}
+
+const audienceJoin = () => window.FFCDashboard.audienceJoin;
+
+describe('FFCDashboard.audienceJoin.load', () => {
+	it('empties the section when parents array is empty', () => {
+		mockAjaxSuccess({ parents: [], max_groups: 3, joined_count: 0 });
+		audienceJoin().load();
+		expect(document.querySelector('#ffc-audience-join-section').innerHTML).toBe('');
+	});
+
+	it('renders a heading + description when parents have items', () => {
+		mockAjaxSuccess({
+			parents: [{ id: 1, name: 'Adults', color: '#aa0000', children: [], is_member: false }],
+			max_groups: 5,
+			joined_count: 0,
+		});
+		audienceJoin().load();
+		const section = document.querySelector('#ffc-audience-join-section');
+		expect(section.querySelector('h3').textContent).toBe('Join Groups');
+		expect(section.querySelector('.ffc-audience-limit-msg').textContent).toContain('5'); // {max} replaced
+	});
+
+	it('renders a Join button on a non-member leaf group', () => {
+		mockAjaxSuccess({
+			parents: [{ id: 42, name: 'Beta', color: '#00aa00', children: [], is_member: false }],
+			max_groups: 3,
+			joined_count: 0,
+		});
+		audienceJoin().load();
+		const btn = document.querySelector('#ffc-audience-join-section .ffc-audience-join-btn');
+		expect(btn).not.toBeNull();
+		expect(btn.getAttribute('data-id')).toBe('42');
+		expect(btn.disabled).toBe(false);
+	});
+
+	it('renders a Leave button on a member leaf group', () => {
+		mockAjaxSuccess({
+			parents: [{ id: 7, name: 'In', color: '#0000aa', children: [], is_member: true }],
+			max_groups: 3,
+			joined_count: 1,
+		});
+		audienceJoin().load();
+		const btn = document.querySelector('#ffc-audience-join-section .ffc-audience-leave-btn');
+		expect(btn).not.toBeNull();
+		expect(btn.getAttribute('data-id')).toBe('7');
+	});
+
+	it('disables the Join button when joined_count >= max_groups', () => {
+		mockAjaxSuccess({
+			parents: [{ id: 9, name: 'Group', color: null, children: [], is_member: false }],
+			max_groups: 1,
+			joined_count: 1,
+		});
+		audienceJoin().load();
+		const btn = document.querySelector('#ffc-audience-join-section .ffc-audience-join-btn');
+		expect(btn.disabled).toBe(true);
+	});
+
+	it('renders a parent accordion when the parent has children', () => {
+		mockAjaxSuccess({
+			parents: [{
+				id: 1, name: 'Parent', color: '#000',
+				children: [
+					{ id: 2, name: 'Child A', color: null, children: [], is_member: false },
+					{ id: 3, name: 'Child B', color: null, children: [], is_member: true },
+				],
+			}],
+			max_groups: 5,
+			joined_count: 1,
+		});
+		audienceJoin().load();
+		const section = document.querySelector('#ffc-audience-join-section');
+		expect(section.querySelector('.ffc-audience-parent-header')).not.toBeNull();
+		// One join, one leave (child A non-member, child B member).
+		expect(section.querySelectorAll('.ffc-audience-join-btn').length).toBe(1);
+		expect(section.querySelectorAll('.ffc-audience-leave-btn').length).toBe(1);
+	});
+
+	it('empties the section when AJAX errors out', () => {
+		// Pre-populate so we can prove the error branch clears it.
+		document.querySelector('#ffc-audience-join-section').innerHTML = '<p>old</p>';
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			if (opts.error) opts.error({});
+			return {};
+		});
+		audienceJoin().load();
+		expect(document.querySelector('#ffc-audience-join-section').innerHTML).toBe('');
+	});
+
+	it('is a no-op when the section element is missing from the DOM', () => {
+		// Remove the section entirely.
+		document.querySelector('#ffc-audience-join-section').remove();
+		const ajaxSpy = vi.spyOn(window.$, 'ajax');
+		audienceJoin().load();
+		expect(ajaxSpy).not.toHaveBeenCalled();
+		// Re-add for subsequent tests in same file (none after).
+		document.getElementById('ffc-dashboard').insertAdjacentHTML(
+			'beforeend',
+			'<div id="ffc-audience-join-section"></div>'
+		);
+	});
+});

--- a/tests/js/dashboard-profile.test.js
+++ b/tests/js/dashboard-profile.test.js
@@ -1,0 +1,143 @@
+// Render tests for the Profile panel (assets/js/ffc-user-dashboard-profile.js).
+//
+// The panel renders the user's profile read view + the action buttons
+// (edit, change password) + the audience-join section placeholder. The
+// password change form / LGPD export buttons are exercised by their own
+// handlers — tested separately if/when needed. This file focuses on the
+// `render(profile)` path that builds the DOM from the profile state.
+//
+// Sprint B of #168.
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { installDashboardFixtures, loadDashboardCore, loadPanel } from './dashboard-fixtures.js';
+
+beforeAll(() => {
+	installDashboardFixtures();
+	Object.assign(window.ffcDashboard.strings, {
+		name: 'Name',
+		linkedEmails: 'Emails',
+		cpfRf: 'CPF/RF',
+		phone: 'Phone:',
+		department: 'Department:',
+		organization: 'Organization:',
+		notesLabel: 'Notes:',
+		audienceGroups: 'Groups',
+		memberSince: 'Member since:',
+		editProfile: 'Edit Profile',
+		changePassword: 'Change Password',
+		leaveAllGroups: 'Leave all groups',
+		logout: 'Log out',
+		preferences: 'Preferences',
+		notifications: 'Notifications',
+		lgpd: 'Privacy',
+	});
+	window.ffcDashboard.logoutUrl = 'https://x.test/logout';
+
+	// Inject the panel's tab container.
+	const dash = document.getElementById('ffc-dashboard');
+	if (dash && ! document.getElementById('tab-profile')) {
+		const el = document.createElement('div');
+		el.id = 'tab-profile';
+		el.className = 'ffc-tab-content';
+		dash.appendChild(el);
+	}
+	loadDashboardCore();
+	loadPanel('profile');
+});
+
+beforeEach(() => {
+	document.getElementById('tab-profile').innerHTML = '';
+});
+
+const panel = () => window.FFCDashboard.panels.profile;
+
+function makeProfile(over = {}) {
+	return Object.assign({
+		display_name: 'Maria Silva',
+		names: ['Maria Silva'],
+		email: 'maria@example.com',
+		emails: ['maria@example.com'],
+		cpf_masked: '123.***.***-**',
+		cpfs_masked: ['123.***.***-**'],
+		phone: '(11) 99999-0000',
+		department: 'Engenharia',
+		organization: 'ACME',
+		notes: '',
+		audience_groups: [],
+		member_since: '01/01/2025',
+		preferences: {},
+	}, over);
+}
+
+describe('FFCDashboard.panels.profile.render', () => {
+	it('renders the profile container', () => {
+		panel().render(makeProfile());
+		expect(document.querySelector('#tab-profile .ffc-profile-info')).not.toBeNull();
+	});
+
+	it('renders the logout link when ffcDashboard.logoutUrl is set', () => {
+		panel().render(makeProfile());
+		const logout = document.querySelector('#tab-profile .ffc-logout-link');
+		expect(logout).not.toBeNull();
+		expect(logout.getAttribute('href')).toBe('https://x.test/logout');
+	});
+
+	it('renders core fields with their localised labels', () => {
+		panel().render(makeProfile({
+			phone: '11 99999-0000',
+			department: 'TI',
+			organization: 'ACME',
+		}));
+		const text = document.querySelector('#tab-profile').textContent;
+		expect(text).toContain('Phone:');
+		expect(text).toContain('11 99999-0000');
+		expect(text).toContain('Department:');
+		expect(text).toContain('TI');
+		expect(text).toContain('Organization:');
+		expect(text).toContain('ACME');
+	});
+
+	it('renders the Notes block only when notes is non-empty', () => {
+		panel().render(makeProfile({ notes: '' }));
+		expect(document.querySelector('#tab-profile').textContent).not.toContain('Notes:');
+
+		panel().render(makeProfile({ notes: 'Important note' }));
+		expect(document.querySelector('#tab-profile').textContent).toContain('Notes:');
+		expect(document.querySelector('#tab-profile').textContent).toContain('Important note');
+	});
+
+	it('renders audience-group chips when audience_groups has items', () => {
+		panel().render(makeProfile({
+			audience_groups: [
+				{ name: 'Alpha', color: '#aa0000' },
+				{ name: 'Beta',  color: '#00aa00' },
+			],
+		}));
+		const container = document.querySelector('#tab-profile');
+		expect(container.textContent).toContain('Alpha');
+		expect(container.textContent).toContain('Beta');
+		// "Leave all groups" button only when there are groups.
+		expect(document.querySelector('#tab-profile .ffc-leave-all-groups-btn')).not.toBeNull();
+	});
+
+	it('omits the "Leave all groups" button when audience_groups is empty', () => {
+		panel().render(makeProfile({ audience_groups: [] }));
+		expect(document.querySelector('#tab-profile .ffc-leave-all-groups-btn')).toBeNull();
+	});
+
+	it('renders the Edit Profile and Change Password buttons', () => {
+		panel().render(makeProfile());
+		expect(document.querySelector('#tab-profile .ffc-profile-edit-btn')).not.toBeNull();
+		expect(document.querySelector('#tab-profile .ffc-password-toggle-btn')).not.toBeNull();
+	});
+
+	it('renders the audience-join section placeholder', () => {
+		panel().render(makeProfile());
+		expect(document.querySelector('#tab-profile #ffc-audience-join-section')).not.toBeNull();
+	});
+
+	it('stores the profile on the panel state', () => {
+		const profile = makeProfile({ display_name: 'João' });
+		panel().render(profile);
+		expect(panel().state).toBe(profile);
+	});
+});

--- a/tests/js/dashboard-reregistrations.test.js
+++ b/tests/js/dashboard-reregistrations.test.js
@@ -1,0 +1,120 @@
+// Render tests for the Reregistrations panel
+// (assets/js/ffc-user-dashboard-reregistrations.js).
+//
+// The panel reads from #tab-reregistrations and writes a filter bar +
+// table(s) split by `is_active` (Active / Completed). Tests cover empty
+// state, sectioning, row classes, validation-code rendering, edit button
+// visibility, and search filtering.
+//
+// Sprint B of #168.
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { installDashboardFixtures, loadDashboardCore, loadPanel } from './dashboard-fixtures.js';
+
+beforeAll(() => {
+	installDashboardFixtures();
+	// Add the strings this panel reads. The fixtures default doesn't carry
+	// reregistration-specific keys.
+	Object.assign(window.ffcDashboard.strings, {
+		active: 'Active',
+		completed: 'Completed',
+		noReregistrations: 'No reregistrations found.',
+		reregistrationTitle: 'Campaign',
+		period: 'Period',
+		status: 'Status',
+		submittedAt: 'Submitted',
+		validationCode: 'Validation Code',
+		actions: 'Actions',
+		editReregistration: 'Edit',
+		downloadFicha: 'Download Ficha',
+	});
+	// Inject the panel's tab container, which install... doesn't include.
+	const dash = document.getElementById('ffc-dashboard');
+	if (dash && ! document.getElementById('tab-reregistrations')) {
+		const el = document.createElement('div');
+		el.id = 'tab-reregistrations';
+		el.className = 'ffc-tab-content';
+		dash.appendChild(el);
+	}
+	loadDashboardCore();
+	loadPanel('reregistrations');
+});
+
+beforeEach(() => {
+	document.getElementById('tab-reregistrations').innerHTML = '';
+	window.localStorage.setItem('ffc_page_size', '25');
+});
+
+const panel = () => window.FFCDashboard.panels.reregistrations;
+
+function makeRereg(over = {}) {
+	return Object.assign({
+		reregistration_id: 1,
+		title: 'Campaign',
+		start_date: '2026-01-01',
+		end_date: '2026-12-31',
+		start_date_formatted: '01/01/2026',
+		end_date_formatted: '31/12/2026',
+		status: 'pending',
+		status_label: 'Pending',
+		submitted_at: '',
+		auth_code: '',
+		is_active: true,
+		can_submit: true,
+		can_download: false,
+		magic_link: '',
+	}, over);
+}
+
+describe('FFCDashboard.panels.reregistrations.render', () => {
+	it('renders the empty state when there are no items', () => {
+		panel().render([], 1);
+		const container = document.getElementById('tab-reregistrations');
+		expect(container.querySelector('.ffc-empty-state')).not.toBeNull();
+		expect(container.textContent).toContain('No reregistrations found.');
+	});
+
+	it('splits into Active and Completed sections', () => {
+		panel().render([
+			makeRereg({ is_active: true, title: 'Open' }),
+			makeRereg({ is_active: false, title: 'Done' }),
+		], 1);
+		const headers = Array.from(document.querySelectorAll('#tab-reregistrations h3')).map((h) => h.textContent);
+		expect(headers).toEqual(['Active', 'Completed']);
+	});
+
+	it("applies 'past-row' to completed rows", () => {
+		panel().render([
+			makeRereg({ is_active: false, title: 'Done' }),
+		], 1);
+		expect(document.querySelectorAll('#tab-reregistrations tr.past-row').length).toBe(1);
+	});
+
+	it('renders the Edit button when can_submit is true, omits it otherwise', () => {
+		panel().render([
+			makeRereg({ can_submit: true, reregistration_id: 10 }),
+			makeRereg({ can_submit: false, reregistration_id: 20 }),
+		], 1);
+		const buttons = document.querySelectorAll('#tab-reregistrations .ffc-rereg-open-form');
+		expect(buttons.length).toBe(1);
+		expect(buttons[0].getAttribute('data-reregistration-id')).toBe('10');
+	});
+
+	it('renders the Download Ficha link only when both can_download and magic_link present', () => {
+		panel().render([
+			makeRereg({ can_download: true, magic_link: 'https://x.test/m' }),
+			makeRereg({ can_download: false, magic_link: 'https://x.test/m' }),
+			makeRereg({ can_download: true, magic_link: '' }),
+		], 1);
+		const buttons = document.querySelectorAll('#tab-reregistrations .ffc-btn-pdf');
+		expect(buttons.length).toBe(1);
+	});
+
+	it('renders the auth_code in a <code> tag when present, dash when absent', () => {
+		panel().render([
+			makeRereg({ auth_code: 'ABC123' }),
+			makeRereg({ auth_code: '' }),
+		], 1);
+		expect(document.querySelectorAll('#tab-reregistrations code.ffc-auth-code').length).toBe(1);
+		expect(document.querySelectorAll('#tab-reregistrations code.ffc-auth-code')[0].textContent).toBe('ABC123');
+	});
+});

--- a/tests/js/geofence-frontend-helpers.test.js
+++ b/tests/js/geofence-frontend-helpers.test.js
@@ -1,0 +1,340 @@
+// More unit tests for `window.FFCGeofence` defined in
+// `assets/js/ffc-geofence-frontend.js` — covers the pure helpers and DOM-
+// manipulation methods left at 0% after #160. Sprint A of #168.
+//
+// Companion to `geofence-frontend.test.js` (validateDateTime / pickHideMode).
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(() => {
+	// `window.ffcGeofenceConfig._global.strings` is what `getString()` looks
+	// up; populate it so the i18n-key tests can prove the lookup path.
+	window.ffcGeofenceConfig = {
+		_global: {
+			strings: {
+				someKey: 'translated-some-key',
+			},
+		},
+	};
+	loadScript('assets/js/ffc-geofence-frontend.js');
+});
+
+beforeEach(() => {
+	// Each test starts with a fresh form wrapper at #ffc-form-1.
+	document.body.innerHTML = `
+		<div id="ffc-form-1" class="ffc-form-wrapper">
+			<h2 class="ffc-form-title">Title</h2>
+			<form class="ffc-submission-form"><input name="x" /></form>
+		</div>
+	`;
+	// Clear localStorage between tests so cache state doesn't bleed.
+	window.localStorage.clear();
+});
+
+const G = () => window.FFCGeofence;
+
+// ----------------------------------------------------------------------
+// getString — i18n lookup with fallback
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.getString', () => {
+	it('returns the translated value when the key exists', () => {
+		expect(G().getString('someKey', 'fallback')).toBe('translated-some-key');
+	});
+
+	it('returns the fallback when the key is missing', () => {
+		expect(G().getString('unknownKey', 'fallback-value')).toBe('fallback-value');
+	});
+
+	it('returns the fallback when the strings object is missing entirely', () => {
+		const saved = window.ffcGeofenceConfig;
+		window.ffcGeofenceConfig = undefined;
+		try {
+			expect(G().getString('anything', 'fb')).toBe('fb');
+		} finally {
+			window.ffcGeofenceConfig = saved;
+		}
+	});
+});
+
+// ----------------------------------------------------------------------
+// Pure formatters — formatDate / formatTime / escapeHtml
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.formatDate', () => {
+	it('zero-pads single-digit month and day', () => {
+		expect(G().formatDate(new Date(2026, 0, 5))).toBe('2026-01-05');  // Jan = month 0
+	});
+
+	it('handles a two-digit month and day without padding', () => {
+		expect(G().formatDate(new Date(2026, 11, 31))).toBe('2026-12-31'); // Dec = month 11
+	});
+});
+
+describe('FFCGeofence.formatTime', () => {
+	it('zero-pads single-digit hour and minute', () => {
+		expect(G().formatTime(new Date(2026, 0, 1, 7, 5))).toBe('07:05');
+	});
+
+	it('handles double-digit hour and minute', () => {
+		expect(G().formatTime(new Date(2026, 0, 1, 23, 59))).toBe('23:59');
+	});
+});
+
+describe('FFCGeofence.escapeHtml', () => {
+	it('escapes <, >, &, and quote characters', () => {
+		const out = G().escapeHtml('<script>alert("x&y")</script>');
+		// Implementation uses textContent → innerHTML, so the encoded form
+		// is the standard HTML entity set. Just assert the dangerous chars
+		// are gone.
+		expect(out).not.toContain('<script>');
+		expect(out).toContain('&lt;');
+		expect(out).toContain('&gt;');
+		expect(out).toContain('&amp;');
+	});
+
+	it('leaves plain text unchanged', () => {
+		expect(G().escapeHtml('hello world')).toBe('hello world');
+	});
+});
+
+// ----------------------------------------------------------------------
+// Haversine distance — calculateDistance / deg2rad
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.calculateDistance', () => {
+	it('returns 0 for identical coordinates', () => {
+		expect(G().calculateDistance(0, 0, 0, 0)).toBe(0);
+	});
+
+	it('approximates the well-known São Paulo → Rio distance (~360 km)', () => {
+		// Source coords: SP (-23.5505, -46.6333), RJ (-22.9068, -43.1729).
+		// Real great-circle distance ≈ 360 km. Function returns metres.
+		const metres = G().calculateDistance(-23.5505, -46.6333, -22.9068, -43.1729);
+		const km = metres / 1000;
+		expect(km).toBeGreaterThan(355);
+		expect(km).toBeLessThan(365);
+	});
+
+	it('is symmetric — d(a,b) == d(b,a)', () => {
+		const ab = G().calculateDistance(10, 20, 30, 40);
+		const ba = G().calculateDistance(30, 40, 10, 20);
+		expect(Math.abs(ab - ba)).toBeLessThan(1e-6);
+	});
+});
+
+describe('FFCGeofence.deg2rad', () => {
+	it('converts 180° to π', () => {
+		expect(G().deg2rad(180)).toBeCloseTo(Math.PI, 10);
+	});
+
+	it('converts 0° to 0', () => {
+		expect(G().deg2rad(0)).toBe(0);
+	});
+
+	it('converts -90° to -π/2', () => {
+		expect(G().deg2rad(-90)).toBeCloseTo(-Math.PI / 2, 10);
+	});
+});
+
+// ----------------------------------------------------------------------
+// Browser detection — isSafari
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.isSafari', () => {
+	const origUA = navigator.userAgent;
+	const origMaxTouch = navigator.maxTouchPoints;
+
+	function setUA(ua, maxTouchPoints = 0) {
+		Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+		Object.defineProperty(navigator, 'maxTouchPoints', { value: maxTouchPoints, configurable: true });
+	}
+
+	afterEach(() => {
+		setUA(origUA, origMaxTouch);
+	});
+
+	it('returns true for iPhone UA', () => {
+		setUA('Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1');
+		expect(G().isSafari()).toBe(true);
+	});
+
+	it('returns true for desktop Safari UA', () => {
+		setUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/15.0 Safari/605.1.15');
+		expect(G().isSafari()).toBe(true);
+	});
+
+	it('returns true for iPad-as-desktop (maxTouchPoints > 1 + Macintosh UA)', () => {
+		setUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/15.0 Safari/605.1.15', 5);
+		expect(G().isSafari()).toBe(true);
+	});
+
+	it('returns false for Chrome UA', () => {
+		setUA('Mozilla/5.0 (Windows NT 10.0; Win64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36');
+		expect(G().isSafari()).toBe(false);
+	});
+
+	it('returns false for Firefox UA', () => {
+		setUA('Mozilla/5.0 (X11; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0');
+		expect(G().isSafari()).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// Location cache — localStorage roundtrip with TTL
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.getLocationCache / setLocationCache', () => {
+	it('round-trips a location under the same formId', () => {
+		G().setLocationCache('ffc-form-42', { latitude: -23.5, longitude: -46.6, accuracy: 10 }, 600);
+		const got = G().getLocationCache('ffc-form-42');
+		expect(got).toEqual({ latitude: -23.5, longitude: -46.6, accuracy: 10 });
+	});
+
+	it('returns null when no cache entry exists for the formId', () => {
+		expect(G().getLocationCache('ffc-form-missing')).toBeNull();
+	});
+
+	it('returns null and clears the entry when the TTL expired', () => {
+		// Set with TTL of -10s — already expired.
+		G().setLocationCache('ffc-form-7', { latitude: 1, longitude: 2 }, -10);
+		expect(G().getLocationCache('ffc-form-7')).toBeNull();
+		expect(window.localStorage.getItem('ffc_geo_ffc-form-7')).toBeNull();
+	});
+
+	it('returns null when the cached JSON is malformed', () => {
+		window.localStorage.setItem('ffc_geo_ffc-form-junk', 'not-json{');
+		expect(G().getLocationCache('ffc-form-junk')).toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------
+// Blocked-message rendering — handleBlocked / showBlockedMessage
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.handleBlocked', () => {
+	function wrapper() { return window.jQuery('#ffc-form-1'); }
+
+	it("hides the form entirely when hideMode === 'hide'", () => {
+		G().handleBlocked(wrapper(), 'hide', 'Blocked.');
+		const el = document.getElementById('ffc-form-1');
+		// jQuery .hide() sets inline display:none
+		expect(el.style.display).toBe('none');
+	});
+
+	it("hides the form fields and shows a blocked message when hideMode === 'message'", () => {
+		G().handleBlocked(wrapper(), 'message', 'You are blocked');
+		const root = document.getElementById('ffc-form-1');
+		expect(root.querySelector('.ffc-submission-form').style.display).toBe('none');
+		expect(root.querySelector('.ffc-form-title').style.display).toBe('none');
+		const blocked = root.querySelector('.ffc-geofence-blocked');
+		expect(blocked).not.toBeNull();
+		expect(blocked.textContent).toContain('You are blocked');
+	});
+
+	it('escapes HTML in the blocked message to prevent XSS', () => {
+		G().handleBlocked(wrapper(), 'message', '<img src=x onerror=alert(1)>');
+		const blocked = document.querySelector('#ffc-form-1 .ffc-geofence-blocked');
+		// The img tag must not have been parsed as HTML.
+		expect(blocked.innerHTML).not.toContain('<img');
+		expect(blocked.innerHTML).toContain('&lt;img');
+	});
+});
+
+describe('FFCGeofence.showAdminBypassMessages', () => {
+	function wrapper() { return window.jQuery('#ffc-form-1'); }
+
+	it('renders a generic bypass message when bypassInfo is null', () => {
+		G().showAdminBypassMessages(wrapper(), null);
+		const bypass = document.querySelector('#ffc-form-1 .ffc-geofence-admin-bypass');
+		expect(bypass).not.toBeNull();
+		expect(bypass.textContent).toMatch(/Bypass|bypass/);
+	});
+
+	it('renders a datetime-specific message when hasDatetime is true', () => {
+		G().showAdminBypassMessages(wrapper(), { hasDatetime: true, hasGeo: false });
+		const messages = document.querySelectorAll('#ffc-form-1 .ffc-geofence-admin-bypass');
+		expect(messages.length).toBe(1);
+		expect(messages[0].textContent).toMatch(/Date|date|Time|time/);
+	});
+
+	it('renders both datetime and geo messages when both flags are set', () => {
+		G().showAdminBypassMessages(wrapper(), { hasDatetime: true, hasGeo: true });
+		const messages = document.querySelectorAll('#ffc-form-1 .ffc-geofence-admin-bypass');
+		expect(messages.length).toBe(2);
+	});
+});
+
+// ----------------------------------------------------------------------
+// Form show / reset — class toggling
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.showForm / resetForm', () => {
+	function wrapper() { return window.jQuery('#ffc-form-1'); }
+
+	it("adds 'ffc-validated' class on showForm", () => {
+		G().showForm(wrapper());
+		expect(document.getElementById('ffc-form-1').classList.contains('ffc-validated')).toBe(true);
+	});
+
+	it("removes 'ffc-validated' class and clears blocked messages on resetForm", () => {
+		G().handleBlocked(wrapper(), 'message', 'something');
+		G().showForm(wrapper());
+		// Sanity: both states present.
+		expect(document.querySelector('#ffc-form-1 .ffc-geofence-blocked')).not.toBeNull();
+
+		G().resetForm(wrapper());
+		expect(document.getElementById('ffc-form-1').classList.contains('ffc-validated')).toBe(false);
+		expect(document.querySelector('#ffc-form-1 .ffc-geofence-blocked')).toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------
+// Loading-message lifecycle
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.show/update/hideLoadingMessage', () => {
+	function wrapper() { return window.jQuery('#ffc-form-1'); }
+
+	it('show appends a loading message with a spinner', () => {
+		G().showLoadingMessage(wrapper(), 'Detecting…');
+		const el = document.querySelector('#ffc-form-1 .ffc-geofence-loading-msg');
+		expect(el).not.toBeNull();
+		expect(el.textContent).toContain('Detecting…');
+		expect(el.querySelector('.ffc-spinner')).not.toBeNull();
+	});
+
+	it('update rewrites the message text without losing the spinner', () => {
+		G().showLoadingMessage(wrapper(), 'Phase 1');
+		G().updateLoadingMessage(wrapper(), 'Phase 2');
+		const el = document.querySelector('#ffc-form-1 .ffc-geofence-loading-msg');
+		expect(el.textContent).toContain('Phase 2');
+		expect(el.textContent).not.toContain('Phase 1');
+	});
+
+	it('hide removes the loading-msg element entirely', () => {
+		G().showLoadingMessage(wrapper(), 'gone soon');
+		G().hideLoadingMessage(wrapper());
+		expect(document.querySelector('#ffc-form-1 .ffc-geofence-loading-msg')).toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------
+// applyGpsFallback — allow vs block branches
+// ----------------------------------------------------------------------
+
+describe('FFCGeofence.applyGpsFallback', () => {
+	function wrapper() { return window.jQuery('#ffc-form-1'); }
+
+	it("shows the form when gpsFallback === 'allow'", () => {
+		G().applyGpsFallback(wrapper(), { gpsFallback: 'allow', hideMode: 'message' });
+		expect(document.getElementById('ffc-form-1').classList.contains('ffc-validated')).toBe(true);
+	});
+
+	it("blocks the form when gpsFallback === 'block'", () => {
+		G().applyGpsFallback(wrapper(), { gpsFallback: 'block', hideMode: 'message' });
+		const root = document.getElementById('ffc-form-1');
+		expect(root.classList.contains('ffc-validated')).toBe(false);
+		expect(document.querySelector('#ffc-form-1 .ffc-geofence-blocked')).not.toBeNull();
+	});
+});

--- a/tests/js/tiny-scripts.test.js
+++ b/tests/js/tiny-scripts.test.js
@@ -1,0 +1,168 @@
+// Tests for the three small isolated scripts in `assets/js/` that are
+// pure IIFE side-effect modules (no public global API).
+//
+//   - ffc-dark-mode.js          (32 LOC)  — toggles `.ffc-dark-mode` on <html>.
+//   - ffc-user-capabilities.js  (37 LOC)  — bulk-toggle buttons on the user profile.
+//   - ffc-smtp-settings.js      (36 LOC)  — mode toggle + disable-all in admin.
+//
+// Each script registers handlers / applies state on parse. Tests
+// reload the script via `vm.runInThisContext` with the desired
+// environment in place, then assert against DOM / window state.
+//
+// Sprint C of #168.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+// ----------------------------------------------------------------------
+// ffc-dark-mode.js
+// ----------------------------------------------------------------------
+
+describe('ffc-dark-mode', () => {
+	beforeEach(() => {
+		document.documentElement.classList.remove('ffc-dark-mode');
+		window.ffcDarkMode = undefined;
+	});
+
+	it("does nothing when the setting is 'off'", () => {
+		window.ffcDarkMode = { mode: 'off' };
+		loadScript('assets/js/ffc-dark-mode.js');
+		expect(document.documentElement.classList.contains('ffc-dark-mode')).toBe(false);
+	});
+
+	it("does nothing when ffcDarkMode is undefined (default)", () => {
+		loadScript('assets/js/ffc-dark-mode.js');
+		expect(document.documentElement.classList.contains('ffc-dark-mode')).toBe(false);
+	});
+
+	it("adds the class when mode === 'on'", () => {
+		window.ffcDarkMode = { mode: 'on' };
+		loadScript('assets/js/ffc-dark-mode.js');
+		expect(document.documentElement.classList.contains('ffc-dark-mode')).toBe(true);
+	});
+
+	it("applies the OS preference when mode === 'auto' and prefers-color-scheme matches", () => {
+		// jsdom doesn't implement matchMedia by default — install a stub
+		// that flags dark mode and exposes addEventListener.
+		const listeners = [];
+		window.matchMedia = (query) => ({
+			matches: true,
+			media: query,
+			addEventListener(_, cb) { listeners.push(cb); },
+			removeEventListener() {},
+			addListener() {},
+			removeListener() {},
+			dispatchEvent() { return true; },
+			onchange: null,
+		});
+		window.ffcDarkMode = { mode: 'auto' };
+		loadScript('assets/js/ffc-dark-mode.js');
+		expect(document.documentElement.classList.contains('ffc-dark-mode')).toBe(true);
+		// And the change handler responds when the OS preference flips.
+		expect(listeners.length).toBe(1);
+		listeners[0]({ matches: false });
+		expect(document.documentElement.classList.contains('ffc-dark-mode')).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// ffc-user-capabilities.js
+// ----------------------------------------------------------------------
+
+describe('ffc-user-capabilities', () => {
+	beforeEach(async () => {
+		document.body.innerHTML = `
+			<button id="ffc-grant-all-caps">Grant all</button>
+			<button id="ffc-revoke-all-caps">Revoke all</button>
+			<button id="ffc-grant-certificates">Grant certs</button>
+			<button id="ffc-grant-appointments">Grant appts</button>
+			<input type="checkbox" name="ffc_cap_certificate_view" />
+			<input type="checkbox" name="ffc_cap_certificate_edit" />
+			<input type="checkbox" name="ffc_cap_ffc_appointment_view" />
+			<input type="checkbox" name="ffc_cap_ffc_appointment_edit" />
+			<input type="checkbox" name="ffc_cap_other_thing" />
+		`;
+		loadScript('assets/js/ffc-user-capabilities.js');
+		// jQuery 4 defers `$(document).ready(cb)` to a microtask even when
+		// the document is already complete — wait one tick so the script's
+		// handlers are bound before the test simulates clicks.
+		await new Promise((r) => setTimeout(r, 0));
+	});
+
+	it('Grant All checks every ffc_cap_* checkbox', () => {
+		document.getElementById('ffc-grant-all-caps').click();
+		const boxes = document.querySelectorAll('input[name^="ffc_cap_"]');
+		boxes.forEach((b) => expect(b.checked).toBe(true));
+	});
+
+	it('Revoke All unchecks every ffc_cap_* checkbox', () => {
+		// First grant, then revoke.
+		document.getElementById('ffc-grant-all-caps').click();
+		document.getElementById('ffc-revoke-all-caps').click();
+		const boxes = document.querySelectorAll('input[name^="ffc_cap_"]');
+		boxes.forEach((b) => expect(b.checked).toBe(false));
+	});
+
+	it('Grant certificates only checks the certificate caps', () => {
+		document.getElementById('ffc-grant-certificates').click();
+		expect(document.querySelector('input[name="ffc_cap_certificate_view"]').checked).toBe(true);
+		expect(document.querySelector('input[name="ffc_cap_certificate_edit"]').checked).toBe(true);
+		expect(document.querySelector('input[name="ffc_cap_ffc_appointment_view"]').checked).toBe(false);
+		expect(document.querySelector('input[name="ffc_cap_other_thing"]').checked).toBe(false);
+	});
+
+	it('Grant appointments only checks the appointment caps', () => {
+		document.getElementById('ffc-grant-appointments').click();
+		expect(document.querySelector('input[name="ffc_cap_ffc_appointment_view"]').checked).toBe(true);
+		expect(document.querySelector('input[name="ffc_cap_ffc_appointment_edit"]').checked).toBe(true);
+		expect(document.querySelector('input[name="ffc_cap_certificate_view"]').checked).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// ffc-smtp-settings.js
+// ----------------------------------------------------------------------
+
+describe('ffc-smtp-settings', () => {
+	beforeEach(async () => {
+		document.body.innerHTML = `
+			<div id="smtp-mode-options">
+				<label><input type="radio" name="ffc_settings[smtp_mode]" value="wordpress" checked />WordPress</label>
+				<label><input type="radio" name="ffc_settings[smtp_mode]" value="custom" />Custom</label>
+			</div>
+			<input type="checkbox" id="disable_all_emails" />
+			<div id="smtp-options" class="ffc-hidden" style="display:none">
+				<input id="smtp_host" />
+				<select id="smtp_secure"><option>tls</option></select>
+			</div>
+		`;
+		loadScript('assets/js/ffc-smtp-settings.js');
+		await new Promise((r) => setTimeout(r, 0));
+	});
+
+	it("reveals #smtp-options when smtp_mode is changed to 'custom'", () => {
+		const radio = document.querySelector('input[name="ffc_settings[smtp_mode]"][value="custom"]');
+		radio.checked = true;
+		window.$(radio).trigger('change');
+		expect(document.getElementById('smtp-options').classList.contains('ffc-hidden')).toBe(false);
+	});
+
+	it('disables SMTP inputs when #disable_all_emails is checked', () => {
+		const cb = document.getElementById('disable_all_emails');
+		cb.checked = true;
+		window.$(cb).trigger('change');
+		const inputs = document.querySelectorAll(
+			'#smtp-mode-options input, #smtp-options input, #smtp-options select'
+		);
+		inputs.forEach((i) => expect(i.disabled).toBe(true));
+	});
+
+	it('disables nothing on page load when emails are not disabled', () => {
+		// `toggleEmailOptions()` runs once on script load — with the
+		// default fixture (#disable_all_emails unchecked), the inputs
+		// should stay enabled.
+		const inputs = document.querySelectorAll(
+			'#smtp-mode-options input, #smtp-options input, #smtp-options select'
+		);
+		inputs.forEach((i) => expect(i.disabled).toBe(false));
+	});
+});

--- a/tests/js/webview-warning.test.js
+++ b/tests/js/webview-warning.test.js
@@ -1,0 +1,90 @@
+// Tests for `assets/js/ffc-webview-warning.js`.
+//
+// The script is a pure IIFE that:
+//   1. Bails fast unless the UA matches an Android WebView or iOS in-app
+//      browser (Facebook, Instagram, TikTok, WhatsApp, LinkedIn, Line,
+//      Twitter for iPhone).
+//   2. Bails if sessionStorage flag is set (user dismissed previously).
+//   3. Anchors a banner above the first matching `.ffc-form-wrapper`,
+//      `.ffc-public-csv-download`, or `.ffc-submission-form` element.
+//   4. Adds a dismiss button that sets the sessionStorage flag.
+//
+// Sprint C of #168.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+const STORAGE_KEY = 'ffc_webview_warning_dismissed';
+
+function setUA(ua) {
+	Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+}
+
+const ORIG_UA = navigator.userAgent;
+
+beforeEach(() => {
+	window.sessionStorage.clear();
+	document.body.innerHTML = `<div class="ffc-form-wrapper"><form class="ffc-submission-form"></form></div>`;
+	setUA(ORIG_UA);
+});
+
+describe('ffc-webview-warning', () => {
+	it('renders no banner on a plain desktop browser UA', () => {
+		setUA('Mozilla/5.0 (Windows NT 10.0; Win64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36');
+		loadScript('assets/js/ffc-webview-warning.js');
+		expect(document.querySelector('.ffc-webview-warning')).toBeNull();
+	});
+
+	it('renders the banner on an Android WebView UA', () => {
+		setUA('Mozilla/5.0 (Linux; Android 13; Pixel 7; wv) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36');
+		loadScript('assets/js/ffc-webview-warning.js');
+		const banner = document.querySelector('.ffc-webview-warning');
+		expect(banner).not.toBeNull();
+		expect(banner.querySelector('h3')).not.toBeNull();
+		expect(banner.querySelector('.ffc-webview-warning-open')).not.toBeNull();
+		expect(banner.querySelector('.ffc-webview-warning-dismiss')).not.toBeNull();
+	});
+
+	it('renders the banner on an Instagram in-app UA', () => {
+		setUA('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 Instagram 310.0.0');
+		loadScript('assets/js/ffc-webview-warning.js');
+		expect(document.querySelector('.ffc-webview-warning')).not.toBeNull();
+	});
+
+	it('renders the banner on a Facebook in-app UA (FBAN marker)', () => {
+		setUA('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 FBAN/FBIOS;FBAV/440.0.0');
+		loadScript('assets/js/ffc-webview-warning.js');
+		expect(document.querySelector('.ffc-webview-warning')).not.toBeNull();
+	});
+
+	it('does NOT render when the dismissed flag is already set in sessionStorage', () => {
+		setUA('Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36');
+		window.sessionStorage.setItem(STORAGE_KEY, '1');
+		loadScript('assets/js/ffc-webview-warning.js');
+		expect(document.querySelector('.ffc-webview-warning')).toBeNull();
+	});
+
+	it('dismisses by removing the banner and setting the sessionStorage flag', () => {
+		setUA('Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36');
+		loadScript('assets/js/ffc-webview-warning.js');
+		const dismiss = document.querySelector('.ffc-webview-warning-dismiss');
+		expect(dismiss).not.toBeNull();
+		dismiss.click();
+		expect(document.querySelector('.ffc-webview-warning')).toBeNull();
+		expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+	});
+
+	it('anchors the banner above the .ffc-form-wrapper', () => {
+		setUA('Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36');
+		loadScript('assets/js/ffc-webview-warning.js');
+		const wrapper = document.querySelector('.ffc-form-wrapper');
+		expect(wrapper.previousElementSibling).not.toBeNull();
+		expect(wrapper.previousElementSibling.classList.contains('ffc-webview-warning')).toBe(true);
+	});
+
+	it('does nothing when no anchor element is present in the DOM', () => {
+		document.body.innerHTML = '<div>nothing to anchor against</div>';
+		setUA('Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36');
+		loadScript('assets/js/ffc-webview-warning.js');
+		expect(document.querySelector('.ffc-webview-warning')).toBeNull();
+	});
+});


### PR DESCRIPTION
Closes #168.

## Summary

Four sprints implementing the easy-testability JS coverage uplift from #168. Each commit is independently revertable.

| Sprint | Commit | What |
|---|---|---|
| A | `fb153bd` | 37 tests for the rest of `ffc-geofence-frontend.js` — pure helpers, DOM methods, browser detection, location cache, blocked-message rendering, GPS fallback. |
| B | `07e5af9` | 23 tests across the 3 dashboard panels left at 0% (reregistrations, profile read view, audience-join with mocked `$.ajax`). |
| C | `b107c81` | 25 tests across 5 small isolated IIFE scripts (dark-mode, user-capabilities, smtp-settings, webview-warning, already-submitted-notice). |
| D | `f10baaa` | `JS_COVERAGE_FLOOR_LINES` ratchets 7 → 15 to lock in the bigger baseline without firing on minor flux. |

## Coverage delta

| | Before (main) | After (this PR) |
|---|---:|---:|
| Total tests | 42 | **127** (+85) |
| **Overall line coverage** | **8.67%** | **16.86%** |
| `ffc-geofence-frontend.js` | 39% | 57% |
| `ffc-user-dashboard-reregistrations.js` | 0% | 75% |
| `ffc-user-dashboard-profile.js` | 0% | 40% |
| `ffc-user-dashboard-audience-join.js` | 0% | 56% |
| `ffc-dark-mode.js` | 0% | ~90% |
| `ffc-user-capabilities.js` | 0% | ~90% |
| `ffc-smtp-settings.js` | 0% | ~85% |
| `ffc-webview-warning.js` | 0% | ~60% |
| `ffc-already-submitted-notice.js` | 0% | ~65% |
| `JS_COVERAGE_FLOOR_LINES` | 7 | **15** |

## Notes

- **Profile panel at 40%** — below the 60-80% target. Its render builds 6+ sections (read view, password form, preferences, notifications, LGPD); this PR covers the read view and core actions only. Deeper coverage of the action-handler flows warrants its own focused PR when those flows surface bugs.
- **`$(document).ready(cb)` deferral** — jQuery 4 defers ready callbacks to a microtask even when `document.readyState === 'complete'`. Tests for scripts using that pattern await one tick via `await new Promise((r) => setTimeout(r, 0))` after `loadScript`.
- **UA override pattern** — `Object.defineProperty(navigator, 'userAgent', { configurable: true })` works in jsdom; tests restore the original UA in `beforeEach` to avoid cross-test bleed.

## Test plan

- [x] `npm run test:js` — **127 / 127 OK** (was 42).
- [x] `npm run test:js:coverage` — line coverage **16.86%**, gate (floor 15) passes.
- [x] `npm run lint:js` — clean (9 pre-existing unused-vars warnings unchanged).
- [x] `vendor/bin/phpunit` — runs unchanged (no PHP touched).

## What's deferred to future PRs

- `ffc-frontend.js` (500 LOC, hub), `ffc-frontend-helpers.js` (656 LOC), `ffc-core.js` (300 LOC) — extract-pure-helpers-then-test, larger sprint of its own.
- `ffc-csv-download.js`, `ffc-reregistration-frontend.js` — large critical-path files.
- `ffc-admin.js` + admin pages — separate sprint.
- `ffc-audience.js` (1470 LOC) — skipped per #167.
- Profile panel deep coverage — separate sprint when needed.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_