### PR TITLE
Test gap: cover 6 untested JS files (closes #308)

### DIFF
--- a/tests/js/admin-code-editor.test.js
+++ b/tests/js/admin-code-editor.test.js
@@ -1,0 +1,167 @@
+// Tests for `assets/js/ffc-admin-code-editor.js`.
+//
+// Wraps the WordPress code-editor (CodeMirror) around #ffc_pdf_layout
+// when wp_enqueue_code_editor() provided settings. Falls back to a
+// "syntax highlighting disabled" notice otherwise.
+//
+// We can't run the real CodeMirror in jsdom, so the tests focus on:
+//   - bail when #ffc_pdf_layout is absent;
+//   - disabled-notice path (no window.wp.codeEditor);
+//   - CodeMirror init path uses the provided settings;
+//   - submit handler invokes cm.save() so the textarea carries the
+//     latest editor content.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+function reset() {
+	document.body.innerHTML = '';
+	delete window.ffcCodeEditor;
+	delete window.wp;
+}
+
+async function loadOnReady() {
+	loadScript('assets/js/ffc-admin-code-editor.js');
+	// $( handler ) defers to a microtask in jQuery 4 even when ready.
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('ffc-admin-code-editor.js — bail paths', () => {
+	beforeEach(reset);
+
+	it('does not throw when #ffc_pdf_layout is absent', async () => {
+		await expect(loadOnReady()).resolves.not.toThrow();
+	});
+
+	it('renders the disabled notice when ffcCodeEditor.enabled is false', async () => {
+		document.body.innerHTML =
+			'<form><textarea id="ffc_pdf_layout">html</textarea></form>';
+		window.ffcCodeEditor = {
+			enabled: false,
+			settings: {},
+			strings: {
+				syntaxDisabledNotice: 'Syntax highlighting is disabled.',
+				openProfile: 'Open profile',
+			},
+			profileUrl: 'https://example.test/profile',
+		};
+
+		await loadOnReady();
+
+		const notice = document.querySelector('.ffc-code-editor-notice');
+		expect(notice).not.toBeNull();
+		expect(notice.textContent).toContain('Syntax highlighting is disabled.');
+		expect(notice.querySelector('a').getAttribute('href')).toBe(
+			'https://example.test/profile'
+		);
+	});
+
+	it('renders the disabled notice when window.wp.codeEditor is missing', async () => {
+		document.body.innerHTML =
+			'<form><textarea id="ffc_pdf_layout">html</textarea></form>';
+		window.ffcCodeEditor = {
+			enabled: true,
+			settings: { codemirror: {} },
+			strings: { syntaxDisabledNotice: 'Disabled.' },
+		};
+
+		await loadOnReady();
+
+		expect(document.querySelector('.ffc-code-editor-notice')).not.toBeNull();
+	});
+
+	it('renders the disabled notice when initialize() throws', async () => {
+		document.body.innerHTML =
+			'<form><textarea id="ffc_pdf_layout">html</textarea></form>';
+		window.ffcCodeEditor = {
+			enabled: true,
+			settings: { codemirror: {} },
+			strings: { syntaxDisabledNotice: 'Disabled.' },
+		};
+		window.wp = {
+			codeEditor: {
+				initialize: () => {
+					throw new Error('boom');
+				},
+			},
+		};
+
+		await loadOnReady();
+
+		expect(document.querySelector('.ffc-code-editor-notice')).not.toBeNull();
+	});
+});
+
+describe('ffc-admin-code-editor.js — CodeMirror init path', () => {
+	beforeEach(reset);
+
+	it('initializes CodeMirror with the provided settings', async () => {
+		document.body.innerHTML =
+			'<form><div class="ffc-code-editor-wrapper"><textarea id="ffc_pdf_layout">html</textarea></div></form>';
+		const initialize = vi.fn(() => ({
+			codemirror: {
+				addOverlay: vi.fn(),
+				on: vi.fn(),
+				save: vi.fn(),
+			},
+		}));
+		window.ffcCodeEditor = {
+			enabled: true,
+			settings: { codemirror: { lineNumbers: true } },
+			theme: 'dark',
+			strings: {},
+		};
+		window.wp = { codeEditor: { initialize } };
+
+		await loadOnReady();
+
+		expect(initialize).toHaveBeenCalledWith(
+			'ffc_pdf_layout',
+			window.ffcCodeEditor.settings
+		);
+		expect(
+			document
+				.querySelector('.ffc-code-editor-wrapper')
+				.classList.contains('ffc-code-editor-theme-dark')
+		).toBe(true);
+	});
+
+	it('syncs the textarea on form submit via cm.save()', async () => {
+		document.body.innerHTML =
+			'<form id="f"><textarea id="ffc_pdf_layout">html</textarea></form>';
+		const save = vi.fn();
+		window.ffcCodeEditor = {
+			enabled: true,
+			settings: { codemirror: {} },
+			strings: {},
+		};
+		window.wp = {
+			codeEditor: {
+				initialize: () => ({
+					codemirror: { addOverlay: vi.fn(), on: vi.fn(), save },
+				}),
+			},
+		};
+
+		await loadOnReady();
+
+		window.$('#f').trigger('submit');
+
+		expect(save).toHaveBeenCalled();
+	});
+
+	it('bails silently when initialize() returns nothing usable', async () => {
+		document.body.innerHTML =
+			'<form><textarea id="ffc_pdf_layout"></textarea></form>';
+		window.ffcCodeEditor = {
+			enabled: true,
+			settings: { codemirror: {} },
+			strings: {},
+		};
+		window.wp = {
+			codeEditor: { initialize: () => null },
+		};
+
+		await expect(loadOnReady()).resolves.not.toThrow();
+		expect(document.querySelector('.ffc-code-editor-notice')).toBeNull();
+	});
+});

--- a/tests/js/admin-pdf.test.js
+++ b/tests/js/admin-pdf.test.js
@@ -1,0 +1,193 @@
+// Tests for `assets/js/ffc-admin-pdf.js`.
+//
+// PDF template management on the admin form-editor screen. Exposes
+// `window.FFC.Admin.PDF.loadTemplate` and binds click handlers for the
+// load-template / preview / import flows.
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+function installFFC() {
+	window.FFC = {
+		version: '6.6.1',
+		registerModule: vi.fn(),
+		Admin: {
+			showNotification: vi.fn(),
+		},
+	};
+}
+
+function reset() {
+	document.body.innerHTML = '';
+	delete window.FFC;
+	delete window.ffc_ajax;
+	if (window.fetch && window.fetch.mockRestore) {
+		window.fetch.mockRestore();
+	}
+	delete window.fetch;
+}
+
+describe('ffc-admin-pdf.js — module shape', () => {
+	beforeEach(() => {
+		reset();
+		installFFC();
+		loadScript('assets/js/ffc-admin-pdf.js');
+	});
+
+	afterEach(reset);
+
+	it('exposes FFC.Admin.PDF.loadTemplate on the window', () => {
+		expect(typeof window.FFC.Admin.PDF.loadTemplate).toBe('function');
+	});
+
+	it('registers the Admin.PDF module with FFC.registerModule', () => {
+		expect(window.FFC.registerModule).toHaveBeenCalledWith(
+			'Admin.PDF',
+			'6.6.1'
+		);
+	});
+});
+
+describe('ffc-admin-pdf.js — load-template button', () => {
+	beforeEach(() => {
+		reset();
+		installFFC();
+		document.body.innerHTML =
+			'<button id="ffc_load_template_btn">Load</button>';
+		window.ffc_ajax = {
+			strings: {
+				selectTemplate: 'Choose a template',
+				cancel: 'Cancel',
+			},
+		};
+		loadScript('assets/js/ffc-admin-pdf.js');
+	});
+
+	afterEach(reset);
+
+	it('appends a modal with localized strings on click', () => {
+		window.$('#ffc_load_template_btn').trigger('click');
+
+		const modal = document.querySelector('#ffc-template-modal');
+		expect(modal).not.toBeNull();
+		expect(modal.textContent).toContain('Choose a template');
+		expect(modal.querySelector('#ffc-modal-cancel').textContent).toBe(
+			'Cancel'
+		);
+	});
+
+	it('lists the hardcoded template catalog', () => {
+		window.$('#ffc_load_template_btn').trigger('click');
+
+		const options = document.querySelectorAll('.ffc-template-option');
+		expect(options.length).toBeGreaterThanOrEqual(4);
+		const files = Array.from(options).map((o) => o.getAttribute('data-file'));
+		expect(files).toContain('certificado_1.html');
+		expect(files).toContain('declaracao.html');
+	});
+});
+
+describe('ffc-admin-pdf.js — loadTemplate (fetch path)', () => {
+	beforeEach(() => {
+		reset();
+		installFFC();
+		document.body.innerHTML = '<textarea id="ffc_pdf_layout"></textarea>';
+		loadScript('assets/js/ffc-admin-pdf.js');
+	});
+
+	afterEach(reset);
+
+	it('writes fetched HTML into #ffc_pdf_layout on success', async () => {
+		window.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: () => Promise.resolve('<h1>Certificado</h1>'),
+		});
+
+		window.FFC.Admin.PDF.loadTemplate('certificado_1.html', 'Modelo 1');
+		// Flush fetch → response → text → populate chain.
+		await new Promise((r) => setTimeout(r, 0));
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(document.querySelector('#ffc_pdf_layout').value).toBe(
+			'<h1>Certificado</h1>'
+		);
+		// Success notification was fired (in addition to the initial "loading").
+		expect(window.FFC.Admin.showNotification).toHaveBeenCalledTimes(2);
+	});
+
+	it('surfaces a 404 error notification via showNotification', async () => {
+		window.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 404,
+			text: () => Promise.resolve(''),
+		});
+
+		window.FFC.Admin.PDF.loadTemplate('missing.html', 'Missing');
+		await new Promise((r) => setTimeout(r, 0));
+		await new Promise((r) => setTimeout(r, 0));
+
+		const calls = window.FFC.Admin.showNotification.mock.calls;
+		const errorCall = calls.find((c) => c[1] === 'error');
+		expect(errorCall).toBeDefined();
+		expect(errorCall[0]).toMatch(/not found/i);
+	});
+});
+
+describe('ffc-admin-pdf.js — preview button', () => {
+	beforeEach(() => {
+		reset();
+		installFFC();
+		document.body.innerHTML = `
+			<button id="ffc_btn_preview">Preview</button>
+			<textarea id="ffc_pdf_layout"></textarea>
+			<input id="ffc_bg_image_input" />
+			<input id="title" value="Test Form" />
+			<div id="ffc-fields-container"></div>
+		`;
+		loadScript('assets/js/ffc-admin-pdf.js');
+	});
+
+	afterEach(reset);
+
+	it('alerts when the layout textarea is empty', () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+		window.$('#ffc_btn_preview').trigger('click');
+
+		expect(alertSpy).toHaveBeenCalled();
+		expect(alertSpy.mock.calls[0][0]).toMatch(/empty/i);
+		expect(document.querySelector('#ffc-preview-modal')).toBeNull();
+
+		alertSpy.mockRestore();
+	});
+
+	it('opens a preview modal with the replaced placeholders', () => {
+		document.querySelector('#ffc_pdf_layout').value =
+			'Hello {{name}}! Your form: {{form_title}}.';
+
+		window.$('#ffc_btn_preview').trigger('click');
+
+		const modal = document.querySelector('#ffc-preview-modal');
+		expect(modal).not.toBeNull();
+		const iframe = modal.querySelector('iframe');
+		expect(iframe).not.toBeNull();
+		// The iframe content is written via document.write(), so query the
+		// iframe's own document tree.
+		const body = iframe.contentDocument.body;
+		expect(body.innerHTML).toContain('Test Form');
+		// {{name}} → "John Doe" from the hardcoded sample catalog.
+		expect(body.innerHTML).toContain('John Doe');
+		expect(body.innerHTML).not.toContain('{{name}}');
+	});
+
+	it('expands {{qr_code}} into the placeholder SVG', () => {
+		document.querySelector('#ffc_pdf_layout').value = '<p>{{qr_code}}</p>';
+
+		window.$('#ffc_btn_preview').trigger('click');
+
+		const iframe = document.querySelector('#ffc-preview-modal iframe');
+		const body = iframe.contentDocument.body;
+		expect(body.innerHTML).toContain('<svg');
+		expect(body.innerHTML).toContain('QR Code');
+	});
+});

--- a/tests/js/calendar-admin.test.js
+++ b/tests/js/calendar-admin.test.js
@@ -1,0 +1,24 @@
+// Smoke + targeted tests for `assets/js/ffc-calendar-admin.js`.
+//
+// The file is 28 LoC — a $(document).ready wrapper that calls
+// FFCCalendarAdmin.bindEvents() (currently empty). The tests pin the
+// load-time contract: the IIFE evaluates without throwing and the
+// ready handler is registered.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+describe('ffc-calendar-admin.js', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('evaluates the IIFE without throwing', () => {
+		expect(() => loadScript('assets/js/ffc-calendar-admin.js')).not.toThrow();
+	});
+
+	it('does not leak globals beyond jQuery', () => {
+		// The file is a private IIFE; nothing should be exposed on window.
+		loadScript('assets/js/ffc-calendar-admin.js');
+		expect(window.FFCCalendarAdmin).toBeUndefined();
+	});
+});

--- a/tests/js/calendar-frontend.test.js
+++ b/tests/js/calendar-frontend.test.js
@@ -1,0 +1,337 @@
+// Tests for `assets/js/ffc-calendar-frontend.js`.
+//
+// Exposes `window.ffcCalendarFrontend` — the booking-flow controller for
+// the self-scheduling shortcode. The file is 696 LoC; this suite covers
+// the discrete, deterministic methods (formatDate, renderTimeSlots,
+// selectTimeSlot, openModal/closeModal, resetCalendar, validateForm,
+// showError) and the FFC.request integration for `loadTimeSlots` /
+// `submitBooking` via a mocked window.FFC.request.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+function installGlobals() {
+	window.ffcCalendar = {
+		nonce: 'test-nonce',
+		ajaxurl: '/wp-admin/admin-ajax.php',
+		strings: {
+			availableTimes: 'Available Times',
+			yourInformation: 'Your Information',
+			noSlots: 'No slots available',
+			error: 'An error occurred',
+			loading: 'Loading…',
+			submit: 'Book Appointment',
+			timeout: 'Connection timeout. Please try again.',
+			networkError: 'Network error. Please check your connection.',
+			consentRequired: 'Consent is required',
+			fillRequired: 'Please fill all required fields',
+			months: [
+				'January',
+				'February',
+				'March',
+				'April',
+				'May',
+				'June',
+				'July',
+				'August',
+				'September',
+				'October',
+				'November',
+				'December',
+			],
+		},
+	};
+	window.FFC = {
+		request: vi.fn(),
+	};
+}
+
+function reset() {
+	document.body.innerHTML = '';
+	delete window.ffcCalendarFrontend;
+	delete window.ffcCalendar;
+	delete window.FFC;
+	delete window.FFCCalendarCore;
+}
+
+describe('ffc-calendar-frontend.js — module shape', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('exposes ffcCalendarFrontend on the window with init/bindEvents', () => {
+		expect(typeof window.ffcCalendarFrontend).toBe('object');
+		expect(typeof window.ffcCalendarFrontend.init).toBe('function');
+		expect(typeof window.ffcCalendarFrontend.bindEvents).toBe('function');
+		expect(typeof window.ffcCalendarFrontend.loadTimeSlots).toBe('function');
+	});
+
+	it('initial state has no date / time selected', () => {
+		expect(window.ffcCalendarFrontend.selectedDate).toBeNull();
+		expect(window.ffcCalendarFrontend.selectedTime).toBeNull();
+		expect(window.ffcCalendarFrontend.calendarId).toBeNull();
+	});
+});
+
+describe('ffc-calendar-frontend.js — formatDate', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('formats YYYY-MM-DD using the localized month name', () => {
+		expect(window.ffcCalendarFrontend.formatDate('2026-05-20')).toBe(
+			'20 May 2026'
+		);
+	});
+
+	it('falls back to the raw month number when months array is short', () => {
+		window.ffcCalendar.strings.months = ['Jan'];
+		expect(window.ffcCalendarFrontend.formatDate('2026-05-20')).toBe(
+			'20 05 2026'
+		);
+	});
+
+	it('returns the input verbatim when the format is not YYYY-MM-DD', () => {
+		expect(window.ffcCalendarFrontend.formatDate('invalid')).toBe('invalid');
+	});
+});
+
+describe('ffc-calendar-frontend.js — renderTimeSlots', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		document.body.innerHTML = '<div id="ffc-timeslots-container"></div>';
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('renders an empty-state message when slots is empty', () => {
+		window.ffcCalendarFrontend.renderTimeSlots([]);
+		expect(
+			document.querySelector('#ffc-timeslots-container .ffc-no-slots')
+		).not.toBeNull();
+	});
+
+	it('renders one .ffc-timeslot per slot with the time data attribute', () => {
+		window.ffcCalendarFrontend.renderTimeSlots([
+			{ time: '09:00', display: '09:00', available: 3, total: 5 },
+			{ time: '09:30', display: '09:30', available: 0, total: 5 },
+		]);
+
+		const slots = document.querySelectorAll(
+			'#ffc-timeslots-container .ffc-timeslot'
+		);
+		expect(slots).toHaveLength(2);
+		expect(slots[0].getAttribute('data-time')).toBe('09:00');
+		expect(slots[0].getAttribute('tabindex')).toBe('0');
+		expect(slots[1].classList.contains('ffc-timeslot-full')).toBe(true);
+		expect(slots[1].getAttribute('aria-disabled')).toBe('true');
+	});
+});
+
+describe('ffc-calendar-frontend.js — selectTimeSlot', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		document.body.innerHTML = `
+			<div class="ffc-timeslots-wrapper">
+				<div id="ffc-timeslots-container">
+					<div class="ffc-timeslot" data-time="09:00" role="option" aria-selected="false"></div>
+					<div class="ffc-timeslot selected" data-time="09:30" role="option" aria-selected="true"></div>
+				</div>
+			</div>
+			<div class="ffc-booking-form-wrapper" style="display:none;">
+				<form id="ffc-self-scheduling-form">
+					<input id="ffc-form-date" type="hidden" value="" />
+					<input id="ffc-form-time" type="hidden" value="" />
+				</form>
+			</div>
+			<div id="ffc-self-scheduling-modal"><div class="ffc-modal-content"><div class="ffc-modal-title"></div></div></div>
+		`;
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('marks the clicked slot as selected and stores the time', () => {
+		const $slot = window.$('.ffc-timeslot[data-time="09:00"]');
+		window.ffcCalendarFrontend.selectedDate = '2026-05-20';
+
+		window.ffcCalendarFrontend.selectTimeSlot($slot);
+
+		expect(window.ffcCalendarFrontend.selectedTime).toBe('09:00');
+		expect($slot.hasClass('selected')).toBe(true);
+		expect($slot.attr('aria-selected')).toBe('true');
+		// Sibling that was previously selected gets cleared.
+		const $other = window.$('.ffc-timeslot[data-time="09:30"]');
+		expect($other.hasClass('selected')).toBe(false);
+		expect($other.attr('aria-selected')).toBe('false');
+	});
+
+	it('switches view from time-slots to the booking form', () => {
+		const $slot = window.$('.ffc-timeslot[data-time="09:00"]');
+		window.ffcCalendarFrontend.selectedDate = '2026-05-20';
+
+		window.ffcCalendarFrontend.selectTimeSlot($slot);
+
+		expect(
+			window.getComputedStyle(
+				document.querySelector('.ffc-timeslots-wrapper')
+			).display
+		).toBe('none');
+		// hidden fields populated.
+		expect(document.querySelector('#ffc-form-date').value).toBe('2026-05-20');
+		expect(document.querySelector('#ffc-form-time').value).toBe('09:00');
+	});
+});
+
+describe('ffc-calendar-frontend.js — modal open/close', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		document.body.innerHTML = `
+			<button id="trigger">Open</button>
+			<div id="ffc-self-scheduling-modal" style="display:none;">
+				<button class="ffc-modal-close">×</button>
+				<div class="ffc-timeslots-wrapper"></div>
+				<div class="ffc-booking-form-wrapper"></div>
+			</div>
+			<div class="ffc-timeslot selected" aria-selected="true"></div>
+		`;
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('openModal shows the modal and locks body scroll', () => {
+		window.ffcCalendarFrontend.openModal();
+
+		const modal = document.querySelector('#ffc-self-scheduling-modal');
+		expect(window.getComputedStyle(modal).display).not.toBe('none');
+		expect(document.body.style.overflow).toBe('hidden');
+	});
+
+	it('closeModal hides the modal, restores scroll, and clears selection', () => {
+		// Pre-open so the close path has state to reverse.
+		window.ffcCalendarFrontend.openModal();
+		window.ffcCalendarFrontend.selectedTime = '09:00';
+
+		window.ffcCalendarFrontend.closeModal();
+
+		const modal = document.querySelector('#ffc-self-scheduling-modal');
+		expect(window.getComputedStyle(modal).display).toBe('none');
+		expect(document.body.style.overflow).toBe('');
+		expect(window.ffcCalendarFrontend.selectedTime).toBeNull();
+		expect(document.querySelector('.ffc-timeslot.selected')).toBeNull();
+	});
+});
+
+describe('ffc-calendar-frontend.js — loadTimeSlots / FFC.request', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		document.body.innerHTML = `
+			<div id="ffc-self-scheduling-modal" style="display:none;">
+				<div class="ffc-modal-content"><div class="ffc-modal-title"></div></div>
+				<div class="ffc-timeslots-wrapper">
+					<div class="ffc-timeslots-loading" style="display:none;">Loading</div>
+					<div id="ffc-timeslots-container"></div>
+				</div>
+				<div class="ffc-booking-form-wrapper"></div>
+				<button class="ffc-modal-close">×</button>
+			</div>
+		`;
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('invokes FFC.request with the calendar id, date, and nonce options', async () => {
+		window.FFC.request.mockResolvedValue({ slots: [] });
+
+		window.ffcCalendarFrontend.loadTimeSlots(42, '2026-05-20');
+
+		expect(window.FFC.request).toHaveBeenCalledWith(
+			'ffc_get_available_slots',
+			{ calendar_id: 42, date: '2026-05-20' },
+			expect.objectContaining({
+				nonce: 'test-nonce',
+				ajaxUrl: '/wp-admin/admin-ajax.php',
+			})
+		);
+		// Stores selection ahead of the AJAX resolve.
+		expect(window.ffcCalendarFrontend.calendarId).toBe(42);
+		expect(window.ffcCalendarFrontend.selectedDate).toBe('2026-05-20');
+	});
+
+	it('renders the slots payload on resolve', async () => {
+		window.FFC.request.mockResolvedValue({
+			slots: [{ time: '10:00', display: '10:00', available: 2, total: 3 }],
+		});
+
+		window.ffcCalendarFrontend.loadTimeSlots(7, '2026-05-21');
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(
+			document.querySelectorAll('#ffc-timeslots-container .ffc-timeslot')
+		).toHaveLength(1);
+	});
+
+	it('renders an error message when FFC.request rejects', async () => {
+		window.FFC.request.mockRejectedValue(new Error('boom'));
+
+		window.ffcCalendarFrontend.loadTimeSlots(7, '2026-05-21');
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const msg = document.querySelector(
+			'#ffc-timeslots-container .ffc-message-error'
+		);
+		expect(msg).not.toBeNull();
+		expect(msg.textContent).toBe('An error occurred');
+	});
+});
+
+describe('ffc-calendar-frontend.js — validateForm', () => {
+	beforeEach(() => {
+		reset();
+		installGlobals();
+		document.body.innerHTML = `
+			<form id="ffc-self-scheduling-form">
+				<input id="name" required value="" />
+				<input id="ffc-booking-consent" type="checkbox" />
+			</form>
+			<div class="ffc-form-messages"></div>
+			<div id="ffc-self-scheduling-modal"><div class="ffc-modal-content"></div></div>
+		`;
+		loadScript('assets/js/ffc-calendar-frontend.js');
+	});
+
+	it('fails when consent is not checked', () => {
+		document.querySelector('#name').value = 'Jane';
+		const ok = window.ffcCalendarFrontend.validateForm(
+			window.$('#ffc-self-scheduling-form')
+		);
+		expect(ok).toBe(false);
+		expect(document.querySelector('.ffc-message-error').textContent).toBe(
+			'Consent is required'
+		);
+	});
+
+	it('fails when a required field is empty (consent checked)', () => {
+		document.querySelector('#ffc-booking-consent').checked = true;
+		const ok = window.ffcCalendarFrontend.validateForm(
+			window.$('#ffc-self-scheduling-form')
+		);
+		expect(ok).toBe(false);
+		expect(document.querySelector('.ffc-message-error').textContent).toBe(
+			'Please fill all required fields'
+		);
+	});
+
+	it('passes when consent + all required fields are filled', () => {
+		document.querySelector('#ffc-booking-consent').checked = true;
+		document.querySelector('#name').value = 'Jane';
+		const ok = window.ffcCalendarFrontend.validateForm(
+			window.$('#ffc-self-scheduling-form')
+		);
+		expect(ok).toBe(true);
+	});
+});

--- a/tests/js/pdf-generator.test.js
+++ b/tests/js/pdf-generator.test.js
@@ -1,0 +1,109 @@
+// Tests for `assets/js/ffc-pdf-generator.js`.
+//
+// The file exposes `window.ffcGeneratePDF` and `window.ffcPdfGenerator`.
+// Full PDF generation pulls in html2canvas + jsPDF and a long async
+// chain that's out of scope here; we cover the load-time contract and
+// the library-availability guard.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+function reset() {
+	document.body.innerHTML = '';
+	delete window.ffcGeneratePDF;
+	delete window.ffcPdfGenerator;
+	delete window.html2canvas;
+	delete window.jspdf;
+	delete window.ffc_ajax;
+}
+
+describe('ffc-pdf-generator.js — public API', () => {
+	beforeEach(reset);
+
+	it('exposes ffcGeneratePDF and ffcPdfGenerator on the window', () => {
+		loadScript('assets/js/ffc-pdf-generator.js');
+
+		expect(typeof window.ffcGeneratePDF).toBe('function');
+		expect(typeof window.ffcPdfGenerator).toBe('object');
+		expect(typeof window.ffcPdfGenerator.generatePDF).toBe('function');
+		expect(typeof window.ffcPdfGenerator.checkLibraries).toBe('function');
+	});
+
+	it('ffcPdfGenerator.generatePDF and window.ffcGeneratePDF are the same function', () => {
+		loadScript('assets/js/ffc-pdf-generator.js');
+		expect(window.ffcPdfGenerator.generatePDF).toBe(window.ffcGeneratePDF);
+	});
+});
+
+describe('ffc-pdf-generator.js — checkLibraries()', () => {
+	beforeEach(reset);
+
+	it('returns false and logs an error when html2canvas is undefined', () => {
+		loadScript('assets/js/ffc-pdf-generator.js');
+		const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const ok = window.ffcPdfGenerator.checkLibraries();
+
+		expect(ok).toBe(false);
+		expect(err).toHaveBeenCalledWith(expect.stringContaining('html2canvas'));
+		err.mockRestore();
+	});
+
+	it('returns false when html2canvas is present but jsPDF is missing', () => {
+		window.html2canvas = function () {};
+		loadScript('assets/js/ffc-pdf-generator.js');
+		const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const ok = window.ffcPdfGenerator.checkLibraries();
+
+		expect(ok).toBe(false);
+		expect(err).toHaveBeenCalledWith(expect.stringContaining('jsPDF'));
+		err.mockRestore();
+	});
+
+	it('returns true when both libraries are present', () => {
+		window.html2canvas = function () {};
+		window.jspdf = { jsPDF: function () {} };
+		loadScript('assets/js/ffc-pdf-generator.js');
+
+		expect(window.ffcPdfGenerator.checkLibraries()).toBe(true);
+	});
+});
+
+describe('ffc-pdf-generator.js — generateAndDownloadPDF guard', () => {
+	beforeEach(reset);
+
+	it('alerts and bails when libraries are unavailable', () => {
+		loadScript('assets/js/ffc-pdf-generator.js');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const result = window.ffcGeneratePDF({ html: '<p>hi</p>' }, 'doc.pdf');
+
+		expect(result).toBeUndefined();
+		expect(alertSpy).toHaveBeenCalled();
+		// Default message when ffc_ajax.strings is absent.
+		expect(alertSpy.mock.calls[0][0]).toMatch(/PDF libraries/i);
+		// No DOM side effects when bailing early.
+		expect(document.querySelector('#ffc-pdf-overlay')).toBeNull();
+		expect(document.querySelector('.ffc-pdf-temp-container')).toBeNull();
+
+		alertSpy.mockRestore();
+		errSpy.mockRestore();
+	});
+
+	it('uses ffc_ajax.strings.pdfLibrariesFailed for the alert when present', () => {
+		window.ffc_ajax = {
+			strings: { pdfLibrariesFailed: 'Erro: bibliotecas PDF indisponíveis.' },
+		};
+		loadScript('assets/js/ffc-pdf-generator.js');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		window.ffcGeneratePDF({}, 'x.pdf');
+
+		expect(alertSpy).toHaveBeenCalledWith(
+			'Erro: bibliotecas PDF indisponíveis.'
+		);
+		alertSpy.mockRestore();
+	});
+});

--- a/tests/js/user-dashboard-cal-export.test.js
+++ b/tests/js/user-dashboard-cal-export.test.js
@@ -1,0 +1,156 @@
+// Tests for `assets/js/ffc-user-dashboard-cal-export.js`.
+//
+// The file exposes `FFCDashboard.calExport.buildButton(event)` and binds
+// the dropdown click handlers (toggle, ICS download, click-outside). It
+// depends on a minimal `FFCDashboard.helpers.pad2` shim + global
+// `ffcDashboard` localized strings, both of which we install before
+// loading the script.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+function installDeps() {
+	window.FFCDashboard = {
+		helpers: {
+			pad2(n) {
+				return n < 10 ? '0' + n : '' + n;
+			},
+		},
+	};
+	window.ffcDashboard = {
+		siteName: 'Test Site',
+		wpTimezone: 'America/Sao_Paulo',
+		strings: {
+			exportToCalendar: 'Export to Calendar',
+			otherIcs: 'Other (.ics)',
+		},
+	};
+}
+
+function makeEvent(overrides = {}) {
+	return {
+		uid: 'evt-1',
+		date: '2026-05-20',
+		startTime: '09:00',
+		endTime: '10:30',
+		summary: 'Appointment',
+		description: 'Bring docs',
+		location: 'Room 4',
+		...overrides,
+	};
+}
+
+describe('ffc-user-dashboard-cal-export — buildButton', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		installDeps();
+		loadScript('assets/js/ffc-user-dashboard-cal-export.js');
+	});
+
+	it('exposes calExport.buildButton on FFCDashboard', () => {
+		expect(typeof window.FFCDashboard.calExport.buildButton).toBe('function');
+	});
+
+	it('renders a wrapping div with .ffc-cal-export-wrap and a dropdown', () => {
+		const html = window.FFCDashboard.calExport.buildButton(makeEvent());
+		const tmp = document.createElement('div');
+		tmp.innerHTML = html;
+
+		expect(tmp.querySelector('.ffc-cal-export-wrap')).not.toBeNull();
+		expect(tmp.querySelector('.ffc-cal-export-btn')).not.toBeNull();
+		expect(tmp.querySelector('.ffc-cal-export-dropdown')).not.toBeNull();
+	});
+
+	it('builds a Google Calendar URL with required params + ctz timezone', () => {
+		const html = window.FFCDashboard.calExport.buildButton(makeEvent());
+		const tmp = document.createElement('div');
+		tmp.innerHTML = html;
+
+		const links = Array.from(tmp.querySelectorAll('a'));
+		const google = links.find((a) =>
+			a.getAttribute('href').startsWith('https://calendar.google.com/')
+		);
+		expect(google).toBeDefined();
+		const href = google.getAttribute('href');
+		expect(href).toContain('action=TEMPLATE');
+		expect(href).toContain('text=Appointment');
+		// 2026-05-20 09:00 → 20260520T090000, 2026-05-20 10:30 → 20260520T103000
+		expect(href).toContain('20260520T090000');
+		expect(href).toContain('20260520T103000');
+		expect(href).toContain('location=Room%204');
+		expect(href).toContain('ctz=America%2FSao_Paulo');
+	});
+
+	it('builds an Outlook URL with rru=addevent and ISO-like local time', () => {
+		const html = window.FFCDashboard.calExport.buildButton(makeEvent());
+		const tmp = document.createElement('div');
+		tmp.innerHTML = html;
+
+		const outlook = Array.from(tmp.querySelectorAll('a')).find((a) =>
+			a.getAttribute('href').startsWith('https://outlook.live.com/')
+		);
+		expect(outlook).toBeDefined();
+		const href = outlook.getAttribute('href');
+		expect(href).toContain('rru=addevent');
+		expect(href).toContain('subject=Appointment');
+		expect(href).toContain('startdt=2026-05-20T09%3A00%3A00');
+		expect(href).toContain('enddt=2026-05-20T10%3A30%3A00');
+	});
+
+	it('escapes quotes in the embedded JSON so the data attribute parses safely', () => {
+		const html = window.FFCDashboard.calExport.buildButton(
+			makeEvent({ summary: "Quoted 'title' & more" })
+		);
+		// JSON `"` quotes are entity-encoded so they don't break the host
+		// data-event="..." attribute; the apostrophe receives the same
+		// treatment for consistency.
+		expect(html).toContain('&quot;summary&quot;');
+		expect(html).toContain('&#39;title&#39;');
+
+		// And parsing it back round-trips to a usable object — the encoded
+		// form decodes cleanly when the browser reads the attribute.
+		const tmp = document.createElement('div');
+		tmp.innerHTML = html;
+		const raw = tmp.querySelector('.ffc-cal-export-ics').getAttribute('data-event');
+		expect(() => JSON.parse(raw)).not.toThrow();
+		expect(JSON.parse(raw).summary).toBe("Quoted 'title' & more");
+	});
+
+	it('localizes the trigger button label from ffcDashboard.strings', () => {
+		window.ffcDashboard.strings.exportToCalendar = 'Salvar no calendário';
+		// Re-evaluating the script picks up the new strings via the closure.
+		loadScript('assets/js/ffc-user-dashboard-cal-export.js');
+		const html = window.FFCDashboard.calExport.buildButton(makeEvent());
+		expect(html).toContain('Salvar no calendário');
+	});
+});
+
+describe('ffc-user-dashboard-cal-export — dropdown interactions', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		installDeps();
+		loadScript('assets/js/ffc-user-dashboard-cal-export.js');
+		document.body.innerHTML = window.FFCDashboard.calExport.buildButton(
+			makeEvent()
+		);
+	});
+
+	it('triggers an ICS download when the .ics link is clicked', () => {
+		// Stub the download primitives that jsdom does not implement.
+		const createObjectURL = vi.fn(() => 'blob:fake');
+		const revokeObjectURL = vi.fn();
+		window.URL.createObjectURL = createObjectURL;
+		window.URL.revokeObjectURL = revokeObjectURL;
+
+		// Spy on anchor click so we can verify the download was attempted.
+		const clickSpy = vi
+			.spyOn(window.HTMLAnchorElement.prototype, 'click')
+			.mockImplementation(() => {});
+
+		window.$('.ffc-cal-export-ics').trigger('click');
+
+		expect(createObjectURL).toHaveBeenCalled();
+		expect(clickSpy).toHaveBeenCalled();
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+		clickSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary

Fourth slice of #254 §7 — Vitest coverage for the last 6 `assets/js/*.js` files that had no direct tests. 49 new tests, ~2000 LoC of source now exercised. Per-file breakdown:

| File | Source LoC | Tests | Focus |
|---|---|---|---|
| `ffc-calendar-admin.js` | 28 | 2 | Smoke load + no-global-leak |
| `ffc-admin-code-editor.js` | 105 | 7 | CodeMirror init / disabled-notice fallbacks |
| `ffc-user-dashboard-cal-export.js` | 148 | 7 | buildButton output, Google/Outlook URLs, ICS download |
| `ffc-pdf-generator.js` | 559 | 7 | Public API exposure, `checkLibraries()`, alert-on-missing-libs guard |
| `ffc-calendar-frontend.js` | 696 | 17 | formatDate / renderTimeSlots / modal / `FFC.request` integration / validateForm |
| `ffc-admin-pdf.js` | 464 | 9 | `loadTemplate` fetch, template modal, preview iframe + placeholder replacement |

All tests follow the established pattern from `tests/js/audience-admin-deep.test.js`: `loadScript()` evaluates the IIFE via `vm.runInThisContext` so V8 coverage attributes execution to the original file. `$(document).ready` callbacks are awaited via `await new Promise((r) => setTimeout(r, 0))` per the convention noted in `already-submitted-notice.test.js`.

The PDF / calendar deep async paths (real html2canvas + jsPDF chains, full `submitBooking` AJAX → confirmation flow) are out of scope — they require live binaries or a long chain of intermediate microtasks; the tests instead pin the discrete, testable surface (guard branches, public API, deterministic rendering).

## Notes

- Dropdown-toggle interaction tests in `ffc-user-dashboard-cal-export.js` are deliberately excluded — they depend on jQuery's delegated-handler ordering + `stopPropagation` between siblings on `document`, which `.trigger('click')` does not faithfully reproduce in jsdom (production-only behavior).
- `npm run test:js` after the change: **871/871 passing**.
- ESLint clean on the 6 new test files.

## Test plan

- [x] `npx vitest run tests/js/{calendar-admin,admin-code-editor,user-dashboard-cal-export,pdf-generator,calendar-frontend,admin-pdf}.test.js` → 49/49 passing.
- [x] Full `npm run test:js` → 871/871 passing, no regressions.
- [x] ESLint clean on new test files.
- [ ] CI: ESLint (zero-error), Stylelint, Vitest + coverage.

`JS_COVERAGE_FLOOR_LINES` ratchet deferred to #310 once all §7 sub-issues land.

Refs #254 §7. Closes #308.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_