### PR TITLE
Test cleanup: remove dead markTestSkipped() guards (closes #302)

### DIFF
--- a/tests/Unit/ActivityLogBufferTest.php
+++ b/tests/Unit/ActivityLogBufferTest.php
@@ -61,12 +61,6 @@ class ActivityLogBufferTest extends TestCase {
         Functions\when( 'current_time' )->justReturn( '2026-02-08 12:00:00' );
         Functions\when( 'add_action' )->justReturn( true );
 
-        // Mock Utils::get_user_ip()
-        if ( ! class_exists( '\FreeFormCertificate\Core\Utils' ) ) {
-            // Skip if Utils not autoloaded – isolated test.
-            $this->markTestSkipped( 'Utils class not available in isolated test.' );
-        }
-
         $result = ActivityLog::log( 'test_action', 'info', array(), 0, 0 );
 
         $this->assertTrue( $result );

--- a/tests/Unit/SubmissionRestControllerTest.php
+++ b/tests/Unit/SubmissionRestControllerTest.php
@@ -136,11 +136,6 @@ class SubmissionRestControllerTest extends TestCase {
         // Mock WP_REST_Request
         $request = Mockery::mock( 'WP_REST_Request' );
 
-        // Need to define WP_Error class for this test
-        if ( ! class_exists( 'WP_Error' ) ) {
-            $this->markTestSkipped( 'WP_Error class not available in isolated test.' );
-        }
-
         $result = $ctrl->get_submissions( $request );
         $this->assertInstanceOf( \WP_Error::class, $result );
     }


### PR DESCRIPTION
## Summary

Removes 2 dead `markTestSkipped()` guards identified in #302. Both are
defensive branches that never fire in the current test environment:

- `WP_Error` is stubbed globally in `tests/bootstrap.php:124-125`.
- `\FreeFormCertificate\Core\Utils` is loaded by the FFC PSR-4
  autoloader registered in `tests/bootstrap.php:273-275`.

Confirmed by running the affected tests before the change — both
already pass (not skip). The branches were defensive carry-over from
an earlier test-infra iteration.

## Test plan

- [x] `vendor/bin/phpunit --testsuite unit` → 4189 tests, 10656
      assertions, all green.
- [x] `grep -rn 'markTestSkipped' tests/` returns 0 hits.
- [ ] CI: PHPStan + WPCS + PHPUnit matrix.

Refs #254 §6
Closes #302


---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_