### PR TITLE
JS coverage medium: core/helpers + dynamic-fragments + device-signals/frontend partial (#170)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,15 +33,14 @@ jobs:
     # ffc-geofence-admin.js shipped via #160 (S2 of #161).
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
-      # Ratcheted 3 → 6 in S4 of #163 (panel tests pushed coverage to 7.37%),
-      # then 6 → 7 in #165 (architectural exclusions cleaned the denominator),
-      # then 7 → 15 in Sprint D of #168 (Sprints A+B+C of #168 added 60+
-      # tests across geofence helpers, remaining panels, and 5 small
-      # scripts, taking overall line coverage to 16.86%). The ~1.8% buffer
-      # below the current baseline catches a real regression without
-      # firing on minor flux. Bump again whenever a PR genuinely improves
-      # the number.
-      JS_COVERAGE_FLOOR_LINES: '15'
+      # Ratcheted 3 → 6 → 7 → 15 across #163 / #165 / #168, then 15 → 24
+      # in Sprint H of #170 (medium sprints E+F+G added ~45 tests
+      # covering core/frontend-helpers, dynamic-fragments, and the
+      # load-side of device-signals + frontend.js, taking overall line
+      # coverage to 25.78%). The ~1.8% buffer below the current baseline
+      # catches a real regression without firing on minor flux. Bump
+      # again whenever a PR genuinely improves the number.
+      JS_COVERAGE_FLOOR_LINES: '24'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/device-signals-and-frontend.test.js
+++ b/tests/js/device-signals-and-frontend.test.js
@@ -1,0 +1,119 @@
+// Tests for the early-return and load-side behaviour of:
+//
+//   - assets/js/ffc-device-signals.js   — bails when crypto.subtle or
+//     ThumbmarkJS is unavailable, disables thumbmark telemetry on load.
+//   - assets/js/ffc-frontend.js         — exposes window.ffcUtils after
+//     load + wires the alert helper.
+//
+// Both files have heavy real-runtime dependencies (SubtleCrypto, the
+// vendored thumbmarkjs library, jQuery AJAX, form submit pipelines)
+// that make deep unit testing expensive. Sprint G of #170 covers the
+// cheap parts here; the AJAX-heavy and crypto-heavy paths warrant
+// integration testing in a real browser environment, tracked as a
+// future sprint.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+// Save originals once.
+const ORIG_CRYPTO     = window.crypto;
+const ORIG_THUMBMARK  = window.ThumbmarkJS;
+const ORIG_FFC_CONFIG = window.ffc_device_config;
+
+beforeEach(() => {
+	// window.crypto is a non-writable property in jsdom — use
+	// defineProperty to swap it.
+	Object.defineProperty(window, 'crypto', { value: ORIG_CRYPTO, configurable: true });
+	window.ThumbmarkJS = ORIG_THUMBMARK;
+	window.ffc_device_config = ORIG_FFC_CONFIG;
+	document.body.innerHTML = '';
+});
+
+// ----------------------------------------------------------------------
+// ffc-device-signals.js — early returns
+// ----------------------------------------------------------------------
+
+describe('ffc-device-signals — early returns', () => {
+	it('bails silently when crypto.subtle is unavailable', () => {
+		// jsdom's window.crypto exists but without subtle. We can also
+		// nuke it entirely to exercise the first guard.
+		const c = { /* no subtle */ };
+		// Override with a configurable descriptor so we can restore it later.
+		Object.defineProperty(window, 'crypto', { value: c, configurable: true });
+		// Ensure ThumbmarkJS doesn't accidentally satisfy the second guard.
+		delete window.ThumbmarkJS;
+
+		// Loading should not throw, and should not register any
+		// observable side effect.
+		expect(() => loadScript('assets/js/ffc-device-signals.js')).not.toThrow();
+	});
+
+	it('bails silently when ThumbmarkJS is unavailable', () => {
+		// crypto.subtle is faked to PASS the first guard so we hit the
+		// second one.
+		Object.defineProperty(window, 'crypto', {
+			value: { subtle: {}, randomUUID: () => 'uuid', getRandomValues: () => {} },
+			configurable: true,
+		});
+		delete window.ThumbmarkJS;
+
+		expect(() => loadScript('assets/js/ffc-device-signals.js')).not.toThrow();
+	});
+
+	it("calls ThumbmarkJS.setOption('logging', false) on first load when both deps are present", () => {
+		const setOption = vi.fn();
+		const getFingerprintData = vi.fn(() => Promise.resolve({}));
+		Object.defineProperty(window, 'crypto', {
+			value: { subtle: {}, randomUUID: () => 'uuid', getRandomValues: () => {} },
+			configurable: true,
+		});
+		window.ThumbmarkJS = {
+			setOption,
+			getFingerprintData,
+			stableStringify: JSON.stringify,
+		};
+
+		loadScript('assets/js/ffc-device-signals.js');
+		expect(setOption).toHaveBeenCalledWith('logging', false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// ffc-frontend.js — public surface after load
+// ----------------------------------------------------------------------
+
+describe('ffc-frontend — load-side', () => {
+	beforeEach(() => {
+		// frontend.js touches window.FFC.Frontend.Masks at module scope;
+		// load the helpers module first so that namespace exists.
+		window.ffc_ajax = {
+			ajax_url: '/wp-admin/admin-ajax.php',
+			nonce: 'test-nonce',
+			strings: {},
+		};
+		loadScript('assets/js/ffc-core.js');
+		loadScript('assets/js/ffc-frontend-helpers.js');
+	});
+
+	it('republishes window.ffcUtils as the Frontend.Masks namespace', () => {
+		loadScript('assets/js/ffc-frontend.js');
+		// frontend.js does `window.ffcUtils = window.FFC.Frontend.Masks;`
+		expect(window.ffcUtils).toBe(window.FFC.Frontend.Masks);
+		// And the mask helpers still resolve.
+		expect(typeof window.ffcUtils.applyCpfRf).toBe('function');
+	});
+
+	it('does not throw when loaded against a page that has no forms', () => {
+		document.body.innerHTML = '<div>no forms here</div>';
+		expect(() => loadScript('assets/js/ffc-frontend.js')).not.toThrow();
+	});
+
+	it('does not throw when loaded against a page with one .ffc-submission-form', () => {
+		document.body.innerHTML = `
+			<form class="ffc-submission-form" data-form-id="1">
+				<input name="cpf_rf" />
+				<input type="hidden" name="form_id" value="1" />
+			</form>
+		`;
+		expect(() => loadScript('assets/js/ffc-frontend.js')).not.toThrow();
+	});
+});

--- a/tests/js/dynamic-fragments.test.js
+++ b/tests/js/dynamic-fragments.test.js
@@ -1,0 +1,200 @@
+// Tests for `assets/js/ffc-dynamic-fragments.js`.
+//
+// The script is a pure IIFE that:
+//   1. Bails early if the page has none of the FFC interactive elements
+//      (`.ffc-captcha-row`, `.ffc-verification-form`, etc.).
+//   2. Bails if it can't find an ajax URL via `ffcDynamic` / `ffc_ajax`
+//      / `ffcCalendar`.
+//   3. Otherwise fires an XHR to `ffc_get_dynamic_fragments` and patches
+//      the DOM with fresh captcha, nonces, user data, and geofence config.
+//
+// Sprint F of #170.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+// Stash the original XMLHttpRequest so tests can restore it.
+const RealXHR = window.XMLHttpRequest;
+
+class MockXHR {
+	constructor() {
+		MockXHR.lastInstance = this;
+		this.status = 200;
+		this.responseText = '{}';
+		this.requestHeaders = {};
+		this.payload = '';
+	}
+	open(method, url) { this.method = method; this.url = url; }
+	setRequestHeader(k, v) { this.requestHeaders[k] = v; }
+	send(payload) { this.payload = payload; MockXHR.sendCount++; }
+	// Test helper — triggers the onload handler with the canned response.
+	deliver(responseObj, status = 200) {
+		this.status = status;
+		this.responseText = JSON.stringify(responseObj);
+		if (typeof this.onload === 'function') this.onload();
+	}
+}
+MockXHR.sendCount = 0;
+MockXHR.lastInstance = null;
+
+function installXHRMock() {
+	MockXHR.sendCount = 0;
+	MockXHR.lastInstance = null;
+	window.XMLHttpRequest = MockXHR;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	window.XMLHttpRequest = RealXHR;
+	window.ffcDynamic = undefined;
+	window.ffc_ajax = undefined;
+	window.ffcCalendar = undefined;
+	window.ffcGeofenceConfig = undefined;
+});
+
+describe('ffc-dynamic-fragments — early returns', () => {
+	it('does nothing when no FFC element is on the page', () => {
+		installXHRMock();
+		document.body.innerHTML = '<div>nothing here</div>';
+		window.ffcDynamic = { ajaxUrl: '/ajax' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		expect(MockXHR.sendCount).toBe(0);
+	});
+
+	it('does nothing when no ajaxUrl source is configured', () => {
+		installXHRMock();
+		document.body.innerHTML = '<div class="ffc-captcha-row"></div>';
+		// ffcDynamic / ffc_ajax / ffcCalendar all undefined.
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		expect(MockXHR.sendCount).toBe(0);
+	});
+
+	it('fires XHR when there is a captcha row + an ajaxUrl', () => {
+		installXHRMock();
+		document.body.innerHTML = '<div class="ffc-captcha-row"></div>';
+		window.ffcDynamic = { ajaxUrl: '/wp-admin/admin-ajax.php' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		expect(MockXHR.sendCount).toBe(1);
+		expect(MockXHR.lastInstance.method).toBe('POST');
+		expect(MockXHR.lastInstance.url).toBe('/wp-admin/admin-ajax.php');
+		expect(MockXHR.lastInstance.payload).toContain('action=ffc_get_dynamic_fragments');
+	});
+
+	it('falls back to ffc_ajax when ffcDynamic is missing', () => {
+		installXHRMock();
+		document.body.innerHTML = '<div class="ffc-form-container"></div>';
+		window.ffc_ajax = { ajax_url: '/fallback' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		expect(MockXHR.lastInstance.url).toBe('/fallback');
+	});
+
+	it('collects form_ids from ffc-form-* wrappers into the payload', () => {
+		installXHRMock();
+		document.body.innerHTML = `
+			<div class="ffc-form-wrapper" id="ffc-form-42">
+				<div class="ffc-captcha-row"></div>
+			</div>
+			<div class="ffc-form-wrapper" id="ffc-form-99"></div>
+		`;
+		window.ffcDynamic = { ajaxUrl: '/x' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		expect(MockXHR.lastInstance.payload).toContain('form_ids%5B%5D=42');
+		expect(MockXHR.lastInstance.payload).toContain('form_ids%5B%5D=99');
+	});
+});
+
+describe('ffc-dynamic-fragments — applyFragments via XHR onload', () => {
+	beforeEach(() => {
+		installXHRMock();
+	});
+
+	function setupAndDeliver(html, response) {
+		document.body.innerHTML = html;
+		window.ffcDynamic = { ajaxUrl: '/x' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		MockXHR.lastInstance.deliver(response);
+	}
+
+	it('updates the per-form captcha (label, hash, blanks the answer)', () => {
+		setupAndDeliver(
+			`<div class="ffc-form-wrapper" id="ffc-form-7">
+				<div class="ffc-captcha-row"><span class="ffc-captcha-label-text">old-label</span></div>
+				<input type="hidden" name="ffc_captcha_hash" value="old-hash" />
+				<input type="text" name="ffc_captcha_ans" value="123" />
+			</div>`,
+			{
+				success: true,
+				data: {
+					captchas: {
+						'7': { label: 'new-label', hash: 'new-hash' },
+					},
+				},
+			}
+		);
+		expect(document.querySelector('.ffc-captcha-label-text').textContent).toBe('new-label');
+		expect(document.querySelector('input[name="ffc_captcha_hash"]').value).toBe('new-hash');
+		expect(document.querySelector('input[name="ffc_captcha_ans"]').value).toBe('');
+	});
+
+	it('updates the default captcha when no per-form captchas matched', () => {
+		setupAndDeliver(
+			`<div class="ffc-form-container">
+				<div class="ffc-captcha-row"><span class="ffc-captcha-label-text">stale</span></div>
+				<input type="hidden" name="ffc_captcha_hash" value="stale-hash" />
+				<input type="text" name="ffc_captcha_ans" value="abc" />
+			</div>`,
+			{
+				success: true,
+				data: {
+					captcha: { label: 'fresh', hash: 'fresh-hash' },
+				},
+			}
+		);
+		expect(document.querySelector('.ffc-captcha-label-text').textContent).toBe('fresh');
+		expect(document.querySelector('input[name="ffc_captcha_hash"]').value).toBe('fresh-hash');
+		expect(document.querySelector('input[name="ffc_captcha_ans"]').value).toBe('');
+	});
+
+	it('refreshes ffcGeofenceConfig and triggers FFCGeofence.recheck()', () => {
+		// Pre-existing geofence config + recheck spy.
+		window.ffcGeofenceConfig = { 7: { datetime: { enabled: false } } };
+		window.FFCGeofence = { recheck: vi.fn() };
+
+		setupAndDeliver(
+			`<div class="ffc-form-wrapper" id="ffc-form-7"><div class="ffc-captcha-row"></div></div>`,
+			{
+				success: true,
+				data: { geofence: { 7: { datetime: { enabled: true, dateStart: '2026-01-01' } } } },
+			}
+		);
+		expect(window.ffcGeofenceConfig[7].datetime.enabled).toBe(true);
+		expect(window.FFCGeofence.recheck).toHaveBeenCalledOnce();
+	});
+
+	it('does nothing when response.success is false', () => {
+		setupAndDeliver(
+			`<div class="ffc-form-wrapper" id="ffc-form-9">
+				<div class="ffc-captcha-row"><span class="ffc-captcha-label-text">stale</span></div>
+			</div>`,
+			{ success: false, data: { captchas: { 9: { label: 'x', hash: 'y' } } } }
+		);
+		expect(document.querySelector('.ffc-captcha-label-text').textContent).toBe('stale');
+	});
+
+	it('does nothing when xhr.status !== 200', () => {
+		document.body.innerHTML = '<div class="ffc-form-wrapper" id="ffc-form-1"><div class="ffc-captcha-row"><span class="ffc-captcha-label-text">stale</span></div></div>';
+		window.ffcDynamic = { ajaxUrl: '/x' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		MockXHR.lastInstance.deliver({ success: true, data: { captcha: { label: 'fresh', hash: 'h' } } }, 500);
+		expect(document.querySelector('.ffc-captcha-label-text').textContent).toBe('stale');
+	});
+
+	it('silently swallows JSON parse errors', () => {
+		document.body.innerHTML = '<div class="ffc-form-container"><div class="ffc-captcha-row"></div></div>';
+		window.ffcDynamic = { ajaxUrl: '/x' };
+		loadScript('assets/js/ffc-dynamic-fragments.js');
+		const xhr = MockXHR.lastInstance;
+		xhr.responseText = 'not-json{';
+		// Should not throw.
+		expect(() => { if (typeof xhr.onload === 'function') xhr.onload(); }).not.toThrow();
+	});
+});

--- a/tests/js/ffc-frontend-helpers.test.js
+++ b/tests/js/ffc-frontend-helpers.test.js
@@ -1,0 +1,230 @@
+// Tests for the public helpers exposed by:
+//   - assets/js/ffc-core.js              → window.FFC.{getString, log, ajax, ...}
+//   - assets/js/ffc-frontend-helpers.js  → window.FFC.Frontend.{Validation, Masks, UI}
+//
+// Both modules already publish their helpers on the FFC global namespace,
+// so this commit is a pure "test in place" pass — no extraction needed,
+// contrary to what Sprint E of #170 originally scoped.
+//
+// Sprint E of #170.
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(() => {
+	// ffc-core.js needs `window.ffc_ajax` (and friends) set for `getString`
+	// / `getAjaxUrl`. The actual values don't matter — just their presence.
+	window.ffc_ajax = {
+		ajax_url: '/wp-admin/admin-ajax.php',
+		nonce: 'test-nonce',
+		strings: {
+			greeting: 'Hello',
+		},
+	};
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-frontend-helpers.js');
+});
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+});
+
+// ----------------------------------------------------------------------
+// window.FFC core helpers
+// ----------------------------------------------------------------------
+
+describe('FFC.getString', () => {
+	it('returns the localized value when the key exists', () => {
+		expect(window.FFC.getString('greeting', 'Hi')).toBe('Hello');
+	});
+
+	it('returns the default when the key is missing', () => {
+		expect(window.FFC.getString('absentKey', 'fallback')).toBe('fallback');
+	});
+
+	it('returns the default when `ffc_ajax.strings` is missing entirely', () => {
+		const saved = window.ffc_ajax;
+		window.ffc_ajax = { ajax_url: '/x', nonce: 'n' }; // no strings
+		try {
+			expect(window.FFC.getString('any', 'def')).toBe('def');
+		} finally {
+			window.ffc_ajax = saved;
+		}
+	});
+});
+
+describe('FFC.getAjaxUrl / getNonce', () => {
+	it('returns the ajax_url from the localized object', () => {
+		expect(window.FFC.getAjaxUrl()).toBe('/wp-admin/admin-ajax.php');
+	});
+
+	it('returns the nonce from the localized object', () => {
+		expect(window.FFC.getNonce()).toBe('test-nonce');
+	});
+});
+
+describe('FFC.isModuleLoaded', () => {
+	it('returns true when FFC.<module> exists', () => {
+		// FFC.Frontend was registered by ffc-frontend-helpers.js.
+		expect(window.FFC.isModuleLoaded('Frontend')).toBe(true);
+	});
+
+	it('returns false when the module is not registered', () => {
+		expect(window.FFC.isModuleLoaded('Nonexistent')).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// FFC.Frontend.Validation
+// ----------------------------------------------------------------------
+
+describe('FFC.Frontend.Validation.validateCPF', () => {
+	const V = () => window.FFC.Frontend.Validation;
+
+	it('accepts a valid CPF (with formatting)', () => {
+		// 529.982.247-25 is a known-valid test CPF.
+		expect(V().validateCPF('529.982.247-25')).toBe(true);
+	});
+
+	it('accepts a valid CPF (digits only)', () => {
+		expect(V().validateCPF('52998224725')).toBe(true);
+	});
+
+	it('rejects a CPF that is too short', () => {
+		expect(V().validateCPF('12345')).toBe(false);
+	});
+
+	it('rejects all-same-digit CPFs (e.g. 111.111.111-11)', () => {
+		expect(V().validateCPF('11111111111')).toBe(false);
+		expect(V().validateCPF('00000000000')).toBe(false);
+	});
+
+	it('rejects a CPF with an invalid first check digit', () => {
+		expect(V().validateCPF('52998224715')).toBe(false); // last 2 digits wrong
+	});
+
+	it('rejects a CPF with an invalid second check digit', () => {
+		expect(V().validateCPF('52998224724')).toBe(false); // last digit off by 1
+	});
+});
+
+describe('FFC.Frontend.Validation.validateRF', () => {
+	const V = () => window.FFC.Frontend.Validation;
+
+	it('accepts a 7-digit RF', () => {
+		expect(V().validateRF('1234567')).toBe(true);
+	});
+
+	it('strips formatting before validating', () => {
+		expect(V().validateRF('123.456-7')).toBe(true);
+	});
+
+	it('rejects an RF that is too short', () => {
+		expect(V().validateRF('123')).toBe(false);
+	});
+
+	it('rejects an RF that is too long', () => {
+		expect(V().validateRF('12345678')).toBe(false);
+	});
+
+	it('rejects an RF with letters mixed in (after digit-stripping it must be 7 digits)', () => {
+		expect(V().validateRF('abc1234')).toBe(false); // only 4 digits after strip
+	});
+});
+
+describe('FFC.Frontend.Validation.validateEmail', () => {
+	const V = () => window.FFC.Frontend.Validation;
+
+	it('accepts a well-formed email', () => {
+		expect(V().validateEmail('user@example.com')).toBe(true);
+		expect(V().validateEmail('first.last+tag@sub.domain.co')).toBe(true);
+	});
+
+	it('rejects emails missing the @ sign', () => {
+		expect(V().validateEmail('userexample.com')).toBe(false);
+	});
+
+	it('rejects emails missing the local part', () => {
+		expect(V().validateEmail('@example.com')).toBe(false);
+	});
+
+	it('rejects emails missing the TLD', () => {
+		expect(V().validateEmail('user@example')).toBe(false);
+	});
+
+	it('rejects emails with whitespace', () => {
+		expect(V().validateEmail('user @example.com')).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// FFC.Frontend.UI — DOM injection of error / success
+// ----------------------------------------------------------------------
+
+describe('FFC.Frontend.UI.showFormError', () => {
+	const U = () => window.FFC.Frontend.UI;
+
+	beforeEach(() => {
+		document.body.innerHTML = '<form id="f"><input name="x" /></form>';
+	});
+
+	it('injects an error notice into the form', () => {
+		U().showFormError(window.$('#f'), 'Something went wrong');
+		const notice = document.querySelector('#f .ffc-message-error, #f .ffc-error-message');
+		// Different versions of the plugin use one of two class names. Just
+		// assert SOMETHING was injected with the message text.
+		expect(document.querySelector('#f').textContent).toContain('Something went wrong');
+	});
+
+	it('replaces a previous error rather than stacking', () => {
+		U().showFormError(window.$('#f'), 'first');
+		U().showFormError(window.$('#f'), 'second');
+		const form = document.querySelector('#f');
+		expect(form.textContent).toContain('second');
+		expect(form.textContent).not.toContain('first');
+	});
+});
+
+describe('FFC.Frontend.UI.showFormSuccess', () => {
+	const U = () => window.FFC.Frontend.UI;
+
+	beforeEach(() => {
+		document.body.innerHTML = '<form id="f"><input name="x" /></form>';
+	});
+
+	it('replaces the form HTML with the success payload', () => {
+		U().showFormSuccess(window.$('#f'), '<div class="ok">Success!</div>');
+		expect(document.querySelector('#f .ok')).not.toBeNull();
+		expect(document.querySelector('#f').textContent).toContain('Success!');
+	});
+});
+
+// ----------------------------------------------------------------------
+// FFC.Frontend.Masks — input formatting
+// ----------------------------------------------------------------------
+
+describe('FFC.Frontend.Masks', () => {
+	const M = () => window.FFC.Frontend.Masks;
+
+	beforeEach(() => {
+		document.body.innerHTML = '<input id="t" type="text" />';
+	});
+
+	it('applyCpfRf binds an input handler that masks CPF format (XXX.XXX.XXX-XX)', async () => {
+		const $i = window.$('#t');
+		M().applyCpfRf($i);
+		$i.val('52998224725').trigger('input');
+		await new Promise((r) => setTimeout(r, 0));
+		// CPF mask: 529.982.247-25
+		expect($i.val()).toBe('529.982.247-25');
+	});
+
+	it('applyAuthCode binds an input handler that masks auth-code (NNNN-NNNN)', async () => {
+		const $i = window.$('#t');
+		M().applyAuthCode($i);
+		// Auth codes are typically 8 chars, alpha-num.
+		$i.val('ABCD1234').trigger('input');
+		await new Promise((r) => setTimeout(r, 0));
+		// Mask inserts a dash at the midpoint: ABCD-1234.
+		expect($i.val()).toBe('ABCD-1234');
+	});
+});


### PR DESCRIPTION
Closes #170.

## Summary

Four sprints (E + F + G + H) from #170. Each commit is independently revertable.

| Sprint | Commit | What |
|---|---|---|
| E | `e7fbdd3` | 28 tests covering `window.FFC.*` (core) and `window.FFC.Frontend.{Validation, Masks, UI}` (frontend-helpers). **No extraction needed** — those files already publish their helpers on the FFC namespace, so the originally-planned refactor wasn't necessary. |
| F | `ca7b293` | 11 tests for `ffc-dynamic-fragments.js` (cache-refresh IIFE). Custom `MockXHR` over `window.XMLHttpRequest` to drive `applyFragments` paths. |
| G | `f1e89ec` | 6 load-side tests for `device-signals` + `frontend.js`. The deep paths (SubtleCrypto + thumbmarkjs fingerprint pipeline, AJAX form submit) explicitly deferred — they need a dedicated PR with heavier mocking infra. |
| H | `0ef0ec7` | `JS_COVERAGE_FLOOR_LINES` ratchets 15 → 24. |

## Coverage delta

| | Before (main) | After (this PR) |
|---|---:|---:|
| Total tests | 127 | **172** (+45) |
| **Overall line coverage** | **16.86%** | **25.78%** |
| `ffc-core.js` | 0% | **59%** |
| `ffc-frontend-helpers.js` | 0% | **63%** |
| `ffc-dynamic-fragments.js` | 0% | **73%** |
| `ffc-device-signals.js` | 0% | **38%** |
| `ffc-frontend.js` | 0% | **27%** |
| `JS_COVERAGE_FLOOR_LINES` | 15 | **24** |

## Notes

- **Sprint E plan revised mid-implementation**: the original issue body proposed "extract pure helpers, then test". After reading `ffc-core.js` / `ffc-frontend-helpers.js`, I found both already publish their helpers on `window.FFC`. Extraction would have been pure churn. Tests go straight against the existing public surface; the commit message documents this.

- **Sprint G partial**: device-signals and frontend.js both have heavy dependency surfaces (SubtleCrypto, thumbmarkjs, jQuery AJAX, jsdom-incompatible APIs). This commit ships the cheap parts (early-returns, telemetry-off enforcement, load-side namespace registration). The crypto + AJAX paths are deferred to a focused future sprint that builds the necessary mocking layer. Coverage moved from 0 to 38% / 27% respectively without that infrastructure — a real but partial win.

- **`window.crypto` is non-writable in jsdom**: tests that need to mutate it use `Object.defineProperty(window, 'crypto', { value, configurable: true })` and restore the original in `beforeEach`.

- **XHR mocking pattern**: `tests/js/dynamic-fragments.test.js` introduces a `MockXHR` class that captures `method` / `url` / `payload` and exposes `deliver(response, status)` to trigger `onload`. Reusable for any future IIFE script that uses raw XHR.

## Test plan

- [x] `npm run test:js` — **172 / 172 OK** (was 127).
- [x] `npm run test:js:coverage` — line coverage **25.78%**, gate (floor 24) passes.
- [x] `npm run lint:js` — clean (9 pre-existing unused-vars warnings unchanged).
- [x] `vendor/bin/phpunit` — runs unchanged (no PHP touched).

## What's deferred

- Device-fingerprint full pipeline (SubtleCrypto + thumbmarkjs).
- Frontend.js form-submit AJAX flow + magic-link verification + PDF handoff.
- `ffc-csv-download.js` (668 LOC, File API).
- `ffc-reregistration-frontend.js` (507 LOC).
- Admin pages (`ffc-admin.js`, field-builder, submission-edit, etc.).
- Calendar subsystem.
- Profile panel deep coverage (form save + password change + LGPD).

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_