### PR TITLE
Coverage ratchet: PHP 50 → 55 after §7 sprint (closes #310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,17 @@ jobs:
     # below the current line-coverage baseline so the gate doesn't fire
     # on day one but does catch a regression. Ratchet the floor upward
     # whenever a PR genuinely improves coverage.
+    #
+    # 50 → 55 in the §7 ratchet (#310) — closes out the #254 §7 test-gap
+    # sprint that landed direct unit coverage for the RateLimitLogger /
+    # RateLimitStats pair (#311), the ReregistrationSubmissionDetails
+    # renderer (#312), the ActivityLogClearPlaintext + EmailHashRehash
+    # migration strategies (#313), the 9 Form Editor metaboxes (#315),
+    # and the §7.4a Recruitment slice (#316, REST × 4 + trait + Reason
+    # repository). Conservative 5pp bump leaves headroom for the
+    # in-flight §7.4b (#317) and §7.4c (#318) follow-ups.
     env:
-      COVERAGE_FLOOR_LINES: '50'
+      COVERAGE_FLOOR_LINES: '55'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-composer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,14 @@ jobs:
       # coverage to 85.53%. Bumping 77 → 82 locks the gain in with a
       # ~3.5pp buffer. Bump again whenever a PR genuinely improves the
       # number.
+      #
+      # Held at 82 through the §7 ratchet (#310). #314 added smoke +
+      # targeted Vitest coverage for the 6 previously-0% files (calendar
+      # admin/frontend, admin-code-editor, admin-pdf, pdf-generator,
+      # user-dashboard-cal-export) — but smoke tier only, and overall
+      # measured 85.16% locally (below the #200 high-water-mark of
+      # 85.53%). No headroom to bump on JS; wait for §7.4b/c follow-ups
+      # or a dedicated JS-deep PR before ratcheting again.
       JS_COVERAGE_FLOOR_LINES: '82'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Closes out the #254 §7 test-gap sprint with the coverage-floor ratchet.

### PHP floor — 50 → 55

Merged §7 PRs added direct unit coverage for ~4,683 LoC of previously-untested source plus 149 new tests:

| PR | Class(es) | Source LoC | Tests |
|---|---|---|---|
| #311 | `RateLimitLogger` + `RateLimitStats` | 143 | 17 |
| #312 | `ReregistrationSubmissionDetailsRenderer` | 1 class | 15 |
| #313 | `ActivityLogClearPlaintext` + `EmailHashRehash` migration strategies | 661 | 24 |
| #315 | 9 Form Editor metaboxes | 1,945 | 36 |
| #316 | §7.4a Recruitment slice (REST × 4 + trait + Reason repository) | 1,934 | 57 |
| **Total** | | **4,683+** | **149** |

5pp bump (conservative) leaves headroom for the in-flight §7.4b (#317 — list tables) and §7.4c (#318 — admin pages) follow-ups so they can do their own incremental ratchets when they land.

### JS floor — held at 82

#314 added Vitest coverage for the 6 previously-0% files (`ffc-calendar-admin`, `ffc-calendar-frontend`, `ffc-admin-code-editor`, `ffc-admin-pdf`, `ffc-pdf-generator`, `ffc-user-dashboard-cal-export`) — 49 new tests across ~2,000 LoC — but at the smoke tier. Local `npm run test:js:coverage` measures **85.16% overall**, just below the #200 high-water-mark of 85.53% that motivated the current 82 floor. No headroom to bump on JS yet; deferred until a dedicated JS-deep PR.

## Test plan

- [x] Local sanity: `npm run test:js:coverage` → 85.16% (above the held 82 floor).
- [ ] CI: PHP coverage at or above 55% (the new floor). If CI measures below 55%, this PR adjusts the floor down before merge — we don't merge a regression-gating change that fails on its own baseline.
- [ ] CI: JS coverage at or above 82% (unchanged).
- [ ] CI: PHPStan / WPCS / ESLint / Stylelint all clean (this PR touches only `.yml` files).

Closes #310. Refs #254 §7.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_