### PR TITLE
Release v6.6.1 — code-quality sweep bundle (closes #254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+---
+
+## [6.6.1] (2026-05-18)
+
+Code-quality sweep bundle from the umbrella audit (#254): test-gap closeout
+(§7), nonce-verification audit (§4 follow-up), dead-code reauditing (§5
+follow-up), and the residual cleanup that landed between the §1-§6 PRs
+and the §7 batch. See the issue body for the full inventory.
+
 > ### ⚠ Breaking change for `GET /forms` REST consumers
 >
 > The `GET /forms` REST endpoint now uses real pagination via `page` and

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.0
+ * Version:            6.6.1
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.0' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.1' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.5.4
+Stable tag: 6.6.1
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

Consolidates the umbrella audit #254 into a release. Bumps:

- `ffcertificate.php` Plugin header `Version:` **6.6.0 → 6.6.1**
- `ffcertificate.php` `FFC_VERSION` constant **6.6.0 → 6.6.1**
- `readme.txt` `Stable tag:` **6.5.4 → 6.6.1**
- `CHANGELOG.md`: renames `[Unreleased]` → `[6.6.1] (2026-05-18)`, opens fresh empty `[Unreleased]` above it.

### ⚠ Breaking change — surface in the GitHub Release notes

The `[6.6.1]` section in CHANGELOG opens with the prominent banner for the `GET /forms` REST pagination change (#260 / PR #266). External integrators that pass `?limit=N` are affected. Release notes / GitHub Release description should foreground that section.

### What this release ships

| § | Highlights | PRs |
|---|---|---|
| 1 | Open inline follow-ups closed (#256/#260/#261; #257/#258 false positives; #259/#262 split standalone) | #264, #266, #265 |
| 2 | Debug shim, CSS aliases, FFC_DEBUG, legacy compat shims, delegate framing | #263, #270, #271, #272 |
| 3 | SettingsReader generic + typed accessors; REST Form pagination | #274, #266 |
| 4 | 5 reuse helpers + POST/GET sanitize umbrella + AJAX → FFC.request migration | #278, #280/#282/#285/#287, #297/#298/#299 |
| 5 | Dead-code cleanup; 2 orphan classes kept with corrected docblocks (tracked in #322/#323) | #263, #324 |
| 6 | markTestSkipped dead-guard cleanup | #303 |
| 7 | 279 new tests / ~12,664 LoC newly covered. PHP coverage floor 50 → 55. | #311, #312, #313, #314, #315, #316, #319, #320, #321 |

### Not bundled

- **#259** (per-read Calendar rate-limit pool) — feature work, standalone.
- **#262** (Recruitment admin UI polish) — feature work, standalone.
- **#300** (nonce helper) — WPCS upstream doesn't recognize static methods as verifiers; closed `not_planned`.
- **#322 / #323** — UserService wire-up + MigrationUserProfiles wire-up-or-retire; future refactors.

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` — green before the bump (4419 tests on the tip of main pre-merge).
- [x] Version markers verified — `grep -rn "6.6.1"` returns only the 3 update targets + CLAUDE.md's existing `v6.6.1` references.
- [ ] CI: full matrix + coverage floor (PHP 55 / JS 82).

Closes #254.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_