### PR TITLE
Hotfix: appointment created_at TypeError in PdfGenerator

### DIFF
--- a/includes/generators/class-ffc-pdf-generator.php
+++ b/includes/generators/class-ffc-pdf-generator.php
@@ -770,8 +770,17 @@ class PdfGenerator {
 		);
 
 		// Generate HTML using the existing generate_html() method.
+		//
+		// `appointment.created_at` is a DATETIME string (housekeeping
+		// column kept as DATETIME per the Category A exception in
+		// CLAUDE.md). `generate_html()` expects a unix timestamp
+		// (`?int`) for the PDF date stamp — convert here. UTC because
+		// `created_at` is auto-set by MySQL `DEFAULT CURRENT_TIMESTAMP`
+		// which writes in the DB's timezone (UTC by convention).
 		$calendar_title = $calendar['title'] ?? __( 'Appointment Receipt', 'ffcertificate' );
-		$html           = $this->generate_html( $data, $calendar_title, $form_config, $appointment['created_at'] ?? null );
+		$created_at_str = isset( $appointment['created_at'] ) ? (string) $appointment['created_at'] : '';
+		$created_at_ts  = '' !== $created_at_str ? strtotime( $created_at_str . ' UTC' ) : false;
+		$html           = $this->generate_html( $data, $calendar_title, $form_config, false !== $created_at_ts ? $created_at_ts : null );
 
 		// Generate filename.
 		$validation_code = $appointment['validation_code'] ?? '';


### PR DESCRIPTION
## 🚨 Hotfix — fatal in appointment magic-link flow

User reported production 500 on:

```
GET /dashboard/?tab=appointments → "Ver Comprovante de Agendamento" → magic link → admin-ajax.php 500
```

### Stack trace

```
PHP Fatal error:  Uncaught TypeError: 
  FreeFormCertificate\Generators\PdfGenerator::generate_html(): 
  Argument #4 ($submission_date) must be of type ?int, string given,
  called in class-ffc-pdf-generator.php on line 774

#0 PdfGenerator->generate_appointment_pdf_data()
#1 VerificationResponseRenderer->generate_appointment_verification_pdf()
#2 VerificationHandler->handle_magic_verification_ajax()
```

### Root cause

- `generate_html()` was migrated in 6.6.0 (#249 sub-escopo a/b) to accept `?int $submission_date` (unix UTC seconds) — `submitted_at` on submissions/reregistrations became `BIGINT UNSIGNED`.
- `generate_appointment_pdf_data()` (line 774) was still passing `$appointment['created_at']` straight through. That column is a `DATETIME` string — the housekeeping column kept as DATETIME per the **Category A exception** in CLAUDE.md (added in #256 / PR #264).
- DATETIME string → `?int` parameter → fatal TypeError.

### Fix

Convert the DATETIME string to a unix timestamp via `strtotime(... . ' UTC')` before passing to `generate_html()`. UTC matches MySQL's `CURRENT_TIMESTAMP` default writes (UTC by convention on hosting). Falls back to `null` on missing/unparseable value — same semantic as the original `?? null`.

### Verification

- [x] PHPStan level 8: clean.
- [x] PHPUnit `PdfGeneratorTest`: 32 tests, 53 assertions, OK.
- [x] Code path traced from `handle_magic_verification_ajax → generate_appointment_verification_pdf → generate_appointment_pdf_data` confirms the fix is at the right point.

Unblocks the magic-link "Ver Comprovante de Agendamento" flow on production. Hotfix branched directly from `main` (not part of the #283 frontend POST sanitize PR — that's independent).

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_