### PR TITLE
Refactor: Utils::verify_post_nonce / verify_get_nonce helpers (closes #300)

### DIFF
--- a/includes/migrations/class-ffc-migration-user-profiles.php
+++ b/includes/migrations/class-ffc-migration-user-profiles.php
@@ -2,11 +2,24 @@
 /**
  * MigrationUserProfiles
  *
- * Populates ffc_user_profiles table with data from existing ffc_users.
- * Sources: wp_users.display_name, wp_usermeta.ffc_registration_date,
- * and names extracted from submissions.
+ * One-time backfill that populates `ffc_user_profiles` rows for WP
+ * users that already hold the `ffc_user` role but were created before
+ * 4.9.4 (when the profile table landed). Sources: `wp_users.display_name`
+ * and names extracted from submissions. New users get a profile
+ * automatically via `UserCreator` on registration, so this migration
+ * only matters on installs that upgraded from 4.9.3 or earlier without
+ * ever running it.
  *
- * Safe to run multiple times — skips users that already have a profile.
+ * The migration is idempotent: rows that already have a profile are
+ * skipped. Earlier versions of this docblock said the source was a
+ * table named `ffc_users` — that's wrong, the source is WP users
+ * filtered by the `ffc_user` role (`get_users(['role' => 'ffc_user'])`).
+ *
+ * Status (snapshot v6.6.1): the class is NOT registered in
+ * `MigrationStatusCalculator::get_strategies()` and the activator
+ * does not call `run()`, so it cannot be triggered from the admin
+ * UI today. Wiring it up (or formally retiring it) is tracked in
+ * #323.
  *
  * @package FreeFormCertificate\Migrations
  * @since 4.9.4
@@ -52,7 +65,7 @@ class MigrationUserProfiles {
 			);
 		}
 
-		// Get all ffc_users that don't have a profile yet.
+		// Get all WP users holding the ffc_user role that don't have a profile yet.
 		$users = get_users(
 			array(
 				'role'   => 'ffc_user',

--- a/includes/services/class-ffc-user-service.php
+++ b/includes/services/class-ffc-user-service.php
@@ -2,8 +2,18 @@
 /**
  * UserService
  *
- * Centralized service for user data retrieval and operations.
- * Single point of truth used by REST controller, PrivacyHandler, and UserCleanup.
+ * Centralized aggregator for user data retrieval and operations: merges
+ * WP core user data, the FFC `ffc_user_profiles` row, and the granted
+ * capability map into a single view-model. Designed as a single point
+ * of truth for callers that today still inline that aggregation
+ * ad-hoc (`Api\UserDataRestController`, `Privacy\PrivacyHandler`,
+ * `UserDashboard\UserCleanup`).
+ *
+ * Status (snapshot v6.6.1): the class is declared, exported via the
+ * `Services` PSR-4 mapping, and fully tested in `UserServiceTest`, but
+ * no production caller invokes it yet — the wire-up is tracked in
+ * #322 so the API stays stable while the migration happens one
+ * call-site at a time.
  *
  * @package FreeFormCertificate\Services
  * @since 4.9.7


### PR DESCRIPTION
## Summary

Closes Item 1 of #300 — collapses the verbose `wp_verify_nonce(Utils::get_post_string('field'), 'action')` (and GET-side mirror) idiom into single-line helpers. 49 sites migrated.

### New helpers

```php
Utils::verify_post_nonce( string $action, string $field = 'nonce' ): bool
Utils::verify_get_nonce( string $action, string $field = '_wpnonce' ): bool
```

Both default to the conventional field name (`'nonce'` matches the AJAX convention; `'_wpnonce'` matches `wp_nonce_url()`); admin save handlers using per-form names (`ffc_settings_nonce`, `ffc_capabilities_nonce`, …) pass `$field` explicitly so action+field both stay visible.

### Migration

- **31 POST-side sites** → `Utils::verify_post_nonce()`.
- **18 GET-side sites** → `Utils::verify_get_nonce()`.
- Sites using the default field name drop the redundant second arg.

### Design note (per #300 trade-off discussion)

The helper does **not** bundle the cap check (`current_user_can`). Capability gates vary per route and conflating them would either over-fit or hide intent. Callers still do `if ( ! Utils::verify_post_nonce(...) || ! current_user_can(...) )` exactly as they would with raw `wp_verify_nonce`.

### Tests touched

- `tests/Unit/UtilsTest.php`: **7 new tests** pinning the helpers' contract — true / false / missing / mismatched / custom field, for both POST and GET variants.
- `tests/Unit/AdminUserCapabilitiesTest.php` + `tests/Unit/AdminUserCustomFieldsTest.php`: the existing alias mocks of `Utils` now respond to `verify_post_nonce` with the same nonce-aware semantics the old `wp_verify_nonce` stubs provided.

### Item 2 — out of scope

#300 Item 2 (rename `_ffc_pcd_nonce` → `_wpnonce` on the public CSV form) is **deliberately skipped**. It's a breaking change for any integrator scripting against the form via curl/Postman, with marginal payoff (aesthetic alignment with WP convention). Closing that item separately as `not_planned`.

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/UtilsTest.php` — 7 new helper tests pass; existing get_post_string / get_get_string tests still pass.
- [x] Full `vendor/bin/phpunit --testsuite=unit` → **4426/4426** passing, no regressions.
- [ ] CI: PHPUnit matrix (8.1–8.4) + PHP coverage floor (55).
- [ ] CI: PHPStan level 8 / WPCS clean.

Closes #300. Refs #254 §4 (audit follow-up).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_