### PR TITLE
Fix WP_Scripts doing_it_wrong — 'ffc-admin' → 'ffc-admin-js' in 4 script deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`WP_Scripts::add` doing_it_wrong notice — four enqueues declared a missing `ffc-admin` dependency.** WordPress 6.9.1 added a `doing_it_wrong` warning when a script is enqueued with a handle that hasn't been registered; the plugin's admin script is registered as `ffc-admin-js` but four call sites mistakenly listed it as `ffc-admin` (the *style* handle) in their deps array — `class-ffc-form-list-columns.php` (forms list inline toggles, added in #210), `class-ffc-settings-tab.php` (settings autosave), `class-ffc-tab-cache.php` (cache actions), and `class-ffc-tab-geolocation.php` (geolocation autosave). All four now declare `ffc-admin-js`. Functional impact was nil — WordPress still loaded the scripts — but the notice spammed `debug.log` on every admin page render.
+
 - **Reregistration "Email Notifications" toggles overlapping their labels.** WordPress admin core ships a `.form-table td fieldset label { display: inline-block }` rule that overrode the plugin's `.ffc-toggle { display: inline-flex }`, collapsing the toggle track over the start of the label text. The reregistration edit page wrapped the three notification toggles in a `<fieldset>` (triggering that rule); `.ffc-toggle` now also declares the rule on `.form-table td .ffc-toggle` + `.form-table td fieldset .ffc-toggle` to win the specificity battle, and the offending `<fieldset>` was replaced with a plain `<div>` since it carried no `<legend>`. `position: relative` is also added so the visually-hidden checkbox is scoped to the label, not the viewport.
 
 ### Changed

--- a/includes/admin/class-ffc-form-list-columns.php
+++ b/includes/admin/class-ffc-form-list-columns.php
@@ -71,7 +71,7 @@ class FormListColumns {
 		wp_enqueue_script(
 			'ffc-form-list-features',
 			FFC_PLUGIN_URL . "assets/js/ffc-form-list-features{$s}.js",
-			array( 'jquery', 'ffc-core', 'ffc-admin' ),
+			array( 'jquery', 'ffc-core', 'ffc-admin-js' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/settings/class-ffc-settings-tab.php
+++ b/includes/settings/class-ffc-settings-tab.php
@@ -212,7 +212,7 @@ abstract class SettingsTab {
 		wp_enqueue_script(
 			'ffc-admin-autosave',
 			FFC_PLUGIN_URL . "assets/js/ffc-admin-autosave{$s}.js",
-			array( 'jquery', 'ffc-core', 'ffc-admin' ),
+			array( 'jquery', 'ffc-core', 'ffc-admin-js' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/settings/tabs/class-ffc-tab-cache.php
+++ b/includes/settings/tabs/class-ffc-tab-cache.php
@@ -52,12 +52,12 @@ class TabCache extends SettingsTab {
 		$this->enqueue_autosave_infra();
 
 		// Inline AJAX for the Warm / Clear cache buttons. Depends on
-		// ffc-core (FFC.request) + ffc-admin (showNotification).
+		// ffc-core (FFC.request) + ffc-admin-js (showNotification).
 		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
 		wp_enqueue_script(
 			'ffc-cache-actions',
 			FFC_PLUGIN_URL . "assets/js/ffc-cache-actions{$s}.js",
-			array( 'jquery', 'ffc-core', 'ffc-admin' ),
+			array( 'jquery', 'ffc-core', 'ffc-admin-js' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/settings/tabs/class-ffc-tab-geolocation.php
+++ b/includes/settings/tabs/class-ffc-tab-geolocation.php
@@ -71,7 +71,7 @@ class TabGeolocation extends SettingsTab {
 		wp_enqueue_script(
 			'ffc-admin-autosave',
 			FFC_PLUGIN_URL . "assets/js/ffc-admin-autosave{$s}.js",
-			array( 'jquery', 'ffc-core', 'ffc-admin' ),
+			array( 'jquery', 'ffc-core', 'ffc-admin-js' ),
 			FFC_VERSION,
 			true
 		);

--- a/tests/Unit/TabSmtpTest.php
+++ b/tests/Unit/TabSmtpTest.php
@@ -125,7 +125,7 @@ class TabSmtpTest extends TestCase {
             ->with( 'ffc-core', Mockery::type( 'string' ), array( 'jquery' ), Mockery::type( 'string' ), true )
             ->once();
         Functions\expect( 'wp_enqueue_script' )
-            ->with( 'ffc-admin-autosave', Mockery::type( 'string' ), array( 'jquery', 'ffc-core', 'ffc-admin' ), Mockery::type( 'string' ), true )
+            ->with( 'ffc-admin-autosave', Mockery::type( 'string' ), array( 'jquery', 'ffc-core', 'ffc-admin-js' ), Mockery::type( 'string' ), true )
             ->once();
 
         $this->tab->enqueue_scripts( 'ffc_form_page_ffc-settings' );


### PR DESCRIPTION
## Summary

User reported repeated `WP_Scripts::add was called incorrectly` notices in `debug.log`:

> O script com o identificador "ffc-form-list-features" foi enfileirado com dependências que não estão registradas: ffc-admin.

Root cause: WordPress 6.9.1 added a `doing_it_wrong` warning when a script is enqueued with an unregistered dependency handle. Four call sites listed `ffc-admin` in their deps array, but the registered handle is `ffc-admin-js` — `ffc-admin` is the **style** handle (`wp_enqueue_style( 'ffc-admin', … )` in `class-ffc-admin-user-columns.php:508`). Easy mix-up, pre-existing (introduced in PR #211 for the forms-list inline toggles, copied into three more sites).

WordPress silently dropped the missing dep and loaded the scripts anyway, so there was no functional impact — but the notice spammed `debug.log` on every admin page render.

## Sites fixed

| File | Script |
|------|--------|
| `includes/admin/class-ffc-form-list-columns.php` | `ffc-form-list-features` (the reported one — added in #210/#211) |
| `includes/settings/class-ffc-settings-tab.php` | `ffc-admin-autosave` parent enqueue (used by SMTP + other tabs) |
| `includes/settings/tabs/class-ffc-tab-cache.php` | `ffc-cache-actions` |
| `includes/settings/tabs/class-ffc-tab-geolocation.php` | `ffc-admin-autosave` |

`TabSmtpTest` expectation updated to match.

## Test plan

- [ ] PHPUnit (54 tests touching these handles, including TabSmtpTest)
- [ ] WPCS clean
- [ ] Open `wp-admin/edit.php?post_type=ffc_form`, the Settings tabs, and confirm `debug.log` no longer accumulates the notice

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_