### PR TITLE
Reuse: POST/GET sanitize — admin + reregistration area (closes #286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- POST/GET sanitize migration continues — admin + reregistration area:
+  inline `sanitize_text_field(wp_unslash($_POST/$_GET[...]))` patterns
+  migrated to `Utils::get_post_string` / `get_get_string` across 14
+  files in `includes/admin/` and `includes/reregistration/` (settings
+  save handlers, list pages, CSV exporters, submission actions, user
+  capability + custom-field editors, locations AJAX endpoint, form-editor
+  save handler, activity log page, assets manager). This closes the
+  #276 POST/GET sanitize umbrella.
 - POST/GET sanitize migration continues — frontend area: 36 sites
   migrated to `Utils::get_post_string` / `get_get_string` across
   `public-csv-download.php`, `public-csv-exporter.php`,

--- a/includes/admin/class-ffc-admin-activity-log-page.php
+++ b/includes/admin/class-ffc-admin-activity-log-page.php
@@ -90,7 +90,7 @@ class AdminActivityLogPage {
 	 */
 	public function handle_csv_export(): void {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce checked below
-		if ( ! isset( $_GET['page'] ) || sanitize_text_field( wp_unslash( $_GET['page'] ) ) !== 'ffc-activity-log' ) {
+		if ( \FreeFormCertificate\Core\Utils::get_get_string( 'page' ) !== 'ffc-activity-log' ) {
 			return;
 		}
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -118,12 +118,12 @@ class AdminActivityLogPage {
 			$args['level'] = $level;
 		}
 
-		$action = isset( $_GET['log_action'] ) ? sanitize_text_field( wp_unslash( $_GET['log_action'] ) ) : '';
+		$action = \FreeFormCertificate\Core\Utils::get_get_string( 'log_action' );
 		if ( $action ) {
 			$args['action'] = $action;
 		}
 
-		$search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+		$search = \FreeFormCertificate\Core\Utils::get_get_string( 's' );
 		if ( $search ) {
 			$args['search'] = $search;
 		}
@@ -201,8 +201,8 @@ class AdminActivityLogPage {
 		$current_page = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
 		$per_page     = 50;
 		$level        = isset( $_GET['level'] ) ? sanitize_key( wp_unslash( $_GET['level'] ) ) : '';
-		$action       = isset( $_GET['log_action'] ) ? sanitize_text_field( wp_unslash( $_GET['log_action'] ) ) : '';
-		$search       = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+		$action       = \FreeFormCertificate\Core\Utils::get_get_string( 'log_action' );
+		$search       = \FreeFormCertificate\Core\Utils::get_get_string( 's' );
         // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Get logs.

--- a/includes/admin/class-ffc-admin-assets-manager.php
+++ b/includes/admin/class-ffc-admin-assets-manager.php
@@ -177,7 +177,7 @@ class AdminAssetsManager {
 	private function is_ffc_page(): bool {
 		$is_ffc_post_type = ( 'ffc_form' === $this->post_type );
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Page routing check, no nonce needed.
-		$is_ffc_menu = ( isset( $_GET['page'] ) && strpos( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 'ffc-' ) !== false );
+		$is_ffc_menu = strpos( \FreeFormCertificate\Core\Utils::get_get_string( 'page' ), 'ffc-' ) !== false;
 
 		return $is_ffc_post_type || $is_ffc_menu;
 	}

--- a/includes/admin/class-ffc-admin-submission-edit-page.php
+++ b/includes/admin/class-ffc-admin-submission-edit-page.php
@@ -540,7 +540,7 @@ class AdminSubmissionEditPage {
 		}
 
 		// Process user link change (simplified: value is user ID, empty string, or __keep__).
-		$linked_user_id = isset( $_POST['linked_user_id'] ) ? sanitize_text_field( wp_unslash( $_POST['linked_user_id'] ) ) : '__keep__';
+		$linked_user_id = \FreeFormCertificate\Core\Utils::get_post_string( 'linked_user_id', '__keep__' );
 
         // phpcs:enable WordPress.Security.NonceVerification.Missing
 

--- a/includes/admin/class-ffc-admin-user-capabilities.php
+++ b/includes/admin/class-ffc-admin-user-capabilities.php
@@ -268,8 +268,7 @@ class AdminUserCapabilities {
 	 */
 	public static function save_capability_fields( int $user_id ): void {
 		// Verify nonce.
-		if ( ! isset( $_POST['ffc_capabilities_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_capabilities_nonce'] ) ), 'ffc_user_capabilities' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_capabilities_nonce' ), 'ffc_user_capabilities' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-ffc-admin-user-custom-fields.php
+++ b/includes/admin/class-ffc-admin-user-custom-fields.php
@@ -330,8 +330,7 @@ class AdminUserCustomFields {
 	 */
 	public static function save_section( int $user_id ): void {
 		// Verify nonce.
-		if ( ! isset( $_POST['ffc_user_custom_fields_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_user_custom_fields_nonce'] ) ), 'ffc_save_user_custom_fields' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_user_custom_fields_nonce' ), 'ffc_save_user_custom_fields' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-ffc-admin.php
+++ b/includes/admin/class-ffc-admin.php
@@ -210,7 +210,7 @@ class Admin {
 	 */
 	public function handle_submission_actions(): void {
         // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verified per-action below via wp_verify_nonce and check_admin_referer.
-		if ( ! isset( $_GET['page'] ) || sanitize_text_field( wp_unslash( $_GET['page'] ) ) !== 'ffc-submissions' ) {
+		if ( \FreeFormCertificate\Core\Utils::get_get_string( 'page' ) !== 'ffc-submissions' ) {
 			return;
 		}
 
@@ -218,7 +218,7 @@ class Admin {
 		if ( isset( $_GET['submission_id'] ) && isset( $_GET['action'] ) ) {
 			$id                   = absint( wp_unslash( $_GET['submission_id'] ) );
 			$action               = sanitize_key( wp_unslash( $_GET['action'] ) );
-			$nonce                = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+			$nonce                = \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' );
 			$manipulation_actions = array( 'trash', 'restore', 'delete' );
 
 			if ( in_array( $action, $manipulation_actions, true ) ) {
@@ -508,7 +508,7 @@ class Admin {
 		$moved        = isset( $_GET['moved'] ) ? absint( wp_unslash( $_GET['moved'] ) ) : 0;
 		$conflicts    = isset( $_GET['conflicts'] ) ? absint( wp_unslash( $_GET['conflicts'] ) ) : 0;
 		$to_form      = isset( $_GET['to_form'] ) ? absint( wp_unslash( $_GET['to_form'] ) ) : 0;
-		$conflict_raw = isset( $_GET['conflict_id'] ) ? sanitize_text_field( wp_unslash( $_GET['conflict_id'] ) ) : '';
+		$conflict_raw = \FreeFormCertificate\Core\Utils::get_get_string( 'conflict_id' );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$conflict_ids = array();

--- a/includes/admin/class-ffc-csv-exporter.php
+++ b/includes/admin/class-ffc-csv-exporter.php
@@ -223,7 +223,7 @@ class CsvExporter {
 			wp_send_json_error( __( 'Permission denied.', 'ffcertificate' ), 403 );
 		}
 
-		$job_id = isset( $_POST['job_id'] ) ? sanitize_text_field( wp_unslash( $_POST['job_id'] ) ) : '';
+		$job_id = \FreeFormCertificate\Core\Utils::get_post_string( 'job_id' );
 		$job    = get_transient( 'ffc_csv_export_' . $job_id );
 
 		if ( ! $job || get_current_user_id() !== (int) $job['user_id'] ) {
@@ -314,7 +314,7 @@ class CsvExporter {
 	 */
 	public function ajax_download(): void {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'ffc_csv_export' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( 'nonce' ), 'ffc_csv_export' ) ) {
 			wp_die( esc_html__( 'Security check failed.', 'ffcertificate' ) );
 		}
 
@@ -322,7 +322,7 @@ class CsvExporter {
 			wp_die( esc_html__( 'Permission denied.', 'ffcertificate' ) );
 		}
 
-		$job_id = isset( $_GET['job_id'] ) ? sanitize_text_field( wp_unslash( $_GET['job_id'] ) ) : '';
+		$job_id = \FreeFormCertificate\Core\Utils::get_get_string( 'job_id' );
 		$job    = get_transient( 'ffc_csv_export_' . $job_id );
 
 		if ( ! $job || get_current_user_id() !== (int) $job['user_id'] ) {

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -33,7 +33,7 @@ class FormEditorSaveHandler {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
-		if ( ! isset( $_POST['ffc_form_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_form_nonce'] ) ), 'ffc_save_form_data' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_form_nonce' ), 'ffc_save_form_data' ) ) {
 			return;
 		}
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {

--- a/includes/admin/class-ffc-locations-ajax-endpoint.php
+++ b/includes/admin/class-ffc-locations-ajax-endpoint.php
@@ -60,7 +60,7 @@ class LocationsAjaxEndpoint {
 			wp_send_json_error( array( 'message' => __( 'You do not have permission to manage locations.', 'ffcertificate' ) ), 403 );
 		}
 
-		$name = isset( $_POST['name'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['name'] ) ) ) : '';
+		$name = trim( \FreeFormCertificate\Core\Utils::get_post_string( 'name' ) );
 		if ( '' === $name ) {
 			wp_send_json_error( array( 'message' => __( 'Location name is required.', 'ffcertificate' ) ), 400 );
 		}

--- a/includes/admin/class-ffc-settings-save-handler.php
+++ b/includes/admin/class-ffc-settings-save-handler.php
@@ -52,12 +52,12 @@ class SettingsSaveHandler {
 		}
 
 		// Handle General/SMTP/QR Settings.
-		if ( isset( $_POST['ffc_settings_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_settings_nonce'] ) ), 'ffc_settings_action' ) ) {
+		if ( wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_settings_nonce' ), 'ffc_settings_action' ) ) {
 			$this->save_general_and_specific_settings();
 		}
 
 		// Handle User Access Settings (v3.1.0).
-		if ( isset( $_POST['ffc_user_access_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_user_access_nonce'] ) ), 'ffc_user_access_settings' ) ) {
+		if ( wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_user_access_nonce' ), 'ffc_user_access_settings' ) ) {
 			$this->save_user_access_settings();
 		}
 
@@ -415,8 +415,8 @@ class SettingsSaveHandler {
 	 */
 	private function handle_danger_zone(): void {
         // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified in handle_all_submissions() via check_admin_referer.
-		$target        = isset( $_POST['delete_target'] ) ? sanitize_text_field( wp_unslash( $_POST['delete_target'] ) ) : 'all';
-		$reset_counter = isset( $_POST['reset_counter'] ) && sanitize_text_field( wp_unslash( $_POST['reset_counter'] ) ) === '1';
+		$target        = \FreeFormCertificate\Core\Utils::get_post_string( 'delete_target', 'all' );
+		$reset_counter = \FreeFormCertificate\Core\Utils::get_post_string( 'reset_counter' ) === '1';
         // phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		/**

--- a/includes/admin/class-ffc-settings.php
+++ b/includes/admin/class-ffc-settings.php
@@ -213,7 +213,7 @@ class Settings {
 		}
         // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ffc_clear_qr_cache' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'ffc_clear_qr_cache' ) ) {
 			return;
 		}
 
@@ -356,7 +356,7 @@ class Settings {
 		$migration_key = sanitize_key( wp_unslash( $_GET['ffc_run_migration'] ) );
 
 		// Verify nonce.
-		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ffc_migration_' . $migration_key ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'ffc_migration_' . $migration_key ) ) {
 			wp_die( esc_html__( 'Security check failed.', 'ffcertificate' ) );
 		}
 
@@ -545,9 +545,9 @@ class Settings {
 		}
 
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above via check_ajax_referer.
-		$format = isset( $_POST['format'] ) ? sanitize_text_field( wp_unslash( $_POST['format'] ) ) : 'F j, Y';
+		$format = \FreeFormCertificate\Core\Utils::get_post_string( 'format', 'F j, Y' );
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above via check_ajax_referer.
-		$custom_format = isset( $_POST['custom_format'] ) ? sanitize_text_field( wp_unslash( $_POST['custom_format'] ) ) : '';
+		$custom_format = \FreeFormCertificate\Core\Utils::get_post_string( 'custom_format' );
 
 		// Sample date for preview.
 		$sample_date = '2026-01-04 15:30:45';

--- a/includes/admin/class-ffc-submissions-list.php
+++ b/includes/admin/class-ffc-submissions-list.php
@@ -377,7 +377,7 @@ class SubmissionsList extends \WP_List_Table {
 		$status  = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : 'publish';
 		$search  = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
 		$orderby = ( ! empty( $_GET['orderby'] ) ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
-		$order   = ( ! empty( $_GET['order'] ) && sanitize_text_field( wp_unslash( $_GET['order'] ) ) === 'asc' ) ? 'ASC' : 'DESC';
+		$order   = \FreeFormCertificate\Core\Utils::get_get_string( 'order' ) === 'asc' ? 'ASC' : 'DESC';
 
 		$filter_form_ids = array();
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- empty() existence check only.

--- a/includes/reregistration/class-ffc-reregistration-admin.php
+++ b/includes/reregistration/class-ffc-reregistration-admin.php
@@ -179,7 +179,7 @@ class ReregistrationAdmin {
 
 		// Enqueue PDF libraries on submissions view.
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : '';
+		$view = \FreeFormCertificate\Core\Utils::get_get_string( 'view' );
 		if ( 'submissions' === $view ) {
 			wp_enqueue_script( 'html2canvas', FFC_PLUGIN_URL . 'libs/js/html2canvas.min.js', array(), FFC_HTML2CANVAS_VERSION, true );
 			wp_enqueue_script( 'jspdf', FFC_PLUGIN_URL . 'libs/js/jspdf.umd.min.js', array(), FFC_JSPDF_VERSION, true );
@@ -198,7 +198,7 @@ class ReregistrationAdmin {
 		}
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
+		$view = \FreeFormCertificate\Core\Utils::get_get_string( 'view', 'list' );
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
@@ -230,7 +230,10 @@ class ReregistrationAdmin {
 	 */
 	private function render_list(): void {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$status_filter = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : null;
+		$status_filter = \FreeFormCertificate\Core\Utils::get_get_string( 'status' );
+		if ( '' === $status_filter ) {
+			$status_filter = null;
+		}
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$audience_filter = isset( $_GET['audience_id'] ) ? absint( $_GET['audience_id'] ) : 0;
 
@@ -543,9 +546,15 @@ class ReregistrationAdmin {
 		}
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$status_filter = isset( $_GET['sub_status'] ) ? sanitize_text_field( wp_unslash( $_GET['sub_status'] ) ) : null;
+		$status_filter = \FreeFormCertificate\Core\Utils::get_get_string( 'sub_status' );
+		if ( '' === $status_filter ) {
+			$status_filter = null;
+		}
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : null;
+		$search = \FreeFormCertificate\Core\Utils::get_get_string( 's' );
+		if ( '' === $search ) {
+			$search = null;
+		}
 
 		$filters = array();
 		if ( $status_filter ) {
@@ -769,7 +778,7 @@ class ReregistrationAdmin {
 		}
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		$page = \FreeFormCertificate\Core\Utils::get_get_string( 'page' );
 		if ( self::MENU_SLUG !== $page ) {
 			return;
 		}
@@ -778,7 +787,7 @@ class ReregistrationAdmin {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['message'] ) ) {
             // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$msg      = sanitize_text_field( wp_unslash( $_GET['message'] ) );
+			$msg      = \FreeFormCertificate\Core\Utils::get_get_string( 'message' );
 			$messages = array(
 				'created'                => __( 'Reregistration created successfully.', 'ffcertificate' ),
 				'updated'                => __( 'Reregistration updated successfully.', 'ffcertificate' ),
@@ -819,7 +828,7 @@ class ReregistrationAdmin {
 		if ( ! isset( $_POST['ffc_action'] ) || 'save_reregistration' !== $_POST['ffc_action'] ) {
 			return;
 		}
-		if ( ! isset( $_POST['ffc_reregistration_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ffc_reregistration_nonce'] ) ), 'save_reregistration' ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_reregistration_nonce' ), 'save_reregistration' ) ) {
 			return;
 		}
 
@@ -834,15 +843,15 @@ class ReregistrationAdmin {
 
         // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above (line 707).
 		$data = array(
-			'title'                      => isset( $_POST['rereg_title'] ) ? sanitize_text_field( wp_unslash( $_POST['rereg_title'] ) ) : '',
-			'start_date'                 => isset( $_POST['rereg_start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['rereg_start_date'] ) ) : '',
-			'end_date'                   => isset( $_POST['rereg_end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['rereg_end_date'] ) ) : '',
+			'title'                      => \FreeFormCertificate\Core\Utils::get_post_string( 'rereg_title' ),
+			'start_date'                 => \FreeFormCertificate\Core\Utils::get_post_string( 'rereg_start_date' ),
+			'end_date'                   => \FreeFormCertificate\Core\Utils::get_post_string( 'rereg_end_date' ),
 			'auto_approve'               => ! empty( $_POST['rereg_auto_approve'] ) ? 1 : 0,
 			'email_invitation_enabled'   => ! empty( $_POST['rereg_email_invitation'] ) ? 1 : 0,
 			'email_reminder_enabled'     => ! empty( $_POST['rereg_email_reminder'] ) ? 1 : 0,
 			'email_confirmation_enabled' => ! empty( $_POST['rereg_email_confirmation'] ) ? 1 : 0,
 			'reminder_days'              => isset( $_POST['rereg_reminder_days'] ) ? absint( $_POST['rereg_reminder_days'] ) : 7,
-			'status'                     => isset( $_POST['rereg_status'] ) ? sanitize_text_field( wp_unslash( $_POST['rereg_status'] ) ) : 'draft',
+			'status'                     => \FreeFormCertificate\Core\Utils::get_post_string( 'rereg_status', 'draft' ),
 		);
 
 		// Collect audience IDs from transfer list hidden inputs.
@@ -893,7 +902,7 @@ class ReregistrationAdmin {
 		}
 
 		$id = absint( $_GET['id'] );
-		if ( ! wp_verify_nonce( isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '', 'delete_reregistration_' . $id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'delete_reregistration_' . $id ) ) {
 			return;
 		}
 

--- a/includes/reregistration/class-ffc-reregistration-csv-exporter.php
+++ b/includes/reregistration/class-ffc-reregistration-csv-exporter.php
@@ -39,7 +39,7 @@ class ReregistrationCsvExporter {
 		}
 
 		$id = absint( $_GET['id'] );
-		if ( ! wp_verify_nonce( isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '', 'export_reregistration_' . $id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'export_reregistration_' . $id ) ) {
 			return;
 		}
 

--- a/includes/reregistration/class-ffc-reregistration-submission-actions.php
+++ b/includes/reregistration/class-ffc-reregistration-submission-actions.php
@@ -36,7 +36,7 @@ class ReregistrationSubmissionActions {
 		$sub_id   = absint( $_GET['sub_id'] );
 		$rereg_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
-		if ( ! wp_verify_nonce( isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '', 'approve_submission_' . $sub_id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'approve_submission_' . $sub_id ) ) {
 			return;
 		}
 
@@ -59,7 +59,7 @@ class ReregistrationSubmissionActions {
 		$sub_id   = absint( $_GET['sub_id'] );
 		$rereg_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
-		if ( ! wp_verify_nonce( isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '', 'reject_submission_' . $sub_id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'reject_submission_' . $sub_id ) ) {
 			return;
 		}
 
@@ -82,7 +82,7 @@ class ReregistrationSubmissionActions {
 		$sub_id   = absint( $_GET['sub_id'] );
 		$rereg_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
-		if ( ! wp_verify_nonce( isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '', 'return_to_draft_submission_' . $sub_id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_get_string( '_wpnonce' ), 'return_to_draft_submission_' . $sub_id ) ) {
 			return;
 		}
 
@@ -102,11 +102,11 @@ class ReregistrationSubmissionActions {
 		}
 
 		$rereg_id = isset( $_POST['reregistration_id'] ) ? absint( $_POST['reregistration_id'] ) : 0;
-		if ( ! wp_verify_nonce( isset( $_POST['ffc_bulk_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['ffc_bulk_nonce'] ) ) : '', 'bulk_submissions_' . $rereg_id ) ) {
+		if ( ! wp_verify_nonce( \FreeFormCertificate\Core\Utils::get_post_string( 'ffc_bulk_nonce' ), 'bulk_submissions_' . $rereg_id ) ) {
 			return;
 		}
 
-		$action = isset( $_POST['bulk_action'] ) ? sanitize_text_field( wp_unslash( $_POST['bulk_action'] ) ) : '';
+		$action = \FreeFormCertificate\Core\Utils::get_post_string( 'bulk_action' );
 		$ids    = isset( $_POST['submission_ids'] ) ? array_map( 'absint', (array) $_POST['submission_ids'] ) : array();
 
 		if ( empty( $ids ) || empty( $action ) ) {

--- a/tests/Unit/AdminAssetsManagerTest.php
+++ b/tests/Unit/AdminAssetsManagerTest.php
@@ -46,6 +46,9 @@ class AdminAssetsManagerTest extends TestCase {
         $this->utils_mock = Mockery::mock('alias:\FreeFormCertificate\Core\Utils');
         $this->utils_mock->shouldReceive('asset_suffix')->andReturn('.min')->byDefault();
         $this->utils_mock->shouldReceive('enqueue_dark_mode')->byDefault();
+        $this->utils_mock->shouldReceive('get_get_string')->andReturnUsing( function ( $key, $default = '' ) {
+            return isset( $_GET[ $key ] ) && is_string( $_GET[ $key ] ) ? $_GET[ $key ] : $default;
+        } )->byDefault();
     }
 
     protected function tearDown(): void {

--- a/tests/Unit/AdminUserCapabilitiesTest.php
+++ b/tests/Unit/AdminUserCapabilitiesTest.php
@@ -93,6 +93,9 @@ class AdminUserCapabilitiesTest extends TestCase {
         $this->utils_mock->shouldReceive( 'asset_suffix' )
             ->andReturn( '.min' )
             ->byDefault();
+        $this->utils_mock->shouldReceive( 'get_post_string' )->andReturnUsing( function ( $key, $default = '' ) {
+            return isset( $_POST[ $key ] ) && is_string( $_POST[ $key ] ) ? $_POST[ $key ] : $default;
+        } )->byDefault();
 
         // Common WP stubs
         Functions\when( '__' )->returnArg();
@@ -272,7 +275,7 @@ class AdminUserCapabilitiesTest extends TestCase {
         // No $_POST nonce set
         unset( $_POST['ffc_capabilities_nonce'] );
 
-        Functions\expect( 'wp_verify_nonce' )->never();
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
 
         $user = new \WP_User( 5 );
         Functions\when( 'get_userdata' )->justReturn( $user );

--- a/tests/Unit/AdminUserCustomFieldsTest.php
+++ b/tests/Unit/AdminUserCustomFieldsTest.php
@@ -51,9 +51,14 @@ class AdminUserCustomFieldsTest extends TestCase {
         Functions\when('absint')->justReturn(1);
         Functions\when('sanitize_text_field')->returnArg();
         Functions\when('wp_unslash')->returnArg();
+        Functions\when('FreeFormCertificate\Core\sanitize_text_field')->returnArg();
+        Functions\when('FreeFormCertificate\Core\wp_unslash')->returnArg();
 
         // Utils alias mock
         $this->utils_mock = Mockery::mock('alias:\FreeFormCertificate\Core\Utils');
+        $this->utils_mock->shouldReceive( 'get_post_string' )->andReturnUsing( function ( $key, $default = '' ) {
+            return isset( $_POST[ $key ] ) && is_string( $_POST[ $key ] ) ? $_POST[ $key ] : $default;
+        } )->byDefault();
         $this->utils_mock->shouldReceive('asset_suffix')->andReturn('.min')->byDefault();
 
         // Repository alias mocks
@@ -176,6 +181,7 @@ class AdminUserCustomFieldsTest extends TestCase {
 
     public function test_save_section_returns_early_without_nonce(): void {
         // No $_POST nonce set
+        Functions\when('wp_verify_nonce')->justReturn(false);
         $this->custom_field_repo_mock->shouldReceive('save_user_data')->never();
 
         AdminUserCustomFields::save_section(1);

--- a/tests/Unit/ReregistrationSubmissionActionsTest.php
+++ b/tests/Unit/ReregistrationSubmissionActionsTest.php
@@ -41,6 +41,8 @@ class ReregistrationSubmissionActionsTest extends TestCase {
         });
         Functions\when('sanitize_text_field')->alias('trim');
         Functions\when('wp_unslash')->returnArg();
+        Functions\when('FreeFormCertificate\Core\sanitize_text_field')->alias('trim');
+        Functions\when('FreeFormCertificate\Core\wp_unslash')->returnArg();
         Functions\when('get_current_user_id')->justReturn(1);
         Functions\when('admin_url')->alias(function ($path = '') {
             return 'https://example.com/wp-admin/' . $path;

--- a/tests/Unit/TabGeolocationTest.php
+++ b/tests/Unit/TabGeolocationTest.php
@@ -40,6 +40,8 @@ class TabGeolocationTest extends TestCase {
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'sanitize_textarea_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
         Functions\when( 'absint' )->alias( function ( $val ) {
             return abs( (int) $val );
         } );

--- a/tests/Unit/TabUserAccessTest.php
+++ b/tests/Unit/TabUserAccessTest.php
@@ -215,6 +215,8 @@ class TabUserAccessTest extends TestCase {
         Functions\when( 'wp_verify_nonce' )->justReturn( false );
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
 
         $this->tab->save_settings();
 
@@ -231,6 +233,8 @@ class TabUserAccessTest extends TestCase {
 
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
         Functions\when( 'wp_verify_nonce' )->justReturn( false );
         Functions\expect( 'update_option' )->never();
 
@@ -254,6 +258,8 @@ class TabUserAccessTest extends TestCase {
 
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
         Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
         Functions\when( 'esc_url_raw' )->returnArg();
         Functions\when( 'sanitize_textarea_field' )->returnArg();
@@ -287,6 +293,8 @@ class TabUserAccessTest extends TestCase {
 
         Functions\when( 'sanitize_text_field' )->returnArg();
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
         Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
         Functions\when( 'esc_url_raw' )->returnArg();
         Functions\when( 'sanitize_textarea_field' )->returnArg();


### PR DESCRIPTION
## Summary

Fourth and final filha of the #276 POST/GET sanitize umbrella — migrates
admin + reregistration sites to the `Utils::get_post_string` /
`get_get_string` helpers introduced in #279. Closes #286 and completes
#276.

## Scope

Migrated 14 files (~45 call sites):

**Admin (`includes/admin/`)**
- `class-ffc-admin-activity-log-page.php` (4 sites)
- `class-ffc-admin-assets-manager.php` (1 site)
- `class-ffc-admin-submission-edit-page.php` (1 site)
- `class-ffc-admin-user-capabilities.php` (1 site)
- `class-ffc-admin-user-custom-fields.php` (1 site)
- `class-ffc-admin.php` (3 sites)
- `class-ffc-csv-exporter.php` (3 sites)
- `class-ffc-form-editor-save-handler.php` (1 site)
- `class-ffc-locations-ajax-endpoint.php` (1 site)
- `class-ffc-settings-save-handler.php` (4 sites)
- `class-ffc-settings.php` (4 sites)
- `class-ffc-submissions-list.php` (1 site)

**Reregistration (`includes/reregistration/`)**
- `class-ffc-reregistration-admin.php` (12 sites)
- `class-ffc-reregistration-csv-exporter.php` (1 site)
- `class-ffc-reregistration-submission-actions.php` (6 sites)

Pattern: each verbose
`isset($_POST[k]) ? sanitize_text_field(wp_unslash($_POST[k])) : default`
collapses to one `Utils::get_post_string('k', default)` call.

## Test fixes

Several Unit tests required updates because the migrated nonce-guard
sites used to short-circuit via `! isset($_POST[k])` before calling
`wp_verify_nonce()`. After the migration `wp_verify_nonce()` is always
called (with `''` when the nonce key is missing). Affected tests:

- `AdminAssetsManagerTest` — Utils `get_get_string` alias mock default.
- `AdminUserCapabilitiesTest` — Utils `get_post_string` default + stub
  `wp_verify_nonce → false` in the without-nonce test.
- `AdminUserCustomFieldsTest` — Utils `get_post_string` default + Core
  namespaced stubs + stub `wp_verify_nonce → false` in the without-nonce
  test.
- `ReregistrationSubmissionActionsTest` / `TabGeolocationTest` /
  `TabUserAccessTest` — added namespaced `FreeFormCertificate\Core\*`
  function stubs to survive test-isolation pollution.

## Test plan

- [x] `vendor/bin/phpunit --testsuite unit` → 4189 tests, 10656 assertions, 0 failures.
- [ ] CI: PHPStan level 8, WPCS, PHPUnit matrix (8.1–8.4), coverage floor.

Refs #254 #276


---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_