### PR TITLE
FormCache: integrate W3TC / LiteSpeed / Super Cache / WP Rocket purges — closes #225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **FormCache now propagates invalidation to third-party page-cache plugins** (closes #225). New `FormCache::purge_external_caches( $form_id, $reason = '' )` is a best-effort sweep that calls `\W3TC\Dispatcher::component('CacheFlush')->flush_post( $form_id )`, `\LiteSpeed\Purge::add( 'P_' . $form_id )`, `wpsc_delete_post_cache( $form_id )` (WP Super Cache), `rocket_clean_post( $form_id )` (WP Rocket) — each guarded by `class_exists` / `function_exists` + a try/catch so a misbehaving cache plugin can never break the host action. Closes with `do_action( 'ffc_form_cache_purged', $form_id, $reason )` so Cloudflare APO, Redis page caches, and custom CDN purgers can hook the same signal. New `purge_external_caches_for_all_forms( $reason )` iterates every published form. Wired into: the "Clear all cache" admin AJAX endpoint, the legacy admin_init handler (same button, no-JS fallback), and the form-editor save handler when the geofence config changes — so a manual datetime edit propagates through to the public CSV download page + the rendered form page immediately. `clear_form_cache()` (the hot-path object-cache flush called on every save_post / submission) is unchanged — third-party purges only fire when the public-facing state actually moved.
+
 ### Fixed
 
 - **Reregistration "Email Notifications" toggles overlapping their labels.** WordPress admin core ships a `.form-table td fieldset label { display: inline-block }` rule that overrode the plugin's `.ffc-toggle { display: inline-flex }`, collapsing the toggle track over the start of the label text. The reregistration edit page wrapped the three notification toggles in a `<fieldset>` (triggering that rule); `.ffc-toggle` now also declares the rule on `.form-table td .ffc-toggle` + `.form-table td fieldset .ffc-toggle` to win the specificity battle, and the offending `<fieldset>` was replaced with a plain `<div>` since it carried no `<legend>`. `position: relative` is also added so the visually-hidden checkbox is scoped to the label, not the viewport.

--- a/includes/admin/class-ffc-cache-actions-ajax-endpoint.php
+++ b/includes/admin/class-ffc-cache-actions-ajax-endpoint.php
@@ -79,6 +79,10 @@ class CacheActionsAjaxEndpoint {
 		self::guard( self::ACTION_CLEAR );
 
 		\FreeFormCertificate\Submissions\FormCache::clear_all_cache();
+		// Also sweep page-cache invalidation on every form so visitors
+		// see the change immediately, not just the plugin's own object
+		// cache — admins clicking "Clear all cache" expect that scope.
+		\FreeFormCertificate\Submissions\FormCache::purge_external_caches_for_all_forms( 'manual_clear_all' );
 
 		wp_send_json_success(
 			array(

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -186,6 +186,12 @@ class FormEditorSaveHandler {
 				set_transient( 'ffc_geofence_error_' . get_current_user_id(), $validation_errors, 45 );
 			} else {
 				update_post_meta( $post_id, '_ffc_geofence_config', $clean_geofence );
+				// Public visibility of date_start/date_end (the form's
+				// availability window) flows through page caches —
+				// invalidate so the public CSV download page + the
+				// rendered form page pick up the change immediately.
+				\FreeFormCertificate\Submissions\FormCache::clear_form_cache( $post_id );
+				\FreeFormCertificate\Submissions\FormCache::purge_external_caches( $post_id, 'geofence_changed' );
 			}
 		}
 

--- a/includes/admin/class-ffc-settings.php
+++ b/includes/admin/class-ffc-settings.php
@@ -587,6 +587,7 @@ class Settings {
 
 			// Autoloader handles class loading.
 			\FreeFormCertificate\Submissions\FormCache::clear_all_cache();
+			\FreeFormCertificate\Submissions\FormCache::purge_external_caches_for_all_forms( 'manual_clear_all' );
 
 			wp_safe_redirect(
 				add_query_arg(

--- a/includes/submissions/class-ffc-form-cache.php
+++ b/includes/submissions/class-ffc-form-cache.php
@@ -179,6 +179,85 @@ class FormCache {
 	}
 
 	/**
+	 * Best-effort external page-cache purge across known third-party
+	 * plugins, plus an action hook for anything else (Cloudflare APO,
+	 * Redis page cache, custom setups).
+	 *
+	 * Call this IN ADDITION TO {@see self::clear_form_cache()} when
+	 * the form's public-facing state has changed in a way visitors
+	 * would notice on a cached page (form started early, datetime
+	 * edited, public toggles flipped). Routine internal-only cache
+	 * touches (every `save_post`, every submission) should only call
+	 * `clear_form_cache()` to keep them cheap.
+	 *
+	 * Each integration is wrapped in a try/catch so a misbehaving
+	 * third-party plugin can never break the host action.
+	 *
+	 * @param int    $form_id The form post id whose public pages
+	 *                        should be invalidated.
+	 * @param string $reason  Free-form tag passed to the action hook
+	 *                        ('early_open', 'geofence_changed', etc.)
+	 *                        — lets external integrations log /
+	 *                        rate-limit / branch on the source.
+	 */
+	public static function purge_external_caches( int $form_id, string $reason = '' ): void {
+		if ( $form_id <= 0 ) {
+			return;
+		}
+
+		// W3 Total Cache.
+		if ( class_exists( '\W3TC\Dispatcher' ) ) {
+			try {
+				\W3TC\Dispatcher::component( 'CacheFlush' )->flush_post( $form_id );
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort.
+				// Swallow — host action must not fail on a third-party glitch.
+			}
+		}
+
+		// LiteSpeed Cache.
+		if ( class_exists( '\LiteSpeed\Purge' ) ) {
+			try {
+				\LiteSpeed\Purge::add( 'P_' . $form_id );
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort.
+				// Swallow.
+			}
+		}
+
+		// WP Super Cache.
+		if ( function_exists( 'wpsc_delete_post_cache' ) ) {
+			try {
+				wpsc_delete_post_cache( $form_id );
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort.
+				// Swallow.
+			}
+		}
+
+		// WP Rocket.
+		if ( function_exists( 'rocket_clean_post' ) ) {
+			try {
+				rocket_clean_post( $form_id );
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort.
+				// Swallow.
+			}
+		}
+
+		/**
+		 * Fires after the plugin has invalidated the form's public-
+		 * page cache. Third-party integrations (Cloudflare APO, Redis
+		 * page cache, custom CDN purger) can hook this to invalidate
+		 * their own layer.
+		 *
+		 * @param int    $form_id The form post id whose pages just
+		 *                        had their cache invalidated.
+		 * @param string $reason  Source tag — currently one of
+		 *                        'early_open', 'geofence_changed',
+		 *                        'manual_clear_all', or empty when
+		 *                        unspecified.
+		 */
+		do_action( 'ffc_form_cache_purged', $form_id, $reason );
+	}
+
+	/**
 	 * Clear all form caches
 	 */
 	public static function clear_all_cache(): bool {
@@ -187,6 +266,38 @@ class FormCache {
 		}
 
 		return wp_cache_flush();
+	}
+
+	/**
+	 * Sweep external page-cache purges across every published form.
+	 *
+	 * Called by the "Clear all cache" admin button so that, after the
+	 * plugin's own object cache has been wiped, third-party page caches
+	 * (W3 Total Cache, LiteSpeed, Super Cache, WP Rocket, CDN APO via
+	 * the action hook) also drop their cached versions of FFC form
+	 * pages — otherwise an admin clicking "Clear all cache" still sees
+	 * stale public pages.
+	 *
+	 * @param string $reason Forwarded to {@see self::purge_external_caches()}.
+	 * @return int Number of forms iterated.
+	 */
+	public static function purge_external_caches_for_all_forms( string $reason = 'manual_clear_all' ): int {
+		$ids = get_posts(
+			array(
+				'post_type'        => 'ffc_form',
+				'post_status'      => 'publish',
+				'numberposts'      => -1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'orderby'          => 'ID',
+				'order'            => 'ASC',
+				'suppress_filters' => false,
+			)
+		);
+		foreach ( $ids as $id ) {
+			self::purge_external_caches( (int) $id, $reason );
+		}
+		return count( $ids );
 	}
 
 	/**

--- a/tests/Unit/CacheActionsAjaxEndpointTest.php
+++ b/tests/Unit/CacheActionsAjaxEndpointTest.php
@@ -129,7 +129,12 @@ class CacheActionsAjaxEndpointTest extends TestCase {
         Mockery::mock( 'alias:FreeFormCertificate\Submissions\FormCache' )
             ->shouldReceive( 'clear_all_cache' )
             ->once()
-            ->andReturn( true );
+            ->andReturn( true )
+            ->getMock()
+            ->shouldReceive( 'purge_external_caches_for_all_forms' )
+            ->once()
+            ->with( 'manual_clear_all' )
+            ->andReturn( 0 );
 
         try {
             CacheActionsAjaxEndpoint::handle_clear();

--- a/tests/Unit/FormCacheTest.php
+++ b/tests/Unit/FormCacheTest.php
@@ -937,4 +937,137 @@ class FormCacheTest extends TestCase {
     public function test_cache_group_constant(): void {
         $this->assertSame( 'ffc_forms', FormCache::CACHE_GROUP );
     }
+
+    // ==================================================================
+    // purge_external_caches() — third-party cache plugin integration
+    // ==================================================================
+
+    public function test_purge_external_caches_skips_when_form_id_is_zero(): void {
+        $fired = false;
+        Functions\when( 'do_action' )->alias( function () use ( &$fired ) {
+            $fired = true;
+        } );
+
+        FormCache::purge_external_caches( 0 );
+
+        $this->assertFalse( $fired, 'Hook should not fire for non-positive form_id' );
+    }
+
+    public function test_purge_external_caches_fires_action_hook_with_form_id_and_reason(): void {
+        $captured = array();
+        Functions\when( 'do_action' )->alias(
+            function ( $hook, $form_id = null, $reason = null ) use ( &$captured ) {
+                if ( 'ffc_form_cache_purged' === $hook ) {
+                    $captured = array( $form_id, $reason );
+                }
+            }
+        );
+
+        FormCache::purge_external_caches( 42, 'early_open' );
+
+        $this->assertSame( array( 42, 'early_open' ), $captured );
+    }
+
+    public function test_purge_external_caches_fires_with_empty_reason_by_default(): void {
+        $captured = array();
+        Functions\when( 'do_action' )->alias(
+            function ( $hook, $form_id = null, $reason = null ) use ( &$captured ) {
+                if ( 'ffc_form_cache_purged' === $hook ) {
+                    $captured = array( $form_id, $reason );
+                }
+            }
+        );
+
+        FormCache::purge_external_caches( 7 );
+
+        $this->assertSame( array( 7, '' ), $captured );
+    }
+
+    public function test_purge_external_caches_calls_wp_super_cache_when_available(): void {
+        $GLOBALS['__wpsc_called_with'] = null;
+        $GLOBALS['__wpsc_should_throw'] = false;
+        if ( ! function_exists( 'wpsc_delete_post_cache' ) ) {
+            // phpcs:ignore Squiz.PHP.Eval.Discouraged -- defining a missing global stub for the test.
+            eval( 'function wpsc_delete_post_cache( $id ) { if ( ! empty( $GLOBALS["__wpsc_should_throw"] ) ) { throw new \RuntimeException( "boom" ); } $GLOBALS["__wpsc_called_with"] = $id; }' );
+        }
+
+        Functions\when( 'do_action' )->justReturn( true );
+
+        FormCache::purge_external_caches( 99, 'test' );
+
+        $this->assertSame( 99, $GLOBALS['__wpsc_called_with'] );
+        unset( $GLOBALS['__wpsc_called_with'], $GLOBALS['__wpsc_should_throw'] );
+    }
+
+    public function test_purge_external_caches_calls_wp_rocket_when_available(): void {
+        $GLOBALS['__rocket_called_with'] = null;
+        if ( ! function_exists( 'rocket_clean_post' ) ) {
+            // phpcs:ignore Squiz.PHP.Eval.Discouraged -- defining a missing global stub for the test.
+            eval( 'function rocket_clean_post( $id ) { $GLOBALS["__rocket_called_with"] = $id; }' );
+        }
+
+        Functions\when( 'do_action' )->justReturn( true );
+
+        FormCache::purge_external_caches( 123, 'manual_clear_all' );
+
+        $this->assertSame( 123, $GLOBALS['__rocket_called_with'] );
+        unset( $GLOBALS['__rocket_called_with'] );
+    }
+
+    public function test_purge_external_caches_swallows_third_party_exceptions(): void {
+        $GLOBALS['__wpsc_should_throw'] = true;
+        if ( ! function_exists( 'wpsc_delete_post_cache' ) ) {
+            // phpcs:ignore Squiz.PHP.Eval.Discouraged -- stub already defined by sibling tests; harmless to redeclare guard.
+            eval( 'function wpsc_delete_post_cache( $id ) { if ( ! empty( $GLOBALS["__wpsc_should_throw"] ) ) { throw new \RuntimeException( "boom" ); } }' );
+        }
+        $hook_fired = false;
+        Functions\when( 'do_action' )->alias( function () use ( &$hook_fired ) {
+            $hook_fired = true;
+        } );
+
+        // Must NOT throw — the host action keeps going.
+        FormCache::purge_external_caches( 50 );
+
+        $this->assertTrue( $hook_fired, 'Hook should still fire after third-party throws' );
+        unset( $GLOBALS['__wpsc_should_throw'] );
+    }
+
+    // ==================================================================
+    // purge_external_caches_for_all_forms()
+    // ==================================================================
+
+    public function test_purge_external_caches_for_all_forms_iterates_published_forms(): void {
+        Functions\when( 'get_posts' )->justReturn( array( 11, 22, 33 ) );
+
+        $hook_calls = array();
+        Functions\when( 'do_action' )->alias(
+            function ( $hook, $form_id = null, $reason = null ) use ( &$hook_calls ) {
+                if ( 'ffc_form_cache_purged' === $hook ) {
+                    $hook_calls[] = array( $form_id, $reason );
+                }
+            }
+        );
+
+        $count = FormCache::purge_external_caches_for_all_forms( 'manual_clear_all' );
+
+        $this->assertSame( 3, $count );
+        $this->assertSame(
+            array(
+                array( 11, 'manual_clear_all' ),
+                array( 22, 'manual_clear_all' ),
+                array( 33, 'manual_clear_all' ),
+            ),
+            $hook_calls
+        );
+    }
+
+    public function test_purge_external_caches_for_all_forms_handles_empty_list(): void {
+        Functions\when( 'get_posts' )->justReturn( array() );
+        Functions\when( 'do_action' )->justReturn( true );
+
+        $count = FormCache::purge_external_caches_for_all_forms();
+
+        $this->assertSame( 0, $count );
+    }
+
 }

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -381,6 +381,10 @@ class SettingsTest extends TestCase {
         $form_cache_mock = Mockery::mock( 'alias:FreeFormCertificate\Submissions\FormCache' );
         $form_cache_mock->shouldReceive( 'clear_all_cache' )
             ->once();
+        $form_cache_mock->shouldReceive( 'purge_external_caches_for_all_forms' )
+            ->once()
+            ->with( 'manual_clear_all' )
+            ->andReturn( 0 );
 
         Functions\when( 'wp_safe_redirect' )->alias( function () {
             throw new \RuntimeException( 'redirect_called' );


### PR DESCRIPTION
Closes #225. **Pre-requisite for #224** (Start Form Now public button).

## What this PR does

Centralises third-party page-cache invalidation in `FormCache` so every operation that mutates a form's public-facing state can purge **W3 Total Cache**, **LiteSpeed Cache**, **WP Super Cache**, **WP Rocket** (and arbitrary other cache plugins via a hook) in a single call.

## Before this PR

`FormCache::clear_form_cache($form_id)` only flushes the plugin's own object cache. Page caches at higher layers (WP cache plugins + Cloudflare APO) are unaware that the form's metadata changed → public visitors keep seeing the cached version for minutes/hours.

## After this PR

- **`FormCache::purge_external_caches( $form_id, $reason = '' )`** — best-effort sweep:
  - `\W3TC\Dispatcher::component('CacheFlush')->flush_post( $form_id )` if W3TC is loaded.
  - `\LiteSpeed\Purge::add( 'P_' . $form_id )` if LiteSpeed is loaded.
  - `wpsc_delete_post_cache( $form_id )` if WP Super Cache is loaded.
  - `rocket_clean_post( $form_id )` if WP Rocket is loaded.
  - Each integration wrapped in `try/catch` so a misbehaving third-party plugin can never break the host action.
  - Fires `do_action( 'ffc_form_cache_purged', $form_id, $reason )` for everything else (Cloudflare APO, Redis page cache, custom CDN purgers).

- **`FormCache::purge_external_caches_for_all_forms( $reason )`** — sweeps every published `ffc_form`.

- **`clear_form_cache()` is unchanged** — stays lean for the hot path (every `save_post`, every submission). Routine internal-only cache touches don't trigger third-party purges.

## Wiring

| Site | Now also calls |
| --- | --- |
| `CacheActionsAjaxEndpoint::handle_clear` (the "Clear all cache" button) | `purge_external_caches_for_all_forms( 'manual_clear_all' )` |
| `Settings::handle_cache_actions` (legacy admin_init, no-JS fallback) | same |
| `FormEditorSaveHandler` after `_ffc_geofence_config` update | `clear_form_cache( $post_id )` + `purge_external_caches( $post_id, 'geofence_changed' )` |

## Tests

**PHP (8 new on `FormCache`):** skip-on-zero, action-hook payload shape, default-vs-custom reason, WP Super Cache stub invocation, WP Rocket stub invocation, third-party exception swallowing (hook still fires), sweep-all happy path, sweep-all empty list. Existing `CacheActionsAjaxEndpointTest` + `SettingsTest` gained the new mock expectation.

**Suite: PHPUnit 3986/3986 · PHPStan clean · WPCS clean.**

## Out of scope

- Cloudflare API direct integration (needs credentials + UI). Covered via the `ffc_form_cache_purged` hook for now.
- Configuration UI to opt-out of specific integrations. Sites that want to exclude a plugin can use `remove_filter` on `ffc_form_cache_purged`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_