### PR TITLE
Docs: Category A housekeeping exception for created_at/updated_at (closes #256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
   in the geofence metabox row was also removed; visibility there continues to
   be driven by the slideUp/slideDown handlers in `ffc-geofence-admin.js`.
 
+### Documentation
+
+- Classify `created_at` / `updated_at` housekeeping columns as a documented
+  exception to Category A storage (CLAUDE.md). Closes the #249 follow-up
+  deferral inline in `class-ffc-activator.php`.
+
 ---
 
 ## [6.6.0] (2026-05-17)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,35 @@ Existing examples: the Public Operator Access audit ring buffer
 that ever appeared there (#247) was a rendering choice (`gmdate` →
 `wp_date`), never a storage issue.
 
+#### Category A exception — housekeeping timestamps
+
+`created_at` / `updated_at` columns that are (1) MySQL auto-managed
+via `DEFAULT CURRENT_TIMESTAMP` (and `ON UPDATE CURRENT_TIMESTAMP`),
+or (2) PHP-managed but never rendered to end users, stay as DATETIME.
+
+Rationale: these are audit / sort columns only — they never reach a
+display path that would surface TZ drift. BIGINT UNSIGNED would force
+PHP responsibility for every INSERT/UPDATE site (MySQL cannot
+`DEFAULT CURRENT_TIMESTAMP` on BIGINT) with no user-facing benefit.
+
+Current inventory (snapshot at v6.6.1):
+
+| Table | Pattern | Notes |
+| --- | --- | --- |
+| `ffc_reregistration_submissions` | P1 (MySQL auto) | `ORDER BY created_at` in repository |
+| `ffc_recruitment_*` (6 tables) | P2 (PHP-managed, `NOT NULL`) | written via `current_time('mysql')` |
+| `ffc_audience_*` (5 tables) | P1 (MySQL auto) | — |
+| `ffc_rate_limit_*` (3 tables) | P1 (MySQL auto) | — |
+| `ffc_custom_fields*` (3 tables) | P1 (MySQL auto) | — |
+| `ffc_dynamic_rereg_*` (2 tables) | P1 (MySQL auto) | — |
+| `ffc_url_shortener` | P2 (PHP-managed, `NOT NULL`) | — |
+| `ffc_self_scheduling_*` | P3 (hybrid: `created_at` auto, `updated_at` PHP) | — |
+| `ffc_activity_log` | P2 (PHP-managed, `NOT NULL`) | — |
+
+If a future feature renders one of these columns to a user, that
+column must be migrated to Category A storage at that point — not
+left as a hidden TZ-drift trap.
+
 ### Category B — **Wall-clock** (a human commitment, no TZ semantics)
 
 Things like "the appointment is on May 20", "the doctor sees the patient

--- a/includes/class-ffc-activator.php
+++ b/includes/class-ffc-activator.php
@@ -344,10 +344,11 @@ class Activator {
 	 * column uses NULL (not 0) for "not yet submitted", and the backfill
 	 * only touches rows where the old DATETIME is non-NULL.
 	 *
-	 * Sibling instant columns in the same table (`reviewed_at`,
-	 * `created_at`, `updated_at`) intentionally stay DATETIME — they're
-	 * out of scope for #249's (a)(b)(c) and would expand the blast
-	 * radius. Filed as follow-up tech debt.
+	 * `reviewed_at` on the same table was migrated alongside this column
+	 * via {@see self::maybe_migrate_sibling_instants_to_unix()}. The
+	 * housekeeping columns (`created_at`, `updated_at`) stay DATETIME by
+	 * design — see the "Category A exception — housekeeping timestamps"
+	 * subsection of CLAUDE.md.
 	 *
 	 * @since 6.6.0
 	 */
@@ -426,10 +427,10 @@ class Activator {
 	 * UTC int. Tables touched: `ffc_submissions`, `ffc_reregistration_submissions`,
 	 * `ffc_recruitment_call`, and the self-scheduling appointments table.
 	 *
-	 * Out of scope: `created_at` / `updated_at` columns (MySQL
-	 * auto-managed via DEFAULT CURRENT_TIMESTAMP in some tables, PHP-
-	 * managed in others) — each pattern needs individual analysis,
-	 * deferred as separate tech debt.
+	 * Out of scope by design: `created_at` / `updated_at` columns stay
+	 * DATETIME — they're documented as the Category A housekeeping
+	 * exception. See "Category A exception — housekeeping timestamps"
+	 * in CLAUDE.md for rationale + per-table inventory.
 	 *
 	 * Idempotent via the `ffc_sibling_instants_unix_migrated` option flag.
 	 *


### PR DESCRIPTION
Closes #256. Refs #254.

## Summary

Discovery-only decision: classifies `created_at` / `updated_at` housekeeping columns as a documented exception to Category A storage, closing the #249 follow-up deferral inline in `class-ffc-activator.php`. **No schema migration** — the columns are non-user-facing and MySQL's auto-managed semantics work correctly today.

## Rationale

1. **Not user-facing.** These columns are used only as `ORDER BY` keys in admin listings. Never rendered to end users.
2. **MySQL constraint.** BIGINT UNSIGNED cannot use `DEFAULT CURRENT_TIMESTAMP`. Migrating would force PHP responsibility for every INSERT/UPDATE site across 5+ table families.
3. **No TZ-drift bug.** `CURRENT_TIMESTAMP` is TZ-agnostic at the DB level. Mesmo if WP TZ changes, these values don't derive visually because nobody renders them.

## Changes

| Sprint | What |
|---|---|
| 1 | Add "Category A exception — housekeeping timestamps" subsection to `CLAUDE.md` with per-table inventory of all 24+ FFC tables touched. |
| 2 | Update 2 stale docblocks in `class-ffc-activator.php` (`maybe_migrate_submitted_at_to_unix` and `maybe_migrate_sibling_instants_to_unix`) to reference the new exception, removing "deferred as tech debt" framing. |
| 3 | CHANGELOG `[Unreleased]` entry under `Documentation`. |

## Verification

- [x] `grep -n "deferred as separate tech debt\|filed as follow-up tech debt"` em `class-ffc-activator.php` ⇒ 0 hits.
- [x] PHPStan level 8: clean.
- [x] No functional code changes — only docs.

Will be consolidated into **v6.6.1** when the parent #254 cleanup bundle closes.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_