### PR TITLE
Docblock cleanup: orphan-class status (closes #301)

### DIFF
--- a/includes/migrations/class-ffc-migration-user-profiles.php
+++ b/includes/migrations/class-ffc-migration-user-profiles.php
@@ -2,11 +2,24 @@
 /**
  * MigrationUserProfiles
  *
- * Populates ffc_user_profiles table with data from existing ffc_users.
- * Sources: wp_users.display_name, wp_usermeta.ffc_registration_date,
- * and names extracted from submissions.
+ * One-time backfill that populates `ffc_user_profiles` rows for WP
+ * users that already hold the `ffc_user` role but were created before
+ * 4.9.4 (when the profile table landed). Sources: `wp_users.display_name`
+ * and names extracted from submissions. New users get a profile
+ * automatically via `UserCreator` on registration, so this migration
+ * only matters on installs that upgraded from 4.9.3 or earlier without
+ * ever running it.
  *
- * Safe to run multiple times — skips users that already have a profile.
+ * The migration is idempotent: rows that already have a profile are
+ * skipped. Earlier versions of this docblock said the source was a
+ * table named `ffc_users` — that's wrong, the source is WP users
+ * filtered by the `ffc_user` role (`get_users(['role' => 'ffc_user'])`).
+ *
+ * Status (snapshot v6.6.1): the class is NOT registered in
+ * `MigrationStatusCalculator::get_strategies()` and the activator
+ * does not call `run()`, so it cannot be triggered from the admin
+ * UI today. Wiring it up (or formally retiring it) is tracked in
+ * #323.
  *
  * @package FreeFormCertificate\Migrations
  * @since 4.9.4
@@ -52,7 +65,7 @@ class MigrationUserProfiles {
 			);
 		}
 
-		// Get all ffc_users that don't have a profile yet.
+		// Get all WP users holding the ffc_user role that don't have a profile yet.
 		$users = get_users(
 			array(
 				'role'   => 'ffc_user',

--- a/includes/services/class-ffc-user-service.php
+++ b/includes/services/class-ffc-user-service.php
@@ -2,8 +2,18 @@
 /**
  * UserService
  *
- * Centralized service for user data retrieval and operations.
- * Single point of truth used by REST controller, PrivacyHandler, and UserCleanup.
+ * Centralized aggregator for user data retrieval and operations: merges
+ * WP core user data, the FFC `ffc_user_profiles` row, and the granted
+ * capability map into a single view-model. Designed as a single point
+ * of truth for callers that today still inline that aggregation
+ * ad-hoc (`Api\UserDataRestController`, `Privacy\PrivacyHandler`,
+ * `UserDashboard\UserCleanup`).
+ *
+ * Status (snapshot v6.6.1): the class is declared, exported via the
+ * `Services` PSR-4 mapping, and fully tested in `UserServiceTest`, but
+ * no production caller invokes it yet — the wire-up is tracked in
+ * #322 so the API stays stable while the migration happens one
+ * call-site at a time.
  *
  * @package FreeFormCertificate\Services
  * @since 4.9.7


### PR DESCRIPTION
## Summary

Closes #301 by **keeping** both flagged classes (`UserService`, `MigrationUserProfiles`) but fixing the docblocks that made them look like dead code.

### Investigation findings

| Class | Docblock claimed | Reality |
|---|---|---|
| `UserService` | "Single point of truth used by REST controller, PrivacyHandler, and UserCleanup" | Zero callers. The 3 named callers all inline the same aggregation ad-hoc. |
| `MigrationUserProfiles` | "Populates ffc_user_profiles from existing ffc_users" | `ffc_users` is not a table — it's the WP role `ffc_user`. Migration is not registered in the calculator nor called from the activator. |

### Decision: keep both, fix the lies

Both classes are well-designed, well-tested (UserServiceTest: 319 LoC; MigrationUserProfilesTest: 345 LoC), and represent legitimate API surface. Removing them now would foreclose the wire-up paths that ought to land in future PRs. The right fix is to:

1. Stop docblocks from claiming wire-ups that don't exist (this PR).
2. Track the actual wire-up / retire decision in dedicated follow-up sub-issues (#322 + #323) so future readers don't repeat this investigation.

### Changes

- **`UserService`**: docblock rewritten — drops the false "used by REST controller / PrivacyHandler / UserCleanup" claim, replaces with a status snapshot pointing to **#322** (wire-up plan for the 3 ad-hoc call-sites).
- **`MigrationUserProfiles`**: docblock rewritten — corrects the `ffc_users`-the-table myth (it's the `ffc_user` WP role), documents the 4.9.4-era one-time-backfill purpose, points to **#323** (wire-up-or-retire decision). Also fixes the matching inline comment inside `run()`.

No code changes. Diff: 30 insertions, 7 deletions.

## Test plan

- [x] Existing test suites (UserServiceTest + MigrationUserProfilesTest) continue to pass.
- [x] Full `vendor/bin/phpunit --testsuite=unit` → 4419/4419 passing, no regressions.
- [ ] CI: PHPStan / WPCS clean on docblock changes.

Closes #301. Refs #254 §5. See #322 / #323 for next steps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_