### PR TITLE
Hotfix: coerce user_id=0 to NULL in ActivityLog INSERT (FK violation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Activity log INSERT failing under FK after 4.9.7** — `ActivityLog::flush_buffer()` was passing `user_id = 0` for system-event rows (migrations, cron, shutdown handlers). The `fk_ffc_activity_log_user` constraint (added in 4.9.7 with `ON DELETE SET NULL`) references `wp_users(ID)`, and `0` is not a valid WP user ID, so the FK rejected every system-event INSERT. The "no user / anonymous" semantics now map to `NULL` at INSERT time, which the FK accepts. The activator's `create_table()` was also realigned with the post-FK-migration state (`DEFAULT NULL` instead of `DEFAULT 0`) so fresh installs land on the right schema even before `MigrationForeignKeys::run()` executes. Production symptom was a stream of `Cannot add or update a child row: a foreign key constraint fails` warnings on every flushed buffer, with the failing INSERT visibly tied to `'migration_foreign_keys'` / `'shutdown_action_hook'` activity.
+
 ---
 
 ## [6.6.1] (2026-05-18)

--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -221,11 +221,21 @@ class ActivityLog {
 		self::$write_buffer = array();
 
 		foreach ( $entries as $entry ) {
+			// MigrationForeignKeys (4.9.7) adds an ON DELETE SET NULL FK on
+			// `user_id` referencing `wp_users(ID)`. The column is nullable,
+			// but the existing code path passes `0` for system events
+			// (migrations, cron, shutdown handlers) — and `0` is not a valid
+			// wp_users.ID, so the FK rejects the INSERT. Coerce `0` to NULL
+			// here so the "no user / anonymous" semantics map to a NULL
+			// foreign key value, which the FK accepts. wpdb::insert() drops
+			// the format when the value is NULL and writes a literal NULL.
+			$user_id_for_db = $entry['user_id'] > 0 ? $entry['user_id'] : null;
+
 			$row_data   = array(
 				'action'     => $entry['action'],
 				'level'      => $entry['level'],
 				'context'    => $entry['context'],
-				'user_id'    => $entry['user_id'],
+				'user_id'    => $user_id_for_db,
 				'user_ip'    => $entry['user_ip'],
 				'created_at' => $entry['created_at'],
 			);
@@ -269,7 +279,7 @@ class ActivityLog {
             action varchar(100) NOT NULL,
             level varchar(20) NOT NULL DEFAULT 'info',
             context longtext,
-            user_id bigint(20) unsigned DEFAULT 0,
+            user_id bigint(20) unsigned DEFAULT NULL,
             user_ip varchar(100),
             created_at datetime NOT NULL,
             PRIMARY KEY (id),

--- a/tests/Unit/ActivityLogTest.php
+++ b/tests/Unit/ActivityLogTest.php
@@ -488,6 +488,82 @@ class ActivityLogTest extends TestCase {
         $this->assertEmpty($this->getWriteBuffer());
     }
 
+    public function test_flush_buffer_coerces_zero_user_id_to_null_to_satisfy_fk(): void {
+        // System events (migrations, cron, shutdown handlers) pass user_id=0
+        // for "anonymous/system". The FK fk_ffc_activity_log_user (added in
+        // 4.9.7) references wp_users(ID) — and 0 is not a valid wp_users.ID,
+        // so the INSERT trips the FK. flush_buffer() must coerce 0 → null
+        // before INSERTing so the no-user semantics map to a NULL FK value.
+        $this->enableActivityLog();
+
+        $this->setWriteBuffer([
+            [
+                'action'            => 'migration_foreign_keys',
+                'level'             => 'info',
+                'context'           => '{"added":[],"skipped":[]}',
+                'context_encrypted' => null,
+                'user_id'           => 0,
+                'user_ip'           => '0.0.0.0',
+                'submission_id'     => 0,
+                'created_at'        => '2026-03-01 10:00:00',
+            ],
+        ]);
+
+        $this->wpdb->shouldReceive('prepare')->andReturn('DESCRIBE wp_ffc_activity_log');
+        $this->wpdb->shouldReceive('get_col')->andReturn([
+            'id', 'action', 'level', 'context', 'user_id', 'user_ip',
+            'created_at', 'submission_id', 'context_encrypted',
+        ]);
+
+        $captured_data = null;
+        $this->wpdb->shouldReceive('insert')->andReturnUsing(
+            function ($table, $data) use (&$captured_data) {
+                $captured_data = $data;
+                return 1;
+            }
+        );
+
+        ActivityLog::flush_buffer();
+
+        $this->assertNotNull($captured_data);
+        $this->assertNull($captured_data['user_id'], 'user_id=0 must be coerced to NULL before INSERT');
+    }
+
+    public function test_flush_buffer_preserves_nonzero_user_id(): void {
+        $this->enableActivityLog();
+
+        $this->setWriteBuffer([
+            [
+                'action'            => 'submission_created',
+                'level'             => 'info',
+                'context'           => '{}',
+                'context_encrypted' => null,
+                'user_id'           => 42,
+                'user_ip'           => '127.0.0.1',
+                'submission_id'     => 0,
+                'created_at'        => '2026-03-01 10:00:00',
+            ],
+        ]);
+
+        $this->wpdb->shouldReceive('prepare')->andReturn('DESCRIBE wp_ffc_activity_log');
+        $this->wpdb->shouldReceive('get_col')->andReturn([
+            'id', 'action', 'level', 'context', 'user_id', 'user_ip',
+            'created_at', 'submission_id', 'context_encrypted',
+        ]);
+
+        $captured_data = null;
+        $this->wpdb->shouldReceive('insert')->andReturnUsing(
+            function ($table, $data) use (&$captured_data) {
+                $captured_data = $data;
+                return 1;
+            }
+        );
+
+        ActivityLog::flush_buffer();
+
+        $this->assertSame(42, $captured_data['user_id']);
+    }
+
     public function test_flush_buffer_omits_submission_id_when_column_missing(): void {
         $this->enableActivityLog();
 


### PR DESCRIPTION
## Production bug

Stream of FK warnings in production logs starting 2026-05-18T21:42:26 UTC:

```
WordPress database error Cannot add or update a child row: a foreign key
constraint fails (`wp_ffc_activity_log`, CONSTRAINT
`fk_ffc_activity_log_user` FOREIGN KEY (`user_id`) REFERENCES `wp_users`
(`ID`) ON DELETE SET NULL) for query INSERT INTO `wp_ffc_activity_log`
(..., `user_id`, ...) VALUES (..., 0, ...)
made by shutdown_action_hook, do_action('shutdown'), ...
FreeFormCertificate\Core\ActivityLog::flush_buffer
```

Every system-event activity log entry (migrations, cron, shutdown handlers) hits this — the call sites pass `user_id = 0` for "anonymous / no-user" semantics, but the FK constraint added in 4.9.7 (`ON DELETE SET NULL` referencing `wp_users(ID)`) rejects `0` because it's not a valid WP user ID.

## Fix

**`ActivityLog::flush_buffer()`** — coerce `user_id <= 0` to NULL at INSERT time. `wpdb::insert()` drops the format mapping when the value is NULL and writes a literal NULL, which the FK accepts.

The in-memory write buffer keeps the legacy `0` shape so call sites don't need updating; only the INSERT path translates.

**`ActivityLog::create_table()`** — column DDL realigned with the post-FK-migration state: `user_id bigint(20) unsigned DEFAULT NULL` (was `DEFAULT 0`). Cosmetic without the runtime fix, but keeps the activator coherent with what `MigrationForeignKeys::run()` ALTERs it to anyway.

## Tests

- `test_flush_buffer_coerces_zero_user_id_to_null_to_satisfy_fk` — captures the row data passed to `wpdb->insert()` and asserts `user_id` is NULL when the buffered entry had `0`.
- `test_flush_buffer_preserves_nonzero_user_id` — guards the inverse regression (real user IDs must not get nulled).

Full unit suite: **4421/4421** passing locally.

## Release note (for CHANGELOG `[Unreleased]`)

Already added under `Fixed`. Belongs in a v6.6.2 hotfix release — affected installs that have run the 4.9.7 FK migration will silence the log spam on upgrade.

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → 4421/4421.
- [ ] CI: PHPUnit matrix + coverage floor (PHP 55, JS 82).
- [ ] CI: PHPStan / WPCS.

Refs: production error log timestamped 2026-05-18T21:42:26 UTC; FK added in 4.9.7; `MigrationForeignKeys::run()` at `includes/migrations/class-ffc-migration-foreign-keys.php`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H689qwDBF5E9Uqg1PmD3ic)_