### PR TITLE
ci: bump Coverage timeout-minutes 15 → 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
   coverage:
     name: Coverage (PHP 8.1)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Bumped 15 → 20 after the pcov+3881-test suite started routinely
+    # finishing at 14m–15m and tripping the previous ceiling on busy
+    # CI runners (#176/#177 cancelled at 15m09s/15m14s/15m12s). Real
+    # baseline is ~13–14m; 20m leaves comfortable headroom without
+    # masking a true regression.
+    timeout-minutes: 20
     # Promoted from advisory to gating in S3 of #161. The floor is set
     # below the current line-coverage baseline so the gate doesn't fire
     # on day one but does catch a regression. Ratchet the floor upward


### PR DESCRIPTION
Tiny CI fix — bump `timeout-minutes` for the Coverage (PHP 8.1) job from 15 → 20.

## Why

The pcov + 3881-test suite routinely finishes at 14–15 minutes and tripped the previous 15-minute ceiling on busy runners several times this week:
- PR #176: cancelled at 15m12s (twice, second cancelled at 15m14s after a retrigger).
- PR #177: cancelled at 15m12s.

Each time the merge had to bypass the gate. The real baseline is ~13–14m; 20m leaves comfortable headroom without masking a true regression.

## Test plan

- [x] Lint check on the YAML — passes.
- [ ] CI run on this PR will validate the new value.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_