### PR TITLE
JS coverage deep: profile + device-signals + frontend (#173)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,14 +33,15 @@ jobs:
     # ffc-geofence-admin.js shipped via #160 (S2 of #161).
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
-      # Ratcheted 3 → 6 → 7 → 15 across #163 / #165 / #168, then 15 → 24
-      # in Sprint H of #170 (medium sprints E+F+G added ~45 tests
-      # covering core/frontend-helpers, dynamic-fragments, and the
-      # load-side of device-signals + frontend.js, taking overall line
-      # coverage to 25.78%). The ~1.8% buffer below the current baseline
-      # catches a real regression without firing on minor flux. Bump
-      # again whenever a PR genuinely improves the number.
-      JS_COVERAGE_FLOOR_LINES: '24'
+      # Ratcheted 3 → 6 → 7 → 15 → 24 across #163 / #165 / #168 / #170,
+      # then 24 → 28 in Sprint L of #173 (deep sprints I+J+K added ~36
+      # tests covering profile save/password/LGPD/notif, device-signals
+      # fingerprint pipeline, and frontend form-submission, taking
+      # overall line coverage to 30.09%). The ~2% buffer below the
+      # current baseline catches a real regression without firing on
+      # minor flux. Bump again whenever a PR genuinely improves the
+      # number.
+      JS_COVERAGE_FLOOR_LINES: '28'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/dashboard-profile-deep.test.js
+++ b/tests/js/dashboard-profile-deep.test.js
@@ -1,0 +1,357 @@
+// Deep coverage for `assets/js/ffc-user-dashboard-profile.js` — covers
+// the form-save, password-change, LGPD privacy, and notification-
+// preferences flows left out of #168 S4 (which only covered the
+// read-view render).
+//
+// Pattern: render the panel with a fixture profile, simulate user
+// interactions via DOM events (jQuery dispatches them as the
+// document-level handlers expect), mock `$.ajax` to capture the
+// request and drive the success/error branches.
+//
+// Sprint I of #173.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { installDashboardFixtures, loadDashboardCore, loadPanel } from './dashboard-fixtures.js';
+
+beforeAll(() => {
+	installDashboardFixtures();
+	Object.assign(window.ffcDashboard.strings, {
+		// Profile-form strings.
+		editProfile: 'Edit Profile',
+		save: 'Save',
+		cancel: 'Cancel',
+		saving: 'Saving…',
+		saveError: 'Error saving profile',
+		// Password strings.
+		changePassword: 'Change Password',
+		currentPassword: 'Current Password',
+		newPassword: 'New Password',
+		confirmPassword: 'Confirm Password',
+		passwordError: 'All fields required',
+		passwordMismatch: 'Passwords do not match',
+		passwordTooShort: 'Min 8 characters',
+		passwordChanged: 'Password changed!',
+		// LGPD / notifications.
+		exportRequested: 'Export requested',
+		deletionRequested: 'Deletion requested',
+		confirmDeletion: 'Are you sure?',
+		notificationsSaved: 'Saved',
+		// Profile fields.
+		name: 'Name',
+		phone: 'Phone:',
+		department: 'Department:',
+		organization: 'Organization:',
+		notesLabel: 'Notes:',
+		notesPlaceholder: 'Personal notes…',
+		linkedEmails: 'Emails',
+		cpfRf: 'CPF/RF',
+		audienceGroups: 'Groups',
+		leaveAllGroups: 'Leave all groups',
+		memberSince: 'Member since:',
+		logout: 'Log Out',
+		preferences: 'Preferences',
+		notifications: 'Notifications',
+		lgpd: 'Privacy',
+	});
+	window.ffcDashboard.restUrl = 'https://x.test/wp-json/ffc/v1/';
+	window.ffcDashboard.logoutUrl = 'https://x.test/logout';
+
+	const dash = document.getElementById('ffc-dashboard');
+	if (dash && ! document.getElementById('tab-profile')) {
+		const el = document.createElement('div');
+		el.id = 'tab-profile';
+		el.className = 'ffc-tab-content';
+		dash.appendChild(el);
+	}
+	loadDashboardCore();
+	loadPanel('profile');
+	// bindEvents() is normally called from FFCDashboard.init() — invoke
+	// it manually so the document-level delegates land before the tests
+	// click anything.
+	window.FFCDashboard.panels.profile.bindEvents();
+});
+
+const PROFILE_FIXTURE = {
+	display_name: 'Maria Silva',
+	names: ['Maria Silva'],
+	email: 'maria@example.com',
+	emails: ['maria@example.com'],
+	cpf_masked: '123.***.***-**',
+	cpfs_masked: ['123.***.***-**'],
+	phone: '11 99999-0000',
+	department: 'TI',
+	organization: 'ACME',
+	notes: '',
+	audience_groups: [],
+	member_since: '01/01/2025',
+	preferences: { newsletter: true, marketing: false },
+};
+
+beforeEach(() => {
+	document.getElementById('tab-profile').innerHTML = '';
+	window.FFCDashboard.panels.profile.state = null;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function panel() {
+	return window.FFCDashboard.panels.profile;
+}
+
+function mockAjax(impl) {
+	return vi.spyOn(window.$, 'ajax').mockImplementation(impl);
+}
+
+function mockAjaxSuccess(response) {
+	return mockAjax((opts) => { if (opts.success) opts.success(response); return {}; });
+}
+
+function mockAjaxError(xhr) {
+	return mockAjax((opts) => { if (opts.error) opts.error(xhr); return {}; });
+}
+
+// ----------------------------------------------------------------------
+// showEditForm via .ffc-profile-edit-btn click
+// ----------------------------------------------------------------------
+
+describe('profile.showEditForm', () => {
+	it('replaces the read view with an edit form populated from state', () => {
+		panel().render(PROFILE_FIXTURE);
+		window.$('.ffc-profile-edit-btn').trigger('click');
+		const form = document.querySelector('#tab-profile .ffc-profile-edit-form');
+		expect(form).not.toBeNull();
+		expect(document.getElementById('ffc-edit-display-name').value).toBe('Maria Silva');
+		expect(document.getElementById('ffc-edit-phone').value).toBe('11 99999-0000');
+		expect(document.getElementById('ffc-edit-department').value).toBe('TI');
+		expect(document.getElementById('ffc-edit-organization').value).toBe('ACME');
+	});
+
+	it("does nothing when state is null (defensive — shouldn't happen at runtime)", () => {
+		panel().state = null;
+		document.getElementById('tab-profile').innerHTML = '<button class="ffc-profile-edit-btn">Edit</button>';
+		window.$('.ffc-profile-edit-btn').trigger('click');
+		expect(document.querySelector('#tab-profile .ffc-profile-edit-form')).toBeNull();
+	});
+
+	it('cancel button re-renders the read view from the preserved state', () => {
+		panel().render(PROFILE_FIXTURE);
+		window.$('.ffc-profile-edit-btn').trigger('click');
+		expect(document.querySelector('#tab-profile .ffc-profile-edit-form')).not.toBeNull();
+		window.$('.ffc-profile-cancel-btn').trigger('click');
+		// Read view is back.
+		expect(document.querySelector('#tab-profile .ffc-profile-info')).not.toBeNull();
+		expect(document.querySelector('#tab-profile .ffc-profile-edit-form')).toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------
+// saveProfile — AJAX PUT + state refresh on success / error display
+// ----------------------------------------------------------------------
+
+describe('profile.saveProfile', () => {
+	it('sends a PUT to user/profile with the form values as JSON', () => {
+		panel().render(PROFILE_FIXTURE);
+		window.$('.ffc-profile-edit-btn').trigger('click');
+		// User edits a field.
+		document.getElementById('ffc-edit-display-name').value = 'Maria S. Silva';
+
+		const spy = mockAjaxSuccess({ ...PROFILE_FIXTURE, display_name: 'Maria S. Silva' });
+		window.$('.ffc-profile-save-btn').trigger('click');
+
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.method).toBe('PUT');
+		expect(call.url).toContain('user/profile');
+		const payload = JSON.parse(call.data);
+		expect(payload.display_name).toBe('Maria S. Silva');
+		expect(payload.phone).toBe('11 99999-0000');
+		expect(payload.department).toBe('TI');
+		expect(payload.organization).toBe('ACME');
+	});
+
+	it('on success: replaces state and re-renders the read view', () => {
+		panel().render(PROFILE_FIXTURE);
+		window.$('.ffc-profile-edit-btn').trigger('click');
+		document.getElementById('ffc-edit-display-name').value = 'Updated';
+
+		const updated = { ...PROFILE_FIXTURE, display_name: 'Updated' };
+		mockAjaxSuccess(updated);
+		window.$('.ffc-profile-save-btn').trigger('click');
+
+		expect(panel().state).toEqual(updated);
+		// Read view rendered (the .ffc-profile-info container).
+		expect(document.querySelector('#tab-profile .ffc-profile-info')).not.toBeNull();
+	});
+
+	it('on error: shows the server message and re-enables the save button', () => {
+		panel().render(PROFILE_FIXTURE);
+		window.$('.ffc-profile-edit-btn').trigger('click');
+
+		mockAjaxError({ responseJSON: { message: 'Custom server error' } });
+		window.$('.ffc-profile-save-btn').trigger('click');
+
+		const status = document.querySelector('.ffc-profile-save-status');
+		expect(status.textContent).toBe('Custom server error');
+		expect(document.querySelector('.ffc-profile-save-btn').disabled).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// changePassword — client-side validation + AJAX
+// ----------------------------------------------------------------------
+
+describe('profile.changePassword', () => {
+	beforeEach(() => {
+		// Render the read view so the password form fields exist
+		// (#ffc-current-password etc. are inside .ffc-password-form).
+		panel().render(PROFILE_FIXTURE);
+	});
+
+	function setPasswords(current, neu, conf) {
+		document.getElementById('ffc-current-password').value = current;
+		document.getElementById('ffc-new-password').value = neu;
+		document.getElementById('ffc-confirm-password').value = conf;
+	}
+
+	it('rejects when any field is blank (no AJAX call)', () => {
+		const spy = mockAjax(() => ({}));
+		setPasswords('', '', '');
+		window.$('.ffc-password-save-btn').trigger('click');
+		expect(spy).not.toHaveBeenCalled();
+		expect(document.querySelector('.ffc-password-status').textContent).toBe('All fields required');
+	});
+
+	it('rejects when new + confirm mismatch', () => {
+		const spy = mockAjax(() => ({}));
+		setPasswords('old', 'abcdefgh', 'abcdefgi');
+		window.$('.ffc-password-save-btn').trigger('click');
+		expect(spy).not.toHaveBeenCalled();
+		expect(document.querySelector('.ffc-password-status').textContent).toBe('Passwords do not match');
+	});
+
+	it('rejects when new password is shorter than 8 chars', () => {
+		const spy = mockAjax(() => ({}));
+		setPasswords('old', 'short', 'short');
+		window.$('.ffc-password-save-btn').trigger('click');
+		expect(spy).not.toHaveBeenCalled();
+		expect(document.querySelector('.ffc-password-status').textContent).toBe('Min 8 characters');
+	});
+
+	it('on success: clears the password fields and shows the response message', () => {
+		const spy = mockAjaxSuccess({ message: 'Done!' });
+		setPasswords('oldpass', 'newpass123', 'newpass123');
+		window.$('.ffc-password-save-btn').trigger('click');
+
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.method).toBe('POST');
+		expect(call.url).toContain('user/change-password');
+		const payload = JSON.parse(call.data);
+		expect(payload.current_password).toBe('oldpass');
+		expect(payload.new_password).toBe('newpass123');
+
+		expect(document.querySelector('.ffc-password-status').textContent).toBe('Done!');
+		expect(document.getElementById('ffc-current-password').value).toBe('');
+		expect(document.getElementById('ffc-new-password').value).toBe('');
+		expect(document.getElementById('ffc-confirm-password').value).toBe('');
+	});
+
+	it('on error: surfaces the server message', () => {
+		mockAjaxError({ responseJSON: { message: 'Wrong current password' } });
+		setPasswords('badpass', 'newpass123', 'newpass123');
+		window.$('.ffc-password-save-btn').trigger('click');
+
+		expect(document.querySelector('.ffc-password-status').textContent).toBe('Wrong current password');
+	});
+});
+
+// ----------------------------------------------------------------------
+// privacyRequest — LGPD export + delete (with confirm)
+// ----------------------------------------------------------------------
+
+describe('profile.privacyRequest', () => {
+	beforeEach(() => {
+		panel().render(PROFILE_FIXTURE);
+	});
+
+	it('Export button POSTs without asking for confirmation', () => {
+		const spy = mockAjaxSuccess({ ok: true });
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+		// The LGPD section is rendered if the panel template includes it
+		// — render() emits it conditionally so the button may or may not
+		// be there. Check first whether it exists; if not, inject it.
+		if (! document.querySelector('.ffc-lgpd-export-btn')) {
+			document.getElementById('tab-profile').insertAdjacentHTML(
+				'beforeend',
+				'<button class="ffc-lgpd-export-btn"></button><span class="ffc-lgpd-status"></span>'
+			);
+		}
+		window.$('.ffc-lgpd-export-btn').trigger('click');
+
+		expect(confirmSpy).not.toHaveBeenCalled(); // export skips confirm.
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.method).toBe('POST');
+		expect(JSON.parse(call.data).type).toBe('export_personal_data');
+	});
+
+	it('Delete button asks for confirmation; cancels if user declines', () => {
+		const spy = mockAjax(() => ({}));
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+		if (! document.querySelector('.ffc-lgpd-delete-btn')) {
+			document.getElementById('tab-profile').insertAdjacentHTML(
+				'beforeend',
+				'<button class="ffc-lgpd-delete-btn"></button><span class="ffc-lgpd-status"></span>'
+			);
+		}
+		window.$('.ffc-lgpd-delete-btn').trigger('click');
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('Delete button proceeds when confirmation is accepted', () => {
+		const spy = mockAjaxSuccess({ ok: true });
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+		if (! document.querySelector('.ffc-lgpd-delete-btn')) {
+			document.getElementById('tab-profile').insertAdjacentHTML(
+				'beforeend',
+				'<button class="ffc-lgpd-delete-btn"></button><span class="ffc-lgpd-status"></span>'
+			);
+		}
+		window.$('.ffc-lgpd-delete-btn').trigger('click');
+
+		expect(spy).toHaveBeenCalledOnce();
+		expect(JSON.parse(spy.mock.calls[0][0].data).type).toBe('remove_personal_data');
+	});
+});
+
+// ----------------------------------------------------------------------
+// saveNotificationPreferences — toggle change triggers AJAX
+// ----------------------------------------------------------------------
+
+describe('profile.saveNotificationPreferences', () => {
+	it('fires AJAX on .ffc-notif-toggle change and updates state.preferences from the response', () => {
+		panel().render(PROFILE_FIXTURE);
+
+		// Inject a notification toggle if the rendered profile didn't
+		// include one (template logic varies by preference shape).
+		if (! document.querySelector('.ffc-notif-toggle')) {
+			document.getElementById('tab-profile').insertAdjacentHTML(
+				'beforeend',
+				'<input type="checkbox" class="ffc-notif-toggle" data-key="newsletter" /><span class="ffc-notif-status"></span>'
+			);
+		}
+
+		const spy = mockAjaxSuccess({ preferences: { newsletter: false, marketing: false } });
+		const toggle = document.querySelector('.ffc-notif-toggle');
+		toggle.checked = false;
+		window.$(toggle).trigger('change');
+
+		expect(spy).toHaveBeenCalledOnce();
+		expect(panel().state.preferences.newsletter).toBe(false);
+	});
+});

--- a/tests/js/device-signals-deep.test.js
+++ b/tests/js/device-signals-deep.test.js
@@ -1,0 +1,265 @@
+// Deep coverage for `assets/js/ffc-device-signals.js` — exercises the
+// full fingerprint pipeline that Sprint G of #170 deferred:
+//   - generateUuid + getOrCreateDeviceId (localStorage roundtrip)
+//   - sha256Hex via mocked window.crypto.subtle.digest
+//   - mapComponents (14 signal slots)
+//   - collectSignals (getFingerprintData → mapComponents → hash each)
+//   - attachToForms (writes JSON into <input name="ffc_device_signals">)
+//
+// Strategy: replace SubtleCrypto + ThumbmarkJS with deterministic
+// fakes, load the script, wait for the form-attach promise to settle,
+// and assert against the hidden input's serialised payload.
+//
+// Sprint J of #173.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+const ORIG_CRYPTO     = window.crypto;
+const ORIG_THUMBMARK  = window.ThumbmarkJS;
+const ORIG_FFC_CONFIG = window.ffc_device_config;
+
+/**
+ * Deterministic 32-byte hash mock for SubtleCrypto.digest. The output
+ * varies with input (so different signals produce different hex strings)
+ * but is stable across runs so assertions can be exact.
+ */
+function fakeDigest(_algorithm, data) {
+	const view = new Uint8Array(data);
+	const out = new Uint8Array(32);
+	for (let i = 0; i < 32; i++) {
+		out[i] = (view.length > 0 ? view[i % view.length] + i : i) & 0xff;
+	}
+	return Promise.resolve(out.buffer);
+}
+
+function installCryptoMock() {
+	Object.defineProperty(window, 'crypto', {
+		value: {
+			subtle: { digest: vi.fn(fakeDigest) },
+			randomUUID: () => '11111111-2222-3333-4444-555555555555',
+			getRandomValues: (arr) => {
+				for (let i = 0; i < arr.length; i++) arr[i] = i & 0xff;
+				return arr;
+			},
+		},
+		configurable: true,
+	});
+}
+
+function installThumbmarkMock(fingerprintData = {}) {
+	window.ThumbmarkJS = {
+		setOption: vi.fn(),
+		stableStringify: (v) => JSON.stringify(v),
+		getFingerprintData: vi.fn(() => Promise.resolve(fingerprintData)),
+	};
+}
+
+function fullFingerprintFixture() {
+	return {
+		system: {
+			useragent: 'Mozilla/5.0 (Linux) AppleWebKit/537.36 Chrome/120.0.0.0',
+			platform: 'Linux',
+			hardwareConcurrency: 8,
+		},
+		locales: {
+			timezone: 'America/Sao_Paulo',
+			languages: 'pt-BR',
+		},
+		hardware: {
+			deviceMemory: 16,
+		},
+		screen:       { width: 1920, height: 1080 },
+		canvas:       { hash: 'canvas-abc' },
+		audio:        { fingerprint: 0.123456 },
+		webgl:        { vendor: 'NVIDIA' },
+		fonts:        ['Arial', 'Helvetica'],
+		plugins:      ['Chrome PDF'],
+		permissions:  { notifications: 'default' },
+		mediaQueries: { dark: false },
+		math:         { sin: 0.5 },
+	};
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	window.localStorage.clear();
+	Object.defineProperty(window, 'crypto', { value: ORIG_CRYPTO, configurable: true });
+	window.ThumbmarkJS = ORIG_THUMBMARK;
+	window.ffc_device_config = ORIG_FFC_CONFIG;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// Wait long enough for the chained promises in collectSignals to settle.
+function flush() { return new Promise((r) => setTimeout(r, 0)).then(() => new Promise((r) => setTimeout(r, 0))); }
+
+describe('ffc-device-signals — fingerprint pipeline', () => {
+	it('does not touch any form when no .ffc-submission-form exists on the page', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['ua', 'tz'] };
+
+		document.body.innerHTML = '<div>no forms here</div>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		// No hidden input was created.
+		expect(document.querySelector('input[name="ffc_device_signals"]')).toBeNull();
+	});
+
+	it('creates a hidden #ffc_device_signals input on each ffc-submission-form', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['ua', 'tz', 'screen'] };
+
+		document.body.innerHTML = `
+			<form class="ffc-submission-form" id="f1"></form>
+			<form class="ffc-submission-form" id="f2"></form>
+		`;
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		expect(document.querySelector('#f1 input[name="ffc_device_signals"]')).not.toBeNull();
+		expect(document.querySelector('#f2 input[name="ffc_device_signals"]')).not.toBeNull();
+	});
+
+	it('hashes each enabled signal and serialises the result as JSON', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['ua', 'tz', 'screen', 'canvas'] };
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		const input = document.querySelector('input[name="ffc_device_signals"]');
+		expect(input).not.toBeNull();
+		const payload = JSON.parse(input.value);
+		// Each enabled signal that mapComponents produced should land as
+		// a 64-char hex digest.
+		for (const key of ['ua', 'tz', 'screen', 'canvas']) {
+			expect(payload[key]).toBeTypeOf('string');
+			expect(payload[key]).toMatch(/^[0-9a-f]{64}$/);
+		}
+		// SHA-256 mock was called once per enabled signal.
+		expect(window.crypto.subtle.digest).toHaveBeenCalled();
+	});
+
+	it('skips signals that are absent from ffc_device_config.signals (allowlist)', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['ua'] }; // only `ua` enabled
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		const payload = JSON.parse(document.querySelector('input[name="ffc_device_signals"]').value);
+		expect(Object.keys(payload)).toEqual(['ua']);
+	});
+
+	it("persists a cookie-style device UUID via localStorage when 'cookie' signal is enabled", async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['cookie'] };
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		// The script writes a fresh UUID to localStorage on first run.
+		expect(window.localStorage.getItem('ffc_device_id')).toBe('11111111-2222-3333-4444-555555555555');
+		// And ships the hash in the payload.
+		const payload = JSON.parse(document.querySelector('input[name="ffc_device_signals"]').value);
+		expect(payload.cookie).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('reuses the persisted device UUID on subsequent loads', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['cookie'] };
+
+		// Must match the script's UUID-shape regex `/^[0-9a-f-]{30,40}$/i`
+		// (hex + dashes, 30-40 chars). Anything else triggers a regen.
+		window.localStorage.setItem('ffc_device_id', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		expect(window.localStorage.getItem('ffc_device_id')).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+	});
+
+	it('falls back to getRandomValues when crypto.randomUUID is unavailable', async () => {
+		installCryptoMock();
+		// Drop randomUUID — script must use the getRandomValues fallback.
+		delete window.crypto.randomUUID;
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ffc_device_config = { signals: ['cookie'] };
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		const stored = window.localStorage.getItem('ffc_device_id');
+		expect(stored).toMatch(/^[0-9a-f-]+$/); // looks like a UUID.
+		// Sanity: not the randomUUID value used in installCryptoMock.
+		expect(stored).not.toBe('11111111-2222-3333-4444-555555555555');
+	});
+
+	it('produces a partial payload (cookie only) when ThumbmarkJS.getFingerprintData rejects', async () => {
+		installCryptoMock();
+		installThumbmarkMock(); // valid mock
+		window.ThumbmarkJS.getFingerprintData = vi.fn(() => Promise.reject(new Error('thumbmark down')));
+		window.ffc_device_config = { signals: ['cookie', 'ua', 'tz'] };
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		const payload = JSON.parse(document.querySelector('input[name="ffc_device_signals"]').value);
+		expect(Object.keys(payload)).toEqual(['cookie']);
+		expect(payload.cookie).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('falls back to JSON.stringify when ThumbmarkJS.stableStringify throws', async () => {
+		installCryptoMock();
+		installThumbmarkMock(fullFingerprintFixture());
+		window.ThumbmarkJS.stableStringify = () => { throw new Error('stringify failed'); };
+		window.ffc_device_config = { signals: ['screen'] };
+
+		document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+		loadScript('assets/js/ffc-device-signals.js');
+		await flush();
+
+		// Screen signal should still hash and land in the payload.
+		const payload = JSON.parse(document.querySelector('input[name="ffc_device_signals"]').value);
+		expect(payload.screen).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('coarse-grains the UA — three-part minor.patch is stripped before hashing', async () => {
+		installCryptoMock();
+		// The script's regex `/(\d+)\.\d+\.\d+/g, '$1'` strips a 3-part
+		// version number, leaving just the major. Two fixtures whose
+		// last 3 segments differ should hash identically once stripped.
+		const fp1 = fullFingerprintFixture();
+		fp1.system.useragent = 'Chrome/120.1.2';
+		const fp2 = fullFingerprintFixture();
+		fp2.system.useragent = 'Chrome/120.9.8';
+
+		// Run twice with different fingerprints, capture each payload.
+		async function runWith(fp) {
+			installThumbmarkMock(fp);
+			window.ffc_device_config = { signals: ['ua'] };
+			document.body.innerHTML = '<form class="ffc-submission-form"></form>';
+			loadScript('assets/js/ffc-device-signals.js');
+			await flush();
+			return JSON.parse(document.querySelector('input[name="ffc_device_signals"]').value).ua;
+		}
+
+		const h1 = await runWith(fp1);
+		const h2 = await runWith(fp2);
+		expect(h1).toBe(h2);
+	});
+});

--- a/tests/js/frontend-deep.test.js
+++ b/tests/js/frontend-deep.test.js
@@ -1,0 +1,246 @@
+// Deep coverage for `assets/js/ffc-frontend.js` — exercises the AJAX
+// flows that Sprint G of #170 deferred: form submission, magic-link
+// verification, error / success branches, rate-limit branch.
+//
+// Strategy: install jQuery first (already in setup.js), load FFC core +
+// frontend-helpers (frontend.js touches FFC.Frontend.* at module scope),
+// then load frontend.js. The IIFE registers document-level submit and
+// load-time handlers. Dispatch synthetic events and mock `$.ajax` to
+// drive the responses.
+//
+// Sprint K of #173.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(async () => {
+	window.ffc_ajax = {
+		ajax_url: '/wp-admin/admin-ajax.php',
+		nonce: 'test-nonce',
+		strings: {
+			fillRequired: 'Please fill all required fields',
+			processing: 'Processing…',
+			error: 'Error occurred',
+			connectionError: 'Connection error',
+		},
+	};
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-frontend-helpers.js');
+	loadScript('assets/js/ffc-frontend.js');
+	// jQuery 4 defers `$(document).ready(cb)` to a microtask — wait for
+	// it so handleFormSubmission's submit delegate is wired before the
+	// first test triggers a form submit.
+	await new Promise((r) => setTimeout(r, 0));
+});
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	// Reset location.hash + search between tests (jsdom allows this).
+	window.history.replaceState({}, '', '/');
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function mockAjax(impl) {
+	return vi.spyOn(window.$, 'ajax').mockImplementation(impl);
+}
+
+// ----------------------------------------------------------------------
+// handleFormSubmission — registered on $(document) at script load time
+// ----------------------------------------------------------------------
+
+describe('frontend.handleFormSubmission', () => {
+	function setupForm({ withRequired = false } = {}) {
+		document.body.innerHTML = `
+			<form class="ffc-submission-form">
+				<input type="hidden" name="form_id" value="42" />
+				<input type="text" name="name" ${withRequired ? 'required' : ''} />
+				<button type="submit">Send</button>
+			</form>
+		`;
+		return window.$('form.ffc-submission-form');
+	}
+
+	it('blocks submission when a required field is empty', () => {
+		const $form = setupForm({ withRequired: true });
+		const spy = mockAjax(() => ({}));
+		$form.trigger('submit');
+		expect(spy).not.toHaveBeenCalled();
+		// First required field is marked invalid.
+		const input = document.querySelector('input[name="name"]');
+		expect(input.classList.contains('ffc-field-error')).toBe(true);
+		expect(input.getAttribute('aria-invalid')).toBe('true');
+	});
+
+	it('inserts an accessible alert above the form when validation fails', () => {
+		const $form = setupForm({ withRequired: true });
+		mockAjax(() => ({}));
+		$form.trigger('submit');
+		const alert = document.querySelector('.ffc-accessible-alert');
+		expect(alert).not.toBeNull();
+		expect(alert.textContent).toContain('Please fill all required fields');
+		expect(alert.getAttribute('role')).toBe('alert');
+	});
+
+	it('sends the AJAX with form data + action + nonce when valid', () => {
+		const $form = setupForm();
+		const spy = mockAjax(() => ({}));
+		document.querySelector('input[name="name"]').value = 'Maria';
+		$form.trigger('submit');
+
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.type).toBe('POST');
+		expect(call.url).toBe('/wp-admin/admin-ajax.php');
+		expect(call.data).toContain('form_id=42');
+		expect(call.data).toContain('name=Maria');
+		expect(call.data).toContain('action=ffc_submit_form');
+		expect(call.data).toContain('nonce=test-nonce');
+	});
+
+	it('on success: replaces the form HTML with response.data.html', () => {
+		const $form = setupForm();
+		mockAjax((opts) => {
+			opts.success({
+				success: true,
+				data: { html: '<div class="ok-card">Submission OK</div>' },
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		expect(document.querySelector('form.ffc-submission-form .ok-card')).not.toBeNull();
+	});
+
+	it('on success with pdf_data: adds data-pdf-data attribute on the download button', () => {
+		const $form = setupForm();
+		mockAjax((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					html: '<button class="ffc-download-btn">Download</button>',
+					pdf_data: { filename: 'cert.pdf', content: 'base64...' },
+				},
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		const btn = document.querySelector('.ffc-download-btn');
+		expect(btn).not.toBeNull();
+		const pdfAttr = btn.getAttribute('data-pdf-data');
+		expect(pdfAttr).not.toBeNull();
+		expect(JSON.parse(pdfAttr).filename).toBe('cert.pdf');
+	});
+
+	it('triggers window.ffcGeneratePDF when pdf_data is in the response', () => {
+		vi.useFakeTimers();
+		const generatePDF = vi.fn();
+		window.ffcGeneratePDF = generatePDF;
+
+		const $form = setupForm();
+		mockAjax((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					html: '<button class="ffc-download-btn">D</button>',
+					pdf_data: { filename: 'doc.pdf' },
+				},
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		// The script defers via setTimeout(500). Fast-forward.
+		vi.advanceTimersByTime(600);
+
+		expect(generatePDF).toHaveBeenCalledOnce();
+		expect(generatePDF.mock.calls[0][1]).toBe('doc.pdf');
+		vi.useRealTimers();
+		delete window.ffcGeneratePDF;
+	});
+
+	it('on success but response.success=false: shows the error message via FFC.Frontend.UI.showFormError', () => {
+		const $form = setupForm();
+		mockAjax((opts) => {
+			opts.success({
+				success: false,
+				data: { message: 'Custom failure' },
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		// FFC.Frontend.UI.showFormError injects a notice into the form.
+		expect(document.querySelector('form.ffc-submission-form').textContent).toContain('Custom failure');
+	});
+
+	it('on success: refresh_captcha branch hits FFC.Frontend.UI.refreshCaptcha', () => {
+		const $form = setupForm();
+		// Add the captcha bits the UI helper expects.
+		$form.append('<div class="ffc-captcha-row"><span class="ffc-captcha-label-text">old</span></div>');
+		$form.append('<input type="hidden" name="ffc_captcha_hash" value="old-h" />');
+		mockAjax((opts) => {
+			opts.success({
+				success: false,
+				data: {
+					message: 'Bad captcha',
+					refresh_captcha: true,
+					new_label: 'new-label',
+					new_hash: 'new-hash',
+				},
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		expect(document.querySelector('.ffc-captcha-label-text').textContent).toBe('new-label');
+		expect(document.querySelector('input[name="ffc_captcha_hash"]').value).toBe('new-hash');
+	});
+
+	it('on error with rate_limit payload: calls FFC.Frontend.RateLimit.show', () => {
+		const $form = setupForm();
+		const showSpy = vi.spyOn(window.FFC.Frontend.RateLimit, 'show').mockImplementation(() => {});
+		mockAjax((opts) => {
+			opts.error({
+				responseJSON: {
+					data: { rate_limit: true, message: 'Slow down', wait_seconds: 30 },
+				},
+			});
+			return {};
+		});
+		$form.trigger('submit');
+		expect(showSpy).toHaveBeenCalledWith('Slow down', 30);
+	});
+
+	it('on generic error: shows the connection-error alert', () => {
+		const $form = setupForm();
+		mockAjax((opts) => {
+			opts.error({ responseJSON: null });
+			return {};
+		});
+		$form.trigger('submit');
+		const alert = document.querySelector('.ffc-accessible-alert');
+		expect(alert).not.toBeNull();
+		expect(alert.textContent).toContain('Connection error');
+	});
+});
+
+// ----------------------------------------------------------------------
+// showAccessibleAlert — DOM injection helper, accessible via the
+// validation path which calls it directly.
+// ----------------------------------------------------------------------
+
+describe('frontend.showAccessibleAlert (via required-field validation)', () => {
+	it('removes any previous alert before injecting a new one', () => {
+		document.body.innerHTML = `
+			<form class="ffc-submission-form">
+				<input type="text" required />
+				<button type="submit">Send</button>
+			</form>
+		`;
+		mockAjax(() => ({}));
+		// First submit → first alert.
+		window.$('form').trigger('submit');
+		expect(document.querySelectorAll('.ffc-accessible-alert').length).toBe(1);
+		// Second submit → still only one alert.
+		window.$('form').trigger('submit');
+		expect(document.querySelectorAll('.ffc-accessible-alert').length).toBe(1);
+	});
+});


### PR DESCRIPTION
Closes #173.

## Summary

Four sprints (I + J + K + L) from #173. Each commit independently revertable.

| Sprint | Commit | What |
|---|---|---|
| I | `fb243ea` | 15 tests for profile panel save / password change / LGPD privacy / notifications. Profile **40% → 86%**. |
| J | `824b014` | 10 tests for device-signals fingerprint pipeline end-to-end (mocked SubtleCrypto + ThumbmarkJS). Device-signals **38% → 96%**. |
| K | `239d177` | 11 tests for frontend.js form-submission flow (validation, success, error, rate-limit, refresh-captcha branches). Frontend.js **27% → 56%**. |
| L | `47a9886` | Floor ratchet 24 → 28. |

## Coverage delta

| | Before (main) | After (this PR) |
|---|---:|---:|
| Total tests | 172 | **208** (+36) |
| **Overall line coverage** | **25.78%** | **30.09%** |
| `ffc-user-dashboard-profile.js` | 40% | **86%** |
| `ffc-device-signals.js` | 38% | **96%** |
| `ffc-frontend.js` | 27% | **56%** |
| `JS_COVERAGE_FLOOR_LINES` | 24 | **28** |

## Mocking infrastructure introduced (reusable)

- **`fakeDigest(algo, data)`** — deterministic 32-byte hash returning Promise<ArrayBuffer>; varies with input so different signals produce different hex strings.
- **`installCryptoMock()`** — replaces `window.crypto` with a stub `{ subtle: { digest: fakeDigest }, randomUUID, getRandomValues }`.
- **`installThumbmarkMock(fingerprintData)`** — replaces `window.ThumbmarkJS` with vi-tracked `{ setOption, stableStringify, getFingerprintData }`.
- **`mockAjaxSuccess(response)` / `mockAjaxError(xhr)`** — `vi.spyOn(window.$, 'ajax')` patterns now used across 4 test files.

## Notes

- **`$(document).ready(cb)` deferral** — frontend.js and several panels register their event delegates inside the ready callback. Tests with `beforeAll(async () => { ...; await flush(); })` ensure delegates are wired before the first test triggers an event.
- **`window.crypto` is non-writable in jsdom** — tests use `Object.defineProperty(window, 'crypto', { value, configurable: true })` to swap and restore.
- **Magic-link verification deferred** — runs once via `$(document).ready` + `setTimeout(100)`, reads `window.location`. Testing different URL configurations would need either re-loading the script (which duplicates the submit delegate) or exposing the function for direct call. Both have downsides bigger than the test value; tracked as a follow-up.
- **Profile LGPD / notification sections** — emitted conditionally by `render()`. Tests inject the buttons inline when the template omits them, so the click handler is the unit under test regardless of the preference shape.

## Test plan

- [x] `npm run test:js` — **208 / 208 OK** (was 172).
- [x] `npm run test:js:coverage` — line coverage **30.09%**, gate (floor 28) passes.
- [x] `npm run lint:js` — clean (9 pre-existing unused-vars warnings unchanged).
- [x] `vendor/bin/phpunit` — runs unchanged (no PHP touched).

## What's deferred

- Magic-link verification + setupDynamicMaskObserver in frontend.js.
- `ffc-csv-download.js` (668 LOC, File API).
- `ffc-reregistration-frontend.js` (507 LOC).
- Admin pages (`ffc-admin.js`, field-builder, submission-edit, etc.) — next sprint per the roadmap.
- Calendar subsystem.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_