### PR TITLE
Test gap: cover 9 Form Editor metaboxes (closes #306)

### DIFF
--- a/tests/Unit/FormEditorBuilderMetaboxTest.php
+++ b/tests/Unit/FormEditorBuilderMetaboxTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorBuilderMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorBuilderMetabox
+ */
+class FormEditorBuilderMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorBuilderMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_attr_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'checked' )->justReturn( '' );
+
+        $this->metabox = new FormEditorBuilderMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( $fields_meta = '' ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $fields_meta );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 22;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_with_no_saved_fields_outputs_add_field_button(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'ffc-add-field', $html );
+        $this->assertStringContainsString( 'Add New Field', $html );
+    }
+
+    public function test_render_emits_field_template_for_dynamic_field_cloning(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'ffc-field-template', $html );
+        $this->assertStringContainsString( 'ffc-hidden', $html );
+    }
+
+    public function test_render_mentions_the_minimal_required_field_tags(): void {
+        $html = $this->render();
+
+        // The description hints the operator at the required field keys.
+        $this->assertStringContainsString( '<code>name</code>', $html );
+        $this->assertStringContainsString( '<code>email</code>', $html );
+        $this->assertStringContainsString( '<code>cpf_rf</code>', $html );
+    }
+
+    public function test_render_iterates_saved_fields_payload(): void {
+        $saved = array(
+            array(
+                'name'  => 'name',
+                'label' => 'Full Name',
+                'type'  => 'text',
+            ),
+        );
+        $html = $this->render( $saved );
+
+        // Saved fields surface their label in a builder row.
+        $this->assertStringContainsString( 'Full Name', $html );
+    }
+}

--- a/tests/Unit/FormEditorDeviceLimitMetaboxTest.php
+++ b/tests/Unit/FormEditorDeviceLimitMetaboxTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorDeviceLimitMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorDeviceLimitMetabox
+ */
+class FormEditorDeviceLimitMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorDeviceLimitMetabox $metabox;
+
+    /** @var array<string, mixed> */
+    private array $meta_values = array();
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_attr_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'wp_kses' )->returnArg();
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'checked' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        // Per-key meta values: each key looked up by the renderer.
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key ) {
+            return $this->meta_values[ $key ] ?? '';
+        } );
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'wp_parse_args' )->alias( function ( $a, $d ) { return array_merge( (array) $d, (array) $a ); } );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'apply_filters' )->returnArg( 2 );
+
+        $this->metabox = new FormEditorDeviceLimitMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render(): string {
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 66;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_emits_device_limit_label_row(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'ffc-restriction-label', $html );
+        $this->assertStringContainsString( 'physical device', $html );
+    }
+
+    public function test_render_disables_warning_when_master_toggle_off(): void {
+        $this->meta_values['_ffc_device_limit_enabled'] = '0';
+
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'ffc-restriction-label', $html );
+    }
+
+    public function test_render_pre_populates_max_input_from_meta(): void {
+        $this->meta_values['_ffc_device_limit_enabled'] = '1';
+        $this->meta_values['_ffc_device_limit_max']     = '3';
+
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'value="3"', $html );
+    }
+
+    public function test_render_does_not_throw_with_no_meta(): void {
+        $html = $this->render();
+        $this->assertNotSame( '', $html );
+    }
+}

--- a/tests/Unit/FormEditorEmailMetaboxTest.php
+++ b/tests/Unit/FormEditorEmailMetaboxTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorEmailMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorEmailMetabox
+ */
+class FormEditorEmailMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorEmailMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'wp_editor' )->alias( function ( $content, $id ) {
+            echo '<textarea id="' . $id . '">' . $content . '</textarea>';
+        } );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'checked' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+
+        $this->metabox = new FormEditorEmailMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( $config = array() ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $config );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 33;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_exposes_master_toggle_for_user_email(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'Send Email to User?', $html );
+        $this->assertStringContainsString( 'ffc_config[send_user_email]', $html );
+    }
+
+    public function test_render_pre_populates_subject_and_body_from_config(): void {
+        $html = $this->render(
+            array(
+                'send_user_email' => '1',
+                'email_subject'   => 'Your custom subject',
+                'email_body'      => '<p>Your custom body</p>',
+            )
+        );
+
+        $this->assertStringContainsString( 'Your custom subject', $html );
+        $this->assertStringContainsString( '<p>Your custom body</p>', $html );
+        $this->assertStringContainsString( 'name="ffc_config[email_subject]"', $html );
+    }
+
+    public function test_render_collapses_subject_body_when_master_is_off(): void {
+        $html = $this->render( array( 'send_user_email' => '0' ) );
+
+        // Collapsed wrapper carries the ffc-collapsed modifier class.
+        $this->assertStringContainsString( 'ffc-collapsed', $html );
+    }
+
+    public function test_render_uses_default_subject_when_meta_empty(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'Your Certificate', $html );
+    }
+}

--- a/tests/Unit/FormEditorGeofenceMetaboxTest.php
+++ b/tests/Unit/FormEditorGeofenceMetaboxTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorGeofenceMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorGeofenceMetabox
+ */
+class FormEditorGeofenceMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorGeofenceMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_attr_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'wp_kses' )->returnArg();
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'checked' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'get_transient' )->justReturn( array() );
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'apply_filters' )->returnArg( 2 );
+
+        $this->metabox = new FormEditorGeofenceMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( $config = array() ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $config );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 77;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_outputs_geofence_container_with_tabbed_layout(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'ffc-geofence-container', $html );
+        $this->assertStringContainsString( 'ffc-geofence-tabs', $html );
+    }
+
+    public function test_render_emits_datetime_and_geolocation_tab_buttons(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'data-tab="datetime"', $html );
+        $this->assertStringContainsString( 'data-tab="geolocation"', $html );
+        $this->assertStringContainsString( 'Date & Time', $html );
+        $this->assertStringContainsString( 'Geolocation', $html );
+    }
+
+    public function test_render_does_not_throw_with_partial_geofence_config(): void {
+        $html = $this->render(
+            array(
+                'date_start' => '2026-01-01',
+                'date_end'   => '2026-12-31',
+            )
+        );
+
+        $this->assertNotSame( '', $html );
+        $this->assertStringContainsString( 'ffc-geofence-container', $html );
+    }
+
+    public function test_render_does_not_throw_when_config_is_not_array(): void {
+        $html = $this->render( '' );
+        $this->assertNotSame( '', $html );
+    }
+}

--- a/tests/Unit/FormEditorLayoutMetaboxTest.php
+++ b/tests/Unit/FormEditorLayoutMetaboxTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorLayoutMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorLayoutMetabox
+ */
+class FormEditorLayoutMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorLayoutMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'wp_nonce_field' )->alias( function ( $action, $name ) { echo "<input name=\"{$name}\" />"; } );
+
+        if ( ! defined( 'FFC_PLUGIN_DIR' ) ) {
+            define( 'FFC_PLUGIN_DIR', '/tmp/ffc_test/' );
+        }
+
+        $this->metabox = new FormEditorLayoutMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( array $config = array() ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $config );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 11;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_emits_nonce_field_with_expected_name(): void {
+        $html = $this->render();
+        $this->assertStringContainsString( 'name="ffc_form_nonce"', $html );
+    }
+
+    public function test_render_pre_populates_layout_textarea_from_meta(): void {
+        $html = $this->render( array( 'pdf_layout' => '<h1>Hello</h1>' ) );
+        $this->assertStringContainsString( '<h1>Hello</h1>', $html );
+        $this->assertStringContainsString( 'name="ffc_config[pdf_layout]"', $html );
+    }
+
+    public function test_render_pre_populates_bg_image_input_from_meta(): void {
+        $html = $this->render( array( 'bg_image' => 'https://example.com/bg.png' ) );
+        $this->assertStringContainsString( 'https://example.com/bg.png', $html );
+        $this->assertStringContainsString( 'id="ffc_bg_image_input"', $html );
+    }
+
+    public function test_render_exposes_action_buttons(): void {
+        $html = $this->render();
+        $this->assertStringContainsString( 'id="ffc_btn_import_html"', $html );
+        $this->assertStringContainsString( 'id="ffc_btn_media_lib"', $html );
+        $this->assertStringContainsString( 'id="ffc_btn_preview"', $html );
+    }
+}

--- a/tests/Unit/FormEditorPublicCsvDownloadMetaboxTest.php
+++ b/tests/Unit/FormEditorPublicCsvDownloadMetaboxTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorPublicCsvDownloadMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorPublicCsvDownloadMetabox
+ */
+class FormEditorPublicCsvDownloadMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorPublicCsvDownloadMetabox $metabox;
+
+    /** @var array<string, mixed> */
+    private array $meta_values = array();
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_attr_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'checked' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'admin_url' )->alias( function ( $path = '' ) { return '/wp-admin/' . $path; } );
+        Functions\when( 'wp_nonce_url' )->returnArg();
+        Functions\when( 'site_url' )->alias( function ( $path = '' ) { return 'https://example.com' . $path; } );
+        Functions\when( 'home_url' )->alias( function ( $path = '' ) { return 'https://example.com' . $path; } );
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'apply_filters' )->returnArg( 2 );
+
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key ) {
+            return $this->meta_values[ $key ] ?? '';
+        } );
+
+        $this->metabox = new FormEditorPublicCsvDownloadMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render(): string {
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 88;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_emits_three_operator_sub_toggles(): void {
+        $html = $this->render();
+
+        // The 3 sibling sub-features gated under the master, named via
+        // bracket notation on the ffc_csv_public form group.
+        $this->assertStringContainsString( 'ffc_csv_public[download_enabled]', $html );
+        $this->assertStringContainsString( 'ffc_csv_public[start_early_enabled]', $html );
+        $this->assertStringContainsString( 'ffc_csv_public[extend_end_enabled]', $html );
+    }
+
+    public function test_render_emits_the_master_present_sentinel(): void {
+        $html = $this->render();
+
+        // Hidden sentinel that guarantees the group is present in $_POST even
+        // when every toggle is off — required by the save handler.
+        $this->assertStringContainsString( 'ffc_csv_public[present]', $html );
+    }
+
+    public function test_render_pre_populates_limit_from_meta(): void {
+        $this->meta_values['_ffc_csv_public_enabled'] = '1';
+        $this->meta_values['_ffc_csv_public_limit']   = 250;
+
+        $html = $this->render();
+
+        $this->assertStringContainsString( '250', $html );
+    }
+
+    public function test_render_pre_populates_count_from_meta(): void {
+        $this->meta_values['_ffc_csv_public_count'] = 17;
+
+        $html = $this->render();
+
+        $this->assertStringContainsString( '17', $html );
+    }
+
+    public function test_render_does_not_throw_with_no_meta(): void {
+        $html = $this->render();
+        $this->assertNotSame( '', $html );
+    }
+}

--- a/tests/Unit/FormEditorQuizMetaboxTest.php
+++ b/tests/Unit/FormEditorQuizMetaboxTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorQuizMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorQuizMetabox
+ */
+class FormEditorQuizMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorQuizMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'checked' )->justReturn( '' );
+
+        $this->metabox = new FormEditorQuizMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( $config = array() ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $config );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 44;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_emits_master_quiz_toggle_with_default_off(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'Enable Quiz Mode', $html );
+        $this->assertStringContainsString( 'ffc_quiz_enabled', $html );
+        // Defaults: quiz off → settings rows carry the ffc-hidden class.
+        $this->assertStringContainsString( 'ffc-quiz-setting ffc-hidden', $html );
+    }
+
+    public function test_render_uncollapses_quiz_settings_when_enabled(): void {
+        $html = $this->render( array( 'quiz_enabled' => '1' ) );
+
+        // Settings rows lose the ffc-hidden suffix when quiz is on.
+        $this->assertStringNotContainsString( 'ffc-quiz-setting ffc-hidden', $html );
+        $this->assertStringContainsString( 'ffc-quiz-setting', $html );
+    }
+
+    public function test_render_pre_populates_passing_score_and_max_attempts(): void {
+        $html = $this->render(
+            array(
+                'quiz_enabled'        => '1',
+                'quiz_passing_score'  => '80',
+                'quiz_max_attempts'   => '3',
+            )
+        );
+
+        $this->assertStringContainsString( 'value="80"', $html );
+        $this->assertStringContainsString( 'value="3"', $html );
+        $this->assertStringContainsString( 'ffc_config[quiz_passing_score]', $html );
+        $this->assertStringContainsString( 'ffc_config[quiz_max_attempts]', $html );
+    }
+
+    public function test_render_falls_back_to_defaults_when_config_not_array(): void {
+        // get_post_meta returns the empty string for missing/non-array values
+        // — the renderer must coerce that to a defaulted array without errors.
+        $html = $this->render( '' );
+
+        $this->assertStringContainsString( 'value="70"', $html ); // default passing score
+        $this->assertStringContainsString( 'value="0"', $html );  // default max attempts
+    }
+}

--- a/tests/Unit/FormEditorRestrictionMetaboxTest.php
+++ b/tests/Unit/FormEditorRestrictionMetaboxTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorRestrictionMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorRestrictionMetabox
+ */
+class FormEditorRestrictionMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorRestrictionMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_attr_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'esc_textarea' )->returnArg();
+        Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'wp_kses' )->returnArg();
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+        Functions\when( 'checked' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+
+        $this->metabox = new FormEditorRestrictionMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( $config = array() ): string {
+        Functions\when( 'get_post_meta' )->justReturn( $config );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 55;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_outputs_restriction_section_table(): void {
+        $html = $this->render();
+
+        $this->assertStringContainsString( 'Form Restrictions', $html );
+        $this->assertStringContainsString( 'form-table', $html );
+    }
+
+    public function test_render_includes_restriction_label_rows(): void {
+        $html = $this->render();
+
+        // Each toggle ships inside a .ffc-restriction-label row.
+        $this->assertStringContainsString( 'ffc-restriction-label', $html );
+    }
+
+    public function test_render_does_not_throw_when_config_is_empty_string(): void {
+        // get_post_meta returning '' must coerce safely.
+        $html = $this->render( '' );
+
+        $this->assertNotSame( '', $html );
+    }
+
+    public function test_render_does_not_throw_when_config_is_array(): void {
+        $html = $this->render(
+            array(
+                'one_per_cpf'   => '1',
+                'one_per_ip'    => '1',
+                'require_login' => '1',
+            )
+        );
+
+        $this->assertNotSame( '', $html );
+    }
+}

--- a/tests/Unit/FormEditorShortcodeMetaboxTest.php
+++ b/tests/Unit/FormEditorShortcodeMetaboxTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\FormEditorShortcodeMetabox;
+
+/**
+ * @covers \FreeFormCertificate\Admin\FormEditorShortcodeMetabox
+ */
+class FormEditorShortcodeMetaboxTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private FormEditorShortcodeMetabox $metabox;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
+        Functions\when( 'wp_kses_post' )->returnArg();
+
+        $this->metabox = new FormEditorShortcodeMetabox();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function render( int $post_id ): string {
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = $post_id;
+        ob_start();
+        $this->metabox->render( $post );
+        return (string) ob_get_clean();
+    }
+
+    public function test_render_emits_the_shortcode_with_post_id(): void {
+        $html = $this->render( 42 );
+
+        $this->assertStringContainsString( '[ffc_form id="42"]', $html );
+        $this->assertStringContainsString( 'ffc-shortcode-display', $html );
+    }
+
+    public function test_render_includes_tip_list_with_placeholder_examples(): void {
+        $html = $this->render( 7 );
+
+        $this->assertStringContainsString( 'ffc-tips-list', $html );
+        $this->assertStringContainsString( '{{field_name}}', $html );
+        $this->assertStringContainsString( '{{auth_code}}', $html );
+    }
+
+    public function test_render_uses_the_provided_post_id_verbatim_in_the_shortcode(): void {
+        $this->assertStringContainsString( 'id="1"', $this->render( 1 ) );
+        $this->assertStringContainsString( 'id="9999"', $this->render( 9999 ) );
+    }
+}


### PR DESCRIPTION
## Summary

Fifth slice of #254 §7 — direct unit coverage for the 9 metabox classes extracted from `FormEditorMetaboxRenderer` during the S3 god-object refactor. ~1,945 LoC of UI render methods previously without dedicated tests; the surrounding `FormEditorMetaboxRendererTest` covers the dispatcher but not the per-class branches.

### Coverage per metabox

| Metabox | LoC | Tests | Focus |
|---|---|---|---|
| `FormEditorShortcodeMetabox` | 52 | 3 | Shortcode emission + tips list |
| `FormEditorLayoutMetabox` | 98 | 4 | Nonce, pdf_layout textarea, bg_image, action buttons |
| `FormEditorBuilderMetabox` | 213 | 4 | Add-field button, field template, minimal-tag hints, saved-field iteration |
| `FormEditorEmailMetabox` | 119 | 4 | Master toggle, subject/body, collapsed wrapper, default subject |
| `FormEditorQuizMetabox` | 105 | 4 | Master toggle + conditional row visibility, value pre-population, non-array config |
| `FormEditorRestrictionMetabox` | 196 | 4 | Section table, label rows, safety on empty/array config |
| `FormEditorDeviceLimitMetabox` | 180 | 4 | Label row, warning visibility, max input, safety on no meta |
| `FormEditorGeofenceMetabox` | 413 | 4 | Tabbed container, datetime + geolocation tab buttons, partial config |
| `FormEditorPublicCsvDownloadMetabox` | 569 | 5 | Three operator sub-toggles, `present` sentinel, limit/count, safety on no meta |
| **Total** | **1,945** | **36** | |

All follow the sister test `FormEditorMetaboxRendererTest` pattern: stub WP escape helpers via Brain Monkey, mock `WP_Post` via Mockery, capture render output with `ob_start`/`ob_get_clean`, assert against key markers (class names, name attributes, presence of fixed copy).

## Notes

The CSV-download metabox uses a grouped form-name convention (`ffc_csv_public[download_enabled]` etc.) rather than the meta-key names — tests assert against the actual form-field names that round-trip to the save handler.

Brain Monkey gotcha: namespaced function stubs (`Functions\when('FreeFormCertificate\Security\wp_parse_args')`) pollute Patchwork across the suite — once registered, the namespaced patch persists, but the per-test expectation does not, breaking unrelated downstream tests. These tests rely on PHP's global-fallback semantics (namespace lookup misses → global lookup hits the stub) instead, matching the convention in the rest of the suite.

## Test plan

- [x] Each of the 9 test files passes in isolation.
- [x] Full `vendor/bin/phpunit --testsuite=unit` → 4281/4281 passing, no regressions.
- [ ] CI: PHPUnit matrix (8.1–8.4) + clover coverage floor.
- [ ] CI: PHPStan level 8 (tests dir not scanned).

Coverage-floor ratchet deferred to #310.

Refs #254 §7. Closes #306.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_