### PR TITLE
Docs: correct delegate-comment framing in 2 files (closes #269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
   is an intentional design choice (caller controls WHERE conditions),
   not a shim. 0 of 6 production children override; all construct
   `$conditions` internally.
+- Correct misleading "backward-compatible delegate methods" framing on
+  `ReregistrationFrontend` and `UserDataRestController`:
+  - `ReregistrationFrontend::get_user_reregistrations()` owns join
+    logic across 3 repositories; it is not a delegate.
+  - `UserDataRestController` exposes a facade API surface intentional
+    for external integrators; the methods are not legacy shims.
 
 ---
 

--- a/includes/api/class-ffc-user-data-rest-controller.php
+++ b/includes/api/class-ffc-user-data-rest-controller.php
@@ -71,10 +71,21 @@ class UserDataRestController {
 	}
 
 	// ------------------------------------------------------------------.
-	// Backward-compatible delegate methods.
+	// Facade API — public method surface.
 	//
-	// External code (or tests) may call these directly. Each method.
-	// delegates to the appropriate sub-controller.
+	// Each method below is a single-line delegate to one of the
+	// sub-controllers instantiated in `register_routes()`. The methods
+	// are NOT used internally by the REST routing (sub-controllers
+	// register their own routes), so production grep shows zero callers
+	// today — but the facade is published as a stable entry point for
+	// external integrators (themes, sibling plugins, future code) that
+	// want to invoke a user-data operation programmatically without
+	// depending on the specific sub-controller class.
+	//
+	// Removing methods here would be a breaking change for those
+	// hypothetical integrators. Audit each call site in production code
+	// before deprecating; add `@deprecated` to the docblock with a
+	// release period before removing.
 	// ------------------------------------------------------------------.
 
 	/**

--- a/includes/reregistration/class-ffc-reregistration-frontend.php
+++ b/includes/reregistration/class-ffc-reregistration-frontend.php
@@ -172,11 +172,13 @@ class ReregistrationFrontend {
 	}
 
 	// ------------------------------------------------------------------.
-	// Backward-compatible delegate methods.
+	// Public static helpers used by REST controllers + shortcodes.
 	// ------------------------------------------------------------------.
 
 	/**
-	 * Divisão → Setor mapping (delegates to ReregistrationFieldOptions).
+	 * Divisão → Setor mapping. Pure delegate to ReregistrationFieldOptions
+	 * — kept here so frontend callers can resolve the map without depending
+	 * on `ReregistrationFieldOptions` directly.
 	 *
 	 * @return array<string, array<string>>
 	 */
@@ -186,6 +188,11 @@ class ReregistrationFrontend {
 
 	/**
 	 * Get active reregistrations for a user with submission status.
+	 *
+	 * Aggregates `ReregistrationRepository`, `ReregistrationSubmissionRepository`,
+	 * and `MagicLinkHelper` into a flat array consumed by the dashboard
+	 * shortcode, the REST `/user-data/reregistrations` endpoint, and the
+	 * user-summary REST endpoint. Not a delegate — owns the join logic.
 	 *
 	 * @param int $user_id User ID.
 	 * @return array<int, array<string, mixed>> Array of reregistration data with submission info.


### PR DESCRIPTION
Closes #269. Refs #254.

## Summary

Corrects misleading "backward-compatible delegate methods" framing in 2 files. Investigation under #269 revealed these aren't legacy compat shims — they're either business logic mis-classified (one case) or an intentional facade API surface (the other). **Pure docblock/comment changes; zero behavior.**

## Changes by sprint

| Sprint | What | Diff |
|---|---|---|
| 1 | `ReregistrationFrontend:174-176` section header reframed to "Public static helpers used by REST controllers + shortcodes". Per-method docblocks reflect actual responsibility (`get_user_reregistrations()` is NOT a delegate — owns the join logic across 3 repositories). | +9 / -2 |
| 2 | `UserDataRestController:73-78` section header reframed to "Facade API — public method surface". Explains zero internal callers (sub-controllers register their own routes), the facade as deliberate API contract, and the deprecation procedure for any future removal. | +14 / -3 |
| 3 | CHANGELOG entry under `Documentation` | +6 / 0 |

## Verification

- [x] Both files' section headers no longer say "backward-compatible delegate methods".
- [x] PHPStan level 8: 0 errors.
- [x] No code paths changed — pure docs.

Will be consolidated into **v6.6.1** when the parent #254 cleanup bundle closes.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_