### PR TITLE
JS coverage admin + certs-dashboard: admin.js + FieldBuilder + submission-edit + cert dashboard (#175)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,15 +33,15 @@ jobs:
     # ffc-geofence-admin.js shipped via #160 (S2 of #161).
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
-      # Ratcheted 3 → 6 → 7 → 15 → 24 across #163 / #165 / #168 / #170,
-      # then 24 → 28 in Sprint L of #173 (deep sprints I+J+K added ~36
-      # tests covering profile save/password/LGPD/notif, device-signals
-      # fingerprint pipeline, and frontend form-submission, taking
-      # overall line coverage to 30.09%). The ~2% buffer below the
-      # current baseline catches a real regression without firing on
-      # minor flux. Bump again whenever a PR genuinely improves the
-      # number.
-      JS_COVERAGE_FLOOR_LINES: '28'
+      # Ratcheted 3 → 6 → 7 → 15 → 24 → 28 across #163 / #165 / #168 /
+      # #170 / #173, then 28 → 34 in Sprint Q of #175 (admin+cert-
+      # dashboard sprints M+N+O+P added ~38 tests covering ffc-admin,
+      # FieldBuilder, submission-edit, and the certificates-dashboard
+      # wrapper, taking overall line coverage to 36.67%). The ~2.7%
+      # buffer below the current baseline catches a real regression
+      # without firing on minor flux. Bump again whenever a PR
+      # genuinely improves the number.
+      JS_COVERAGE_FLOOR_LINES: '34'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/admin-core.test.js
+++ b/tests/js/admin-core.test.js
@@ -1,0 +1,188 @@
+// Tests for `assets/js/ffc-admin.js` — the admin hub script.
+//
+// Public surface: window.FFC.Admin.showNotification. The rest of the
+// IIFE wires document-level handlers (#ffc_btn_generate_codes click,
+// restriction-toggle checkboxes, dark-mode-aware menus, etc.). Tests
+// exercise the public helper directly and drive the most-used document
+// handlers via synthetic events.
+//
+// Sprint M of #175.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(async () => {
+	window.ffc_ajax = {
+		ajax_url: '/wp-admin/admin-ajax.php',
+		nonce: 'test-nonce',
+		strings: {
+			dismiss: 'Dismiss',
+			enterValidNumber: 'Please enter a valid number.',
+			generating: 'Generating...',
+			generatingTickets: 'Generating tickets...',
+		},
+	};
+	window.ajaxurl = '/wp-admin/admin-ajax.php';
+	// The Migration Manager block in ffc-admin.js bails early if
+	// `#ffc-migrations-btn` and `#ffc-migrations-menu` are absent —
+	// and the restriction-toggle handlers are inside that same
+	// document-ready block, so they need these stubs to land.
+	document.body.innerHTML = `
+		<button id="ffc-migrations-btn"></button>
+		<div id="ffc-migrations-menu"></div>
+	`;
+	loadScript('assets/js/ffc-admin.js');
+	await new Promise((r) => setTimeout(r, 0));
+});
+
+beforeEach(() => {
+	document.body.innerHTML = `
+		<div id="wpbody-content"><div class="wrap"><h1>Admin</h1></div></div>
+	`;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ----------------------------------------------------------------------
+// FFC.Admin.showNotification
+// ----------------------------------------------------------------------
+
+describe('FFC.Admin.showNotification', () => {
+	it('injects a notice with the message after <h1>', () => {
+		window.FFC.Admin.showNotification('All good', 'success');
+		const notice = document.querySelector('.ffc-admin-notification');
+		expect(notice).not.toBeNull();
+		expect(notice.textContent).toContain('All good');
+		expect(notice.classList.contains('notice-success')).toBe(true);
+		// Sits right after the wrap > h1.
+		const h1 = document.querySelector('.wrap > h1');
+		expect(h1.nextElementSibling).toBe(notice);
+	});
+
+	it('replaces any previous notification rather than stacking', () => {
+		window.FFC.Admin.showNotification('first', 'info');
+		window.FFC.Admin.showNotification('second', 'info');
+		const notices = document.querySelectorAll('.ffc-admin-notification');
+		expect(notices.length).toBe(1);
+		expect(notices[0].textContent).toContain('second');
+	});
+
+	it('defaults to type=info when omitted', () => {
+		window.FFC.Admin.showNotification('plain message');
+		expect(document.querySelector('.ffc-admin-notification.notice-info')).not.toBeNull();
+	});
+
+	it('applies the correct notice class for each type', () => {
+		const types = ['success', 'error', 'warning', 'info'];
+		for (const t of types) {
+			window.FFC.Admin.showNotification('m', t);
+			expect(document.querySelector(`.ffc-admin-notification.notice-${t}`)).not.toBeNull();
+		}
+	});
+
+	it('dismiss button removes the notice after fadeOut', async () => {
+		window.FFC.Admin.showNotification('dismissable');
+		const dismiss = document.querySelector('.ffc-admin-notification .notice-dismiss');
+		dismiss.click();
+		// fadeOut(200) + remove. Wait for the animation to settle.
+		await new Promise((r) => setTimeout(r, 300));
+		expect(document.querySelector('.ffc-admin-notification')).toBeNull();
+	});
+
+	it('falls back to #wpbody-content prepend when no .wrap > h1 exists', () => {
+		document.body.innerHTML = `<div id="wpbody-content"></div>`;
+		window.FFC.Admin.showNotification('no h1');
+		expect(document.querySelector('#wpbody-content .ffc-admin-notification')).not.toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------
+// Generate codes button (#ffc_btn_generate_codes)
+// ----------------------------------------------------------------------
+
+describe('Generate codes — #ffc_btn_generate_codes click', () => {
+	function setupGenerateForm(qty = '') {
+		document.body.innerHTML += `
+			<input id="ffc_qty_codes" value="${qty}" />
+			<span id="ffc_gen_status"></span>
+			<button id="ffc_btn_generate_codes">Generate</button>
+			<textarea id="ffc_generated_list"></textarea>
+		`;
+	}
+
+	it('shows an inline error when quantity is blank', () => {
+		setupGenerateForm('');
+		const spy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		window.$('#ffc_btn_generate_codes').trigger('click');
+		expect(spy).not.toHaveBeenCalled();
+		expect(document.getElementById('ffc_gen_status').textContent).toBe('Please enter a valid number.');
+	});
+
+	it('shows an inline error when quantity is not a number', () => {
+		setupGenerateForm('abc');
+		const spy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		window.$('#ffc_btn_generate_codes').trigger('click');
+		expect(spy).not.toHaveBeenCalled();
+		expect(document.getElementById('ffc_gen_status').textContent).toBe('Please enter a valid number.');
+	});
+
+	it('POSTs ffc_generate_codes with the quantity + nonce', () => {
+		setupGenerateForm('10');
+		const spy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		window.$('#ffc_btn_generate_codes').trigger('click');
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.type).toBe('POST');
+		expect(call.data.action).toBe('ffc_generate_codes');
+		expect(call.data.qty).toBe('10');
+		expect(call.data.nonce).toBe('test-nonce');
+	});
+
+	it("disables the button and shows 'Generating tickets...' status while submitting", () => {
+		setupGenerateForm('5');
+		vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		window.$('#ffc_btn_generate_codes').trigger('click');
+		expect(document.getElementById('ffc_btn_generate_codes').disabled).toBe(true);
+		expect(document.getElementById('ffc_gen_status').textContent).toBe('Generating tickets...');
+	});
+});
+
+// ----------------------------------------------------------------------
+// Restriction-toggle checkboxes (#ffc_restriction_*)
+// ----------------------------------------------------------------------
+
+describe('Restriction toggles', () => {
+	beforeEach(() => {
+		document.body.innerHTML += `
+			<input type="checkbox" id="ffc_restriction_password" />
+			<input type="checkbox" id="ffc_restriction_allowlist" />
+			<input type="checkbox" id="ffc_restriction_denylist" />
+			<input type="checkbox" id="ffc_restriction_ticket" />
+			<div id="ffc_password_field" style="display:none"></div>
+			<div id="ffc_allowlist_field" style="display:none"></div>
+			<div id="ffc_denylist_field" style="display:none"></div>
+			<div id="ffc_ticket_field" style="display:none"></div>
+		`;
+	});
+
+	it('checking #ffc_restriction_password makes #ffc_password_field visible (slideDown)', async () => {
+		const cb = document.getElementById('ffc_restriction_password');
+		cb.checked = true;
+		window.$(cb).trigger('change');
+		// slideDown sets display:block + animates; let it settle.
+		await new Promise((r) => setTimeout(r, 500));
+		expect(document.getElementById('ffc_password_field').style.display).not.toBe('none');
+	});
+
+	it('unchecking #ffc_restriction_allowlist hides #ffc_allowlist_field (slideUp)', async () => {
+		const cb = document.getElementById('ffc_restriction_allowlist');
+		const field = document.getElementById('ffc_allowlist_field');
+		// Start visible.
+		field.style.display = 'block';
+		cb.checked = false;
+		window.$(cb).trigger('change');
+		await new Promise((r) => setTimeout(r, 500));
+		expect(field.style.display).toBe('none');
+	});
+});

--- a/tests/js/admin-field-builder.test.js
+++ b/tests/js/admin-field-builder.test.js
@@ -1,0 +1,169 @@
+// Tests for `assets/js/ffc-admin-field-builder.js`.
+//
+// Public surface: window.FFC.Admin.FieldBuilder.{init, addField, updateJSON}.
+// Sprint N of #175.
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(() => {
+	window.ffc_ajax = {
+		ajax_url: '/wp-admin/admin-ajax.php',
+		nonce: 'test-nonce',
+		strings: {
+			remove: 'Remove',
+			fieldType: 'Field Type:',
+			label: 'Label:',
+			fieldLabel: 'Field Label',
+			nameVariable: 'Name:',
+			fieldName: 'field_name',
+			required: 'Required:',
+			options: 'Options:',
+			separateWithCommas: 'Separate with commas',
+			content: 'Content:',
+			contentPlaceholder: 'Display text',
+			titleOptional: 'Title:',
+			embedUrl: 'URL:',
+			embedUrlPlaceholder: 'https://...',
+			captionOptional: 'Caption:',
+		},
+	};
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-admin-field-builder.js');
+});
+
+beforeEach(() => {
+	document.body.innerHTML = `
+		<div id="ffc-fields-container"></div>
+		<input type="hidden" id="ffc-form-fields-json" />
+	`;
+});
+
+const FB = () => window.FFC.Admin.FieldBuilder;
+
+describe('FFC.Admin.FieldBuilder public API', () => {
+	it('exposes init / addField / updateJSON', () => {
+		expect(typeof FB().init).toBe('function');
+		expect(typeof FB().addField).toBe('function');
+		expect(typeof FB().updateJSON).toBe('function');
+	});
+});
+
+describe('FFC.Admin.FieldBuilder.addField', () => {
+	it("appends a .ffc-field-row to #ffc-fields-container for type='text'", () => {
+		FB().addField('text');
+		const rows = document.querySelectorAll('#ffc-fields-container .ffc-field-row');
+		expect(rows.length).toBe(1);
+		// Header strong contains the uppercased type.
+		expect(rows[0].querySelector('.ffc-field-title strong').textContent).toBe('TEXT');
+	});
+
+	it("appends an info-style row with the content textarea visible", () => {
+		FB().addField('info');
+		const row = document.querySelector('#ffc-fields-container .ffc-field-row');
+		const contentRow = row.querySelector('.ffc-content-row');
+		// Info rows show the content textarea (no inline display:none).
+		expect(contentRow.style.display).not.toBe('none');
+		// Standard rows are hidden for display-only fields.
+		const standardRows = row.querySelectorAll('.ffc-standard-row');
+		standardRows.forEach((r) => expect(r.style.display).toBe('none'));
+	});
+
+	it("appends an embed-style row with the URL input visible", () => {
+		FB().addField('embed');
+		const row = document.querySelector('#ffc-fields-container .ffc-field-row');
+		const embedRow = row.querySelector('.ffc-embed-row');
+		expect(embedRow.style.display).not.toBe('none');
+		// Content row hidden for embed.
+		expect(row.querySelector('.ffc-content-row').style.display).toBe('none');
+	});
+
+	it('writes the new field into the hidden JSON input', () => {
+		FB().addField('text');
+		const json = document.getElementById('ffc-form-fields-json').value;
+		const parsed = JSON.parse(json);
+		expect(parsed.length).toBe(1);
+		expect(parsed[0].type).toBe('text');
+	});
+
+	it('increments an internal counter — multiple fields land with unique indices', () => {
+		FB().addField('text');
+		FB().addField('email');
+		FB().addField('select');
+		const rows = document.querySelectorAll('#ffc-fields-container .ffc-field-row');
+		expect(rows.length).toBe(3);
+		// data-index values should be different.
+		const indices = Array.from(rows).map((r) => r.getAttribute('data-index'));
+		expect(new Set(indices).size).toBe(3);
+	});
+
+	it('selects the correct option in the .ffc-field-type dropdown for the requested type', () => {
+		FB().addField('select');
+		const dropdown = document.querySelector('#ffc-fields-container .ffc-field-row .ffc-field-type');
+		expect(dropdown.value).toBe('select');
+	});
+});
+
+describe('FFC.Admin.FieldBuilder.updateJSON', () => {
+	it('reads the form values from each row and serialises them as JSON', () => {
+		FB().addField('text');
+		FB().addField('email');
+
+		// Fill out fields.
+		const rows = document.querySelectorAll('#ffc-fields-container .ffc-field-row');
+		rows[0].querySelector('.ffc-field-label').value = 'Name';
+		rows[0].querySelector('.ffc-field-name').value = 'name';
+		rows[1].querySelector('.ffc-field-label').value = 'Email';
+		rows[1].querySelector('.ffc-field-name').value = 'email';
+
+		FB().updateJSON();
+		const parsed = JSON.parse(document.getElementById('ffc-form-fields-json').value);
+		expect(parsed.length).toBe(2);
+		expect(parsed[0].label).toBe('Name');
+		expect(parsed[0].name).toBe('name');
+		expect(parsed[1].label).toBe('Email');
+		expect(parsed[1].name).toBe('email');
+	});
+
+	it('captures the `required` checkbox state', () => {
+		FB().addField('text');
+		document.querySelector('.ffc-field-required').checked = true;
+		FB().updateJSON();
+		const parsed = JSON.parse(document.getElementById('ffc-form-fields-json').value);
+		expect(parsed[0].required).toBe(true);
+	});
+
+	it('emits an empty array when no rows are present', () => {
+		// Container exists but no fields.
+		FB().updateJSON();
+		expect(document.getElementById('ffc-form-fields-json').value).toBe('[]');
+	});
+
+	it('falls back to input[name=ffc_form_fields] when #ffc-form-fields-json is absent', () => {
+		document.body.innerHTML = `
+			<div id="ffc-fields-container"></div>
+			<input type="hidden" name="ffc_form_fields" />
+		`;
+		FB().addField('text');
+		FB().updateJSON();
+		const fallback = document.querySelector('input[name="ffc_form_fields"]');
+		const parsed = JSON.parse(fallback.value);
+		expect(parsed.length).toBe(1);
+		expect(parsed[0].type).toBe('text');
+	});
+});
+
+describe('FFC.Admin.FieldBuilder.init — document delegates', () => {
+	it('wires the .ffc-remove-field click that fades and removes the row + updates JSON', async () => {
+		// The handler asks for confirmation before removing — stub
+		// window.confirm to accept.
+		const confirmStub = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		FB().init();
+		FB().addField('text');
+		document.querySelector('.ffc-remove-field').click();
+		// fadeOut animates over 300ms — wait for the animation to finish
+		// AND the post-animation `$(this).remove()` + JSON update.
+		await new Promise((r) => setTimeout(r, 600));
+		expect(document.querySelectorAll('#ffc-fields-container .ffc-field-row').length).toBe(0);
+		confirmStub.mockRestore();
+	});
+});

--- a/tests/js/admin-submission-edit.test.js
+++ b/tests/js/admin-submission-edit.test.js
@@ -1,0 +1,172 @@
+// Tests for `assets/js/ffc-admin-submission-edit.js`.
+//
+// Script uses direct `$(selector).on(...)` binding (not delegated), so
+// the elements must exist BEFORE the script loads. Each describe block
+// sets up its own DOM and re-loads the script in beforeEach.
+//
+// Sprint O of #175.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeEach(() => {
+	window.ffc_submission_edit = {
+		copied_text: 'Copied!',
+		search_min_chars: 'Please enter at least 2 characters.',
+		no_users_found: 'No users found.',
+		search_error: 'Search error',
+	};
+	window.ajaxurl = '/wp-admin/admin-ajax.php';
+	document.body.innerHTML = '';
+});
+
+async function loadOnReady() {
+	loadScript('assets/js/ffc-admin-submission-edit.js');
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+// ----------------------------------------------------------------------
+// Copy magic link
+// ----------------------------------------------------------------------
+
+describe('Copy magic link button', () => {
+	beforeEach(async () => {
+		document.body.innerHTML = `
+			<button class="ffc-copy-magic-link" data-url="https://x.test/magic">Copy</button>
+		`;
+		// Stub document.execCommand — jsdom doesn't implement 'copy'.
+		document.execCommand = vi.fn(() => true);
+		await loadOnReady();
+	});
+
+	it('calls execCommand("copy") on click', () => {
+		document.querySelector('.ffc-copy-magic-link').click();
+		expect(document.execCommand).toHaveBeenCalledWith('copy');
+	});
+
+	it("changes the button text to the localized 'copied' string", () => {
+		const btn = document.querySelector('.ffc-copy-magic-link');
+		btn.click();
+		expect(btn.textContent).toBe('Copied!');
+		expect(btn.disabled).toBe(true);
+	});
+
+	it('restores the original text after a 2-second timeout', async () => {
+		vi.useFakeTimers();
+		const btn = document.querySelector('.ffc-copy-magic-link');
+		const originalText = btn.textContent;
+		btn.click();
+		vi.advanceTimersByTime(2100);
+		expect(btn.textContent).toBe(originalText);
+		expect(btn.disabled).toBe(false);
+		vi.useRealTimers();
+	});
+});
+
+// ----------------------------------------------------------------------
+// Unlink user button (with confirm prompt)
+// ----------------------------------------------------------------------
+
+describe('Unlink user button', () => {
+	beforeEach(async () => {
+		document.body.innerHTML = `
+			<form>
+				<input name="linked_user_id" value="42" />
+				<button type="button" class="ffc-unlink-user-btn" data-confirm="Sure?">Unlink</button>
+			</form>
+		`;
+		await loadOnReady();
+	});
+
+	it('does nothing when the user declines the confirmation', () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const form = document.querySelector('form');
+		const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {});
+		document.querySelector('.ffc-unlink-user-btn').click();
+		expect(submitSpy).not.toHaveBeenCalled();
+		// Hidden input untouched.
+		expect(document.querySelector('input[name="linked_user_id"]').value).toBe('42');
+	});
+
+	it('empties the linked_user_id and submits the form on confirm', () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		const form = document.querySelector('form');
+		const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {});
+		document.querySelector('.ffc-unlink-user-btn').click();
+		expect(submitSpy).toHaveBeenCalledOnce();
+		expect(document.querySelector('input[name="linked_user_id"]').value).toBe('');
+	});
+});
+
+// ----------------------------------------------------------------------
+// User search — AJAX
+// ----------------------------------------------------------------------
+
+describe('User search', () => {
+	beforeEach(async () => {
+		document.body.innerHTML = `
+			<input id="ffc-user-search-input" type="text" />
+			<button class="ffc-search-user-btn" data-nonce="search-nonce">Search</button>
+			<span id="ffc-search-spinner"></span>
+			<div id="ffc-user-search-results"></div>
+			<div id="ffc-selected-user-preview"></div>
+			<input id="ffc-selected-user-id" type="hidden" />
+		`;
+		await loadOnReady();
+	});
+
+	it("alerts when the search term is shorter than 2 characters", () => {
+		globalThis.alert.mockClear?.();
+		document.getElementById('ffc-user-search-input').value = 'a';
+		document.querySelector('.ffc-search-user-btn').click();
+		expect(globalThis.alert).toHaveBeenCalledWith('Please enter at least 2 characters.');
+	});
+
+	it('fires AJAX with the search term + nonce when >= 2 chars', () => {
+		const spy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		document.getElementById('ffc-user-search-input').value = 'maria';
+		document.querySelector('.ffc-search-user-btn').click();
+		expect(spy).toHaveBeenCalledOnce();
+		const call = spy.mock.calls[0][0];
+		expect(call.data.action).toBe('ffc_search_user');
+		expect(call.data.search).toBe('maria');
+		expect(call.data.nonce).toBe('search-nonce');
+	});
+
+	it('renders search results into #ffc-user-search-results on success', () => {
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					users: [
+						{ id: 1, name: 'Maria', email: 'maria@example.com' },
+						{ id: 2, name: 'João',  email: 'joao@example.com'  },
+					],
+				},
+			});
+			return {};
+		});
+		document.getElementById('ffc-user-search-input').value = 'qu';
+		document.querySelector('.ffc-search-user-btn').click();
+		expect(document.querySelectorAll('#ffc-user-search-results .ffc-search-result-item').length).toBe(2);
+	});
+
+	it("renders the no-users message when response.success is false", () => {
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: false, data: { message: 'Custom not-found' } });
+			return {};
+		});
+		document.getElementById('ffc-user-search-input').value = 'qu';
+		document.querySelector('.ffc-search-user-btn').click();
+		expect(document.getElementById('ffc-user-search-results').textContent).toContain('Custom not-found');
+	});
+
+	it('also triggers the search on Enter keypress', () => {
+		const spy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+		const input = document.getElementById('ffc-user-search-input');
+		input.value = 'enter-key';
+		// Build a real keypress event with `which === 13`.
+		const ev = window.$.Event('keypress', { which: 13 });
+		window.$(input).trigger(ev);
+		expect(spy).toHaveBeenCalledOnce();
+	});
+});

--- a/tests/js/certificates-dashboard.test.js
+++ b/tests/js/certificates-dashboard.test.js
@@ -1,0 +1,80 @@
+// Tests for `assets/js/ffc-certificates-dashboard.js`.
+//
+// The script wraps `FFCCalendarCore` (the in-house calendar widget from
+// ffc-calendar-core.js) into a monthly view of forms keyed by their
+// geofence start date. It bails early on three conditions; the rest of
+// the file builds a calendar instance with options and binds AJAX
+// fetches per month.
+//
+// Tests cover the bail paths + the happy-path instantiation. Deeper
+// AJAX/render paths would re-test the calendar component itself, which
+// is out of scope here.
+//
+// Sprint P of #175.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeEach(() => {
+	window.ffcCertificatesDashboard = undefined;
+	window.FFCCalendarCore = undefined;
+	document.body.innerHTML = '';
+});
+
+describe('ffc-certificates-dashboard — bail paths', () => {
+	it('bails silently when FFCCalendarCore is not loaded', async () => {
+		// Settings present but no calendar component.
+		window.ffcCertificatesDashboard = { i18n: {} };
+		document.body.innerHTML = '<div id="ffc-certificates-calendar"></div>';
+		expect(() => loadScript('assets/js/ffc-certificates-dashboard.js')).not.toThrow();
+		await new Promise((r) => setTimeout(r, 0));
+		// No FFCCalendarCore was instantiated since the module wasn't loaded.
+		// (Nothing observable to assert other than "didn't crash".)
+	});
+
+	it('bails silently when window.ffcCertificatesDashboard is undefined', async () => {
+		// Calendar core stubbed but no settings payload.
+		window.FFCCalendarCore = vi.fn();
+		document.body.innerHTML = '<div id="ffc-certificates-calendar"></div>';
+		loadScript('assets/js/ffc-certificates-dashboard.js');
+		await new Promise((r) => setTimeout(r, 0));
+		expect(window.FFCCalendarCore).not.toHaveBeenCalled();
+	});
+
+	it('bails silently when #ffc-certificates-calendar is missing from the DOM', async () => {
+		window.FFCCalendarCore = vi.fn();
+		window.ffcCertificatesDashboard = { i18n: {} };
+		document.body.innerHTML = '<div>nothing</div>';
+		loadScript('assets/js/ffc-certificates-dashboard.js');
+		await new Promise((r) => setTimeout(r, 0));
+		expect(window.FFCCalendarCore).not.toHaveBeenCalled();
+	});
+});
+
+describe('ffc-certificates-dashboard — happy path', () => {
+	it('instantiates FFCCalendarCore on the #ffc-certificates-calendar container', async () => {
+		window.FFCCalendarCore = vi.fn(function () {
+			// Constructor return — the actual core returns an object with methods.
+			return { init: vi.fn(), refresh: vi.fn() };
+		});
+		window.ffcCertificatesDashboard = {
+			i18n: { today: 'Hoje', clear: 'Limpar' },
+			restUrl: '/wp-json/ffc/v1/',
+		};
+		document.body.innerHTML = `
+			<div id="ffc-certificates-calendar"></div>
+			<ul id="ffc-certificates-day-list"></ul>
+			<p class="ffc-certificates-side-empty">Empty</p>
+			<h3 class="ffc-certificates-side-title">Forms</h3>
+		`;
+		loadScript('assets/js/ffc-certificates-dashboard.js');
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(window.FFCCalendarCore).toHaveBeenCalledOnce();
+		// First arg is the jQuery wrapper for the container; assert it
+		// points at our DOM element by checking the underlying [0] node.
+		const callArgs = window.FFCCalendarCore.mock.calls[0];
+		expect(callArgs[0][0]).toBe(document.getElementById('ffc-certificates-calendar'));
+		// Second arg is an options object — confirm it's an object.
+		expect(typeof callArgs[1]).toBe('object');
+	});
+});


### PR DESCRIPTION
Closes #175.

## Summary

Five sprints (M + N + O + P + Q) from #175. Each commit independently revertable.

| Sprint | Commit | What |
|---|---|---|
| M | `38b5e05` | 12 tests for `ffc-admin.js`: showNotification, generate-codes, restriction toggles. **0% → 54%**. |
| N | `9417270` | 12 tests for `FFC.Admin.FieldBuilder`: addField (text/info/embed), updateJSON, remove-field. **0% → 75%**. |
| O | `d932ccc` | 10 tests for `ffc-admin-submission-edit`: copy magic-link, unlink user (with confirm), user-search AJAX. **0% → 77%**. |
| P | `3712477` | 4 tests for `ffc-certificates-dashboard`: 3 bail paths + 1 happy-path instantiation. **0% → 31%**. |
| Q | `b0db358` | Floor ratchet 28 → 34. |

## Coverage delta

| | Before (main) | After (this PR) |
|---|---:|---:|
| Total tests | 208 | **246** (+38) |
| **Overall line coverage** | **30.09%** | **36.67%** |
| `ffc-admin.js` | 0% | **54%** |
| `ffc-admin-field-builder.js` | 0% | **75%** |
| `ffc-admin-submission-edit.js` | 0% | **77%** |
| `ffc-certificates-dashboard.js` | 0% | **31%** |
| `JS_COVERAGE_FLOOR_LINES` | 28 | **34** |

## Notes

- **Migration Manager gate**: `ffc-admin.js` has a `jQuery(document).ready(function($) { if (!$btn.length || !$menu.length) return; ... })` block at line 294 — the restriction-toggle handlers live inside it, and bail when `#ffc-migrations-btn` and `#ffc-migrations-menu` are absent. The Sprint M `beforeAll` stubs both into the body BEFORE `loadScript` so the handlers land.
- **`window.confirm` stub**: FieldBuilder's `.ffc-remove-field` and submission-edit's `.ffc-unlink-user-btn` both call `confirm()`. Tests use `vi.spyOn(window, 'confirm').mockReturnValue(true/false)` to control accept/reject paths.
- **`document.execCommand` stub**: jsdom doesn't implement `'copy'`. Sprint O stubs it with `vi.fn()` so the copy-link button's behaviour is verifiable.
- **Direct `$(selector).on()` binding (not delegated)**: submission-edit uses non-delegated binding for `.ffc-copy-magic-link`, `.ffc-unlink-user-btn`, etc. Tests set up the DOM in `beforeEach`, then call `loadOnReady()` to fire `$(document).ready` after the elements exist.
- **Certificates dashboard wrapper**: only covers bail paths + happy-path instantiation. The AJAX-fetched render logic would re-test `FFCCalendarCore` (calendar-core.js), which is its own future sprint.

## Test plan

- [x] `npm run test:js` — **246 / 246 OK** (was 208).
- [x] `npm run test:js:coverage` — line coverage **36.67%**, gate (floor 34) passes.
- [x] `npm run lint:js` — clean (9 pre-existing unused-vars warnings unchanged).
- [x] `vendor/bin/phpunit` — runs unchanged (no PHP touched).

## What's deferred

- `ffc-csv-download.js` (668 LOC, File API) — next critical-path sprint.
- `ffc-reregistration-frontend.js` (507 LOC) — next critical-path sprint.
- `ffc-audience-admin.js`, `ffc-reregistration-admin.js`, `ffc-custom-fields-admin.js`, `ffc-url-shortener-admin.js`, `ffc-admin-move-submissions.js`, `ffc-recruitment-admin.js` — medium admin pages.
- Calendar subsystem (`ffc-calendar-core.js`, `-editor.js`).
- `ffc-audience.js` (skipped via #167).

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_