### PR TITLE
JS coverage Sprint F2: ffc-reregistration-admin + ffc-audience-admin deep tests (77% → 80%) — closes #198

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,17 +34,15 @@ jobs:
     # Coverage floor enforced in S1 of #163 — see step below.
     env:
       # Ratcheted 3 → 6 → 7 → 15 → 24 → 28 across #163 / #165 / #168 /
-      # #170 / #173, then 28 → 34 in Sprint Q of #175 (admin+cert-
-      # dashboard sprints M+N+O+P), then 34 → 47 across #176 / #177 /
-      # #178 / #179 / #180, 47 → 54 in #183, 54 → 57 in #184,
-      # 57 → 64 in #185 (Sprint C), 64 → 70 in #186 (Sprint B).
-      # Sprint F1 in this PR deep-covers three Tier 4/T3 admin scripts
-      # (ffc-admin-move-submissions 26%→99%, ffc-certificates-dashboard
-      # 31%→99%, ffc-url-shortener-admin 33%→100%), pushing overall
-      # line coverage to 76.79%. Bumping 70 → 74 locks the gain in
-      # with ~2.8pp buffer. Bump again whenever a PR genuinely
-      # improves the number.
-      JS_COVERAGE_FLOOR_LINES: '74'
+      # #170 / #173, then 28 → 34 in Sprint Q of #175, 34 → 47 across
+      # #176-#180, 47 → 54 in #183, 54 → 57 in #184, 57 → 64 in #185,
+      # 64 → 70 in #186, 70 → 74 in #190 (Sprint F1). Sprint F2 in
+      # this PR closes the last two Tier-3 admin scripts —
+      # ffc-reregistration-admin 37%→97% and ffc-audience-admin
+      # 33%→98% — taking overall line coverage to 80.10%. Bumping
+      # 74 → 77 locks the gain in with ~3pp buffer. Bump again
+      # whenever a PR genuinely improves the number.
+      JS_COVERAGE_FLOOR_LINES: '77'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/audience-admin-deep.test.js
+++ b/tests/js/audience-admin-deep.test.js
@@ -1,0 +1,639 @@
+// Sprint F2 — deep coverage for assets/js/ffc-audience-admin.js
+// (466 LOC, previously 33.26%). Five handler groups all wired off the
+// FFCAudienceAdmin singleton's init() at document.ready.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(() => {
+	window.ffcAudienceAdmin = {
+		searchUsersNonce: 'search-nonce',
+		schedulePermissionsNonce: 'perm-nonce',
+		adminNonce: 'admin-nonce',
+		strings: {
+			allEnvironments: 'All Environments',
+			loading: 'Loading…',
+			error: 'Error',
+			bookingDetails: 'Booking Details',
+			confirmCancel: 'Cancel booking?',
+			cancelReason: 'Reason?',
+			cancelled: 'Cancelled',
+			active: 'Active',
+			audience: 'Audience',
+			customUsers: 'Custom Users',
+			allDay: 'All Day',
+			date: 'Date', time: 'Time', environmentLabel: 'Environment',
+			description: 'Description', type: 'Type', status: 'Status',
+			createdBy: 'By', audiences: 'Audiences', users: 'Users',
+			alreadyAdded: 'already added',
+			noUsersFound: 'No users',
+			errorAddingUser: 'Error adding user',
+			confirmRemoveUser: 'Remove?',
+			noUsersYet: 'None yet',
+		},
+	};
+	window.ajaxurl = '/wp-admin/admin-ajax.php';
+});
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	window.$.fx.off = true;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+	// Clean up any modal leftover from booking tests.
+	document.querySelectorAll('#ffc-booking-modal').forEach((el) => el.remove());
+});
+
+async function reload() {
+	loadScript('assets/js/ffc-audience-admin.js');
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+// ----------------------------------------------------------------------
+// bindEvents — day-row time-input gate
+// ----------------------------------------------------------------------
+
+describe('audience-admin — day row time toggle', () => {
+	it('checking the "closed" checkbox disables the time inputs in that row', async () => {
+		document.body.innerHTML = `
+			<div class="ffc-day-row">
+				<input type="checkbox" class="ffc-day-closed">
+				<input type="time" class="ffc-day-open">
+				<input type="time" class="ffc-day-close">
+			</div>
+		`;
+		await reload();
+
+		window.$('.ffc-day-row input[type="checkbox"]').prop('checked', true).trigger('change');
+
+		expect(window.$('input[type="time"]').first().prop('disabled')).toBe(true);
+		expect(window.$('input[type="time"]').last().prop('disabled')).toBe(true);
+	});
+
+	it('unchecking enables them again', async () => {
+		document.body.innerHTML = `
+			<div class="ffc-day-row">
+				<input type="checkbox" class="ffc-day-closed" checked>
+				<input type="time" class="ffc-day-open" disabled>
+			</div>
+		`;
+		await reload();
+
+		window.$('.ffc-day-row input[type="checkbox"]').prop('checked', false).trigger('change');
+
+		expect(window.$('input[type="time"]').prop('disabled')).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// initUserSearch — autocomplete for audience-group member management
+// ----------------------------------------------------------------------
+
+describe('audience-admin — user search autocomplete', () => {
+	function mountSearch() {
+		document.body.innerHTML = `
+			<input id="user_search">
+			<div id="user_results"></div>
+			<div id="selected_users"></div>
+			<input type="hidden" id="selected_user_ids">
+		`;
+	}
+
+	it('bails when query length < 2 (no AJAX)', async () => {
+		mountSearch();
+		await reload();
+		const ajaxSpy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+
+		window.$('#user_search').val('a').trigger('input');
+		// Debounce window for AJAX is 300 ms; if it fired it'd land later.
+		vi.useFakeTimers();
+		vi.advanceTimersByTime(400);
+		expect(ajaxSpy).not.toHaveBeenCalled();
+	});
+
+	it('debounces 300 ms then POSTs ffc_search_users with the query', async () => {
+		mountSearch();
+		await reload();
+		vi.useFakeTimers();
+		const ajaxSpy = vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: true, data: [{ id: 1, name: 'Alice', email: 'a@x' }] });
+			return {};
+		});
+
+		window.$('#user_search').val('alice').trigger('input');
+		vi.advanceTimersByTime(299);
+		expect(ajaxSpy).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(ajaxSpy).toHaveBeenCalled();
+		expect(ajaxSpy.mock.calls[0][0].data).toMatchObject({
+			action: 'ffc_search_users',
+			query: 'alice',
+			nonce: 'search-nonce',
+		});
+
+		// Results dropdown populated.
+		expect(window.$('#user_results').hasClass('active')).toBe(true);
+		expect(window.$('#user_results .ffc-user-result').length).toBe(1);
+	});
+
+	it('selecting a result adds the user and clears the search input', async () => {
+		mountSearch();
+		await reload();
+		// Bypass the debounce: render a result row directly so the
+		// document-level click delegate can pick it up.
+		window.$('#user_results').html('<div class="ffc-user-result" data-id="9" data-name="Alice"></div>').addClass('active');
+
+		window.$('.ffc-user-result').trigger('click');
+
+		expect(window.$('#selected_user_ids').val()).toBe('9');
+		expect(window.$('#selected_users').text()).toContain('Alice');
+		expect(window.$('#user_search').val()).toBe('');
+		expect(window.$('#user_results').hasClass('active')).toBe(false);
+	});
+
+	it('removing a selected user updates the hidden ids list', async () => {
+		mountSearch();
+		await reload();
+		// Pre-populate selection.
+		window.$('#user_results').html('<div class="ffc-user-result" data-id="3" data-name="Bob"></div>');
+		window.$('.ffc-user-result').trigger('click');
+		expect(window.$('#selected_user_ids').val()).toBe('3');
+
+		window.$('#selected_users .ffc-selected-user .remove').trigger('click');
+
+		expect(window.$('#selected_user_ids').val()).toBe('');
+	});
+
+	it('on empty response: hides the results dropdown', async () => {
+		mountSearch();
+		await reload();
+		vi.useFakeTimers();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: true, data: [] });
+			return {};
+		});
+
+		window.$('#user_search').val('zzz').trigger('input');
+		vi.advanceTimersByTime(300);
+
+		expect(window.$('#user_results').hasClass('active')).toBe(false);
+		expect(window.$('#user_results').html()).toBe('');
+	});
+});
+
+// ----------------------------------------------------------------------
+// initEnvironmentFilter — schedule → environment cascade
+// ----------------------------------------------------------------------
+
+describe('audience-admin — schedule → environment filter cascade', () => {
+	function mountCascade() {
+		document.body.innerHTML = `
+			<select id="filter-schedule">
+				<option value="">All</option>
+				<option value="7">Main</option>
+			</select>
+			<select id="filter-environment">
+				<option value="">All Environments</option>
+			</select>
+		`;
+	}
+
+	it('clearing the schedule resets the environment select', async () => {
+		mountCascade();
+		await reload();
+		window.$('#filter-schedule').val('').trigger('change');
+		const opts = window.$('#filter-environment option').map((_, el) => el.textContent).get();
+		expect(opts).toEqual(['All Environments']);
+	});
+
+	it('on schedule change: posts ffc_audience_get_environments and populates the select', async () => {
+		mountCascade();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: true, data: [{ id: 1, name: 'Env A' }, { id: 2, name: 'Env B' }] });
+			return {};
+		});
+
+		window.$('#filter-schedule').val('7').trigger('change');
+
+		const opts = window.$('#filter-environment option').map((_, el) => el.textContent).get();
+		expect(opts).toEqual(['All Environments', 'Env A', 'Env B']);
+	});
+
+	it('on response.success=false: leaves the select with the all-environments placeholder', async () => {
+		mountCascade();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: false });
+			return {};
+		});
+
+		window.$('#filter-schedule').val('7').trigger('change');
+
+		const opts = window.$('#filter-environment option').map((_, el) => el.textContent).get();
+		expect(opts).toEqual(['All Environments']);
+	});
+
+	it('on network error: leaves the select with the all-environments placeholder', async () => {
+		mountCascade();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.error();
+			return {};
+		});
+
+		window.$('#filter-schedule').val('7').trigger('change');
+
+		const opts = window.$('#filter-environment option').map((_, el) => el.textContent).get();
+		expect(opts).toEqual(['All Environments']);
+	});
+});
+
+// ----------------------------------------------------------------------
+// initBookingActions — view + cancel
+// ----------------------------------------------------------------------
+
+describe('audience-admin — booking actions', () => {
+	function mountBookings() {
+		document.body.innerHTML = `
+			<table>
+				<tr>
+					<td>
+						<a class="ffc-view-booking" data-booking-id="42" href="#">View</a> |
+						<a class="ffc-cancel-booking" data-booking-id="42" href="#">Cancel</a>
+						<span class="status-active">Active</span>
+					</td>
+				</tr>
+			</table>
+		`;
+	}
+
+	it('clicking view opens the modal and renders the booking fields', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					booking_date: '2026-06-01', is_all_day: 0,
+					start_time: '08:00', end_time: '18:00',
+					environment_name: 'Hall', description: 'Big event',
+					booking_type: 'audience', status: 'active',
+					created_by: 'Alice', audiences: [{ name: 'G1' }], users: [],
+				},
+			});
+			return {};
+		});
+
+		window.$('.ffc-view-booking').trigger('click');
+
+		expect(window.$('#ffc-booking-modal').length).toBe(1);
+		const text = window.$('#ffc-booking-modal').text();
+		expect(text).toContain('Hall');
+		expect(text).toContain('08:00 - 18:00');
+		expect(text).toContain('Big event');
+		expect(text).toContain('Active');
+	});
+
+	it('all-day bookings render the localised "All Day" text', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					booking_date: '2026-06-01', is_all_day: 1,
+					start_time: '', end_time: '',
+					environment_name: 'Hall', description: '',
+					booking_type: 'users', status: 'active',
+					created_by: 'Bob', audiences: [], users: [{ name: 'U1', email: 'u@x' }],
+				},
+			});
+			return {};
+		});
+
+		window.$('.ffc-view-booking').trigger('click');
+
+		const text = window.$('#ffc-booking-modal').text();
+		expect(text).toContain('All Day');
+		expect(text).toContain('Custom Users');
+		expect(text).toContain('U1');
+	});
+
+	it('cancelled bookings include the cancel reason line', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					booking_date: '2026-06-01', is_all_day: 1,
+					start_time: '', end_time: '',
+					environment_name: 'Hall', description: '',
+					booking_type: 'audience', status: 'cancelled',
+					created_by: 'Bob', audiences: [], users: [],
+					cancel_reason: 'Bad weather',
+				},
+			});
+			return {};
+		});
+
+		window.$('.ffc-view-booking').trigger('click');
+
+		expect(window.$('#ffc-booking-modal').text()).toContain('Bad weather');
+		expect(window.$('#ffc-booking-modal').text()).toContain('Cancelled');
+	});
+
+	it('on view AJAX response.success=false: shows the error message in the modal body', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: false, data: { message: 'Booking missing' } });
+			return {};
+		});
+
+		window.$('.ffc-view-booking').trigger('click');
+
+		expect(window.$('#ffc-booking-modal .ffc-admin-modal-body').text()).toContain('Booking missing');
+	});
+
+	it('on view network error: renders the generic error message', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.error();
+			return {};
+		});
+
+		window.$('.ffc-view-booking').trigger('click');
+
+		expect(window.$('#ffc-booking-modal .ffc-admin-modal-body').text()).toContain('Error');
+	});
+
+	it('clicking the close button removes the modal', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					booking_date: '2026-06-01', is_all_day: 1,
+					start_time: '', end_time: '',
+					environment_name: '', description: '',
+					booking_type: 'audience', status: 'active',
+					created_by: '', audiences: [], users: [],
+				},
+			});
+			return {};
+		});
+		window.$('.ffc-view-booking').trigger('click');
+		expect(window.$('#ffc-booking-modal').length).toBe(1);
+
+		window.$('.ffc-admin-modal-close').trigger('click');
+
+		expect(window.$('#ffc-booking-modal').length).toBe(0);
+	});
+
+	it('Escape key removes the modal', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({
+				success: true,
+				data: {
+					booking_date: '2026-06-01', is_all_day: 1,
+					start_time: '', end_time: '',
+					environment_name: '', description: '',
+					booking_type: 'audience', status: 'active',
+					created_by: '', audiences: [], users: [],
+				},
+			});
+			return {};
+		});
+		window.$('.ffc-view-booking').trigger('click');
+
+		const ev = window.$.Event('keydown', { key: 'Escape' });
+		window.$(document).trigger(ev);
+
+		expect(window.$('#ffc-booking-modal').length).toBe(0);
+	});
+
+	it('cancel: bails when the user declines the confirm', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const ajaxSpy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+
+		window.$('.ffc-cancel-booking').trigger('click');
+
+		expect(ajaxSpy).not.toHaveBeenCalled();
+	});
+
+	it('cancel: bails when the user dismisses the reason prompt', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.spyOn(window, 'prompt').mockReturnValue(null);
+		const ajaxSpy = vi.spyOn(window.$, 'ajax').mockImplementation(() => ({}));
+
+		window.$('.ffc-cancel-booking').trigger('click');
+
+		expect(ajaxSpy).not.toHaveBeenCalled();
+	});
+
+	it('cancel: on success, replaces status pill + removes the cancel link', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.spyOn(window, 'prompt').mockReturnValue('Weather');
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: true });
+			return {};
+		});
+
+		window.$('.ffc-cancel-booking').trigger('click');
+
+		expect(window.$('.status-active').length).toBe(0);
+		expect(window.$('.status-cancelled').text()).toBe('Cancelled');
+		expect(window.$('.ffc-cancel-booking').length).toBe(0);
+	});
+
+	it('cancel: on response.success=false alerts the server message', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.spyOn(window, 'prompt').mockReturnValue('R');
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.success({ success: false, data: { message: 'Already cancelled' } });
+			return {};
+		});
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('.ffc-cancel-booking').trigger('click');
+
+		expect(alertSpy).toHaveBeenCalledWith('Already cancelled');
+		// Cancel link still present + visually restored.
+		expect(window.$('.ffc-cancel-booking').length).toBe(1);
+	});
+
+	it('cancel: on network error, alerts the generic error', async () => {
+		mountBookings();
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.spyOn(window, 'prompt').mockReturnValue('R');
+		vi.spyOn(window.$, 'ajax').mockImplementation((opts) => {
+			opts.error();
+			return {};
+		});
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('.ffc-cancel-booking').trigger('click');
+
+		expect(alertSpy).toHaveBeenCalledWith('Error');
+	});
+});
+
+// ----------------------------------------------------------------------
+// initCalendarPermissions
+// ----------------------------------------------------------------------
+
+describe('audience-admin — calendar permissions', () => {
+	function mountPermissions() {
+		document.body.innerHTML = `
+			<table id="ffc-permissions-table" data-schedule-id="42">
+				<tbody>
+					<tr id="ffc-no-permissions-row"><td><em>No users yet</em></td></tr>
+				</tbody>
+			</table>
+			<input id="ffc-user-search">
+			<input type="hidden" id="ffc-selected-user-id">
+			<div id="ffc-user-search-results"></div>
+			<button id="ffc-add-user-btn" disabled>Add</button>
+		`;
+	}
+
+	it('user search: debounces 300 ms then renders results', async () => {
+		mountPermissions();
+		await reload();
+		vi.useFakeTimers();
+		vi.spyOn(window.$, 'get').mockImplementation((url, data, cb) => {
+			cb({ success: true, data: [{ id: 5, name: 'Alice', email: 'a@x' }] });
+			return {};
+		});
+
+		window.$('#ffc-user-search').val('alice').trigger('input');
+		vi.advanceTimersByTime(300);
+
+		// jsdom has no layout — :visible always false. Assert directly
+		// on the inline display style (jQuery `.show()` sets it).
+		expect(window.$('#ffc-user-search-results').css('display')).not.toBe('none');
+		expect(window.$('.ffc-user-result').length).toBe(1);
+	});
+
+	it('user search: renders the no-users-found message for an empty response', async () => {
+		mountPermissions();
+		await reload();
+		vi.useFakeTimers();
+		vi.spyOn(window.$, 'get').mockImplementation((url, data, cb) => {
+			cb({ success: true, data: [] });
+			return {};
+		});
+
+		window.$('#ffc-user-search').val('xx').trigger('input');
+		vi.advanceTimersByTime(300);
+
+		expect(window.$('#ffc-user-search-results').text()).toContain('No users');
+	});
+
+	it('selecting a user enables the add button', async () => {
+		mountPermissions();
+		await reload();
+		window.$('#ffc-user-search-results').html(
+			'<div class="ffc-user-result" data-id="9" data-name="Alice"></div>',
+		);
+
+		window.$('#ffc-user-search-results .ffc-user-result').trigger('click');
+
+		expect(window.$('#ffc-selected-user-id').val()).toBe('9');
+		expect(window.$('#ffc-add-user-btn').prop('disabled')).toBe(false);
+	});
+
+	it('add: on success appends the row HTML returned by the server', async () => {
+		mountPermissions();
+		await reload();
+		window.$('#ffc-selected-user-id').val('9');
+		window.$('#ffc-add-user-btn').prop('disabled', false);
+		// Simulate the JS state that pairs with the input.
+		window.$('#ffc-user-search-results').html(
+			'<div class="ffc-user-result" data-id="9" data-name="Alice"></div>',
+		);
+		window.$('.ffc-user-result').trigger('click');
+
+		vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({ success: true, data: { html: '<tr data-user-id="9"><td>Alice</td></tr>' } });
+			return {};
+		});
+
+		window.$('#ffc-add-user-btn').trigger('click');
+
+		expect(window.$('#ffc-permissions-table tbody tr[data-user-id="9"]').length).toBe(1);
+		expect(window.$('#ffc-no-permissions-row').length).toBe(0);
+		expect(window.$('#ffc-user-search').val()).toBe('');
+	});
+
+	it('toggle permission: posts the schedule + user + perm + value', async () => {
+		mountPermissions();
+		await reload();
+		window.$('#ffc-permissions-table tbody').append(
+			'<tr data-user-id="9"><td><input type="checkbox" class="ffc-perm-toggle" data-perm="manage" checked></td></tr>',
+		);
+		const postSpy = vi.spyOn(window.$, 'post').mockImplementation(() => ({}));
+
+		window.$('.ffc-perm-toggle').trigger('change');
+
+		expect(postSpy).toHaveBeenCalled();
+		const payload = postSpy.mock.calls[0][1];
+		expect(payload).toMatchObject({
+			action: 'ffc_audience_update_user_permission',
+			schedule_id: 42,
+			user_id: 9,
+			permission: 'manage',
+			value: 1,
+		});
+	});
+
+	it('remove: bails when confirm is declined', async () => {
+		mountPermissions();
+		await reload();
+		window.$('#ffc-permissions-table tbody').append(
+			'<tr data-user-id="9"><td><button class="ffc-remove-user-btn">x</button></td></tr>',
+		);
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const postSpy = vi.spyOn(window.$, 'post').mockImplementation(() => ({}));
+
+		window.$('.ffc-remove-user-btn').trigger('click');
+
+		expect(postSpy).not.toHaveBeenCalled();
+	});
+
+	it('remove: on success removes the row, shows the no-users-yet placeholder when empty', async () => {
+		mountPermissions();
+		await reload();
+		window.$('#ffc-no-permissions-row').remove();
+		window.$('#ffc-permissions-table tbody').append(
+			'<tr data-user-id="9"><td><button class="ffc-remove-user-btn">x</button></td></tr>',
+		);
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({ success: true });
+			return {};
+		});
+
+		window.$('.ffc-remove-user-btn').trigger('click');
+
+		expect(window.$('#ffc-permissions-table tbody tr[data-user-id="9"]').length).toBe(0);
+		expect(window.$('#ffc-no-permissions-row').length).toBe(1);
+	});
+});

--- a/tests/js/reregistration-admin-deep.test.js
+++ b/tests/js/reregistration-admin-deep.test.js
@@ -1,0 +1,522 @@
+// Sprint F2 — deep coverage for assets/js/ffc-reregistration-admin.js
+// (322 LOC, previously 37.57%). Six handlers wired from a single
+// $(document).ready boot; this file mounts each one's fixture in turn
+// and drives the user interactions through to the AJAX layer.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+beforeAll(() => {
+	window.ffcReregistrationAdmin = {
+		ajaxUrl: '/wp-admin/admin-ajax.php',
+		fichaNonce: 'ficha-nonce',
+		viewDetailsNonce: 'details-nonce',
+		adminNonce: 'admin-nonce',
+		strings: {
+			confirmApprove: 'Approve?',
+			confirmReturnToDraft: 'Return to draft?',
+			generatingPdf: 'Generating…',
+			ficha: 'Ficha',
+			errorGenerating: 'PDF error',
+			loadingDetails: 'Loading…',
+			errorLoadingDetails: 'Failed to load',
+			affectedUsers: 'Affected:',
+		},
+	};
+});
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	window.$.fx.off = true;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+async function reload() {
+	loadScript('assets/js/ffc-reregistration-admin.js');
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+// ----------------------------------------------------------------------
+// initSelectAll
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — select-all checkbox', () => {
+	it('checking #cb-select-all checks every submission_ids[] checkbox', async () => {
+		document.body.innerHTML = `
+			<input type="checkbox" id="cb-select-all">
+			<input type="checkbox" name="submission_ids[]" value="1">
+			<input type="checkbox" name="submission_ids[]" value="2">
+			<input type="checkbox" name="submission_ids[]" value="3">
+		`;
+		await reload();
+
+		window.$('#cb-select-all').prop('checked', true).trigger('change');
+
+		const checked = window.$('input[name="submission_ids[]"]:checked').length;
+		expect(checked).toBe(3);
+	});
+
+	it('unchecking #cb-select-all unchecks every submission_ids[] checkbox', async () => {
+		document.body.innerHTML = `
+			<input type="checkbox" id="cb-select-all">
+			<input type="checkbox" name="submission_ids[]" value="1" checked>
+			<input type="checkbox" name="submission_ids[]" value="2" checked>
+		`;
+		await reload();
+
+		window.$('#cb-select-all').prop('checked', false).trigger('change');
+
+		expect(window.$('input[name="submission_ids[]"]:checked').length).toBe(0);
+	});
+});
+
+// ----------------------------------------------------------------------
+// initBulkConfirm
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — bulk-action submit gate', () => {
+	function mountForm() {
+		document.body.innerHTML = `
+			<form id="ffc-submissions-form">
+				<select name="bulk_action">
+					<option value="">—</option>
+					<option value="approve">Approve</option>
+					<option value="return_to_draft">Return</option>
+					<option value="export">Export</option>
+				</select>
+				<input type="checkbox" name="submission_ids[]" value="1">
+			</form>
+		`;
+	}
+
+	it('prevents submit when no action is selected', async () => {
+		mountForm();
+		await reload();
+		const ev = window.$.Event('submit');
+		window.$('#ffc-submissions-form').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+	});
+
+	it('prevents submit when no row is checked', async () => {
+		mountForm();
+		await reload();
+		window.$('select[name="bulk_action"]').val('approve');
+		const ev = window.$.Event('submit');
+		window.$('#ffc-submissions-form').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+	});
+
+	it('prevents submit on approve when the user declines the confirm', async () => {
+		mountForm();
+		await reload();
+		window.$('select[name="bulk_action"]').val('approve');
+		window.$('input[name="submission_ids[]"]').prop('checked', true);
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const ev = window.$.Event('submit');
+		window.$('#ffc-submissions-form').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+	});
+
+	it('lets approve through when the user accepts the confirm', async () => {
+		mountForm();
+		await reload();
+		window.$('select[name="bulk_action"]').val('approve');
+		window.$('input[name="submission_ids[]"]').prop('checked', true);
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		const ev = window.$.Event('submit');
+		// Block jsdom's native submit (Not Implemented).
+		window.$('#ffc-submissions-form').on('submit', (e) => e.preventDefault());
+		window.$('#ffc-submissions-form').trigger(ev);
+		// Our extra preventDefault doesn't count toward the assertion —
+		// the FIRST handler is the IIFE's, which only prevents on confirm=false.
+		// Since confirm returned true, the IIFE didn't preventDefault.
+		// (The native preventDefault later fires from the test guard.)
+		expect(vi.mocked(window.confirm)).toHaveBeenCalledWith('Approve?');
+	});
+
+	it('prevents submit on return_to_draft when the user declines', async () => {
+		mountForm();
+		await reload();
+		window.$('select[name="bulk_action"]').val('return_to_draft');
+		window.$('input[name="submission_ids[]"]').prop('checked', true);
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const ev = window.$.Event('submit');
+		window.$('#ffc-submissions-form').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+		expect(vi.mocked(window.confirm)).toHaveBeenCalledWith('Return to draft?');
+	});
+
+	it('passes a non-confirm action (e.g. export) through without prompting', async () => {
+		mountForm();
+		await reload();
+		window.$('select[name="bulk_action"]').val('export');
+		window.$('input[name="submission_ids[]"]').prop('checked', true);
+		const confirmSpy = vi.spyOn(window, 'confirm');
+		window.$('#ffc-submissions-form').on('submit', (e) => e.preventDefault());
+		window.$('#ffc-submissions-form').trigger('submit');
+		expect(confirmSpy).not.toHaveBeenCalled();
+	});
+});
+
+// ----------------------------------------------------------------------
+// initReturnToDraftConfirm
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — single row return-to-draft button', () => {
+	it('prevents click when the user declines the confirm', async () => {
+		document.body.innerHTML = `<a class="ffc-return-draft-btn" href="?act=return">Return</a>`;
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const ev = window.$.Event('click');
+		window.$('.ffc-return-draft-btn').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+	});
+
+	it('lets the click through when the user accepts the confirm', async () => {
+		document.body.innerHTML = `<a class="ffc-return-draft-btn" href="#">Return</a>`;
+		await reload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		const ev = window.$.Event('click');
+		window.$('.ffc-return-draft-btn').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------
+// initFichaDownload
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — ficha PDF download', () => {
+	function mountBtn() {
+		document.body.innerHTML = `<button type="button" class="ffc-ficha-btn" data-submission-id="42">Ficha</button>`;
+	}
+
+	it('bails when the button has no submission-id', async () => {
+		document.body.innerHTML = `<button class="ffc-ficha-btn">Ficha</button>`;
+		await reload();
+		const postSpy = vi.spyOn(window.$, 'post').mockImplementation(() => ({ fail: () => ({}) }));
+		window.$('.ffc-ficha-btn').trigger('click');
+		expect(postSpy).not.toHaveBeenCalled();
+	});
+
+	it('on success: calls window.ffcGeneratePDF with the payload', async () => {
+		mountBtn();
+		await reload();
+		window.ffcGeneratePDF = vi.fn();
+		vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({
+				success: true,
+				data: { pdf_data: { template: 'x', filename: 'rec.pdf' } },
+			});
+			return { fail: () => ({}) };
+		});
+
+		window.$('.ffc-ficha-btn').trigger('click');
+
+		expect(window.ffcGeneratePDF).toHaveBeenCalledWith(
+			{ template: 'x', filename: 'rec.pdf' },
+			'rec.pdf',
+		);
+	});
+
+	it('on success but no window.ffcGeneratePDF: shows an alert', async () => {
+		mountBtn();
+		await reload();
+		delete window.ffcGeneratePDF;
+		vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({ success: true, data: { pdf_data: { template: 'x' } } });
+			return { fail: () => ({}) };
+		});
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('.ffc-ficha-btn').trigger('click');
+
+		expect(alertSpy).toHaveBeenCalledWith('PDF error');
+	});
+
+	it('on response.success=false: alerts the server message', async () => {
+		mountBtn();
+		await reload();
+		vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({ success: false, data: { message: 'Submission not found' } });
+			return { fail: () => ({}) };
+		});
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('.ffc-ficha-btn').trigger('click');
+
+		expect(alertSpy).toHaveBeenCalledWith('Submission not found');
+	});
+
+	it('on network failure: alerts the generic ficha-error string', async () => {
+		mountBtn();
+		await reload();
+		let failCb;
+		vi.spyOn(window.$, 'post').mockImplementation(() => ({
+			fail: (cb) => {
+				failCb = cb;
+				return {};
+			},
+		}));
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('.ffc-ficha-btn').trigger('click');
+		failCb();
+
+		expect(alertSpy).toHaveBeenCalledWith('PDF error');
+	});
+});
+
+// ----------------------------------------------------------------------
+// initSubmissionDetailsModal
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — submission details modal', () => {
+	function mountModalFixture() {
+		document.body.innerHTML = `
+			<button type="button" class="ffc-view-details-btn" data-submission-id="7">Details</button>
+			<div id="ffc-submission-details-modal" style="display:none">
+				<div class="ffc-modal-backdrop"></div>
+				<div class="ffc-modal-content">
+					<button type="button" class="ffc-modal-close">x</button>
+					<div class="ffc-modal-body"><p class="ffc-modal-loading"></p></div>
+				</div>
+			</div>
+		`;
+	}
+
+	it('opens modal + injects success html', async () => {
+		mountModalFixture();
+		await reload();
+		vi.spyOn(window.$, 'post').mockImplementation(() => ({
+			done: function (cb) {
+				cb({ success: true, data: { html: '<table>fields</table>' } });
+				return { fail: () => ({}) };
+			},
+		}));
+
+		window.$('.ffc-view-details-btn').trigger('click');
+
+		expect(window.$('#ffc-submission-details-modal').css('display')).not.toBe('none');
+		// jsdom reorders text outside <table> nodes; assert on the visible
+		// payload rather than literal HTML preservation.
+		expect(window.$('.ffc-modal-body').text()).toContain('fields');
+	});
+
+	it('shows the server error in the modal when response.success=false', async () => {
+		mountModalFixture();
+		await reload();
+		vi.spyOn(window.$, 'post').mockImplementation(() => ({
+			done: function (cb) {
+				cb({ success: false, data: { message: 'Forbidden' } });
+				return { fail: () => ({}) };
+			},
+		}));
+
+		window.$('.ffc-view-details-btn').trigger('click');
+
+		expect(window.$('.ffc-modal-body').text()).toContain('Forbidden');
+	});
+
+	it('on network failure: renders the localised error', async () => {
+		mountModalFixture();
+		await reload();
+		vi.spyOn(window.$, 'post').mockImplementation(() => ({
+			done: function () {
+				return {
+					fail: (cb) => {
+						cb();
+						return {};
+					},
+				};
+			},
+		}));
+
+		window.$('.ffc-view-details-btn').trigger('click');
+
+		expect(window.$('.ffc-modal-body').text()).toContain('Failed to load');
+	});
+
+	it('close button hides the modal', async () => {
+		mountModalFixture();
+		await reload();
+		// Force open
+		window.$('#ffc-submission-details-modal').show();
+		window.$('#ffc-submission-details-modal .ffc-modal-close').trigger('click');
+		expect(window.$('#ffc-submission-details-modal').css('display')).toBe('none');
+	});
+
+	it('Escape key closes a visible modal', async () => {
+		mountModalFixture();
+		await reload();
+		window.$('#ffc-submission-details-modal').show();
+		// jQuery `:visible` in jsdom reports false because there's no
+		// layout — patch the pseudo so the Escape handler's guard passes.
+		const originalVisible = window.$.expr.pseudos.visible;
+		window.$.expr.pseudos.visible = () => true;
+		try {
+			const ev = window.$.Event('keydown', { key: 'Escape' });
+			window.$(document).trigger(ev);
+			expect(window.$('#ffc-submission-details-modal').css('display')).toBe('none');
+		} finally {
+			window.$.expr.pseudos.visible = originalVisible;
+		}
+	});
+});
+
+// ----------------------------------------------------------------------
+// initTransferList
+// ----------------------------------------------------------------------
+
+describe('rereg-admin — audience transfer list', () => {
+	function mountTransfer(opts) {
+		opts = opts || {};
+		const audiences = opts.audiences || [
+			{ id: 1, name: 'Group A', color: '#aaa' },
+			{ id: 2, name: 'Group B', color: '#bbb' },
+			{ id: 3, name: 'Group C', color: '#ccc' },
+		];
+		const selected = opts.selected || [];
+		document.body.innerHTML = `
+			<form>
+				<div class="ffc-transfer-list"
+					data-audiences='${JSON.stringify(audiences)}'
+					data-selected='${JSON.stringify(selected)}'>
+					<input type="text" class="ffc-transfer-search">
+					<div class="ffc-transfer-available">
+						<div class="ffc-transfer-items"></div>
+					</div>
+					<button type="button" class="ffc-transfer-add">→</button>
+					<button type="button" class="ffc-transfer-add-all">»</button>
+					<button type="button" class="ffc-transfer-remove">←</button>
+					<button type="button" class="ffc-transfer-remove-all">«</button>
+					<div class="ffc-transfer-selected">
+						<div class="ffc-transfer-items"></div>
+					</div>
+					<div class="ffc-transfer-hidden-inputs"></div>
+				</div>
+				<div class="ffc-transfer-member-count"></div>
+				<button type="submit">Save</button>
+			</form>
+		`;
+	}
+
+	it('initial render shows availables on the left and seeds selected hidden inputs', async () => {
+		mountTransfer({ selected: [2] });
+		await reload();
+
+		const $sel = window.$('.ffc-transfer-selected .ffc-transfer-item');
+		const $av = window.$('.ffc-transfer-available .ffc-transfer-item');
+		expect($sel.length).toBe(1);
+		expect($av.length).toBe(2);
+		expect(window.$('.ffc-transfer-hidden-inputs input').length).toBe(1);
+		expect(window.$('.ffc-transfer-hidden-inputs input').val()).toBe('2');
+	});
+
+	it('double-click on an available item moves it to selected', async () => {
+		mountTransfer();
+		await reload();
+		window.$('.ffc-transfer-available .ffc-transfer-item[data-id="1"]').trigger('dblclick');
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item[data-id="1"]').length).toBe(1);
+	});
+
+	it('double-click on a selected item moves it back to available', async () => {
+		mountTransfer({ selected: [1, 2] });
+		await reload();
+		window.$('.ffc-transfer-selected .ffc-transfer-item[data-id="1"]').trigger('dblclick');
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item[data-id="1"]').length).toBe(0);
+		expect(window.$('.ffc-transfer-available .ffc-transfer-item[data-id="1"]').length).toBe(1);
+	});
+
+	it('arrow button "→" moves all highlighted availables to selected', async () => {
+		mountTransfer();
+		await reload();
+		window.$('.ffc-transfer-available .ffc-transfer-item').addClass('ffc-transfer-highlight');
+		window.$('.ffc-transfer-add').trigger('click');
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item').length).toBe(3);
+	});
+
+	it('"add all" button moves every item to selected', async () => {
+		mountTransfer();
+		await reload();
+		window.$('.ffc-transfer-add-all').trigger('click');
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item').length).toBe(3);
+	});
+
+	it('"remove all" button clears the selected column', async () => {
+		mountTransfer({ selected: [1, 2, 3] });
+		await reload();
+		window.$('.ffc-transfer-remove-all').trigger('click');
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item').length).toBe(0);
+	});
+
+	it('search filter narrows the available list', async () => {
+		mountTransfer();
+		await reload();
+		window.$('.ffc-transfer-search').val('group a').trigger('input');
+		const labels = window.$('.ffc-transfer-available .ffc-transfer-label').map((_, el) => el.textContent).get();
+		expect(labels.every((l) => l.toLowerCase().includes('group a'))).toBe(true);
+	});
+
+	it('selecting a parent cascades its children into the selected column', async () => {
+		mountTransfer({
+			audiences: [
+				{ id: 10, name: 'Parent', color: '#000', children: [11, 12] },
+				{ id: 11, name: 'Child 1', color: '#111', parent: 10 },
+				{ id: 12, name: 'Child 2', color: '#222', parent: 10 },
+			],
+		});
+		await reload();
+		window.$('.ffc-transfer-available .ffc-transfer-item[data-id="10"]').trigger('dblclick');
+		// Parent + both children land in selected.
+		expect(window.$('.ffc-transfer-selected .ffc-transfer-item').length).toBe(3);
+	});
+
+	it('debounces member-count AJAX (300 ms) and renders the response', async () => {
+		// Mount + reload under REAL timers so the script's $(document).ready
+		// microtask resolves; then switch to fake timers BEFORE advancing.
+		mountTransfer({ selected: [1] });
+		await reload();
+		vi.useFakeTimers();
+
+		const postSpy = vi.spyOn(window.$, 'post').mockImplementation((url, data, cb) => {
+			cb({ success: true, data: { count: 42 } });
+			return { fail: () => ({}) };
+		});
+
+		// Trigger a fresh debounce by toggling something that re-runs render.
+		window.$('.ffc-transfer-add-all').trigger('click');
+
+		// Just before 300 ms — no AJAX yet.
+		vi.advanceTimersByTime(299);
+		expect(postSpy).not.toHaveBeenCalled();
+
+		// At 300 ms — AJAX fires.
+		vi.advanceTimersByTime(1);
+		expect(postSpy).toHaveBeenCalled();
+		expect(window.$('.ffc-transfer-member-count').text()).toContain('42');
+		vi.useRealTimers();
+	});
+
+	it('form submit with no selection prevents default and pulses the error class', async () => {
+		mountTransfer();
+		await reload();
+		const ev = window.$.Event('submit');
+		window.$('form').trigger(ev);
+		expect(ev.isDefaultPrevented()).toBe(true);
+		expect(window.$('.ffc-transfer-selected').hasClass('ffc-transfer-error')).toBe(true);
+	});
+
+	it('clicking a transfer-item toggles the highlight class', async () => {
+		mountTransfer();
+		await reload();
+		const $first = window.$('.ffc-transfer-available .ffc-transfer-item').first();
+		$first.trigger('click');
+		expect($first.hasClass('ffc-transfer-highlight')).toBe(true);
+		$first.trigger('click');
+		expect($first.hasClass('ffc-transfer-highlight')).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #198.

## Summary

Sprint F2 of the JS coverage roadmap. Deep-covers the last two Tier-3 admin scripts that were deferred when PR #190 split the work.

| File | Before | After |
|---|--:|--:|
| `ffc-reregistration-admin.js` | 37.57% | **96.89%** |
| `ffc-audience-admin.js` | 33.26% | **98.06%** |

Overall JS line coverage **76.79% → 80.10%** (+3.3pp). `JS_COVERAGE_FLOOR_LINES` ratcheted **74 → 77** to lock the gain (~3pp buffer).

## Sprints / commits

| # | Sprint | New tests |
|---|---|--:|
| 2.1 | `ffc-reregistration-admin.js` deep | 31 |
| 2.2 | `ffc-audience-admin.js` deep | 30 |
| 2.3 | Ratchet `JS_COVERAGE_FLOOR_LINES` 74 → 77 | — |

## What's covered

**`ffc-reregistration-admin.js`** — `initSelectAll`, `initBulkConfirm` (action gate, row gate, approve/return confirm + accept/decline branches, passthrough on non-confirm actions), `initReturnToDraftConfirm`, `initFichaDownload` (AJAX happy path + missing `ffcGeneratePDF` fallback + server-side success=false + network fail), `initSubmissionDetailsModal` (open/AJAX/error branches/close button/Escape), `initTransferList` (initial render + hidden inputs, dbl-click moves, arrow buttons, search filter, parent-cascades-children, 300 ms debounced member-count AJAX with fake timers, form-POST validation pulse, highlight toggle).

**`ffc-audience-admin.js`** — day-row time-input gate, `initUserSearch` (query-length-2 bail, 300 ms debounced AJAX, empty results dropdown hide, select/remove), `initEnvironmentFilter` (empty schedule reset, success/non-success/network branches), `initBookingActions` (view modal for audience / all-day custom-users / cancelled-with-reason, server error + network error in modal, close + Escape, cancel-booking confirm-declined, prompt-declined, on-success status pill swap + link removal, response.success=false alerts, network error alerts), `initCalendarPermissions` (debounced search render, no-users-found copy, select enables add button, add appends server row HTML + removes placeholder, toggle posts the right payload, remove confirms + on-success row removal + placeholder restoration).

No production-code changes — every behaviour asserted matched the scripts as shipped.

## Verification

- [x] `npm run test:js:coverage` — **637/637** green, **80.10%** lines
- [x] `npm run lint:js` — 0 errors
- [x] `phpcs` on touched PHP — clean
- [x] Floor at 77 stays ~3pp under the 80.10% baseline

## Coverage roadmap status (after merge)

Every script considered tractable for JS unit coverage is now at ≥ 90% except the architectural-exclusion outlier (`ffc-audience.js` smoke-only at 47%, intentionally per #167). The original roadmap is closed.

Will auto-merge SQUASH per convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_