### PR TITLE
Fix: form-meta autosave silently broken by hook-order race

### DIFF
--- a/includes/admin/class-ffc-form-editor.php
+++ b/includes/admin/class-ffc-form-editor.php
@@ -44,7 +44,15 @@ class FormEditor {
 		add_action( 'add_meta_boxes', array( $this, 'add_custom_metaboxes' ), 20 );
 		add_action( 'save_post', array( $this->save_handler, 'save_form_data' ) );
 		add_action( 'admin_notices', array( $this->save_handler, 'display_save_errors' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		// Priority 20 so we run AFTER AdminAssetsManager (default 10) has
+		// registered `ffc-admin-js`. The `wp_localize_script` call below
+		// attaches `ffcFormMetaAutosave` to that handle; calling localize
+		// before the script is registered makes WP silently drop the
+		// data, leaving the form-meta autosave handler in ffc-admin.js
+		// with a `window.ffcFormMetaAutosave === undefined` guard and
+		// no change listeners wired (toggles stop auto-saving — closes
+		// the post-#240 regression).
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 20 );
 
 		// AJAX handlers for the editor.
 		add_action( 'wp_ajax_ffc_generate_codes', array( $this, 'ajax_generate_random_codes' ) );

--- a/tests/Unit/FormEditorTest.php
+++ b/tests/Unit/FormEditorTest.php
@@ -128,6 +128,47 @@ class FormEditorTest extends TestCase {
         $this->assertContains( 'ffc-geofence-admin', $enqueued );
     }
 
+    /**
+     * Regression for the post-#240 form-meta autosave silent failure.
+     *
+     * `FormEditor::enqueue_scripts()` calls
+     * `wp_localize_script('ffc-admin-js', 'ffcFormMetaAutosave', ...)`
+     * but `ffc-admin-js` is registered by `AdminAssetsManager` on the
+     * same hook. If FormEditor's callback runs first, WP silently drops
+     * the localize data and the JS handler in ffc-admin.js short-
+     * circuits — toggles stop auto-saving with no error surfacing.
+     *
+     * Fix: bump FormEditor's hook priority to 20 so it runs AFTER
+     * AdminAssetsManager (default 10). The assertion below pins that
+     * priority so a future refactor that drops it back to 10 fails
+     * loudly here instead of in the browser.
+     */
+    public function test_enqueue_scripts_runs_after_admin_assets_manager(): void {
+        $captured = array();
+        Functions\when( 'add_action' )->alias(
+            static function ( $hook, $callback, $priority = 10 ) use ( &$captured ) {
+                $captured[] = array( $hook, $callback, $priority );
+                return true;
+            }
+        );
+
+        new FormEditor();
+
+        $enqueue_hooks = array_filter(
+            $captured,
+            static fn( $entry ) => 'admin_enqueue_scripts' === $entry[0]
+                && is_array( $entry[1] )
+                && 'enqueue_scripts' === $entry[1][1]
+        );
+        $this->assertCount( 1, $enqueue_hooks, 'enqueue_scripts must hook into admin_enqueue_scripts exactly once' );
+        $entry = array_values( $enqueue_hooks )[0];
+        $this->assertGreaterThan(
+            10,
+            $entry[2],
+            'enqueue_scripts must run after AdminAssetsManager (priority > 10) so ffc-admin-js is registered before wp_localize_script fires for it.'
+        );
+    }
+
     // ==================================================================
     // add_custom_metaboxes()
     // ==================================================================


### PR DESCRIPTION
## Sintoma

Após PR #240 entregar o auto-save dos master toggles, **o save não disparava** ao mudar on/off no editor de formulário. Sem mensagem de erro, sem badge "Saving…" — só nada.

## Causa raiz

Race de ordem de hooks no `admin_enqueue_scripts`:

- `FormEditor::enqueue_scripts()` (que faz o `wp_localize_script('ffc-admin-js', 'ffcFormMetaAutosave', ...)`) e `AdminAssetsManager::enqueue_admin_assets()` (que registra `ffc-admin-js`) **ambos rodam em priority 10**.
- Em `includes/admin/class-ffc-admin.php`, `new FormEditor()` (linha 168) é instanciado **antes** de `new AdminAssetsManager()` (linha 171).
- WordPress dispara callbacks em ordem de registro no mesmo priority → **FormEditor roda primeiro**.
- `wp_localize_script` chamado com handle ainda-não-registrado: WP **descarta silenciosamente** a data.
- Resultado: `window.ffcFormMetaAutosave === undefined` no browser → guard `if (FORM_META_CFG && FORM_META_CFG.postId)` em `ffc-admin.js` curto-circuita → nenhum listener bound → toggles não salvam.

## Fix

Bump da priority de `FormEditor`'s `add_action` para `20` — garante que roda **após** o AdminAssetsManager (default 10). Localize agora encontra o handle já registrado, data chega na página, JS bind funciona.

### Por que não trocar ordem de instanciação?

Mais frágil — a ordem em `FormEditorAdmin::register()` fica enterrada em outro arquivo, e o próximo refactor que reordenar classes quebraria isso silenciosamente de novo. Priority é explícito no próprio site de bind.

## Regression test

Novo caso em `FormEditorTest` que captura todas as chamadas `add_action` no construtor e asserta que `enqueue_scripts` está hookada com priority > 10. Se alguém algum dia reverter sem perceber, o teste falha loud em vez de o usuário descobrir só ao toggle não salvar.

## Quality gates

| Gate | Result |
|---|---|
| PHPUnit | 4065 / 4065 |
| PHPStan level 8 | clean |
| WPCS | clean |

## Test plan

- [x] Abrir um formulário no editor de certificados
- [x] Clicar em qualquer master toggle (Quiz, Email Send, Restriction × 4, Geofence DateTime/Geo/IP-Permissive, Device Limit, Start Form Early, Postpone Close)
- [x] Badge "Saving…" → "Saved" aparece ao lado do toggle, e fade out depois de ~1.5s
- [x] Reload da página → estado do toggle persiste

https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiExaniSqvNBLpVTszCLNx)_