### PR TITLE
Tech debt: SettingsReader with generic + typed accessors for ffc_settings (closes #273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Centralize `ffc_settings` reads via new
+  `FreeFormCertificate\Settings\SettingsReader` class with generic getter
+  (`get`, `get_bool`, `get_int`, `all`) + 20 typed accessors for high-value
+  boolean/int keys. 25 call sites migrated; WordPress's built-in
+  `alloptions` cache continues to provide the underlying caching (no
+  perf change). Debug toggles continue to be accessed via
+  `Debug::is_enabled($area)`.
 - `GET /forms` REST endpoint: real pagination via `page` and `per_page`
   query args (defaults 1 and 10), with `X-WP-Total`, `X-WP-TotalPages`,
   and `Link` headers (rels: first/prev/next/last) per the WP REST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,30 @@ nenhuma instalação em produção depende deles.
 Quando uma feature nova tornar um desses shims inseguro ou inadequado,
 abra sub-issue específica + breaking-change banner no CHANGELOG.
 
+## Settings reads
+
+Read `ffc_settings` via
+`FreeFormCertificate\Settings\SettingsReader`, not `get_option('ffc_settings')`
+directly:
+
+- Use typed accessors when one exists
+  (`SettingsReader::emails_disabled()`,
+  `SettingsReader::activity_log_retention_days()`, etc.).
+- Fall back to `SettingsReader::get($key, $default)` for keys without
+  a dedicated typed accessor.
+- Use `SettingsReader::all()` when a caller reads 5+ keys (SMTP block,
+  DateFormatter format catalog) and array-style access stays clearer
+  than repeated method calls.
+
+The 14 debug-area toggles continue to be read via
+`Debug::is_enabled($area)` — that helper has the canonical
+`function_exists('get_option')` defensive check and is the typed
+reader for that subset.
+
+Classes that already encapsulate `get_option('ffc_settings')` in
+their own private helper (e.g. `UrlShortenerService::get_settings()`)
+do NOT need to migrate — they're already centralized.
+
 ## Branch naming
 
 Use `claude/<short-kebab-description>`. Examples in main history:

--- a/includes/admin/class-ffc-activity-log-ajax-endpoint.php
+++ b/includes/admin/class-ffc-activity-log-ajax-endpoint.php
@@ -54,8 +54,7 @@ class ActivityLogAjaxEndpoint {
 
 		// Activity log can be globally disabled — render a notice
 		// rather than an empty table.
-		$settings = get_option( 'ffc_settings', array() );
-		if ( empty( $settings['enable_activity_log'] ) || 1 !== (int) $settings['enable_activity_log'] ) {
+		if ( ! \FreeFormCertificate\Settings\SettingsReader::activity_log_enabled() ) {
 			wp_send_json_error(
 				array( 'message' => __( 'Activity Log is currently disabled.', 'ffcertificate' ) ),
 				400

--- a/includes/admin/class-ffc-admin-activity-log-page.php
+++ b/includes/admin/class-ffc-admin-activity-log-page.php
@@ -191,10 +191,7 @@ class AdminActivityLogPage {
 	 */
 	public function render_page(): void {
 		// Check if Activity Log is enabled.
-		$settings   = get_option( 'ffc_settings', array() );
-		$is_enabled = isset( $settings['enable_activity_log'] ) && 1 === $settings['enable_activity_log'];
-
-		if ( ! $is_enabled ) {
+		if ( ! \FreeFormCertificate\Settings\SettingsReader::activity_log_enabled() ) {
 			$this->render_disabled_notice();
 			return;
 		}

--- a/includes/admin/class-ffc-admin-assets-manager.php
+++ b/includes/admin/class-ffc-admin-assets-manager.php
@@ -155,12 +155,7 @@ class AdminAssetsManager {
 	 * @return string 'dark' or 'light'.
 	 */
 	public static function resolve_code_editor_theme(): string {
-		$settings = get_option( 'ffc_settings', array() );
-		if ( ! is_array( $settings ) ) {
-			$settings = array();
-		}
-
-		$choice = isset( $settings['code_editor_theme'] ) ? (string) $settings['code_editor_theme'] : 'dark';
+		$choice = (string) \FreeFormCertificate\Settings\SettingsReader::get( 'code_editor_theme', 'dark' );
 
 		if ( 'light' === $choice ) {
 			return 'light';
@@ -170,7 +165,7 @@ class AdminAssetsManager {
 		}
 
 		// 'auto' — follow the admin dark-mode setting.
-		$dark_mode = isset( $settings['dark_mode'] ) ? (string) $settings['dark_mode'] : 'off';
+		$dark_mode = (string) \FreeFormCertificate\Settings\SettingsReader::get( 'dark_mode', 'off' );
 		return 'on' === $dark_mode ? 'dark' : 'light';
 	}
 

--- a/includes/admin/class-ffc-form-editor-public-csv-download-metabox.php
+++ b/includes/admin/class-ffc-form-editor-public-csv-download-metabox.php
@@ -66,10 +66,7 @@ class FormEditorPublicCsvDownloadMetabox {
 		$extend_end_enabled = $extend_end_raw;
 
 		if ( $limit <= 0 ) {
-			$settings      = get_option( 'ffc_settings', array() );
-			$default_limit = ( is_array( $settings ) && isset( $settings['public_csv_default_limit'] ) )
-				? (int) $settings['public_csv_default_limit']
-				: 1;
+			$default_limit = \FreeFormCertificate\Settings\SettingsReader::get_int( 'public_csv_default_limit', 1 );
 			$limit         = $default_limit > 0 ? $default_limit : 1;
 		}
 
@@ -249,8 +246,7 @@ class FormEditorPublicCsvDownloadMetabox {
 						</p>
 						<?php
 					else :
-						$ffc_settings          = get_option( 'ffc_settings', array() );
-						$csv_download_page_url = $ffc_settings['csv_download_page_url'] ?? '';
+						$csv_download_page_url = (string) \FreeFormCertificate\Settings\SettingsReader::get( 'csv_download_page_url', '' );
 						$ffc_query_string      = 'form_id=' . $post->ID . '&hash=' . $hash;
 						$share_link            = '' !== $csv_download_page_url
 							? $csv_download_page_url . ( str_contains( $csv_download_page_url, '?' ) ? '&' : '?' ) . $ffc_query_string

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -324,10 +324,7 @@ class FormEditorSaveHandler {
 				// Limit: positive integer ≥ 1. Fall back to settings default (min 1).
 				$limit = isset( $public_raw['limit'] ) ? absint( $public_raw['limit'] ) : 0;
 				if ( $limit < 1 ) {
-					$settings      = get_option( 'ffc_settings', array() );
-					$default_limit = ( is_array( $settings ) && isset( $settings['public_csv_default_limit'] ) )
-						? (int) $settings['public_csv_default_limit']
-						: 1;
+					$default_limit = \FreeFormCertificate\Settings\SettingsReader::get_int( 'public_csv_default_limit', 1 );
 					$limit         = $default_limit > 0 ? $default_limit : 1;
 				}
 				update_post_meta( $post_id, '_ffc_csv_public_limit', $limit );

--- a/includes/core/class-ffc-activity-log-query.php
+++ b/includes/core/class-ffc-activity-log-query.php
@@ -342,10 +342,7 @@ class ActivityLogQuery {
 	 * @return int Number of deleted rows
 	 */
 	public static function run_cleanup(): int {
-		$settings       = get_option( 'ffc_settings', array() );
-		$retention_days = isset( $settings['activity_log_retention_days'] )
-			? absint( $settings['activity_log_retention_days'] )
-			: 90;
+		$retention_days = \FreeFormCertificate\Settings\SettingsReader::activity_log_retention_days();
 
 		if ( $retention_days <= 0 ) {
 			return 0;

--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -99,10 +99,7 @@ class ActivityLog {
 	 */
 	public static function log( string $action, string $level = self::LEVEL_INFO, array $context = array(), int $user_id = 0, int $submission_id = 0 ): bool {
 		// CRITICAL: Check admin settings FIRST (before temporary flag).
-		$settings   = get_option( 'ffc_settings', array() );
-		$is_enabled = isset( $settings['enable_activity_log'] ) && absint( $settings['enable_activity_log'] ) === 1;
-
-		if ( ! $is_enabled ) {
+		if ( ! \FreeFormCertificate\Settings\SettingsReader::activity_log_enabled() ) {
 			return false;
 		}
 
@@ -637,8 +634,7 @@ class ActivityLog {
 	 *
 	 * @return bool True if enabled, false otherwise
 	 */
-	public static function is_enabled() {
-		$settings = get_option( 'ffc_settings', array() );
-		return isset( $settings['enable_activity_log'] ) && absint( $settings['enable_activity_log'] ) === 1;
+	public static function is_enabled(): bool {
+		return \FreeFormCertificate\Settings\SettingsReader::activity_log_enabled();
 	}
 }

--- a/includes/core/class-ffc-date-formatter.php
+++ b/includes/core/class-ffc-date-formatter.php
@@ -250,8 +250,7 @@ final class DateFormatter {
 	 * @return array<string, mixed>
 	 */
 	private static function settings(): array {
-		$value = \get_option( 'ffc_settings', array() );
-		return is_array( $value ) ? $value : array();
+		return \FreeFormCertificate\Settings\SettingsReader::all();
 	}
 
 	/**

--- a/includes/core/class-ffc-email-helper-trait.php
+++ b/includes/core/class-ffc-email-helper-trait.php
@@ -31,8 +31,7 @@ trait EmailHelperTrait {
 	 * @return bool
 	 */
 	protected static function ffc_emails_disabled(): bool {
-		$settings = get_option( 'ffc_settings', array() );
-		return ! empty( $settings['disable_all_emails'] );
+		return \FreeFormCertificate\Settings\SettingsReader::emails_disabled();
 	}
 
 	/**

--- a/includes/core/class-ffc-utils.php
+++ b/includes/core/class-ffc-utils.php
@@ -45,8 +45,7 @@ class Utils {
 	 * @since 4.6.17
 	 */
 	public static function enqueue_dark_mode(): void {
-		$settings  = get_option( 'ffc_settings', array() );
-		$dark_mode = isset( $settings['dark_mode'] ) ? $settings['dark_mode'] : 'off';
+		$dark_mode = \FreeFormCertificate\Settings\SettingsReader::get( 'dark_mode', 'off' );
 
 		if ( 'off' === $dark_mode ) {
 			return;

--- a/includes/frontend/class-ffc-csv-download-form-info-builder.php
+++ b/includes/frontend/class-ffc-csv-download-form-info-builder.php
@@ -56,11 +56,8 @@ final class CsvDownloadFormInfoBuilder {
 		// Quota.
 		$limit = (int) get_post_meta( $form_id, PublicCsvDownload::META_LIMIT, true );
 		if ( $limit <= 0 ) {
-			$settings = get_option( 'ffc_settings', array() );
-			$default  = is_array( $settings ) && isset( $settings['public_csv_default_limit'] )
-				? (int) $settings['public_csv_default_limit']
-				: 0;
-			$limit    = $default > 0 ? $default : 1;
+			$default = \FreeFormCertificate\Settings\SettingsReader::get_int( 'public_csv_default_limit', 0 );
+			$limit   = $default > 0 ? $default : 1;
 		}
 		$count           = (int) get_post_meta( $form_id, PublicCsvDownload::META_COUNT, true );
 		$quota_exhausted = $count >= $limit;

--- a/includes/frontend/class-ffc-csv-download-validator.php
+++ b/includes/frontend/class-ffc-csv-download-validator.php
@@ -85,12 +85,8 @@ final class CsvDownloadValidator {
 		// 9. Quota.
 		$limit = (int) get_post_meta( $form_id, PublicCsvDownload::META_LIMIT, true );
 		if ( $limit <= 0 ) {
-			$settings_default = 0;
-			$settings         = get_option( 'ffc_settings', array() );
-			if ( is_array( $settings ) && isset( $settings['public_csv_default_limit'] ) ) {
-				$settings_default = (int) $settings['public_csv_default_limit'];
-			}
-			$limit = $settings_default > 0 ? $settings_default : 1;
+			$settings_default = \FreeFormCertificate\Settings\SettingsReader::get_int( 'public_csv_default_limit', 0 );
+			$limit            = $settings_default > 0 ? $settings_default : 1;
 		}
 
 		$count = (int) get_post_meta( $form_id, PublicCsvDownload::META_COUNT, true );

--- a/includes/frontend/class-ffc-public-csv-exporter.php
+++ b/includes/frontend/class-ffc-public-csv-exporter.php
@@ -255,10 +255,7 @@ class PublicCsvExporter {
 	 * Resolve the configured sync-export row cap, clamped to the min/max.
 	 */
 	public static function get_sync_max_rows(): int {
-		$settings = get_option( 'ffc_settings', array() );
-		$value    = isset( $settings['public_csv_sync_max_rows'] )
-			? absint( $settings['public_csv_sync_max_rows'] )
-			: self::DEFAULT_SYNC_MAX_ROWS;
+		$value = \FreeFormCertificate\Settings\SettingsReader::get_int( 'public_csv_sync_max_rows', self::DEFAULT_SYNC_MAX_ROWS );
 
 		if ( $value < self::SYNC_MAX_ROWS_MIN ) {
 			$value = self::SYNC_MAX_ROWS_MIN;

--- a/includes/generators/class-ffc-pdf-generator.php
+++ b/includes/generators/class-ffc-pdf-generator.php
@@ -250,9 +250,9 @@ class PdfGenerator {
 		$layout = str_replace( '{{form_title}}', esc_html( (string) $form_title ), $layout );
 
 		// Inject settings-based placeholders into data (v4.6.10).
-		$settings = get_option( 'ffc_settings', array() );
-		if ( ! isset( $data['main_address'] ) && ! empty( $settings['main_address'] ) ) {
-			$data['main_address'] = $settings['main_address'];
+		$main_address = \FreeFormCertificate\Settings\SettingsReader::get( 'main_address', '' );
+		if ( ! isset( $data['main_address'] ) && ! empty( $main_address ) ) {
+			$data['main_address'] = $main_address;
 		}
 		if ( ! isset( $data['site_name'] ) ) {
 			$data['site_name'] = get_bloginfo( 'name' );

--- a/includes/integrations/class-ffc-email-handler.php
+++ b/includes/integrations/class-ffc-email-handler.php
@@ -53,7 +53,7 @@ class EmailHandler {
 	 * @param PHPMailer $phpmailer PHPMailer instance.
 	 */
 	public function configure_custom_smtp( $phpmailer ): void {
-		$settings = get_option( 'ffc_settings', array() );
+		$settings = \FreeFormCertificate\Settings\SettingsReader::all();
 
 		if ( isset( $settings['smtp_mode'] ) && 'custom' === $settings['smtp_mode'] ) {
 			$phpmailer->isSMTP();
@@ -300,7 +300,7 @@ class EmailHandler {
 	 * @return bool True if email was sent, false otherwise
 	 */
 	public function send_wp_user_notification( int $user_id, string $context = 'submission' ): bool {
-		$settings = get_option( 'ffc_settings', array() );
+		$settings = \FreeFormCertificate\Settings\SettingsReader::all();
 
 		// Debug logging.
 		if ( class_exists( '\FreeFormCertificate\Core\Debug' ) ) {

--- a/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-appointment-ajax-handler.php
@@ -153,9 +153,7 @@ class AppointmentAjaxHandler {
 			// Determine if a confirmation email was actually sent.
 			$email_sent = false;
 			if ( ! $requires_approval ) {
-				$settings        = get_option( 'ffc_settings', array() );
-				$emails_disabled = ! empty( $settings['disable_all_emails'] );
-				if ( ! $emails_disabled && $calendar ) {
+				if ( ! \FreeFormCertificate\Settings\SettingsReader::emails_disabled() && $calendar ) {
 					$email_config = json_decode( $calendar['email_config'] ?? '{}', true );
 					$email_sent   = ! empty( $email_config['send_user_confirmation'] );
 				}

--- a/includes/settings/class-ffc-settings-reader.php
+++ b/includes/settings/class-ffc-settings-reader.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Settings Reader.
+ *
+ * Centralized accessor for `ffc_settings` option reads.
+ *
+ * @package FreeFormCertificate\Settings
+ * @since   6.6.1
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Read-side facade over the `ffc_settings` WP option.
+ *
+ * WordPress already caches the option via the autoloaded-options cache
+ * (`wp_load_alloptions()`) — so this class adds no perf layer of its
+ * own. Its job is:
+ *
+ *   1. Single source of truth for the option key.
+ *   2. Typed accessors with explicit casts + defaults for the
+ *      high-value boolean / integer keys, replacing scattered
+ *      `$settings['key'] ?? default` patterns.
+ *   3. Generic `get()` for the long tail of keys that don't warrant
+ *      a dedicated typed accessor yet.
+ *
+ * Debug-area toggles are NOT exposed here — they're already typed via
+ * {@see \FreeFormCertificate\Core\Debug::is_enabled()}, which is the
+ * canonical reader for that subset.
+ */
+final class SettingsReader {
+
+	/**
+	 * WP option key that backs every read in this class.
+	 */
+	public const OPTION_KEY = 'ffc_settings';
+
+	// ──────────────────────────────────────────────────────────────.
+	// Generic accessors.
+	// ──────────────────────────────────────────────────────────────.
+
+	/**
+	 * Read a value from `ffc_settings`.
+	 *
+	 * @param string $key     Settings key.
+	 * @param mixed  $default Value returned when the key is absent.
+	 * @return mixed
+	 */
+	public static function get( string $key, $default = null ) {
+		$settings = get_option( self::OPTION_KEY, array() );
+		if ( ! is_array( $settings ) ) {
+			return $default;
+		}
+		return $settings[ $key ] ?? $default;
+	}
+
+	/**
+	 * Bool-typed read with explicit cast.
+	 *
+	 * @param string $key     Settings key.
+	 * @param bool   $default Returned when the key is absent.
+	 * @return bool
+	 */
+	public static function get_bool( string $key, bool $default = false ): bool {
+		$value = self::get( $key, $default );
+		return (bool) $value;
+	}
+
+	/**
+	 * Int-typed read with explicit cast.
+	 *
+	 * @param string $key     Settings key.
+	 * @param int    $default Returned when the key is absent.
+	 * @return int
+	 */
+	public static function get_int( string $key, int $default = 0 ): int {
+		$value = self::get( $key, $default );
+		return (int) $value;
+	}
+
+	// ──────────────────────────────────────────────────────────────.
+	// Typed bool accessors (high-value keys).
+	// ──────────────────────────────────────────────────────────────.
+
+	/** Whether the "disable all outgoing emails" master toggle is on. */
+	public static function emails_disabled(): bool {
+		return self::get_bool( 'disable_all_emails' );
+	}
+
+	/** Whether the activity-log subsystem is enabled. */
+	public static function activity_log_enabled(): bool {
+		return self::get_bool( 'enable_activity_log' );
+	}
+
+	/** Whether the WP admin bar is allowed for the FFC user role. */
+	public static function admin_bar_allowed(): bool {
+		return self::get_bool( 'allow_admin_bar' );
+	}
+
+	/** Whether the FFC user role is blocked from wp-admin. */
+	public static function wp_admin_blocked(): bool {
+		return self::get_bool( 'block_wp_admin' );
+	}
+
+	/**
+	 * Whether site administrators bypass the FFC user-side restrictions
+	 * (admin-bar gating, wp-admin block, etc.).
+	 */
+	public static function admins_bypassed(): bool {
+		return self::get_bool( 'bypass_for_admins' );
+	}
+
+	/** Whether the QR-code cache is enabled. */
+	public static function qr_cache_enabled(): bool {
+		return self::get_bool( 'qr_cache_enabled' );
+	}
+
+	/**
+	 * Whether the URL-shortener feature is enabled. Defaults to true
+	 * (the feature is on out-of-the-box).
+	 */
+	public static function url_shortener_enabled(): bool {
+		return self::get_bool( 'url_shortener_enabled', true );
+	}
+
+	/**
+	 * Whether auto-creation of short URLs is enabled. Defaults to true.
+	 */
+	public static function url_shortener_auto_create_enabled(): bool {
+		return self::get_bool( 'url_shortener_auto_create', true );
+	}
+
+	/** Whether IP-geolocation lookups are cached. */
+	public static function ip_cache_enabled(): bool {
+		return self::get_bool( 'ip_cache_enabled' );
+	}
+
+	/** Whether the IP-geolocation provider lookup is enabled. */
+	public static function ip_api_enabled(): bool {
+		return self::get_bool( 'ip_api_enabled' );
+	}
+
+	/** Whether admins are notified when a capability is granted. */
+	public static function notify_capability_grant_enabled(): bool {
+		return self::get_bool( 'notify_capability_grant' );
+	}
+
+	// ──────────────────────────────────────────────────────────────.
+	// Typed int accessors (TTLs / limits).
+	// ──────────────────────────────────────────────────────────────.
+
+	/**
+	 * Retention window for `ffc_activity_log` rows, in days. Rows
+	 * older than this are eligible for the daily cleanup cron.
+	 */
+	public static function activity_log_retention_days(): int {
+		return self::get_int( 'activity_log_retention_days', 90 );
+	}
+
+	/** TTL for the WP object cache entries the plugin manages. */
+	public static function cache_expiration_seconds(): int {
+		return self::get_int( 'cache_expiration', 3600 );
+	}
+
+	/**
+	 * Number of days after which an obsolete shortcode reference
+	 * surfaces a warning in the admin notices stream.
+	 */
+	public static function obsolete_shortcode_days(): int {
+		return self::get_int( 'obsolete_shortcode_days', 30 );
+	}
+
+	/** TTL for cached GPS-resolved locations. */
+	public static function gps_cache_ttl(): int {
+		return self::get_int( 'gps_cache_ttl', 600 );
+	}
+
+	/** TTL for cached IP-resolved locations. */
+	public static function ip_cache_ttl(): int {
+		return self::get_int( 'ip_cache_ttl', 600 );
+	}
+
+	/** Default row count returned by the public CSV download endpoint. */
+	public static function public_csv_default_limit(): int {
+		return self::get_int( 'public_csv_default_limit', 100 );
+	}
+
+	/** Hard ceiling on rows the synchronous CSV export will emit. */
+	public static function public_csv_sync_max_rows(): int {
+		return self::get_int( 'public_csv_sync_max_rows', 5000 );
+	}
+
+	/** Default pixel size for generated QR codes. */
+	public static function qr_default_size(): int {
+		return self::get_int( 'qr_default_size', 256 );
+	}
+
+	/** Length (characters) of generated short-URL slugs. */
+	public static function url_shortener_code_length(): int {
+		return self::get_int( 'url_shortener_code_length', 6 );
+	}
+}

--- a/includes/settings/class-ffc-settings-reader.php
+++ b/includes/settings/class-ffc-settings-reader.php
@@ -53,11 +53,21 @@ final class SettingsReader {
 	 * @return mixed
 	 */
 	public static function get( string $key, $default = null ) {
-		$settings = get_option( self::OPTION_KEY, array() );
-		if ( ! is_array( $settings ) ) {
-			return $default;
-		}
+		$settings = self::all();
 		return $settings[ $key ] ?? $default;
+	}
+
+	/**
+	 * Return the raw `ffc_settings` array. Prefer the typed accessors
+	 * or `get()` when reading 1-2 keys; reach for `all()` only when a
+	 * caller reads 5+ keys from the same array and array-style access
+	 * stays clearer than repeated method calls (e.g. SMTP config block).
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function all(): array {
+		$settings = get_option( self::OPTION_KEY, array() );
+		return is_array( $settings ) ? $settings : array();
 	}
 
 	/**

--- a/includes/settings/class-ffc-settings-tab.php
+++ b/includes/settings/class-ffc-settings-tab.php
@@ -239,7 +239,6 @@ abstract class SettingsTab {
 	 * @return string
 	 */
 	public function get_option( string $key, string $default = '' ): string {
-		$settings = get_option( 'ffc_settings', array() );
-		return (string) ( isset( $settings[ $key ] ) ? $settings[ $key ] : $default );
+		return (string) SettingsReader::get( $key, $default );
 	}
 }

--- a/includes/settings/views/ffc-tab-migrations.php
+++ b/includes/settings/views/ffc-tab-migrations.php
@@ -247,10 +247,7 @@ try {
 	// ──────────────────────────────────────────────────────────────.
 	// Obsolete Shortcode Cleanup (v5.1.0)
 	// ──────────────────────────────────────────────────────────────.
-	$ffcertificate_settings     = get_option( 'ffc_settings', array() );
-	$ffcertificate_cleanup_days = is_array( $ffcertificate_settings ) && isset( $ffcertificate_settings['obsolete_shortcode_days'] )
-		? max( 1, (int) $ffcertificate_settings['obsolete_shortcode_days'] )
-		: 90;
+	$ffcertificate_cleanup_days = max( 1, \FreeFormCertificate\Settings\SettingsReader::get_int( 'obsolete_shortcode_days', 90 ) );
 
 	$ffcertificate_user_id        = get_current_user_id();
 	$ffcertificate_cleanup_report = get_transient( 'ffc_obsolete_cleanup_report_' . $ffcertificate_user_id );

--- a/includes/settings/views/ffc-tab-url-shortener.php
+++ b/includes/settings/views/ffc-tab-url-shortener.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$ffc_settings = get_option( 'ffc_settings', array() );
+$ffc_settings = \FreeFormCertificate\Settings\SettingsReader::all();
 
 $enabled       = isset( $ffc_settings['url_shortener_enabled'] ) ? (int) $ffc_settings['url_shortener_enabled'] : 1;
 $prefix        = $ffc_settings['url_shortener_prefix'] ?? 'go';

--- a/includes/shortcodes/class-ffc-dashboard-asset-manager.php
+++ b/includes/shortcodes/class-ffc-dashboard-asset-manager.php
@@ -197,7 +197,7 @@ class DashboardAssetManager {
 				'canViewReregistrations'  => $can_view_reregistrations,
 				'siteName'                => get_bloginfo( 'name' ),
 				'wpTimezone'              => wp_timezone_string(),
-				'mainAddress'             => ( get_option( 'ffc_settings', array() ) )['main_address'] ?? '',
+				'mainAddress'             => \FreeFormCertificate\Settings\SettingsReader::get( 'main_address', '' ),
 				'strings'                 => array(
 					'loading'                  => __( 'Loading...', 'ffcertificate' ),
 					'error'                    => __( 'Error loading data', 'ffcertificate' ),

--- a/includes/submissions/class-ffc-form-cache.php
+++ b/includes/submissions/class-ffc-form-cache.php
@@ -30,8 +30,7 @@ class FormCache {
 	 * Get cache expiration from settings
 	 */
 	public static function get_expiration(): int {
-		$settings = get_option( 'ffc_settings', array() );
-		return isset( $settings['cache_expiration'] ) ? intval( $settings['cache_expiration'] ) : 3600;
+		return \FreeFormCertificate\Settings\SettingsReader::cache_expiration_seconds();
 	}
 
 	/**

--- a/includes/user-dashboard/class-ffc-capability-manager.php
+++ b/includes/user-dashboard/class-ffc-capability-manager.php
@@ -406,10 +406,7 @@ class CapabilityManager {
 			);
 		}
 
-		$settings       = get_option( 'ffc_settings', array() );
-		$notify_enabled = ! empty( $settings['notify_capability_grant'] );
-
-		if ( ! $notify_enabled || empty( $user->user_email ) ) {
+		if ( ! \FreeFormCertificate\Settings\SettingsReader::notify_capability_grant_enabled() || empty( $user->user_email ) ) {
 			return;
 		}
 

--- a/tests/Unit/CpfRfSplitMigrationStrategyTest.php
+++ b/tests/Unit/CpfRfSplitMigrationStrategyTest.php
@@ -69,6 +69,7 @@ class CpfRfSplitMigrationStrategyTest extends TestCase {
 
         // Namespaced stubs for Core namespace (used by ActivityLog)
         Functions\when( 'FreeFormCertificate\Core\get_option' )->justReturn( array() );
+        Functions\when( 'FreeFormCertificate\Settings\get_option' )->justReturn( array() );
         Functions\when( 'FreeFormCertificate\Core\absint' )->alias( function( $val ) { return abs( (int) $val ); } );
 
         // Construct strategy — constructor calls Utils::get_submissions_table() which uses $wpdb->prefix

--- a/tests/Unit/MigrationForeignKeysTest.php
+++ b/tests/Unit/MigrationForeignKeysTest.php
@@ -32,6 +32,7 @@ class MigrationForeignKeysTest extends TestCase {
 
         // Namespaced stubs for ActivityLog
         Functions\when( 'FreeFormCertificate\Core\get_option' )->justReturn( array() );
+        Functions\when( 'FreeFormCertificate\Settings\get_option' )->justReturn( array() );
         Functions\when( 'FreeFormCertificate\Core\absint' )->alias( function ( $v ) { return abs( (int) $v ); } );
 
         global $wpdb;

--- a/tests/Unit/SettingsReaderTest.php
+++ b/tests/Unit/SettingsReaderTest.php
@@ -66,6 +66,18 @@ class SettingsReaderTest extends TestCase {
 		$this->assertSame( 'fallback', SettingsReader::get( 'anything', 'fallback' ) );
 	}
 
+	public function test_all_returns_raw_array(): void {
+		$this->stub_option( array( 'a' => 1, 'b' => 'two' ) );
+
+		$this->assertSame( array( 'a' => 1, 'b' => 'two' ), SettingsReader::all() );
+	}
+
+	public function test_all_returns_empty_array_when_option_is_not_array(): void {
+		Functions\when( 'get_option' )->justReturn( false );
+
+		$this->assertSame( array(), SettingsReader::all() );
+	}
+
 	public function test_get_bool_casts_truthy_values_to_true(): void {
 		$this->stub_option( array(
 			'as_one'    => 1,

--- a/tests/Unit/SettingsReaderTest.php
+++ b/tests/Unit/SettingsReaderTest.php
@@ -1,0 +1,240 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Settings\SettingsReader;
+
+/**
+ * Tests for SettingsReader: generic + typed accessors over `ffc_settings`.
+ *
+ * @covers \FreeFormCertificate\Settings\SettingsReader
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SettingsReaderTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper: stub `get_option('ffc_settings', [])` to return $settings.
+	 *
+	 * @param array<string, mixed> $settings
+	 */
+	private function stub_option( array $settings ): void {
+		Functions\when( 'get_option' )->alias( function ( $key, $default = null ) use ( $settings ) {
+			if ( SettingsReader::OPTION_KEY === $key ) {
+				return $settings;
+			}
+			return $default;
+		} );
+	}
+
+	// ------------------------------------------------------------------
+	// Generic accessors
+	// ------------------------------------------------------------------
+
+	public function test_get_returns_value_when_key_present(): void {
+		$this->stub_option( array( 'foo' => 'bar', 'baz' => 42 ) );
+
+		$this->assertSame( 'bar', SettingsReader::get( 'foo' ) );
+		$this->assertSame( 42, SettingsReader::get( 'baz' ) );
+	}
+
+	public function test_get_returns_default_when_key_absent(): void {
+		$this->stub_option( array( 'foo' => 'bar' ) );
+
+		$this->assertSame( 'fallback', SettingsReader::get( 'missing', 'fallback' ) );
+		$this->assertNull( SettingsReader::get( 'missing' ) );
+	}
+
+	public function test_get_returns_default_when_settings_is_not_array(): void {
+		// Misconfigured option returning false or a scalar instead of array.
+		Functions\when( 'get_option' )->justReturn( false );
+
+		$this->assertSame( 'fallback', SettingsReader::get( 'anything', 'fallback' ) );
+	}
+
+	public function test_get_bool_casts_truthy_values_to_true(): void {
+		$this->stub_option( array(
+			'as_one'    => 1,
+			'as_string' => '1',
+			'as_true'   => true,
+			'as_yes'    => 'yes',
+		) );
+
+		$this->assertTrue( SettingsReader::get_bool( 'as_one' ) );
+		$this->assertTrue( SettingsReader::get_bool( 'as_string' ) );
+		$this->assertTrue( SettingsReader::get_bool( 'as_true' ) );
+		$this->assertTrue( SettingsReader::get_bool( 'as_yes' ) );
+	}
+
+	public function test_get_bool_casts_falsy_values_to_false(): void {
+		$this->stub_option( array(
+			'as_zero'         => 0,
+			'as_string_zero'  => '0',
+			'as_false'        => false,
+			'as_empty_string' => '',
+		) );
+
+		$this->assertFalse( SettingsReader::get_bool( 'as_zero' ) );
+		$this->assertFalse( SettingsReader::get_bool( 'as_string_zero' ) );
+		$this->assertFalse( SettingsReader::get_bool( 'as_false' ) );
+		$this->assertFalse( SettingsReader::get_bool( 'as_empty_string' ) );
+	}
+
+	public function test_get_bool_returns_default_when_key_absent(): void {
+		$this->stub_option( array() );
+
+		$this->assertFalse( SettingsReader::get_bool( 'missing' ) );
+		$this->assertTrue( SettingsReader::get_bool( 'missing', true ) );
+	}
+
+	public function test_get_int_casts_numeric_strings(): void {
+		$this->stub_option( array(
+			'as_int'    => 42,
+			'as_string' => '99',
+			'as_float'  => 3.7,
+		) );
+
+		$this->assertSame( 42, SettingsReader::get_int( 'as_int' ) );
+		$this->assertSame( 99, SettingsReader::get_int( 'as_string' ) );
+		$this->assertSame( 3, SettingsReader::get_int( 'as_float' ) );
+	}
+
+	public function test_get_int_returns_default_when_key_absent(): void {
+		$this->stub_option( array() );
+
+		$this->assertSame( 0, SettingsReader::get_int( 'missing' ) );
+		$this->assertSame( 600, SettingsReader::get_int( 'missing', 600 ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Typed bool accessors
+	// ------------------------------------------------------------------
+
+	public function test_emails_disabled_reads_disable_all_emails_key(): void {
+		$this->stub_option( array( 'disable_all_emails' => 1 ) );
+		$this->assertTrue( SettingsReader::emails_disabled() );
+
+		$this->stub_option( array() );
+		$this->assertFalse( SettingsReader::emails_disabled() );
+	}
+
+	public function test_activity_log_enabled_reads_enable_activity_log_key(): void {
+		$this->stub_option( array( 'enable_activity_log' => 1 ) );
+		$this->assertTrue( SettingsReader::activity_log_enabled() );
+
+		$this->stub_option( array() );
+		$this->assertFalse( SettingsReader::activity_log_enabled() );
+	}
+
+	public function test_url_shortener_enabled_defaults_to_true(): void {
+		// Key absent → default true (feature is on out-of-the-box).
+		$this->stub_option( array() );
+		$this->assertTrue( SettingsReader::url_shortener_enabled() );
+
+		// Explicit off.
+		$this->stub_option( array( 'url_shortener_enabled' => 0 ) );
+		$this->assertFalse( SettingsReader::url_shortener_enabled() );
+	}
+
+	public function test_url_shortener_auto_create_enabled_defaults_to_true(): void {
+		$this->stub_option( array() );
+		$this->assertTrue( SettingsReader::url_shortener_auto_create_enabled() );
+
+		$this->stub_option( array( 'url_shortener_auto_create' => 0 ) );
+		$this->assertFalse( SettingsReader::url_shortener_auto_create_enabled() );
+	}
+
+	/**
+	 * @dataProvider provider_bool_accessors_default_false
+	 * @param string $method   Accessor method name.
+	 * @param string $key      Option key it reads.
+	 */
+	public function test_bool_accessors_default_to_false( string $method, string $key ): void {
+		$this->stub_option( array() );
+		$this->assertFalse( SettingsReader::$method() );
+
+		$this->stub_option( array( $key => 1 ) );
+		$this->assertTrue( SettingsReader::$method() );
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function provider_bool_accessors_default_false(): array {
+		return array(
+			'emails_disabled'                 => array( 'emails_disabled', 'disable_all_emails' ),
+			'activity_log_enabled'            => array( 'activity_log_enabled', 'enable_activity_log' ),
+			'admin_bar_allowed'               => array( 'admin_bar_allowed', 'allow_admin_bar' ),
+			'wp_admin_blocked'                => array( 'wp_admin_blocked', 'block_wp_admin' ),
+			'admins_bypassed'                 => array( 'admins_bypassed', 'bypass_for_admins' ),
+			'qr_cache_enabled'                => array( 'qr_cache_enabled', 'qr_cache_enabled' ),
+			'ip_cache_enabled'                => array( 'ip_cache_enabled', 'ip_cache_enabled' ),
+			'ip_api_enabled'                  => array( 'ip_api_enabled', 'ip_api_enabled' ),
+			'notify_capability_grant_enabled' => array( 'notify_capability_grant_enabled', 'notify_capability_grant' ),
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Typed int accessors
+	// ------------------------------------------------------------------
+
+	/**
+	 * @dataProvider provider_int_accessors
+	 * @param string $method   Accessor method name.
+	 * @param string $key      Option key it reads.
+	 * @param int    $default  Documented default.
+	 */
+	public function test_int_accessor_returns_default_when_absent( string $method, string $key, int $default ): void {
+		$this->stub_option( array() );
+		$this->assertSame( $default, SettingsReader::$method() );
+	}
+
+	/**
+	 * @dataProvider provider_int_accessors
+	 * @param string $method   Accessor method name.
+	 * @param string $key      Option key it reads.
+	 */
+	public function test_int_accessor_returns_configured_value( string $method, string $key ): void {
+		$this->stub_option( array( $key => 1234 ) );
+		$this->assertSame( 1234, SettingsReader::$method() );
+	}
+
+	/**
+	 * @return array<string, array{string, string, int}>
+	 */
+	public static function provider_int_accessors(): array {
+		return array(
+			'activity_log_retention_days' => array( 'activity_log_retention_days', 'activity_log_retention_days', 90 ),
+			'cache_expiration_seconds'    => array( 'cache_expiration_seconds', 'cache_expiration', 3600 ),
+			'obsolete_shortcode_days'     => array( 'obsolete_shortcode_days', 'obsolete_shortcode_days', 30 ),
+			'gps_cache_ttl'               => array( 'gps_cache_ttl', 'gps_cache_ttl', 600 ),
+			'ip_cache_ttl'                => array( 'ip_cache_ttl', 'ip_cache_ttl', 600 ),
+			'public_csv_default_limit'    => array( 'public_csv_default_limit', 'public_csv_default_limit', 100 ),
+			'public_csv_sync_max_rows'    => array( 'public_csv_sync_max_rows', 'public_csv_sync_max_rows', 5000 ),
+			'qr_default_size'             => array( 'qr_default_size', 'qr_default_size', 256 ),
+			'url_shortener_code_length'   => array( 'url_shortener_code_length', 'url_shortener_code_length', 6 ),
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// OPTION_KEY constant
+	// ------------------------------------------------------------------
+
+	public function test_option_key_constant_is_ffc_settings(): void {
+		$this->assertSame( 'ffc_settings', SettingsReader::OPTION_KEY );
+	}
+}


### PR DESCRIPTION
Closes #273. Refs #254.

## Summary

Centralizes `ffc_settings` reads via new `SettingsReader` class. **Not a perf change** — WordPress's autoload cache already caches the option. Value is in maintainability + testability + type safety.

## Regra 6 — premissa original revisada

| Item original em #254 | Realidade |
|---|---|
| "178 chamadas sem cache" | **32 chamadas** (varredura contou tests + comments) |
| "criar cache para perf" | **WP já cacheia** via autoload/alloptions |
| Valor real | Maintainability, testability, type safety |

## Changes by sprint

| Sprint | What | Diff |
|---|---|---|
| 1 | New `SettingsReader` class with generic + typed accessors + tests | +448 / 0 |
| 2 | Migrate 25 call sites across 22 files | +59 / -81 (net -22) |
| 3 | CHANGELOG + CLAUDE.md doc | +31 / 0 |

## SettingsReader API

- **Generic**: `get($key, $default)`, `get_bool()`, `get_int()`, `all()`
- **11 typed bool accessors**: `emails_disabled()`, `activity_log_enabled()`, `admin_bar_allowed()`, `wp_admin_blocked()`, `admins_bypassed()`, `qr_cache_enabled()`, `url_shortener_enabled()` (default true), `url_shortener_auto_create_enabled()` (default true), `ip_cache_enabled()`, `ip_api_enabled()`, `notify_capability_grant_enabled()`
- **9 typed int accessors**: `activity_log_retention_days()` (90), `cache_expiration_seconds()` (3600), `obsolete_shortcode_days()` (30), `gps_cache_ttl()` (600), `ip_cache_ttl()` (600), `public_csv_default_limit()` (100), `public_csv_sync_max_rows()` (5000), `qr_default_size()` (256), `url_shortener_code_length()` (6)

## Deliberately NOT migrated

- **`Debug::is_enabled($area)`** — already the canonical typed reader for the 14 debug-area toggles; has its own `function_exists('get_option')` defensive check.
- **`UrlShortenerService::get_settings()`** + **`QRCodeGenerator::load_defaults_from_settings()` / `is_cache_enabled()`** — these classes already encapsulate `get_option` in private helpers. Migrating would add a layer with no architectural value (CLAUDE.md: "Don't add abstractions beyond what the task requires").

## Verification

- [x] `grep -rn "get_option(\s*['\"]ffc_settings['\"]" includes/ tests/` excluding (SettingsReader, SaveHandler, Settings, Debug, UrlShortenerService, QRCodeGenerator) ⇒ 0 hits.
- [x] PHPUnit: 4158 tests, 10611 assertions, OK (4116 → 4158 = +42 from SettingsReaderTest).
- [x] PHPStan level 8: 0 errors.
- [x] No JS/CSS changes.

Will be consolidated into **v6.6.1** when the parent #254 cleanup bundle closes.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_