### PR TITLE
feat(recruitment): normalise CPF/RF on CSV import (#172)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -304,21 +304,40 @@ final class RecruitmentCsvImporter {
 		foreach ( $rows as $row ) {
 			$line = (int) $row['_line'];
 
-			// CPF / RF presence + digits-only.
-			$cpf = is_string( $row['cpf'] ) ? trim( $row['cpf'] ) : '';
-			$rf  = is_string( $row['rf'] ) ? trim( $row['rf'] ) : '';
-			if ( '' === $cpf && '' === $rf ) {
+			// CPF / RF normalisation (#172). Strip non-digit characters
+			// (operators paste pre-formatted values like `123.456.789-09`),
+			// then left-pad with zeros when the result is shorter than the
+			// canonical width (Excel/Sheets exports often drop leading
+			// zeros from numeric columns). Reject when the stripped value
+			// is LONGER than canonical — that's almost always garbage.
+			$cpf_raw = is_string( $row['cpf'] ) ? trim( $row['cpf'] ) : '';
+			$rf_raw  = is_string( $row['rf'] ) ? trim( $row['rf'] ) : '';
+
+			$cpf_norm = self::normalise_id( $cpf_raw, 11 );
+			$rf_norm  = self::normalise_id( $rf_raw, 7 );
+
+			if ( '' === $cpf_norm['value'] && '' === $rf_norm['value']
+				&& false === $cpf_norm['too_long'] && false === $rf_norm['too_long'] ) {
 				$errors[] = self::line_error( $line, 'recruitment_csv_missing_cpf_or_rf' );
 				continue;
 			}
-			if ( '' !== $cpf && ! ctype_digit( $cpf ) ) {
-				$errors[] = self::line_error( $line, 'recruitment_csv_cpf_must_be_digits_only' );
+			if ( $cpf_norm['too_long'] ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_cpf_too_long' );
 				continue;
 			}
-			if ( '' !== $rf && ! ctype_digit( $rf ) ) {
-				$errors[] = self::line_error( $line, 'recruitment_csv_rf_must_be_digits_only' );
+			if ( $rf_norm['too_long'] ) {
+				$errors[] = self::line_error( $line, 'recruitment_csv_rf_too_long' );
 				continue;
 			}
+
+			$cpf = $cpf_norm['value'];
+			$rf  = $rf_norm['value'];
+
+			// Persist the normalised values back onto the row so downstream
+			// consumers (upsert_candidate, duplicate detection, etc.) see
+			// the canonical digit string.
+			$row['cpf'] = $cpf;
+			$row['rf']  = $rf;
 
 			// Score: dot-decimal only (or integer).
 			$score_raw = is_string( $row['score'] ) ? trim( $row['score'] ) : (string) $row['score'];
@@ -646,6 +665,36 @@ final class RecruitmentCsvImporter {
 	 */
 	private static function line_error( int $line, string $code ): string {
 		return sprintf( 'line=%d: %s', $line, $code );
+	}
+
+	/**
+	 * Normalise a CPF / RF cell value to its canonical digit-only form.
+	 *
+	 * Strips every non-digit character (so `123.456.789-09` becomes
+	 * `12345678909`), then left-pads with `'0'` when the result is shorter
+	 * than `$expected_length` (Excel/Sheets exports routinely drop
+	 * leading zeros). Returns `too_long => true` when the stripped value
+	 * exceeds the canonical width — callers should surface a clear error.
+	 *
+	 * @param string $raw             The trimmed cell value.
+	 * @param int    $expected_length Canonical width (11 for CPF, 7 for RF).
+	 * @return array{value: string, too_long: bool}
+	 */
+	private static function normalise_id( string $raw, int $expected_length ): array {
+		$digits = preg_replace( '/\D+/', '', $raw );
+		if ( ! is_string( $digits ) ) {
+			$digits = '';
+		}
+		if ( '' === $digits ) {
+			return array( 'value' => '', 'too_long' => false );
+		}
+		if ( strlen( $digits ) > $expected_length ) {
+			return array( 'value' => $digits, 'too_long' => true );
+		}
+		if ( strlen( $digits ) < $expected_length ) {
+			$digits = str_pad( $digits, $expected_length, '0', STR_PAD_LEFT );
+		}
+		return array( 'value' => $digits, 'too_long' => false );
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -686,15 +686,24 @@ final class RecruitmentCsvImporter {
 			$digits = '';
 		}
 		if ( '' === $digits ) {
-			return array( 'value' => '', 'too_long' => false );
+			return array(
+				'value'    => '',
+				'too_long' => false,
+			);
 		}
 		if ( strlen( $digits ) > $expected_length ) {
-			return array( 'value' => $digits, 'too_long' => true );
+			return array(
+				'value'    => $digits,
+				'too_long' => true,
+			);
 		}
 		if ( strlen( $digits ) < $expected_length ) {
 			$digits = str_pad( $digits, $expected_length, '0', STR_PAD_LEFT );
 		}
-		return array( 'value' => $digits, 'too_long' => false );
+		return array(
+			'value'    => $digits,
+			'too_long' => false,
+		);
 	}
 
 	/**

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -275,4 +275,94 @@ class RecruitmentCsvImporterTest extends TestCase {
 		$this->assertFalse( $result['success'] );
 		$this->assertContains( 'recruitment_notice_has_no_adjutancies', $result['errors'] );
 	}
+
+	// ------------------------------------------------------------------
+	// normalise_id helper — strip punctuation + left-pad short values (#172)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Call the private `normalise_id` helper via reflection.
+	 *
+	 * @param string $raw
+	 * @param int    $expected_length
+	 * @return array{value: string, too_long: bool}
+	 */
+	private function normalise( string $raw, int $expected_length ): array {
+		$ref = new \ReflectionClass( RecruitmentCsvImporter::class );
+		$m   = $ref->getMethod( 'normalise_id' );
+		$m->setAccessible( true );
+		return $m->invoke( null, $raw, $expected_length );
+	}
+
+	public function test_normalise_cpf_passes_through_canonical_value(): void {
+		$out = $this->normalise( '12345678909', 11 );
+		$this->assertSame( '12345678909', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_cpf_strips_dots_and_dash(): void {
+		$out = $this->normalise( '123.456.789-09', 11 );
+		$this->assertSame( '12345678909', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_cpf_pads_short_value_with_leading_zeros(): void {
+		// 10 digits → padded to 11.
+		$out = $this->normalise( '1234567890', 11 );
+		$this->assertSame( '01234567890', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_cpf_pads_very_short_value(): void {
+		$out = $this->normalise( '5', 11 );
+		$this->assertSame( '00000000005', $out['value'] );
+	}
+
+	public function test_normalise_cpf_rejects_too_long_value(): void {
+		$out = $this->normalise( '123456789012', 11 );
+		$this->assertTrue( $out['too_long'] );
+		// Value still returned so callers can include it in their error.
+		$this->assertSame( '123456789012', $out['value'] );
+	}
+
+	public function test_normalise_rejects_too_long_after_stripping_punctuation(): void {
+		// 12 digits hidden behind formatting.
+		$out = $this->normalise( '123.456.789.012', 11 );
+		$this->assertTrue( $out['too_long'] );
+	}
+
+	public function test_normalise_returns_empty_on_all_punctuation_input(): void {
+		$out = $this->normalise( '...---', 11 );
+		$this->assertSame( '', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_returns_empty_on_blank_input(): void {
+		$out = $this->normalise( '', 11 );
+		$this->assertSame( '', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_rf_strips_punctuation(): void {
+		$out = $this->normalise( '123.456-7', 7 );
+		$this->assertSame( '1234567', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
+
+	public function test_normalise_rf_pads_short_value(): void {
+		$out = $this->normalise( '12', 7 );
+		$this->assertSame( '0000012', $out['value'] );
+	}
+
+	public function test_normalise_rf_rejects_too_long_value(): void {
+		$out = $this->normalise( '12345678', 7 );
+		$this->assertTrue( $out['too_long'] );
+	}
+
+	public function test_normalise_strips_spaces_and_slashes(): void {
+		// Pathological formatting still produces clean digits.
+		$out = $this->normalise( ' 123  / 456 / 789 - 09 ', 11 );
+		$this->assertSame( '12345678909', $out['value'] );
+		$this->assertFalse( $out['too_long'] );
+	}
 }


### PR DESCRIPTION
Closes #172.

## Summary

The recruitment CSV importer used to reject any CPF / RF that wasn't pure digits and silently accept short values. Operators pasting pre-formatted Excel/Sheets data (`123.456.789-09`, `123.456-7`) had to clean the file by hand; 5-digit "CPFs" got into storage without flagging. This PR normalises both columns inside the importer.

## Behaviour change

For every row, the `cpf` and `rf` cells go through this pipeline BEFORE the existing presence checks:

1. **Strip** every non-digit character (`preg_replace('/\D+/', '', $value)`).
2. **Accept** canonical-length values as-is (CPF=11, RF=7).
3. **Left-pad** shorter values with `'0'` up to canonical width (handles Excel/Sheets dropping leading zeros from numeric columns).
4. **Reject** values that exceed canonical width with a new error code (`recruitment_csv_cpf_too_long` / `recruitment_csv_rf_too_long`).

The persisted value is the canonical digit string — same shape the database has always stored. No migration needed.

### Examples (CPF)

| Input | Stripped | Normalised | Outcome |
|---|---|---|---|
| `12345678909` | `12345678909` | `12345678909` | accepted |
| `123.456.789-09` | `12345678909` | `12345678909` | accepted |
| `1234567890` | `1234567890` | `01234567890` | accepted (padded) |
| `12345` | `12345` | `00000012345` | accepted (padded) |
| `123456789012` | `123456789012` | — | **rejected** with `_too_long` |

### Examples (RF)

| Input | Normalised | Outcome |
|---|---|---|
| `1234567` | `1234567` | accepted |
| `123.456-7` | `1234567` | accepted |
| `12` | `0000012` | accepted (padded) |
| `12345678` | — | **rejected** with `_too_long` |

## Side benefit: duplicate detection

The existing `$seen_pair[$cpf . '|' . $slug]` check now compares normalised values. A CSV with one row `123.456.789-09` and another `12345678909` correctly flags the duplicate.

## What changed

- `includes/recruitment/class-ffc-recruitment-csv-importer.php`:
  - Replaced the two inline `ctype_digit` checks at lines 314–321 with calls to a new `normalise_id($raw, $expected_length)` helper.
  - Added the new error codes `recruitment_csv_cpf_too_long` / `recruitment_csv_rf_too_long`.
  - Normalised values are written back into the row before downstream consumers see them.
- `tests/Unit/RecruitmentCsvImporterTest.php`: 12 new tests for `normalise_id` (CPF and RF: canonical, stripped, padded, too-long, blank, all-punctuation, mixed spaces/slashes). Existing 16 tests untouched.

## Test plan

- [x] `php -l`: clean.
- [x] `vendor/bin/phpstan analyse`: no errors.
- [x] `vendor/bin/phpunit --filter RecruitmentCsvImporter`: **28/28 OK** (16 existing + 12 new).
- [x] `vendor/bin/phpunit` (full suite): **3893/3893 OK**.

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_