### PR TITLE
Reuse: POST/GET sanitize — frontend area (closes #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- POST/GET sanitize migration continues — frontend area: 36 sites
+  migrated to `Utils::get_post_string` / `get_get_string` across
+  `public-csv-download.php`, `public-csv-exporter.php`,
+  `form-processor.php`, `shortcodes.php`, `verification-handler.php`,
+  and `access-restriction-checker.php`.
 - POST/GET sanitize migration continues — audience area: 48 of 55
   scattered `sanitize_text_field(wp_unslash($_POST[...]))` patterns
   migrated to `Utils::get_post_string` / `get_get_string` across

--- a/includes/frontend/class-ffc-access-restriction-checker.php
+++ b/includes/frontend/class-ffc-access-restriction-checker.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -44,7 +46,7 @@ class AccessRestrictionChecker {
 		// ========================================.
 		if ( ! empty( $restrictions['password'] ) && '1' === $restrictions['password'] ) {
             // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in handle_submission_ajax() caller.
-			$password       = isset( $_POST['ffc_password'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['ffc_password'] ) ) ) : '';
+			$password       = trim( Utils::get_post_string( 'ffc_password' ) );
 			$valid_password = isset( $form_config['validation_code'] ) ? $form_config['validation_code'] : '';
 
 			if ( empty( $password ) ) {

--- a/includes/frontend/class-ffc-form-processor.php
+++ b/includes/frontend/class-ffc-form-processor.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 use FreeFormCertificate\Submissions\SubmissionHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -68,7 +70,7 @@ class FormProcessor {
 		}
 
 		// Verify nonce.
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ffc_frontend_nonce' ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( 'nonce' ), 'ffc_frontend_nonce' ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed. Please refresh the page.', 'ffcertificate' ) ) );
 		}
 
@@ -76,13 +78,13 @@ class FormProcessor {
 
 		// ===== DEBUG CAPTCHA =====.
 		\FreeFormCertificate\Core\Debug::log_form( '===== CAPTCHA DEBUG =====' );
-		\FreeFormCertificate\Core\Debug::log_form( 'Answer received', isset( $_POST['ffc_captcha_ans'] ) ? sanitize_text_field( wp_unslash( $_POST['ffc_captcha_ans'] ) ) : 'NOT SET' );
-		\FreeFormCertificate\Core\Debug::log_form( 'Hash received', isset( $_POST['ffc_captcha_hash'] ) ? sanitize_text_field( wp_unslash( $_POST['ffc_captcha_hash'] ) ) : 'NOT SET' );
+		\FreeFormCertificate\Core\Debug::log_form( 'Answer received', Utils::get_post_string( 'ffc_captcha_ans', 'NOT SET' ) );
+		\FreeFormCertificate\Core\Debug::log_form( 'Hash received', Utils::get_post_string( 'ffc_captcha_hash', 'NOT SET' ) );
 
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- isset() check only; values sanitized inside block.
 		if ( isset( $_POST['ffc_captcha_ans'] ) && isset( $_POST['ffc_captcha_hash'] ) ) {
-			$test_answer    = trim( sanitize_text_field( wp_unslash( $_POST['ffc_captcha_ans'] ) ) );
-			$received_hash  = sanitize_text_field( wp_unslash( $_POST['ffc_captcha_hash'] ) );
+			$test_answer    = trim( Utils::get_post_string( 'ffc_captcha_ans' ) );
+			$received_hash  = Utils::get_post_string( 'ffc_captcha_hash' );
 			$generated_hash = wp_hash( $test_answer . 'ffc_math_salt' );
 
 			\FreeFormCertificate\Core\Debug::log_form( 'Trimmed answer', $test_answer );
@@ -186,7 +188,7 @@ class FormProcessor {
 			wp_send_json_error( array( 'message' => __( 'Email address is required.', 'ffcertificate' ) ) );
 		}
 		// Validate LGPD consent (mandatory).
-		if ( empty( $_POST['ffc_lgpd_consent'] ) || sanitize_text_field( wp_unslash( $_POST['ffc_lgpd_consent'] ) ) !== '1' ) {
+		if ( Utils::get_post_string( 'ffc_lgpd_consent' ) !== '1' ) {
 			wp_send_json_error(
 				array(
 					'message' => __( 'You must agree to the Privacy Policy to continue.', 'ffcertificate' ),
@@ -198,8 +200,8 @@ class FormProcessor {
 		$submission_data['ffc_lgpd_consent'] = '1';
 
 		// Capture restriction fields (password/ticket) from POST.
-		$val_password = isset( $_POST['ffc_password'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['ffc_password'] ) ) ) : '';
-		$val_ticket   = isset( $_POST['ffc_ticket'] ) ? strtoupper( trim( sanitize_text_field( wp_unslash( $_POST['ffc_ticket'] ) ) ) ) : '';
+		$val_password = trim( Utils::get_post_string( 'ffc_password' ) );
+		$val_ticket   = strtoupper( trim( Utils::get_post_string( 'ffc_ticket' ) ) );
 
 		$val_cpf = isset( $submission_data['cpf_rf'] ) ? trim( $submission_data['cpf_rf'] ) : '';
 

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -32,6 +32,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 use FreeFormCertificate\Security\Geofence;
 use FreeFormCertificate\Security\RateLimiter;
 
@@ -147,7 +149,7 @@ class PublicCsvDownload {
 		$security_html = $shortcodes->generate_security_fields();
 
 		$prefill_form_id = isset( $_GET['form_id'] ) ? absint( wp_unslash( $_GET['form_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$prefill_hash    = isset( $_GET['hash'] ) ? sanitize_text_field( wp_unslash( $_GET['hash'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$prefill_hash    = Utils::get_get_string( 'hash' );
 
 		// CPF gate mode is per-form. We can't read it without a known form_id;
 		// when prefilled, honour that form's setting. Otherwise render the
@@ -296,7 +298,7 @@ class PublicCsvDownload {
 
 		// 2. Nonce.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), self::NONCE_ACTION ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), self::NONCE_ACTION ) ) {
 			$this->fail_redirect( __( 'Security check failed. Please refresh the page and try again.', 'ffcertificate' ) );
 		}
 
@@ -310,7 +312,7 @@ class PublicCsvDownload {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
 		$form_id = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
-		$posted_hash = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : '';
+		$posted_hash = Utils::get_post_string( 'hash' );
 
 		// 4. Honeypot + CAPTCHA.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
@@ -336,7 +338,7 @@ class PublicCsvDownload {
 
 		// 9b. CPF gate (per-form opt-in, no-op when mode = 'none').
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
-		$cpf_input = isset( $_POST['cpf'] ) ? sanitize_text_field( wp_unslash( $_POST['cpf'] ) ) : '';
+		$cpf_input = Utils::get_post_string( 'cpf' );
 		$cpf_error = $this->validate_cpf_requirement( $form_id, $cpf_input );
 		if ( null !== $cpf_error ) {
 			$this->fail_redirect( $cpf_error );
@@ -395,7 +397,7 @@ class PublicCsvDownload {
 		}
 
 		// 2. Nonce.
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), self::NONCE_ACTION ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), self::NONCE_ACTION ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			wp_send_json_error( array( 'message' => __( 'Security check failed. Please refresh the page and try again.', 'ffcertificate' ) ) );
 		}
 
@@ -405,7 +407,7 @@ class PublicCsvDownload {
 		 * audit log.
 		 */
 		$form_id     = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$posted_hash = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$posted_hash = Utils::get_post_string( 'hash' );
 
 		// 4. Honeypot + CAPTCHA.
 		$security_check = \FreeFormCertificate\Core\SecurityService::validate_security_fields( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -430,7 +432,7 @@ class PublicCsvDownload {
 
 		// 7b. CPF gate (per-form opt-in, no-op when mode = 'none').
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
-		$cpf_input = isset( $_POST['cpf'] ) ? sanitize_text_field( wp_unslash( $_POST['cpf'] ) ) : '';
+		$cpf_input = Utils::get_post_string( 'cpf' );
 		$cpf_error = $this->validate_cpf_requirement( $form_id, $cpf_input );
 		if ( null !== $cpf_error ) {
 			wp_send_json_error( array( 'message' => $cpf_error ) );
@@ -450,12 +452,12 @@ class PublicCsvDownload {
 	 */
 	public function ajax_cert_preview(): void {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), self::NONCE_ACTION ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), self::NONCE_ACTION ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'ffcertificate' ) ) );
 		}
 
 		$form_id     = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$posted_hash = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$posted_hash = Utils::get_post_string( 'hash' );
 
 		$error = $this->validate_hash_only( $form_id, $posted_hash );
 		if ( null !== $error ) {
@@ -506,13 +508,13 @@ class PublicCsvDownload {
 	 */
 	public function ajax_open_early(): void {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), self::NONCE_ACTION ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), self::NONCE_ACTION ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'ffcertificate' ) ), 403 );
 		}
 
 		$form_id     = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$posted_hash = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$cpf_input   = isset( $_POST['cpf'] ) ? sanitize_text_field( wp_unslash( $_POST['cpf'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$posted_hash = Utils::get_post_string( 'hash' );
+		$cpf_input   = Utils::get_post_string( 'cpf' );
 
 		$audit_meta = array(
 			'user_id' => get_current_user_id(),
@@ -582,14 +584,14 @@ class PublicCsvDownload {
 	 */
 	public function ajax_extend_end(): void {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), self::NONCE_ACTION ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), self::NONCE_ACTION ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'ffcertificate' ) ), 403 );
 		}
 
 		$form_id      = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$posted_hash  = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$new_time_end = isset( $_POST['new_time_end'] ) ? sanitize_text_field( wp_unslash( $_POST['new_time_end'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$cpf_input    = isset( $_POST['cpf'] ) ? sanitize_text_field( wp_unslash( $_POST['cpf'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$posted_hash  = Utils::get_post_string( 'hash' );
+		$new_time_end = Utils::get_post_string( 'new_time_end' );
+		$cpf_input    = Utils::get_post_string( 'cpf' );
 
 		$audit_meta = array(
 			'user_id' => get_current_user_id(),
@@ -709,7 +711,7 @@ class PublicCsvDownload {
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce validated below.
 		$form_id = isset( $_GET['form_id'] ) ? absint( wp_unslash( $_GET['form_id'] ) ) : 0;
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+		$nonce = Utils::get_get_string( '_wpnonce' );
 
 		if ( ! wp_verify_nonce( $nonce, self::EXPORT_LOG_NONCE . '_' . $form_id ) ) {
 			wp_die( esc_html__( 'Security check failed.', 'ffcertificate' ), 403 );

--- a/includes/frontend/class-ffc-public-csv-exporter.php
+++ b/includes/frontend/class-ffc-public-csv-exporter.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 use FreeFormCertificate\Core\CsvExportTrait;
 use FreeFormCertificate\Repositories\SubmissionRepository;
 use FreeFormCertificate\Security\RateLimiter;
@@ -321,7 +323,7 @@ class PublicCsvExporter {
 
 		// 2. Nonce.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		if ( ! isset( $_POST['_ffc_pcd_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_ffc_pcd_nonce'] ) ), PublicCsvDownload::NONCE_ACTION ) ) {
+		if ( ! wp_verify_nonce( Utils::get_post_string( '_ffc_pcd_nonce' ), PublicCsvDownload::NONCE_ACTION ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed. Please refresh the page and try again.', 'ffcertificate' ) ) );
 		}
 
@@ -336,7 +338,7 @@ class PublicCsvExporter {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
 		$form_id = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
-		$posted_hash = isset( $_POST['hash'] ) ? sanitize_text_field( wp_unslash( $_POST['hash'] ) ) : '';
+		$posted_hash = Utils::get_post_string( 'hash' );
 
 		if ( $form_id <= 0 || '' === $posted_hash ) {
 			wp_send_json_error( array( 'message' => __( 'Please inform both the Form ID and the Access Hash.', 'ffcertificate' ) ) );
@@ -351,7 +353,7 @@ class PublicCsvExporter {
 
 		// 9b. CPF gate (per-form opt-in, no-op when mode = 'none').
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
-		$cpf_input = isset( $_POST['cpf'] ) ? sanitize_text_field( wp_unslash( $_POST['cpf'] ) ) : '';
+		$cpf_input = Utils::get_post_string( 'cpf' );
 		$cpf_error = $validator->validate_cpf_requirement( $form_id, $cpf_input );
 		if ( null !== $cpf_error ) {
 			wp_send_json_error( array( 'message' => $cpf_error ) );
@@ -465,7 +467,7 @@ class PublicCsvExporter {
 	 */
 	public function ajax_batch(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified via job-scoped nonce below.
-		$job_id = isset( $_POST['job_id'] ) ? sanitize_text_field( wp_unslash( $_POST['job_id'] ) ) : '';
+		$job_id = Utils::get_post_string( 'job_id' );
 		$job    = get_transient( 'ffc_public_csv_' . $job_id );
 
 		if ( ! $job ) {
@@ -474,7 +476,7 @@ class PublicCsvExporter {
 
 		// Verify job-scoped nonce.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified here.
-		$nonce = isset( $_POST['nonce_batch'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce_batch'] ) ) : '';
+		$nonce = Utils::get_post_string( 'nonce_batch' );
 		if ( ! wp_verify_nonce( $nonce, 'ffc_public_csv_batch_' . $job_id ) ) {
 			wp_send_json_error( __( 'Security check failed.', 'ffcertificate' ) );
 		}
@@ -572,7 +574,7 @@ class PublicCsvExporter {
 	 */
 	public function ajax_download(): void {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$job_id = isset( $_GET['job_id'] ) ? sanitize_text_field( wp_unslash( $_GET['job_id'] ) ) : '';
+		$job_id = Utils::get_get_string( 'job_id' );
 		$job    = get_transient( 'ffc_public_csv_' . $job_id );
 
 		if ( ! $job ) {
@@ -580,7 +582,7 @@ class PublicCsvExporter {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$nonce = isset( $_GET['nonce_batch'] ) ? sanitize_text_field( wp_unslash( $_GET['nonce_batch'] ) ) : '';
+		$nonce = Utils::get_get_string( 'nonce_batch' );
 		if ( ! wp_verify_nonce( $nonce, 'ffc_public_csv_batch_' . $job_id ) ) {
 			wp_die( esc_html__( 'Security check failed.', 'ffcertificate' ) );
 		}

--- a/includes/frontend/class-ffc-shortcodes.php
+++ b/includes/frontend/class-ffc-shortcodes.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 use FreeFormCertificate\Core\SecurityService;
 use FreeFormCertificate\Submissions\SubmissionHandler;
 
@@ -111,7 +113,7 @@ class Shortcodes {
 	public function render_verification_page( array $atts ): string {
 		// Check for magic token in URL query string (?token=).
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Token is a display/routing parameter for verification page.
-		$magic_token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+		$magic_token = Utils::get_get_string( 'token' );
 
 		if ( ! empty( $magic_token ) ) {
 			// Magic link access via query string - render preview container.

--- a/includes/frontend/class-ffc-verification-handler.php
+++ b/includes/frontend/class-ffc-verification-handler.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
+use FreeFormCertificate\Core\Utils;
+
 use FreeFormCertificate\Submissions\SubmissionHandler;
 use FreeFormCertificate\Repositories\SubmissionRepository;
 
@@ -665,7 +667,7 @@ class VerificationHandler {
 		// No captcha - token proves legitimacy.
 
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Magic token authentication; no nonce needed for this public endpoint.
-		$token   = isset( $_POST['token'] ) ? sanitize_text_field( wp_unslash( $_POST['token'] ) ) : '';
+		$token   = Utils::get_post_string( 'token' );
 		$user_ip = \FreeFormCertificate\Core\Utils::get_user_ip();
 
 		$rate_check = \FreeFormCertificate\Security\RateLimiter::check_verification( $user_ip );
@@ -773,7 +775,7 @@ class VerificationHandler {
 			);
 		}
 
-		$auth_code = isset( $_POST['ffc_auth_code'] ) ? sanitize_text_field( wp_unslash( $_POST['ffc_auth_code'] ) ) : '';
+		$auth_code = Utils::get_post_string( 'ffc_auth_code' );
         // phpcs:enable WordPress.Security.NonceVerification.Missing
 		$result = $this->search_certificate( $auth_code );
 

--- a/tests/Unit/FrontendShortcodesTest.php
+++ b/tests/Unit/FrontendShortcodesTest.php
@@ -39,6 +39,8 @@ class FrontendShortcodesTest extends TestCase {
         Functions\when( 'absint' )->alias( function ( $val ) { return abs( (int) $val ); } );
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
         Functions\when( 'wp_rand' )->alias( function ( int $min = 0, int $max = 0 ) { return random_int( $min, $max ); } );
         Functions\when( 'wp_hash' )->alias( function ( $data ) { return hash( 'sha256', $data ); } );
         Functions\when( 'get_option' )->justReturn( array() );


### PR DESCRIPTION
Closes #283. Refs #254, #276.

## Summary

Terceira filha de #276. Frontend area migration: **36 sites** migrados para `Utils::get_post_string` / `get_get_string`.

## Changes

| Arquivo | Sites |
|---|---|
| `public-csv-download.php` | 17 |
| `public-csv-exporter.php` | 7 |
| `form-processor.php` | ~7 |
| `shortcodes.php` | 1 |
| `verification-handler.php` | 2 |
| `access-restriction-checker.php` | 1 |

Cada arquivo ganhou `use FreeFormCertificate\Core\Utils;` import.

## Test isolation fix

`FrontendShortcodesTest` setUp gained namespaced `wp_unslash` + `sanitize_text_field` stubs (same pattern from #279/#281).

## Verification

- [x] PHPUnit: 4189 tests, 10657 assertions, OK.
- [x] PHPStan level 8: 0 errors.
- [x] 0 remaining `sanitize_text_field(wp_unslash($_POST|$_GET))` hits in `includes/frontend/`.

Próximo: #276 filha 4 (admin + reregistration, ~47 sites). Após mergear, #276 umbrella fecha.

https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_