### PR TITLE
Tech debt: legacy compat shims audit + remove maybe_wipe_legacy_logs (closes #268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
   the shim has had zero production callers since then. External callers
   (filters/hooks) should migrate to the appropriate `Debug::log_*()`
   method — see `Debug::AREA_*` constants.
+- `PublicCsvDownload::maybe_wipe_legacy_logs()` shim + its
+  `DOWNLOAD_LOG_FORMAT` / `OPTION_LOG_FORMAT` constants. The pre-6.3.3
+  audit log format was wiped on first `plugins_loaded` after upgrade
+  to 6.3.3; the 6.3.0–6.3.2 install base was effectively zero (24h
+  window). After 4+ minor versions, virtually all production installs
+  have run the wipe.
 - Unused `FFC_DEBUG` constant from `ffcertificate.php` and the matching
   PHPStan stub. Defined but never read.
 - Deprecated CSS aliases scheduled for 6.6.0 removal: `.ffc-conditional-field`
@@ -62,6 +68,15 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 - Classify `created_at` / `updated_at` housekeeping columns as a documented
   exception to Category A storage (CLAUDE.md). Closes the #249 follow-up
   deferral inline in `class-ffc-activator.php`.
+- Add "Legacy compat shims — audit log" section to CLAUDE.md
+  documenting the 4 compat shims that remain in the codebase by design
+  (capability migration, cron cleanup, API-contract keys, encryption
+  fallback).
+- Correct misleading "backwards compat" framing on
+  `AbstractRepository::get_allowed_where_columns()` — the empty default
+  is an intentional design choice (caller controls WHERE conditions),
+  not a shim. 0 of 6 production children override; all construct
+  `$conditions` internally.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,22 @@ Existing examples: `appointment_date` (DATE), `start_time` / `end_time`
   may use `gmdate('Y-m-d\TH:i:s\Z', $ts)` — but the column those
   filenames represent should still follow Category A or B.
 
+## Legacy compat shims — audit log
+
+Inventário (snapshot v6.6.1) dos shims de compatibilidade legada que
+permanecem no código por design. Removê-los requer evidência de que
+nenhuma instalação em produção depende deles.
+
+| Shim | Local | Risco se removido | Por que fica |
+|------|-------|--------|----------|
+| `ensure_legacy_caps_renamed()` v1 | `class-ffc-loader.php` | Médio | Idempotent + version-flagged via `ffc_legacy_caps_renamed_v1`; dormant após primeiro `plugins_loaded` post-6.2.0. Custo zero. |
+| Cron cleanup pré-4.6.15 | `class-ffc-activator.php:92-94` | Baixo | 3× `wp_clear_scheduled_hook`. Sites com upgrade auto pulando versões antigas mantêm crons órfãos sem isso. |
+| Keys `count` / `success` / `fail` em `get_audit_log_summary()` | `class-ffc-public-csv-download.php` | **Alto** | Contrato de API pública. Consumidores externos (filters/hooks) podem depender deles. Removível só com banner ⚠ de breaking change. |
+| `cpf_rf_encrypted` legacy column fallback (3-tier) | `class-ffc-pdf-generator.php` | **Alto** | Data loss em PDFs para installs com dados pré-split. Remover só após confirmar que TODAS instalações ativas têm dados migrados para `cpf_encrypted` / `rf_encrypted`. |
+
+Quando uma feature nova tornar um desses shims inseguro ou inadequado,
+abra sub-issue específica + breaking-change banner no CHANGELOG.
+
 ## Branch naming
 
 Use `claude/<short-kebab-description>`. Examples in main history:

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -193,12 +193,6 @@ class Loader {
 			\FreeFormCertificate\Security\RateLimitActivator::maybe_create_tables();
 		}
 
-		// 6.3.3: wipe pre-encryption CSV-download audit logs once. See the
-		// method's docblock for the install-base reasoning.
-		if ( class_exists( '\FreeFormCertificate\Frontend\PublicCsvDownload' ) ) {
-			\FreeFormCertificate\Frontend\PublicCsvDownload::maybe_wipe_legacy_logs();
-		}
-
 		// In-place plugin updates (drop new files via `wp-admin/plugins.php`'s
 		// "Update" button) DO NOT fire `register_activation_hook`. Re-register
 		// the canonical FFC role + the 6.2.0 module-manager / recruitment-tier

--- a/includes/frontend/class-ffc-csv-download-validator.php
+++ b/includes/frontend/class-ffc-csv-download-validator.php
@@ -296,10 +296,7 @@ final class CsvDownloadValidator {
 	 * shows a placeholder — admins can configure encryption to retroactively
 	 * make new entries auditable.
 	 *
-	 * Schema (6.3.3): { ts, ip, mode, cpf_encrypted, result }. Pre-6.3.3
-	 * entries (which used cpf_hash) are wiped on the first plugins_loaded
-	 * after upgrade by maybe_wipe_legacy_logs() — see that method for the
-	 * justification (install base reality + clean break).
+	 * Schema (6.3.3): { ts, ip, mode, cpf_encrypted, result }.
 	 *
 	 * Made `public` in 6.5.13 so `PublicCsvDownload` can record audit
 	 * rows for non-CPF outcomes too (captcha rejection, hash mismatch,

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -59,8 +59,8 @@ class PublicCsvDownload {
 	const DOWNLOAD_LOG_MAX    = 100;
 	const FLASH_TRANSIENT_TTL = 60; // Seconds.
 
-	const EXPORT_LOG_ACTION   = 'ffc_export_csv_public_download_log';
-	const EXPORT_LOG_NONCE    = 'ffc_export_csv_public_download_log';
+	const EXPORT_LOG_ACTION = 'ffc_export_csv_public_download_log';
+	const EXPORT_LOG_NONCE  = 'ffc_export_csv_public_download_log';
 
 	/**
 	 * Validation collaborator (form-access / hash / CPF gates).

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -59,12 +59,6 @@ class PublicCsvDownload {
 	const DOWNLOAD_LOG_MAX    = 100;
 	const FLASH_TRANSIENT_TTL = 60; // Seconds.
 
-	/**
-	 * 6.3.3: schema flag for the audit-log payload. Bumped when the
-	 * structure of {@see META_DOWNLOAD_LOG} entries changes incompatibly.
-	 */
-	const DOWNLOAD_LOG_FORMAT = '1.3.0';
-	const OPTION_LOG_FORMAT   = 'ffc_csv_public_download_log_format';
 	const EXPORT_LOG_ACTION   = 'ffc_export_csv_public_download_log';
 	const EXPORT_LOG_NONCE    = 'ffc_export_csv_public_download_log';
 
@@ -698,35 +692,8 @@ class PublicCsvDownload {
 	}
 
 	// ──────────────────────────────────────────────────────────────.
-	// Audit log maintenance + export.
+	// Audit log export.
 	// ──────────────────────────────────────────────────────────────.
-
-	/**
-	 * One-shot wipe of pre-6.3.3 audit-log entries.
-	 *
-	 * Pre-6.3.3 entries used a write-only `cpf_hash` field (sha256 of the
-	 * digits) which was never read by any code path — it was kept "just in
-	 * case" we ever needed CPF lookups in the log. The 6.3.3 schema replaces
-	 * that with a reversible `cpf_encrypted` field consumed by the new
-	 * audit-CSV exporter. Mixing the two formats would force the exporter
-	 * to render entire columns of "[legacy: hashed only]" placeholders for
-	 * stale 6.3.0–6.3.2 entries that no human can ever recover. Since
-	 * 6.3.0 → 6.3.2 all shipped within the same 24h window and the install
-	 * base for those releases is effectively zero, the cleanest path is to
-	 * delete the legacy log meta on first plugins_loaded after the upgrade
-	 * and let new entries accumulate fresh.
-	 *
-	 * Idempotent: gated on the {@see OPTION_LOG_FORMAT} option flag. Runs
-	 * exactly once per install no matter how many requests fire it.
-	 */
-	public static function maybe_wipe_legacy_logs(): void {
-		if ( self::DOWNLOAD_LOG_FORMAT === (string) get_option( self::OPTION_LOG_FORMAT, '' ) ) {
-			return;
-		}
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
-		delete_metadata( 'post', 0, self::META_DOWNLOAD_LOG, '', true );
-		update_option( self::OPTION_LOG_FORMAT, self::DOWNLOAD_LOG_FORMAT, true );
-	}
 
 	/**
 	 * Admin-post handler for the audit-log CSV export. Streams

--- a/includes/repositories/ffc-abstract-repository.php
+++ b/includes/repositories/ffc-abstract-repository.php
@@ -359,9 +359,19 @@ abstract class AbstractRepository {
 	}
 
 	/**
-	 * Get allowed WHERE clause columns. Override in child classes.
+	 * Allow-list of column names accepted by `build_where_clause()`.
 	 *
-	 * @return array<int, string> Empty array means allow all (for backwards compat).
+	 * Returning an empty array (the default) accepts any column — child
+	 * classes trust callers to construct `$conditions` from internal /
+	 * already-sanitized values rather than user input. The `%i` placeholder
+	 * in `build_where_clause()` prevents SQL identifier injection regardless.
+	 *
+	 * Override and return a non-empty list when a child class accepts
+	 * `$conditions` derived from external input (REST query args, form
+	 * fields, etc.). Audit at v6.6.1: 0 production children override —
+	 * all callers in repos construct conditions internally.
+	 *
+	 * @return array<int, string>
 	 */
 	protected function get_allowed_where_columns(): array {
 		return array();


### PR DESCRIPTION
Closes #268. Refs #254.

## Summary

Conservative audit of 5 legacy compat shims flagged in #254. Of the 5, only **1** was safely removable (`maybe_wipe_legacy_logs`), 3 are kept by design with documented rationale, and the 5th was actually a design choice mis-framed as compat — docblock corrected.

## Audit results per shim

| # | Shim | Verdict |
|---|---|---|
| 1 | `ensure_legacy_caps_renamed()` v1 | Keep (dormant after first run) |
| 2 | Cron cleanup pré-4.6.15 | Keep (cheap cleanup) |
| 3a | `maybe_wipe_legacy_logs()` | **REMOVE** (install base for 6.3.0-6.3.2 was 24h window) |
| 3b | Keys `count/success/fail` in `get_audit_log_summary()` | Keep (public API contract) |
| 4 | `cpf_rf_encrypted` 3-tier fallback | Keep (data loss risk for un-migrated installs) |
| 5 | "Empty array = allow all" in `get_allowed_where_columns()` | **Not a shim** — design choice; framing corrected |

## Changes by sprint

| Sprint | What | Diff |
|---|---|---|
| 1 | Remove `maybe_wipe_legacy_logs()` method + `DOWNLOAD_LOG_FORMAT` / `OPTION_LOG_FORMAT` constants + caller in loader + stale docblock reference | +2 / -44 |
| 2 | CLAUDE.md gets "Legacy compat shims — audit log" section (4 items) + reframe `AbstractRepository::get_allowed_where_columns()` docblock | +28 / -2 |
| 3 | CHANGELOG entries (Removed + Documentation) | +15 / 0 |

## Verification

- [x] `grep -rn "maybe_wipe_legacy_logs\|DOWNLOAD_LOG_FORMAT\|OPTION_LOG_FORMAT"` ⇒ 0 hits.
- [x] CLAUDE.md has the new "Legacy compat shims — audit log" section.
- [x] PHPUnit: 4116 tests, 10544 assertions, OK.
- [x] PHPStan level 8: 0 errors.

Will be consolidated into **v6.6.1** when the parent #254 cleanup bundle closes.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_