### PR TITLE
Tech debt: remove Utils::debug_log() shim + historical comments (closes #267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 - `?limit=N` query arg on the `GET /forms` REST endpoint. Use
   `?per_page=N` instead.
+- `Utils::debug_log()` shim (`@deprecated 6.2.0`). All internal callers
+  were migrated to area-specific `Debug::log_*()` helpers in 6.2.0;
+  the shim has had zero production callers since then. External callers
+  (filters/hooks) should migrate to the appropriate `Debug::log_*()`
+  method — see `Debug::AREA_*` constants.
 - Unused `FFC_DEBUG` constant from `ffcertificate.php` and the matching
   PHPStan stub. Defined but never read.
 - Deprecated CSS aliases scheduled for 6.6.0 removal: `.ffc-conditional-field`

--- a/includes/admin/class-ffc-settings-save-handler.php
+++ b/includes/admin/class-ffc-settings-save-handler.php
@@ -172,9 +172,6 @@ class SettingsSaveHandler {
 				'debug_rest_api',
 				'debug_migrations',
 				'debug_activity_log',
-				// 6.2.0 — added when the legacy `Utils::debug_log()` calls were
-				// migrated to the per-area `Debug` system. Each new area gets
-				// its own toggle in Settings → Advanced → Debug.
 				'debug_frontend',
 				'debug_admin',
 				'debug_self_scheduling',

--- a/includes/core/class-ffc-ajax-trait.php
+++ b/includes/core/class-ffc-ajax-trait.php
@@ -145,7 +145,7 @@ trait AjaxTrait {
 	/**
 	 * Handle uncaught exceptions in AJAX handlers.
 	 *
-	 * Logs the error via Utils::debug_log() and sends a generic JSON error
+	 * Logs the error via Debug::log_form() and sends a generic JSON error
 	 * to prevent internal details from leaking to the frontend.
 	 *
 	 * @since 5.1.1

--- a/includes/core/class-ffc-debug.php
+++ b/includes/core/class-ffc-debug.php
@@ -75,11 +75,6 @@ class Debug {
 	 * Available debug areas.
 	 *
 	 * @since 3.1.0
-	 * @since 6.2.0 Added `AREA_FRONTEND`, `AREA_ADMIN`, `AREA_SELF_SCHEDULING`,
-	 *              `AREA_AUDIENCE`, `AREA_QRCODE` to absorb the 76 calls
-	 *              that used to live on the legacy `Utils::debug_log()` —
-	 *              every call is now toggleable per-area in admin Settings
-	 *              instead of firing whenever `WP_DEBUG=true`.
 	 */
 	const AREA_PDF_GENERATOR   = 'debug_pdf_generator';
 	const AREA_EMAIL_HANDLER   = 'debug_email_handler';
@@ -103,12 +98,6 @@ class Debug {
 	 * @return bool True if debug is enabled for this area
 	 */
 	public static function is_enabled( string $area ): bool {
-		// Defensive: in unit-test contexts where WP isn't fully loaded
-		// (e.g. Brain Monkey tests that exercise code paths now reaching
-		// `Debug::log_*()` after the 6.2.0 legacy migration), `get_option`
-		// may not exist. Fail-closed (debug disabled) rather than fatal —
-		// matches the pre-6.2.0 behaviour of `Utils::debug_log()` which
-		// short-circuited on a missing `WP_DEBUG` constant too.
 		if ( ! function_exists( 'get_option' ) ) {
 			return false;
 		}

--- a/includes/core/class-ffc-utils.php
+++ b/includes/core/class-ffc-utils.php
@@ -468,41 +468,6 @@ class Utils {
 	}
 
 	/**
-	 * Log debug message (only if WP_DEBUG is enabled)
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 *
-	 * Debug log.
-	 * Legacy debug log helper.
-	 *
-	 * @deprecated 6.2.0 Use {@see Debug::log_*()} instead. Each subsystem
-	 *             now has a dedicated helper gated by an admin toggle in
-	 *             Settings → Advanced → Debug — see `Debug::AREA_*`.
-	 *             Calls landing here delegate to the catch-all
-	 *             `AREA_FORM_PROCESSOR` for backwards compatibility, but
-	 *             new code should use the area-specific methods directly.
-	 *
-	 * @param string $message Message to log.
-	 * @param mixed  $data Optional data to log.
-	 * @return void
-	 */
-	public static function debug_log( string $message, $data = null ): void {
-		Debug::log( Debug::AREA_FORM_PROCESSOR, $message, $data );
-	}
-
-	/**
 	 * Generate success HTML response for frontend form submission
 	 *
 	 * Generate success html.

--- a/tests/Unit/DebugTest.php
+++ b/tests/Unit/DebugTest.php
@@ -177,10 +177,6 @@ class DebugTest extends TestCase {
         $areas = array_filter( $constants, function ( $k ) {
             return str_starts_with( $k, 'AREA_' );
         }, ARRAY_FILTER_USE_KEY );
-        // 9 pre-6.2.0 areas + 5 added in 6.2.0 (FRONTEND, ADMIN,
-        // SELF_SCHEDULING, AUDIENCE, QRCODE) when the legacy
-        // `Utils::debug_log()` callsites were migrated to the per-area
-        // `Debug` system.
         $this->assertCount( 14, $areas );
     }
 

--- a/tests/Unit/FrontendShortcodesTest.php
+++ b/tests/Unit/FrontendShortcodesTest.php
@@ -41,9 +41,6 @@ class FrontendShortcodesTest extends TestCase {
         Functions\when( 'wp_unslash' )->returnArg();
         Functions\when( 'wp_rand' )->alias( function ( int $min = 0, int $max = 0 ) { return random_int( $min, $max ); } );
         Functions\when( 'wp_hash' )->alias( function ( $data ) { return hash( 'sha256', $data ); } );
-        // 6.2.0: every legacy `Utils::debug_log()` call became `Debug::log_*()`,
-        // which reads `ffc_settings` to gate per-area. Stub get_option so the
-        // gate is reached without exploding.
         Functions\when( 'get_option' )->justReturn( array() );
 
         if ( ! defined( 'ABSPATH' ) ) {

--- a/tests/Unit/IpGeolocationTest.php
+++ b/tests/Unit/IpGeolocationTest.php
@@ -46,7 +46,6 @@ class IpGeolocationTest extends TestCase {
         Functions\when( 'FreeFormCertificate\Integrations\wp_remote_get' )->justReturn( new \WP_Error( 'test', 'stubbed' ) );
         Functions\when( 'FreeFormCertificate\Integrations\wp_remote_retrieve_body' )->justReturn( '' );
 
-        // Namespaced stubs: FreeFormCertificate\Core\* (for Utils::debug_log)
         if ( ! function_exists( 'FreeFormCertificate\Core\sanitize_text_field' ) ) {
             Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
         }


### PR DESCRIPTION
Closes #267. Refs #254.

## Summary

Removes the `Utils::debug_log()` shim (`@deprecated 6.2.0`) — zero production callers verified by grep. Also corrects a stale docblock and deletes 5 historical comments referencing the 6.2.0 migration (user-decision in #267).

## Changes by sprint

| Sprint | What | Diff |
|---|---|---|
| 1 | Delete `Utils::debug_log()` method + duplicated docblock + 5 historical comments + 1 stale docblock fix | +1 / -58 |
| 2 | CHANGELOG entry under `Removed` | +5 / 0 |

## Files touched

- `includes/core/class-ffc-utils.php` (method + docblock)
- `includes/core/class-ffc-ajax-trait.php` (stale docblock said "via Utils::debug_log()" but code calls Debug::log_form())
- `includes/core/class-ffc-debug.php` (2 historical comments removed)
- `includes/admin/class-ffc-settings-save-handler.php` (historical comment removed)
- `tests/Unit/DebugTest.php` (historical comment removed)
- `tests/Unit/FrontendShortcodesTest.php` (historical comment removed)
- `tests/Unit/IpGeolocationTest.php` (historical comment removed)
- `CHANGELOG.md`

## Verification

- [x] `grep -rn "Utils::debug_log\|->debug_log("` (excluding phpstan-stubs) ⇒ 0 hits.
- [x] PHPUnit: 4116 tests, 10544 assertions, OK.
- [x] Vitest: 811 tests passed.
- [x] PHPStan level 8: 0 errors.

Will be consolidated into **v6.6.1** when the parent #254 cleanup bundle closes.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_