### PR TITLE
Hotfix: .ffc-toggle missing CSS on rereg/audience + 4 more conversions

### DIFF
--- a/includes/audience/class-ffc-audience-admin-audience.php
+++ b/includes/audience/class-ffc-audience-admin-audience.php
@@ -277,14 +277,23 @@ class AudienceAdminAudience {
 						<label for="audience_status"><?php esc_html_e( 'Status', 'ffcertificate' ); ?></label>
 					</th>
 					<td>
-						<select name="audience_status" id="audience_status">
-							<option value="active" <?php selected( $audience->status ?? 'active', 'active' ); ?>>
-								<?php esc_html_e( 'Active', 'ffcertificate' ); ?>
-							</option>
-							<option value="inactive" <?php selected( $audience->status ?? '', 'inactive' ); ?>>
-								<?php esc_html_e( 'Inactive', 'ffcertificate' ); ?>
-							</option>
-						</select>
+						<?php
+						// Hidden sibling carries the "inactive" value when the
+						// toggle is unchecked — POST keeps the same shape as
+						// the old <select> (one of 'active' / 'inactive').
+						?>
+						<input type="hidden" name="audience_status" value="inactive">
+						<?php
+						\FreeFormCertificate\Admin\AdminUI::render_toggle(
+							array(
+								'name'    => 'audience_status',
+								'id'      => 'audience_status',
+								'value'   => 'active',
+								'checked' => 'active' === (string) ( $audience->status ?? 'active' ),
+								'label'   => __( 'Active', 'ffcertificate' ),
+							)
+						);
+						?>
 					</td>
 				</tr>
 				<?php
@@ -307,11 +316,16 @@ class AudienceAdminAudience {
 							</p>
 							<input type="hidden" name="audience_self_join" value="<?php echo esc_attr( $is_self_join ? '1' : '0' ); ?>">
 						<?php else : ?>
-							<label>
-								<input type="checkbox" name="audience_self_join" id="audience_self_join" value="1"
-									<?php checked( $is_self_join ); ?>>
-								<?php esc_html_e( 'Users can join/leave child groups from their dashboard', 'ffcertificate' ); ?>
-							</label>
+							<?php
+							\FreeFormCertificate\Admin\AdminUI::render_toggle(
+								array(
+									'name'    => 'audience_self_join',
+									'id'      => 'audience_self_join',
+									'checked' => $is_self_join,
+									'label'   => __( 'Users can join/leave child groups from their dashboard', 'ffcertificate' ),
+								)
+							);
+							?>
 							<p class="description"><?php esc_html_e( 'When enabled, all descendant audiences inherit this setting. Users can join up to 2 child groups.', 'ffcertificate' ); ?></p>
 						<?php endif; ?>
 					</td>

--- a/includes/audience/class-ffc-audience-admin-import.php
+++ b/includes/audience/class-ffc-audience-admin-import.php
@@ -108,10 +108,15 @@ class AudienceAdminImport {
 							<tr>
 								<th scope="row"><?php esc_html_e( 'Options', 'ffcertificate' ); ?></th>
 								<td>
-									<label>
-										<input type="checkbox" name="create_users" value="1" checked>
-										<?php esc_html_e( 'Create users if they do not exist (with ffc_user role)', 'ffcertificate' ); ?>
-									</label>
+									<?php
+									\FreeFormCertificate\Admin\AdminUI::render_toggle(
+										array(
+											'name'    => 'create_users',
+											'checked' => true,
+											'label'   => __( 'Create users if they do not exist (with ffc_user role)', 'ffcertificate' ),
+										)
+									);
+									?>
 								</td>
 							</tr>
 						</tbody></table>

--- a/includes/audience/class-ffc-audience-loader.php
+++ b/includes/audience/class-ffc-audience-loader.php
@@ -195,10 +195,18 @@ class AudienceLoader {
 		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
 
 		// Admin CSS.
+		if ( function_exists( 'wp_style_is' ) && ! wp_style_is( 'ffc-common', 'registered' ) ) {
+			wp_register_style(
+				'ffc-common',
+				FFC_PLUGIN_URL . "assets/css/ffc-common{$s}.css",
+				array(),
+				FFC_VERSION
+			);
+		}
 		wp_enqueue_style(
 			'ffc-audience-admin',
 			FFC_PLUGIN_URL . "assets/css/ffc-audience-admin{$s}.css",
-			array(),
+			array( 'ffc-common' ),
 			FFC_VERSION
 		);
 

--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page-renderer.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page-renderer.php
@@ -206,10 +206,14 @@ final class RecruitmentNoticeEditPageRenderer {
 		$preview_checked = ! empty( $preview_state['preview_reason'] );
 
 		echo '<tr><th>' . esc_html__( 'Preliminary reasons', 'ffcertificate' ) . '</th><td>';
-		echo '<label for="ffc-notice-pcc-preview_reason" style="display:flex;align-items:center;gap:6px;">';
-		echo '<input id="ffc-notice-pcc-preview_reason" type="checkbox" name="public_columns[preview_reason]" value="1"' . ( $preview_checked ? ' checked' : '' ) . '>';
-		echo esc_html__( 'Show preliminary reasons publicly on this notice', 'ffcertificate' );
-		echo '</label>';
+		\FreeFormCertificate\Admin\AdminUI::render_toggle(
+			array(
+				'name'    => 'public_columns[preview_reason]',
+				'id'      => 'ffc-notice-pcc-preview_reason',
+				'checked' => $preview_checked,
+				'label'   => __( 'Show preliminary reasons publicly on this notice', 'ffcertificate' ),
+			)
+		);
 		echo '<p class="description">' . esc_html__( 'When on, the public shortcode will render the reason label next to the preliminary status badge. Off by default per notice — operators decide all-or-nothing per edital.', 'ffcertificate' ) . '</p>';
 		echo '</td></tr>';
 

--- a/includes/reregistration/class-ffc-reregistration-admin.php
+++ b/includes/reregistration/class-ffc-reregistration-admin.php
@@ -127,10 +127,23 @@ class ReregistrationAdmin {
 
 		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
 
+		// Make sure ffc-common.css is registered + available so the
+		// dependency below resolves even when this page isn't matched
+		// by AdminAssetsManager (post_type=empty + $_GET['page']
+		// already starts with ffc-, but defensive).
+		if ( function_exists( 'wp_style_is' ) && ! wp_style_is( 'ffc-common', 'registered' ) ) {
+			wp_register_style(
+				'ffc-common',
+				FFC_PLUGIN_URL . "assets/css/ffc-common{$s}.css",
+				array(),
+				FFC_VERSION
+			);
+		}
+
 		wp_enqueue_style(
 			'ffc-reregistration-admin',
 			FFC_PLUGIN_URL . "assets/css/ffc-reregistration-admin{$s}.css",
-			array(),
+			array( 'ffc-common' ),
 			FFC_VERSION
 		);
 


### PR DESCRIPTION
Closes the visual bug reported on `ffc-reregistration&view=edit` and folds in 4 toggle conversions discovered after #219 merged.

## Root cause of the visual bug

The 4 reregistration toggles added in #219 (Sprint 2) rendered without their track/background because **`ffc-reregistration-admin.css` was enqueued with `array()` deps**. WordPress's dependency graph never guaranteed `ffc-common.css` (which holds the `.ffc-toggle` rules) would be loaded first — relying instead on `AdminAssetsManager::enqueue_admin_assets` racing to enqueue it. Same shape in `ffc-audience-admin.css`.

Defensive fix: `wp_register_style( 'ffc-common', … )` up-front (guarded with `function_exists( 'wp_style_is' )` so the unit tests don't need to mock the function), then declare it as an explicit dep on the page CSS. WordPress will now always resolve ffc-common before the page styles.

## 4 more conversions folded in

| Local | Item | Today | After |
| --- | --- | --- | --- |
| `ffc-scheduling-audiences&action=edit` | `audience_status` `<select>` (`active` / `inactive`) | select | hidden=inactive + `.ffc-toggle`(active) |
| same page | `audience_self_join` checkbox | checkbox | `.ffc-toggle` |
| `ffc-scheduling-import` | `create_users` checkbox | checkbox | `.ffc-toggle` |
| `ffc-recruitment&action=edit-notice` | `public_columns[preview_reason]` checkbox | checkbox | `.ffc-toggle` |

For the `<select>` case (`audience_status`), the hidden-sibling pattern from #218 applies — `<input type="hidden" name="audience_status" value="inactive">` + a `.ffc-toggle` whose checkbox value is `active`. POST keeps the same shape (`'active'` or `'inactive'`); no migration.

## Out of scope (will get its own PR)

- **Form-builder "Obrigatório" checkbox** (Section 2 — `class-ffc-form-editor-builder-metabox.php` + `ffc-admin-field-builder.js` template). The serialiser reads via `.ffc-field-required` class on the input; converting needs either a new `input_class` arg on `AdminUI::render_toggle` or a hand-rolled toggle markup. Worth a focused PR.

## Suite

PHPUnit **3978/3978** · WPCS clean · PHPStan clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_