### PR TITLE
Test gap: cover ActivityLogClearPlaintext + EmailHashRehash strategies (closes #304)

### DIFF
--- a/tests/Unit/ActivityLogClearPlaintextMigrationStrategyTest.php
+++ b/tests/Unit/ActivityLogClearPlaintextMigrationStrategyTest.php
@@ -1,0 +1,297 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Migrations\Strategies\ActivityLogClearPlaintextMigrationStrategy;
+
+/**
+ * Tests for ActivityLogClearPlaintextMigrationStrategy: NULL-out plaintext
+ * `context` on rows where `context_encrypted` already holds the payload.
+ *
+ * @covers \FreeFormCertificate\Migrations\Strategies\ActivityLogClearPlaintextMigrationStrategy
+ * @runClassInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class ActivityLogClearPlaintextMigrationStrategyTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface */
+    private $wpdb;
+
+    private ActivityLogClearPlaintextMigrationStrategy $strategy;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        global $wpdb;
+        $wpdb              = Mockery::mock( 'wpdb' );
+        $wpdb->prefix      = 'wp_';
+        $wpdb->last_error  = '';
+        $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();
+        $wpdb->shouldReceive( 'query' )->andReturn( 0 )->byDefault();
+        $wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();
+        $wpdb->shouldReceive( 'get_col' )->andReturn( array() )->byDefault();
+        $this->wpdb = $wpdb;
+
+        if ( ! class_exists( 'FreeFormCertificate\Migrations\Strategies\WP_Error' ) ) {
+            class_alias( 'WP_Error', 'FreeFormCertificate\Migrations\Strategies\WP_Error' );
+        }
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'get_option' )->justReturn( 0 );
+        Functions\when( 'update_option' )->justReturn( true );
+        Functions\when( 'is_wp_error' )->alias( function ( $thing ) { return $thing instanceof \WP_Error; } );
+
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\__' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\get_option' )->justReturn( 0 );
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\update_option' )->justReturn( true );
+        Functions\when( 'FreeFormCertificate\Core\get_option' )->justReturn( array() );
+        Functions\when( 'FreeFormCertificate\Settings\get_option' )->justReturn( array() );
+
+        $this->strategy = new ActivityLogClearPlaintextMigrationStrategy();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // get_name()
+    // ------------------------------------------------------------------
+
+    public function test_get_name_returns_human_readable_label(): void {
+        $this->assertSame(
+            'Activity Log: Clear Plaintext Context on Encrypted Rows',
+            $this->strategy->get_name()
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // can_run()
+    // ------------------------------------------------------------------
+
+    public function test_can_run_returns_true_when_table_exists(): void {
+        // table_exists() reads SHOW TABLES LIKE => must return the table name.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( 'wp_ffc_activity_log' );
+
+        $result = $this->strategy->can_run( 'activity_log_clear_plaintext', array() );
+
+        $this->assertTrue( $result );
+    }
+
+    public function test_can_run_returns_wp_error_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null );
+
+        $result = $this->strategy->can_run( 'activity_log_clear_plaintext', array() );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'activity_log_table_missing', $result->get_error_code() );
+    }
+
+    // ------------------------------------------------------------------
+    // calculate_status() — schema short-circuits
+    // ------------------------------------------------------------------
+
+    public function test_calculate_status_returns_complete_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null ); // table_exists => false
+
+        $status = $this->strategy->calculate_status( 'activity_log_clear_plaintext', array() );
+
+        $this->assertSame( 0, $status['total'] );
+        $this->assertSame( 0, $status['pending'] );
+        $this->assertTrue( $status['is_complete'] );
+        $this->assertSame( 100, $status['percent'] );
+    }
+
+    public function test_calculate_status_returns_complete_when_context_column_missing(): void {
+        // table_exists: yes; column_exists(context) -> get_results returns empty.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( 'wp_ffc_activity_log' );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() );
+
+        $status = $this->strategy->calculate_status( 'activity_log_clear_plaintext', array() );
+
+        $this->assertTrue( $status['is_complete'] );
+    }
+
+    // ------------------------------------------------------------------
+    // calculate_status() — counts from queries
+    // ------------------------------------------------------------------
+
+    public function test_calculate_status_reports_pending_and_percent(): void {
+        // Sequence: table_exists, COUNT(total), COUNT(pending). column_exists
+        // returns non-empty for both 'context' + 'context_encrypted'.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log', // table_exists
+            '100',                 // total
+            '40'                   // pending
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array( 'Field' => 'context' ) ) );
+
+        $status = $this->strategy->calculate_status( 'activity_log_clear_plaintext', array() );
+
+        $this->assertSame( 100, $status['total'] );
+        $this->assertSame( 60, $status['migrated'] );
+        $this->assertSame( 40, $status['pending'] );
+        $this->assertSame( 60.0, $status['percent'] );
+        $this->assertFalse( $status['is_complete'] );
+    }
+
+    public function test_calculate_status_handles_zero_total_without_division_by_zero(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log',
+            '0',
+            '0'
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+
+        $status = $this->strategy->calculate_status( 'activity_log_clear_plaintext', array() );
+
+        $this->assertSame( 100.0, (float) $status['percent'] );
+        $this->assertTrue( $status['is_complete'] );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — schema short-circuit
+    // ------------------------------------------------------------------
+
+    public function test_execute_no_op_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null );
+
+        $result = $this->strategy->execute( 'activity_log_clear_plaintext', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertFalse( $result['has_more'] );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — empty-IDs branch (advances cursor to MAX(id))
+    // ------------------------------------------------------------------
+
+    public function test_execute_advances_cursor_to_max_id_when_no_pending_rows(): void {
+        // table_exists yes; column_exists yes; get_col empty (no matching ids);
+        // MAX(id) query returns 999.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log', // table_exists
+            '999'                  // COALESCE(MAX(id), 0)
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array() );
+
+        $cursor_updates = 0;
+        $tracker        = function ( $key, $value ) use ( &$cursor_updates ) {
+            if ( 'ffc_activity_log_clear_plaintext_cursor' === $key ) {
+                $cursor_updates++;
+            }
+            return true;
+        };
+        Functions\when( 'update_option' )->alias( $tracker );
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\update_option' )->alias( $tracker );
+
+        $result = $this->strategy->execute( 'activity_log_clear_plaintext', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertFalse( $result['has_more'] );
+        $this->assertSame( 1, $cursor_updates, 'cursor should be advanced to MAX(id)' );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — happy path
+    // ------------------------------------------------------------------
+
+    public function test_execute_updates_batch_and_advances_cursor(): void {
+        // get_var sequence:
+        //   execute() prelude → table_exists
+        //   calculate_status() → table_exists, COUNT(total), COUNT(pending)
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log', // execute table_exists
+            'wp_ffc_activity_log', // calculate_status table_exists
+            '100',                 // total
+            '95'                   // pending (still has_more)
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array( '10', '20', '30', '42' ) );
+        $this->wpdb->shouldReceive( 'query' )->andReturn( 4 ); // UPDATE affected 4 rows.
+
+        $captured_cursor = null;
+        $tracker         = function ( $key, $value ) use ( &$captured_cursor ) {
+            if ( 'ffc_activity_log_clear_plaintext_cursor' === $key ) {
+                $captured_cursor = $value;
+            }
+            return true;
+        };
+        Functions\when( 'update_option' )->alias( $tracker );
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\update_option' )->alias( $tracker );
+
+        $result = $this->strategy->execute( 'activity_log_clear_plaintext', array( 'batch_size' => 200 ) );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 4, $result['processed'] );
+        $this->assertTrue( $result['has_more'], 'pending > 0 means more work remains' );
+        $this->assertSame( 42, $captured_cursor, 'cursor should advance to last id in batch' );
+    }
+
+    public function test_execute_marks_failure_when_update_query_returns_false(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log',
+            'wp_ffc_activity_log',
+            '50',
+            '50'
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array( '7' ) );
+        $this->wpdb->shouldReceive( 'query' )->andReturn( false );
+        $this->wpdb->last_error = 'Deadlock found when trying to get lock';
+
+        $result = $this->strategy->execute( 'activity_log_clear_plaintext', array() );
+
+        $this->assertFalse( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertContains( 'Deadlock found when trying to get lock', $result['errors'] );
+    }
+
+    public function test_execute_respects_batch_size_from_config(): void {
+        $captured_args = array();
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+            function ( $sql, ...$args ) use ( &$captured_args ) {
+                $captured_args[] = $args;
+                return 'SQL';
+            }
+        );
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_activity_log', // execute table_exists
+            'wp_ffc_activity_log', // calculate_status table_exists
+            '5',
+            '0' // pending=0 → has_more=false
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+        $this->wpdb->shouldReceive( 'get_col' )->andReturn( array( '1', '2', '3' ) );
+        $this->wpdb->shouldReceive( 'query' )->andReturn( 3 );
+
+        $result = $this->strategy->execute( 'activity_log_clear_plaintext', array( 'batch_size' => 50 ) );
+
+        // The SELECT id query receives (table, cursor, batch_size).
+        $found_batch_size = false;
+        foreach ( $captured_args as $args ) {
+            if ( in_array( 50, $args, true ) ) {
+                $found_batch_size = true;
+                break;
+            }
+        }
+        $this->assertTrue( $found_batch_size, 'batch_size from config should reach the prepared statement' );
+        $this->assertFalse( $result['has_more'] );
+    }
+}

--- a/tests/Unit/EmailHashRehashMigrationStrategyTest.php
+++ b/tests/Unit/EmailHashRehashMigrationStrategyTest.php
@@ -1,0 +1,468 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Migrations\Strategies\EmailHashRehashMigrationStrategy;
+
+/**
+ * Tests for EmailHashRehashMigrationStrategy: rehash legacy unsalted
+ * email_hash values using the salted Encryption::hash().
+ *
+ * @covers \FreeFormCertificate\Migrations\Strategies\EmailHashRehashMigrationStrategy
+ * @runClassInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class EmailHashRehashMigrationStrategyTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface */
+    private $wpdb;
+
+    private EmailHashRehashMigrationStrategy $strategy;
+
+    /** @var array<string, mixed> */
+    private array $options;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        global $wpdb;
+        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb->prefix     = 'wp_';
+        $wpdb->last_error = '';
+        $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();
+        $wpdb->shouldReceive( 'query' )->andReturn( 0 )->byDefault();
+        $wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+        $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();
+        $wpdb->shouldReceive( 'update' )->andReturn( 1 )->byDefault();
+        $this->wpdb = $wpdb;
+
+        if ( ! class_exists( 'FreeFormCertificate\Migrations\Strategies\WP_Error' ) ) {
+            class_alias( 'WP_Error', 'FreeFormCertificate\Migrations\Strategies\WP_Error' );
+        }
+
+        // In-memory option store so cursor + completion latch behave naturally.
+        $this->options = array();
+        $get_opt       = function ( $key, $default = false ) {
+            return $this->options[ $key ] ?? $default;
+        };
+        $set_opt = function ( $key, $value ) {
+            $this->options[ $key ] = $value;
+            return true;
+        };
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'is_wp_error' )->alias( function ( $thing ) { return $thing instanceof \WP_Error; } );
+        Functions\when( 'get_option' )->alias( $get_opt );
+        Functions\when( 'update_option' )->alias( $set_opt );
+
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\__' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\get_option' )->alias( $get_opt );
+        Functions\when( 'FreeFormCertificate\Migrations\Strategies\update_option' )->alias( $set_opt );
+        Functions\when( 'FreeFormCertificate\Core\get_option' )->justReturn( array() );
+        Functions\when( 'FreeFormCertificate\Settings\get_option' )->justReturn( array() );
+
+        $this->strategy = new EmailHashRehashMigrationStrategy();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // get_name() + can_run()
+    // ------------------------------------------------------------------
+
+    public function test_get_name_returns_human_readable_label(): void {
+        $this->assertSame( 'Email Hash Rehash', $this->strategy->get_name() );
+    }
+
+    public function test_can_run_returns_true_when_encryption_configured(): void {
+        // Encryption::is_configured() reads SECURE_AUTH_KEY which is set in bootstrap.
+        $result = $this->strategy->can_run( 'email_hash_rehash', array() );
+
+        $this->assertTrue( $result );
+    }
+
+    // ------------------------------------------------------------------
+    // calculate_status() — completion latch wins
+    // ------------------------------------------------------------------
+
+    public function test_calculate_status_reports_100_percent_when_completion_latched(): void {
+        $this->options['ffc_email_hash_rehash_completed'] = true;
+
+        // Both tables exist + have rows: total should still pass through, but
+        // the latch overrides migrated/pending.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',                  // table_exists submissions
+            '50',                                  // total submissions
+            '0',                                   // migrated submissions
+            'wp_ffc_self_scheduling_appointments', // table_exists appointments
+            '20',                                  // total appointments
+            '0'                                    // migrated appointments
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+
+        $status = $this->strategy->calculate_status( 'email_hash_rehash', array() );
+
+        $this->assertSame( 70, $status['total'] );
+        $this->assertSame( 70, $status['migrated'] );
+        $this->assertSame( 0, $status['pending'] );
+        $this->assertSame( 100.0, $status['percent'] );
+        $this->assertTrue( $status['is_complete'] );
+    }
+
+    // ------------------------------------------------------------------
+    // calculate_status() — schema short-circuits
+    // ------------------------------------------------------------------
+
+    public function test_calculate_status_treats_missing_tables_as_zero(): void {
+        // table_exists returns null for both tables.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn( null );
+
+        $status = $this->strategy->calculate_status( 'email_hash_rehash', array() );
+
+        $this->assertSame( 0, $status['total'] );
+        $this->assertSame( 0, $status['pending'] );
+        $this->assertTrue( $status['is_complete'] );
+        $this->assertSame( 100.0, (float) $status['percent'] );
+    }
+
+    public function test_calculate_status_aggregates_pending_from_both_tables(): void {
+        // submissions: total=100, cursor=60 → migrated 60, pending 40.
+        // appointments: total=20, cursor=20 → migrated 20, pending 0.
+        $this->options['ffc_email_hash_rehash_cursor_wp_ffc_submissions']                  = 60;
+        $this->options['ffc_email_hash_rehash_cursor_wp_ffc_self_scheduling_appointments'] = 20;
+
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',                  // table_exists submissions
+            '100',                                 // total submissions
+            '60',                                  // migrated submissions
+            'wp_ffc_self_scheduling_appointments', // table_exists appointments
+            '20',                                  // total appointments
+            '20'                                   // migrated appointments
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( (object) array() ) );
+
+        $status = $this->strategy->calculate_status( 'email_hash_rehash', array() );
+
+        $this->assertSame( 120, $status['total'] );
+        $this->assertSame( 80, $status['migrated'] );
+        $this->assertSame( 40, $status['pending'] );
+        $this->assertFalse( $status['is_complete'] );
+        $this->assertGreaterThan( 0, $status['percent'] );
+        $this->assertLessThan( 100, $status['percent'] );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — completion latch
+    // ------------------------------------------------------------------
+
+    public function test_execute_short_circuits_when_already_completed(): void {
+        $this->options['ffc_email_hash_rehash_completed'] = true;
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertFalse( $result['has_more'] );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — empty tables advance cursor to MAX(id) and latch complete
+    // ------------------------------------------------------------------
+
+    public function test_execute_latches_completion_when_both_tables_fully_walked(): void {
+        // process_table for each table: get_results empty → MAX(id) → cursor advance.
+        // calculate_status() then sees pending=0 because cursor == total covered.
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            // process_table submissions: MAX(id) lookup when no records
+            '50',
+            // process_table appointments: MAX(id) lookup
+            '20',
+            // calculate_status submissions: table_exists, total, migrated
+            'wp_ffc_submissions',
+            '10',
+            '10',
+            // calculate_status appointments: table_exists, total, migrated
+            'wp_ffc_self_scheduling_appointments',
+            '5',
+            '5'
+        );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() );
+        // process_table needs column_exists yes → get_results non-empty. But we
+        // already stubbed get_results to empty, which would also fail
+        // column_exists. Override:
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq ) {
+                $col_seq++;
+                // First 4 calls are column_exists (2 cols × 2 tables) → must
+                // be non-empty; subsequent calls (the SELECT records) → empty.
+                if ( $col_seq <= 4 ) {
+                    return array( (object) array() );
+                }
+                return array();
+            }
+        );
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertFalse( $result['has_more'] );
+        $this->assertTrue(
+            (bool) ( $this->options['ffc_email_hash_rehash_completed'] ?? false ),
+            'completion latch should be set when both tables are fully walked'
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // execute() — happy path: rehash a row whose hash differs
+    // ------------------------------------------------------------------
+
+    public function test_execute_rehashes_row_when_current_hash_differs(): void {
+        $plain     = 'user@example.com';
+        $encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $plain );
+        $this->assertNotNull( $encrypted, 'precondition: Encryption must be configured' );
+        $legacy_hash = hash( 'sha256', $plain ); // pre-fix unsalted hash.
+
+        $record = array(
+            'id'              => 7,
+            'email_encrypted' => $encrypted,
+            'email_hash'      => $legacy_hash,
+        );
+
+        // get_var sequence:
+        //   process_table submissions: table_exists
+        //   process_table appointments: table_exists, MAX(id) (empty)
+        //   calculate_status submissions: table_exists, total, migrated
+        //   calculate_status appointments: table_exists, total, migrated
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',
+            'wp_ffc_self_scheduling_appointments',
+            '0', // appointments MAX(id) when no records
+            'wp_ffc_submissions',
+            '10',
+            '10',
+            'wp_ffc_self_scheduling_appointments',
+            '5',
+            '5'
+        );
+
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq, $record ) {
+                $col_seq++;
+                // 1,2 = column_exists submissions (email_hash, email_encrypted)
+                // 3   = SELECT records from submissions → our test row
+                // 4,5 = column_exists appointments
+                // 6   = SELECT records from appointments → empty
+                // 7,8 = column_exists submissions inside calculate_status
+                // 9,10= column_exists appointments inside calculate_status
+                if ( 3 === $col_seq ) {
+                    return array( $record );
+                }
+                if ( 6 === $col_seq ) {
+                    return array();
+                }
+                return array( (object) array() );
+            }
+        );
+
+        $update_captured = null;
+        $this->wpdb->shouldReceive( 'update' )->andReturnUsing(
+            function ( $table, $data, $where ) use ( &$update_captured ) {
+                $update_captured = compact( 'table', 'data', 'where' );
+                return 1;
+            }
+        );
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 1, $result['processed'] );
+        $this->assertNotNull( $update_captured );
+        $this->assertSame( 'wp_ffc_submissions', $update_captured['table'] );
+        $this->assertSame( 7, $update_captured['where']['id'] );
+        $this->assertSame(
+            \FreeFormCertificate\Core\Encryption::hash( $plain ),
+            $update_captured['data']['email_hash']
+        );
+    }
+
+    public function test_execute_skips_row_when_current_hash_already_correct(): void {
+        $plain     = 'user@example.com';
+        $encrypted = \FreeFormCertificate\Core\Encryption::encrypt( $plain );
+        $this->assertNotNull( $encrypted );
+        $correct_hash = \FreeFormCertificate\Core\Encryption::hash( $plain );
+
+        $record = array(
+            'id'              => 9,
+            'email_encrypted' => $encrypted,
+            'email_hash'      => $correct_hash,
+        );
+
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',
+            'wp_ffc_self_scheduling_appointments',
+            '0',
+            'wp_ffc_submissions', '10', '10',
+            'wp_ffc_self_scheduling_appointments', '5', '5'
+        );
+
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq, $record ) {
+                $col_seq++;
+                if ( 3 === $col_seq ) {
+                    return array( $record );
+                }
+                if ( 6 === $col_seq ) {
+                    return array();
+                }
+                return array( (object) array() );
+            }
+        );
+
+        $update_called = false;
+        $this->wpdb->shouldReceive( 'update' )->andReturnUsing(
+            function () use ( &$update_called ) {
+                $update_called = true;
+                return 1;
+            }
+        );
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertFalse( $update_called, 'idempotent: rows with correct hash skip the UPDATE' );
+    }
+
+    public function test_execute_records_error_when_decryption_fails(): void {
+        $record = array(
+            'id'              => 11,
+            'email_encrypted' => 'not-a-valid-ciphertext',
+            'email_hash'      => 'whatever',
+        );
+
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',
+            'wp_ffc_self_scheduling_appointments',
+            '0',
+            'wp_ffc_submissions', '10', '10',
+            'wp_ffc_self_scheduling_appointments', '5', '5'
+        );
+
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq, $record ) {
+                $col_seq++;
+                if ( 3 === $col_seq ) {
+                    return array( $record );
+                }
+                if ( 6 === $col_seq ) {
+                    return array();
+                }
+                return array( (object) array() );
+            }
+        );
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertNotEmpty( $result['errors'] );
+        $this->assertStringContainsString( 'Could not decrypt email', $result['errors'][0] );
+        $this->assertSame( 0, $result['processed'] );
+    }
+
+    public function test_execute_skips_record_with_empty_encrypted_payload(): void {
+        $record = array(
+            'id'              => 13,
+            'email_encrypted' => '',
+            'email_hash'      => 'irrelevant',
+        );
+
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',
+            'wp_ffc_self_scheduling_appointments',
+            '0',
+            'wp_ffc_submissions', '10', '10',
+            'wp_ffc_self_scheduling_appointments', '5', '5'
+        );
+
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq, $record ) {
+                $col_seq++;
+                if ( 3 === $col_seq ) {
+                    return array( $record );
+                }
+                if ( 6 === $col_seq ) {
+                    return array();
+                }
+                return array( (object) array() );
+            }
+        );
+
+        $update_called = false;
+        $this->wpdb->shouldReceive( 'update' )->andReturnUsing( function () use ( &$update_called ) { $update_called = true; return 1; } );
+
+        $result = $this->strategy->execute( 'email_hash_rehash', array() );
+
+        $this->assertSame( 0, $result['processed'] );
+        $this->assertSame( array(), $result['errors'] );
+        $this->assertFalse( $update_called );
+    }
+
+    public function test_execute_respects_batch_size_from_config(): void {
+        $captured_prepare_args = array();
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+            function ( $sql, ...$args ) use ( &$captured_prepare_args ) {
+                $captured_prepare_args[] = $args;
+                return 'SQL';
+            }
+        );
+
+        $this->wpdb->shouldReceive( 'get_var' )->andReturn(
+            'wp_ffc_submissions',                    // submissions table_exists
+            '0',                                     // submissions MAX(id) (records empty)
+            'wp_ffc_self_scheduling_appointments',   // appointments table_exists
+            '0',                                     // appointments MAX(id)
+            'wp_ffc_submissions', '0', '0',          // status submissions
+            'wp_ffc_self_scheduling_appointments', '0', '0'
+        );
+        $col_seq = 0;
+        $this->wpdb->shouldReceive( 'get_results' )->andReturnUsing(
+            function () use ( &$col_seq ) {
+                $col_seq++;
+                if ( in_array( $col_seq, array( 3, 6 ), true ) ) {
+                    return array();
+                }
+                return array( (object) array() );
+            }
+        );
+
+        $this->strategy->execute( 'email_hash_rehash', array( 'batch_size' => 7 ) );
+
+        $found = false;
+        foreach ( $captured_prepare_args as $args ) {
+            if ( in_array( 7, $args, true ) ) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue( $found, 'batch_size from config should reach the SELECT prepare call' );
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of #254 §7 — direct unit coverage for the two `MigrationStrategyInterface` implementations that mutate sensitive activity-log / email rows (~660 LoC previously without dedicated tests).

These carry SQL `UPDATE` / `DELETE` against PII columns; a silent bug could (a) leave plaintext residuals on encrypted rows, or (b) corrupt hashes on the appointments/submissions tables. The new tests pin the contract end-to-end.

### `ActivityLogClearPlaintextMigrationStrategy` — 12 tests

- `get_name()` label + `can_run()` (true / `WP_Error('activity_log_table_missing')`).
- `calculate_status()`: schema short-circuits (table missing, `context` col missing) → 100% complete; happy path derives total/migrated/pending from COUNT(*); zero-total guard avoids `/0`.
- `execute()`: table-missing no-op; empty-IDs branch advances cursor to `MAX(id)`; happy path runs UPDATE, advances cursor to last id, returns `has_more` from `status.pending`; failure branch surfaces `$wpdb->last_error`; `batch_size` from config reaches the SELECT prepare.

### `EmailHashRehashMigrationStrategy` — 12 tests

- `get_name()`, `can_run()` (relies on `Encryption::is_configured()` via bootstrap `SECURE_AUTH_KEY`).
- `calculate_status()`: completion latch overrides counts → 100%; missing tables → zeros; pending aggregated across `submissions` + `self_scheduling_appointments` tables.
- `execute()`: completion-latch short-circuit; both-tables-walked path latches completion (`update_option`); **rehashes row when current hash differs** from `Encryption::hash($plain)` (uses the real Encryption class — bootstrap configures it); idempotent no-op when hash already correct; surfaces decryption failures into `errors[]`; skips records with empty encrypted payload; `batch_size` reaches the SELECT prepare.

## Pattern

Sister test `CpfRfSplitMigrationStrategyTest`: Mockery `wpdb` mock, namespaced Brain Monkey function stubs (`FreeFormCertificate\Migrations\Strategies\update_option` etc.), in-memory option store so cursor + completion latch behave naturally, `class_alias` for `WP_Error` in the strategy namespace.

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/{ActivityLogClearPlaintext,EmailHashRehash}MigrationStrategyTest.php` → 24/24 (74 assertions).
- [x] Full `vendor/bin/phpunit --testsuite=unit` → 4245/4245, no regressions.
- [ ] CI: PHPUnit matrix (8.1–8.4) + clover coverage floor.
- [ ] CI: PHPStan level 8 (tests dir not scanned).

Coverage-floor ratchet deferred to #310.

Refs #254 §7. Closes #304.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_