### PR TITLE
Test gap: cover 4 Recruitment list tables (closes #317)

### DIFF
--- a/tests/Unit/RecruitmentAdjutanciesListTableTest.php
+++ b/tests/Unit/RecruitmentAdjutanciesListTableTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentAdjutanciesListTable;
+
+/**
+ * Smoke tests for the Adjutancies list table.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentAdjutanciesListTable
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentAdjutanciesListTableTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private RecruitmentAdjutanciesListTable $table;
+
+    /** @var \Mockery\MockInterface */
+    private $noticeAdjRepoMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+
+        $this->noticeAdjRepoMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository' );
+        $this->noticeAdjRepoMock->shouldReceive( 'get_notice_ids_for_adjutancy' )->andReturn( array() )->byDefault();
+
+        $this->table = new RecruitmentAdjutanciesListTable();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function call_protected( string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( $this->table, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $this->table, $args );
+    }
+
+    public function test_get_columns_declares_expected_keys(): void {
+        $cols = $this->table->get_columns();
+
+        $this->assertSame(
+            array( 'cb', 'slug', 'name', 'color', 'usage', 'created_at' ),
+            array_keys( $cols )
+        );
+    }
+
+    public function test_get_sortable_columns_includes_slug_name_created_at(): void {
+        $sortable = $this->call_protected( 'get_sortable_columns' );
+
+        $this->assertArrayHasKey( 'slug', $sortable );
+        $this->assertArrayHasKey( 'name', $sortable );
+        $this->assertArrayHasKey( 'created_at', $sortable );
+        // created_at defaults to DESC.
+        $this->assertTrue( $sortable['created_at'][1] );
+    }
+
+    public function test_get_bulk_actions_returns_only_delete(): void {
+        $actions = $this->call_protected( 'get_bulk_actions' );
+        $this->assertSame( array( 'bulk-delete' ), array_keys( $actions ) );
+    }
+
+    public function test_column_cb_emits_checkbox_named_adjutancy_ids(): void {
+        $html = $this->call_protected( 'column_cb', array( array( 'id' => 99 ) ) );
+
+        $this->assertStringContainsString( 'name="adjutancy_ids[]"', $html );
+        $this->assertStringContainsString( 'value="99"', $html );
+    }
+
+    public function test_column_default_returns_escaped_value_for_known_column(): void {
+        $out = $this->call_protected( 'column_default', array( array( 'name' => 'Adjutant Alpha' ), 'name' ) );
+        $this->assertSame( 'Adjutant Alpha', $out );
+    }
+
+    public function test_column_default_returns_empty_string_for_missing_column(): void {
+        $out = $this->call_protected( 'column_default', array( array(), 'missing' ) );
+        $this->assertSame( '', $out );
+    }
+
+    public function test_column_usage_returns_count_of_referenced_notices(): void {
+        $this->noticeAdjRepoMock->shouldReceive( 'get_notice_ids_for_adjutancy' )
+            ->with( 5 )
+            ->andReturn( array( 1, 2, 3 ) );
+
+        $out = $this->call_protected( 'column_usage', array( array( 'id' => 5 ) ) );
+
+        $this->assertSame( '3', $out );
+    }
+
+    public function test_column_usage_returns_zero_when_unused(): void {
+        $this->noticeAdjRepoMock->shouldReceive( 'get_notice_ids_for_adjutancy' )->andReturn( array() );
+
+        $out = $this->call_protected( 'column_usage', array( array( 'id' => 5 ) ) );
+
+        $this->assertSame( '0', $out );
+    }
+
+    public function test_column_created_at_returns_timestamp_string(): void {
+        $out = $this->call_protected( 'column_created_at', array( array( 'created_at' => '2026-01-01 12:00:00' ) ) );
+        $this->assertSame( '2026-01-01 12:00:00', $out );
+    }
+}

--- a/tests/Unit/RecruitmentCandidatesListTableTest.php
+++ b/tests/Unit/RecruitmentCandidatesListTableTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCandidatesListTable;
+
+/**
+ * Smoke tests for the Candidates list table.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCandidatesListTable
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentCandidatesListTableTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private RecruitmentCandidatesListTable $table;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'get_userdata' )->justReturn( false );
+        Functions\when( 'get_edit_user_link' )->justReturn( '/wp-admin/user-edit.php?user_id=1' );
+
+        $this->table = new RecruitmentCandidatesListTable();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function call_protected( string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( $this->table, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $this->table, $args );
+    }
+
+    public function test_get_columns_declares_expected_keys(): void {
+        $cols = $this->table->get_columns();
+
+        $this->assertSame(
+            array( 'cb', 'name', 'user_id', 'phone', 'created_at' ),
+            array_keys( $cols )
+        );
+    }
+
+    public function test_get_sortable_columns_only_includes_name(): void {
+        $sortable = $this->call_protected( 'get_sortable_columns' );
+
+        $this->assertSame( array( 'name' ), array_keys( $sortable ) );
+    }
+
+    public function test_get_bulk_actions_returns_empty_until_delete_service_lands(): void {
+        $actions = $this->call_protected( 'get_bulk_actions' );
+
+        $this->assertSame( array(), $actions );
+    }
+
+    public function test_column_cb_emits_checkbox_named_candidate_ids(): void {
+        $html = $this->call_protected( 'column_cb', array( array( 'id' => 77 ) ) );
+
+        $this->assertStringContainsString( 'name="candidate_ids[]"', $html );
+        $this->assertStringContainsString( 'value="77"', $html );
+    }
+
+    public function test_column_phone_em_dash_when_phone_empty(): void {
+        $out = $this->call_protected( 'column_phone', array( array( 'phone' => '' ) ) );
+
+        $this->assertSame( '—', $out );
+    }
+
+    public function test_column_phone_emits_escaped_value_when_present(): void {
+        $out = $this->call_protected( 'column_phone', array( array( 'phone' => '+55 11 99999-0000' ) ) );
+
+        $this->assertSame( '+55 11 99999-0000', $out );
+    }
+
+    public function test_column_user_id_em_dash_when_zero(): void {
+        $out = $this->call_protected( 'column_user_id', array( array( 'user_id' => 0 ) ) );
+
+        $this->assertSame( '—', $out );
+    }
+
+    public function test_column_user_id_shows_id_in_code_tags_when_user_missing(): void {
+        Functions\when( 'get_userdata' )->justReturn( false );
+        $out = $this->call_protected( 'column_user_id', array( array( 'user_id' => 42 ) ) );
+
+        $this->assertStringContainsString( '<code>', $out );
+        $this->assertStringContainsString( '#42', $out );
+    }
+
+    public function test_column_user_id_links_to_user_edit_when_user_exists(): void {
+        $user_mock            = Mockery::mock( 'WP_User' );
+        $user_mock->user_login = 'jane';
+        Functions\when( 'get_userdata' )->justReturn( $user_mock );
+
+        $out = $this->call_protected( 'column_user_id', array( array( 'user_id' => 7 ) ) );
+
+        $this->assertStringContainsString( 'jane', $out );
+        $this->assertStringContainsString( '<a href=', $out );
+    }
+
+    public function test_column_default_escapes_value(): void {
+        $out = $this->call_protected( 'column_default', array( array( 'name' => 'Jane' ), 'name' ) );
+        $this->assertSame( 'Jane', $out );
+    }
+
+    public function test_column_default_returns_empty_string_for_missing_column(): void {
+        $out = $this->call_protected( 'column_default', array( array(), 'missing' ) );
+        $this->assertSame( '', $out );
+    }
+
+    public function test_column_created_at_returns_timestamp_string(): void {
+        $out = $this->call_protected( 'column_created_at', array( array( 'created_at' => '2026-03-15 09:30:00' ) ) );
+        $this->assertSame( '2026-03-15 09:30:00', $out );
+    }
+}

--- a/tests/Unit/RecruitmentNoticesListTableTest.php
+++ b/tests/Unit/RecruitmentNoticesListTableTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentNoticesListTable;
+
+/**
+ * Smoke tests for the Notices list table.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticesListTable
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentNoticesListTableTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private RecruitmentNoticesListTable $table;
+
+    /** @var \Mockery\MockInterface */
+    private $noticeAdjRepoMock;
+
+    /** @var \Mockery\MockInterface */
+    private $adminPageMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+
+        $this->noticeAdjRepoMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository' );
+        $this->noticeAdjRepoMock->shouldReceive( 'get_adjutancy_ids_for_notice' )->andReturn( array() )->byDefault();
+
+        $this->adminPageMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentAdminPage' );
+        $this->adminPageMock->shouldReceive( 'notice_status_badge' )->andReturnUsing(
+            fn( $status ) => "<span class=\"ffc-status ffc-status-{$status}\">{$status}</span>"
+        );
+
+        $this->table = new RecruitmentNoticesListTable();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function call_protected( string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( $this->table, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $this->table, $args );
+    }
+
+    public function test_get_columns_declares_full_notice_column_set(): void {
+        $cols = $this->table->get_columns();
+
+        $this->assertSame(
+            array( 'cb', 'code', 'name', 'status', 'reopened', 'adjutancies', 'created_at' ),
+            array_keys( $cols )
+        );
+    }
+
+    public function test_get_sortable_columns_covers_code_name_status_created_at(): void {
+        $sortable = $this->call_protected( 'get_sortable_columns' );
+
+        $this->assertSame(
+            array( 'code', 'name', 'status', 'created_at' ),
+            array_keys( $sortable )
+        );
+        $this->assertTrue( $sortable['created_at'][1] );
+    }
+
+    public function test_get_bulk_actions_returns_only_delete(): void {
+        $actions = $this->call_protected( 'get_bulk_actions' );
+        $this->assertSame( array( 'bulk-delete' ), array_keys( $actions ) );
+    }
+
+    public function test_column_cb_emits_checkbox_named_notice_ids(): void {
+        $html = $this->call_protected( 'column_cb', array( array( 'id' => 12 ) ) );
+
+        $this->assertStringContainsString( 'name="notice_ids[]"', $html );
+        $this->assertStringContainsString( 'value="12"', $html );
+    }
+
+    public function test_column_status_delegates_to_admin_page_badge_helper(): void {
+        $out = $this->call_protected( 'column_status', array( array( 'status' => 'open' ) ) );
+
+        $this->assertStringContainsString( 'ffc-status-open', $out );
+    }
+
+    public function test_column_reopened_yes_when_was_reopened_flag_set(): void {
+        $out = $this->call_protected( 'column_reopened', array( array( 'was_reopened' => '1' ) ) );
+
+        $this->assertSame( 'Yes', $out );
+    }
+
+    public function test_column_reopened_em_dash_when_not_reopened(): void {
+        $out = $this->call_protected( 'column_reopened', array( array( 'was_reopened' => '0' ) ) );
+
+        $this->assertSame( '—', $out );
+    }
+
+    public function test_column_adjutancies_renders_none_pill_when_empty(): void {
+        $this->noticeAdjRepoMock->shouldReceive( 'get_adjutancy_ids_for_notice' )->andReturn( array() );
+
+        $out = $this->call_protected( 'column_adjutancies', array( array( 'id' => 1 ) ) );
+
+        $this->assertStringContainsString( '(none)', $out );
+        $this->assertStringContainsString( '<em>', $out );
+    }
+
+    public function test_column_adjutancies_renders_count_when_attached(): void {
+        $this->noticeAdjRepoMock->shouldReceive( 'get_adjutancy_ids_for_notice' )->andReturn( array( 1, 2, 3, 4 ) );
+
+        $out = $this->call_protected( 'column_adjutancies', array( array( 'id' => 1 ) ) );
+
+        $this->assertSame( '4', $out );
+    }
+
+    public function test_column_default_returns_value_for_known_column(): void {
+        $out = $this->call_protected( 'column_default', array( array( 'name' => 'Concurso 2026' ), 'name' ) );
+        $this->assertSame( 'Concurso 2026', $out );
+    }
+
+    public function test_column_default_returns_empty_string_for_missing_column(): void {
+        $out = $this->call_protected( 'column_default', array( array(), 'missing' ) );
+        $this->assertSame( '', $out );
+    }
+}

--- a/tests/Unit/RecruitmentReasonsListTableTest.php
+++ b/tests/Unit/RecruitmentReasonsListTableTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentReasonsListTable;
+
+/**
+ * Smoke tests for the Reasons list table: column declarations, sortable +
+ * bulk-action contracts, and the deterministic column renderers
+ * (column_cb, column_default, column_applies_to "all" branch). Heavy
+ * methods (column_slug with row_actions, prepare_items with DB) require
+ * the full WordPress admin runtime and are out of scope.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentReasonsListTable
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentReasonsListTableTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private RecruitmentReasonsListTable $table;
+
+    /** @var \Mockery\MockInterface */
+    private $reasonRepoMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+
+        $this->reasonRepoMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentReasonRepository' );
+        $this->reasonRepoMock->shouldReceive( 'count_references' )->andReturn( 0 )->byDefault();
+        $this->reasonRepoMock->shouldReceive( 'decode_applies_to' )->andReturnUsing(
+            fn( $stored ) => '' === $stored ? array( 'denied', 'granted', 'appeal_denied', 'appeal_granted' ) : explode( ',', $stored )
+        );
+        if ( ! defined( 'FreeFormCertificate\Recruitment\RecruitmentReasonRepository::DEFAULT_COLOR' ) ) {
+            // Add the constant via the alias mock's class definition.
+            // (Mockery handles class-constant emulation on aliases.)
+        }
+
+        $this->table = new RecruitmentReasonsListTable();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Call a protected method on the list table via reflection.
+     *
+     * @param array<int, mixed> $args
+     * @return mixed
+     */
+    private function call_protected( string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( $this->table, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $this->table, $args );
+    }
+
+    public function test_get_columns_declares_expected_keys(): void {
+        $cols = $this->table->get_columns();
+
+        $this->assertSame(
+            array( 'cb', 'slug', 'label', 'color', 'applies_to', 'usage', 'created_at' ),
+            array_keys( $cols )
+        );
+    }
+
+    public function test_get_columns_provides_checkbox_html_for_cb_column(): void {
+        $cols = $this->table->get_columns();
+        $this->assertStringContainsString( 'type="checkbox"', $cols['cb'] );
+    }
+
+    public function test_get_sortable_columns_returns_label_slug_created_at(): void {
+        $sortable = $this->call_protected( 'get_sortable_columns' );
+
+        $this->assertArrayHasKey( 'slug', $sortable );
+        $this->assertArrayHasKey( 'label', $sortable );
+        $this->assertArrayHasKey( 'created_at', $sortable );
+        // created_at default-desc convention.
+        $this->assertTrue( $sortable['created_at'][1] );
+    }
+
+    public function test_get_bulk_actions_returns_only_delete(): void {
+        $actions = $this->call_protected( 'get_bulk_actions' );
+        $this->assertSame( array( 'bulk-delete' ), array_keys( $actions ) );
+    }
+
+    public function test_column_cb_emits_checkbox_with_row_id(): void {
+        $html = $this->call_protected( 'column_cb', array( array( 'id' => 42 ) ) );
+
+        $this->assertStringContainsString( 'name="reason_ids[]"', $html );
+        $this->assertStringContainsString( 'value="42"', $html );
+    }
+
+    public function test_column_default_escapes_arbitrary_value(): void {
+        // esc_html stub is identity — assert pass-through.
+        $out = $this->call_protected( 'column_default', array( array( 'label' => 'Plain Text' ), 'label' ) );
+        $this->assertSame( 'Plain Text', $out );
+    }
+
+    public function test_column_default_returns_empty_string_for_missing_column(): void {
+        $out = $this->call_protected( 'column_default', array( array(), 'nonexistent' ) );
+        $this->assertSame( '', $out );
+    }
+
+    public function test_column_applies_to_renders_all_pill_when_stored_value_empty(): void {
+        $out = $this->call_protected( 'column_applies_to', array( array( 'applies_to' => '' ) ) );
+        $this->assertStringContainsString( 'All preview statuses', $out );
+    }
+
+    public function test_column_applies_to_renders_pills_for_each_decoded_value(): void {
+        $out = $this->call_protected( 'column_applies_to', array( array( 'applies_to' => 'denied,granted' ) ) );
+
+        $this->assertStringContainsString( 'Denied', $out );
+        $this->assertStringContainsString( 'Granted', $out );
+    }
+
+    public function test_column_usage_delegates_to_repository_count(): void {
+        $this->reasonRepoMock->shouldReceive( 'count_references' )->with( 7 )->andReturn( 5 );
+
+        $out = $this->call_protected( 'column_usage', array( array( 'id' => 7 ) ) );
+
+        $this->assertSame( '5', $out );
+    }
+
+    public function test_column_created_at_returns_escaped_timestamp_string(): void {
+        $out = $this->call_protected( 'column_created_at', array( array( 'created_at' => '2026-05-18 10:00:00' ) ) );
+        $this->assertSame( '2026-05-18 10:00:00', $out );
+    }
+}


### PR DESCRIPTION
## Summary

Closes §7.4b of #307 — smoke coverage for the 4 `WP_List_Table` subclasses that power the Recruitment admin tabs (~1,479 LoC of source).

### Coverage per class

| List table | LoC | Tests | Focus |
|---|---|---|---|
| `RecruitmentReasonsListTable` | 371 | 11 | Columns + sortable + bulk + cb + applies_to (all + per-pill) + usage delegation + default |
| `RecruitmentAdjutanciesListTable` | 334 | 9 | Columns + sortable + bulk + cb + usage delegation to `NoticeAdjutancyRepository` |
| `RecruitmentNoticesListTable` | 359 | 11 | 7-column declaration + 4 sortable + status badge delegation + reopened (yes / em-dash) + adjutancies (none / count) |
| `RecruitmentCandidatesListTable` | 415 | 12 | Columns + name-only sortable + empty bulk-actions + phone (em-dash / escaped) + user_id (zero / missing / linked) |
| **Total** | **1,479** | **43** | |

`WP_List_Table` is stubbed by `tests/bootstrap.php` (parent class without admin runtime). Protected methods (column renderers + sortable/bulk-action contracts) are exercised via reflection; static dependencies (`RecruitmentReasonRepository`, `RecruitmentNoticeAdjutancyRepository`, `RecruitmentAdminPage::notice_status_badge`) are alias-mocked once per test class under `@runTestsInSeparateProcesses + @preserveGlobalState disabled` — same pattern as #316.

### Out of scope

Heavy methods that depend on the full WordPress admin runtime stay uncovered:
- `column_slug` / `column_code` / `column_name` (call `$this->row_actions()` plus `wp_nonce_url`).
- `prepare_items()` (DB access + `get_items_per_page` + pagination plumbing).
- `process_bulk_action()` (nonce + cap + delete service cascade).

These belong to an integration tier that's out of scope for the unit suite.

## Test plan

- [x] Each new test file passes in isolation (11 + 9 + 11 + 12 = 43 tests).
- [x] Full `vendor/bin/phpunit --testsuite=unit` → 4381/4381 passing, no regressions.
- [ ] CI: PHPUnit matrix + PHP coverage floor (55).
- [ ] CI: PHPStan / WPCS clean.

After this lands, #307 has only §7.4c (#318 — 9 admin pages + renderers + managers) remaining before the umbrella can close.

Refs #254 §7, #307. Closes #317.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_