### PR TITLE
Recruitment: PII reveal toggle + audit log on candidate detail (#330)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-activity-logger.php
+++ b/includes/recruitment/class-ffc-recruitment-activity-logger.php
@@ -314,4 +314,70 @@ final class RecruitmentActivityLogger {
 			get_current_user_id()
 		);
 	}
+
+	/**
+	 * Sensitive PII revealed on the candidate detail screen (#330).
+	 *
+	 * Dedup: a transient keyed on (user_id, candidate_id, field_key) suppresses
+	 * repeated logs within {@see self::PII_REVEAL_DEDUP_SECONDS}. The intent is
+	 * audit-grade trail for investigations — collapsing accidental double-clicks
+	 * and rapid re-reveals of the same field by the same operator keeps the log
+	 * readable without losing signal.
+	 *
+	 * Honors the `audit_pii_reveals` recruitment setting: when the operator
+	 * disables the toggle, the reveal still works but no log row is written.
+	 * Defaults to true (audit on) so production behavior is conservative.
+	 *
+	 * @param int    $candidate_id Candidate row ID.
+	 * @param string $field_key    Logical field key (`cpf`, `rf`, `email`).
+	 * @return bool True if a log entry was written; false on dedup hit or setting off.
+	 */
+	public static function pii_revealed( int $candidate_id, string $field_key ): bool {
+		// Read the option directly so we don't pull in the
+		// RecruitmentSettings::defaults() path (which calls translation
+		// helpers) for what is just a boolean check. Defaults to true
+		// when the key is missing — first save after upgrade keeps audit
+		// on by default.
+		$opts = get_option( 'ffc_recruitment_settings', array() );
+		if ( is_array( $opts ) && array_key_exists( 'audit_pii_reveals', $opts ) && ! $opts['audit_pii_reveals'] ) {
+			return false;
+		}
+
+		$user_id = get_current_user_id();
+
+		// Transient key — short enough to keep readable, distinct per
+		// (user, candidate, field) tuple. wp_using_ext_object_cache() handles
+		// the multi-frontend case automatically (transient API falls back to
+		// the options table when no object cache is wired up).
+		$dedup_key = sprintf(
+			'ffc_pii_reveal_%d_%d_%s',
+			$user_id,
+			$candidate_id,
+			preg_replace( '/[^a-z0-9_]+/', '', $field_key )
+		);
+
+		if ( false !== get_transient( $dedup_key ) ) {
+			return false;
+		}
+		set_transient( $dedup_key, 1, self::PII_REVEAL_DEDUP_SECONDS );
+
+		ActivityLog::log(
+			'recruitment_pii_revealed',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'candidate_id' => $candidate_id,
+				'field_key'    => $field_key,
+			),
+			$user_id
+		);
+
+		return true;
+	}
+
+	/**
+	 * Dedup window for pii_revealed() in seconds. 60s collapses the obvious
+	 * UX cases (operator clicks "Reveal", masks it, clicks again) while still
+	 * splitting genuinely separate review sessions across rows.
+	 */
+	private const PII_REVEAL_DEDUP_SECONDS = 60;
 }

--- a/includes/recruitment/class-ffc-recruitment-admin-page.php
+++ b/includes/recruitment/class-ffc-recruitment-admin-page.php
@@ -977,6 +977,24 @@ final class RecruitmentAdminPage {
 
 		echo '</tbody></table>';
 
+		// PII / audit toggle (#330). Lives at the bottom of the Settings
+		// tab because it's a security knob, not a visual one — operators
+		// who land here are usually adjusting palettes. The default is
+		// `true` so the first save after the upgrade keeps auditing on.
+		echo '<h3>' . esc_html__( 'PII access audit', 'ffcertificate' ) . '</h3>';
+		echo '<p class="description">' . esc_html__( 'When enabled, every reveal of CPF / RF on the candidate detail screen by a non-admin user writes a row to the activity log (with a 60-second dedup per user + candidate + field). Recommended ON for compliance.', 'ffcertificate' ) . '</p>';
+		echo '<table class="form-table"><tbody>';
+		echo '<tr><th>' . esc_html__( 'Audit PII reveals', 'ffcertificate' ) . '</th><td>';
+		\FreeFormCertificate\Admin\AdminUI::render_toggle(
+			array(
+				'name'    => $opt . '[audit_pii_reveals]',
+				'id'      => 'ffc-rs-audit-pii-reveals',
+				'checked' => ! empty( $settings['audit_pii_reveals'] ),
+			)
+		);
+		echo '</td></tr>';
+		echo '</tbody></table>';
+
 		submit_button();
 		echo '</form>';
 	}

--- a/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
@@ -155,21 +155,42 @@ final class RecruitmentCandidateEditPage {
 	 * @return void
 	 */
 	private static function render_sensitive_section( object $candidate ): void {
+		// Resolve the access tier once for the whole postbox so all three
+		// fields (CPF, RF, email) get a consistent treatment per user
+		// (issue #330).
+		$tier = RecruitmentPiiAccessPolicy::resolve( $candidate, get_current_user_id() );
+
 		echo '<div class="postbox" style="margin-top:20px;">';
 		echo '<h2 class="hndle"><span>' . esc_html__( 'Sensitive data (admin only)', 'ffcertificate' ) . '</span></h2>';
 		echo '<div class="inside">';
 
+		if ( RecruitmentPiiAccessPolicy::TIER_REVEAL === $tier ) {
+			echo '<p class="description">' . esc_html__( 'Sensitive fields are masked by default. Click "Reveal" to view; each reveal is recorded in the activity log.', 'ffcertificate' ) . '</p>';
+		}
+
 		echo '<table class="form-table"><tbody>';
 
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- render_sensitive_row returns escaped HTML built from esc_html() and known-safe markup.
 		echo '<tr><th>' . esc_html__( 'CPF', 'ffcertificate' ) . '</th>';
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_decrypted returns escaped HTML.
-		echo '<td>' . self::render_decrypted( (string) ( $candidate->cpf_encrypted ?? '' ), array( DocumentFormatter::class, 'format_cpf' ) ) . ' ';
+		echo '<td>' . self::render_sensitive_row(
+			$tier,
+			(int) $candidate->id,
+			'cpf',
+			(string) ( $candidate->cpf_encrypted ?? '' ),
+			array( DocumentFormatter::class, 'format_cpf' )
+		) . ' ';
 		echo '<span class="description">' . esc_html__( 'CSV import only — not editable here.', 'ffcertificate' ) . '</span></td></tr>';
 
 		echo '<tr><th>' . esc_html__( 'RF', 'ffcertificate' ) . '</th>';
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_decrypted returns escaped HTML.
-		echo '<td>' . self::render_decrypted( (string) ( $candidate->rf_encrypted ?? '' ), array( DocumentFormatter::class, 'format_rf' ) ) . ' ';
+		echo '<td>' . self::render_sensitive_row(
+			$tier,
+			(int) $candidate->id,
+			'rf',
+			(string) ( $candidate->rf_encrypted ?? '' ),
+			array( DocumentFormatter::class, 'format_rf' )
+		) . ' ';
 		echo '<span class="description">' . esc_html__( 'CSV import only — not editable here.', 'ffcertificate' ) . '</span></td></tr>';
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		echo '<tr><th>' . esc_html__( 'Linked WP user', 'ffcertificate' ) . '</th>';
 		echo '<td>';
@@ -223,6 +244,14 @@ final class RecruitmentCandidateEditPage {
 		echo '</td></tr>';
 
 		echo '</tbody></table>';
+
+		// Inline JS for the reveal buttons. Only emitted when the user is
+		// on the `reveal` tier — the `unmasked` and `masked` tiers don't
+		// render the button so the script would be a no-op anyway.
+		if ( RecruitmentPiiAccessPolicy::TIER_REVEAL === $tier ) {
+			self::render_sensitive_reveal_script();
+		}
+
 		echo '</div></div>';
 	}
 
@@ -243,6 +272,136 @@ final class RecruitmentCandidateEditPage {
 			return '<em>—</em>';
 		}
 		return '<code>' . esc_html( $formatter( $plain ) ) . '</code>';
+	}
+
+	/**
+	 * Render one row of the Sensitive data postbox under the access tier.
+	 *
+	 * - `unmasked`: decrypt and show the value immediately, same as
+	 *   render_decrypted().
+	 * - `reveal`: render a `<code>` placeholder with a "Reveal" button
+	 *   alongside; the JS handler (see render_sensitive_reveal_script())
+	 *   POSTs to /candidates/{id}/reveal-pii on click and swaps the
+	 *   placeholder text in place.
+	 * - `masked`: render the placeholder without the button — the user
+	 *   has no path to see this value at all.
+	 *
+	 * @param string   $tier         One of RecruitmentPiiAccessPolicy::TIER_*.
+	 * @param int      $candidate_id Candidate row ID (used by the reveal handler).
+	 * @param string   $field_key    Logical key (`cpf`, `rf`, `email`).
+	 * @param string   $cipher       Encrypted column value.
+	 * @param callable $formatter    Formatter for the plaintext (used in unmasked tier).
+	 * @return string Already-escaped HTML.
+	 */
+	private static function render_sensitive_row( string $tier, int $candidate_id, string $field_key, string $cipher, callable $formatter ): string {
+		if ( '' === $cipher ) {
+			return '<em>—</em>';
+		}
+
+		if ( RecruitmentPiiAccessPolicy::TIER_UNMASKED === $tier ) {
+			return self::render_decrypted( $cipher, $formatter );
+		}
+
+		// reveal + masked both start with the placeholder. reveal adds a
+		// button next to it (the JS swaps the placeholder text on
+		// success); masked stops at the placeholder.
+		$placeholder = '<code class="ffc-pii-placeholder" data-ffc-pii-field="' . esc_attr( $field_key ) . '">' . esc_html( self::mask_placeholder_for( $field_key ) ) . '</code>';
+
+		if ( RecruitmentPiiAccessPolicy::TIER_REVEAL !== $tier ) {
+			return $placeholder;
+		}
+
+		$button = ' <button type="button"'
+			. ' class="button button-secondary ffc-pii-reveal-btn"'
+			. ' data-ffc-pii-candidate="' . esc_attr( (string) $candidate_id ) . '"'
+			. ' data-ffc-pii-field="' . esc_attr( $field_key ) . '">'
+			. esc_html__( 'Reveal', 'ffcertificate' )
+			. '</button>';
+
+		return $placeholder . $button;
+	}
+
+	/**
+	 * Per-field masked placeholder. Mirrors the shape of the real value
+	 * (e.g. `***.***.***-**` for CPF) so the operator can tell which
+	 * field is which before clicking.
+	 *
+	 * @param string $field_key One of `cpf`, `rf`, `email`.
+	 * @return string
+	 */
+	private static function mask_placeholder_for( string $field_key ): string {
+		switch ( $field_key ) {
+			case 'cpf':
+				return '***.***.***-**';
+			case 'rf':
+				return '****-*';
+			case 'email':
+				return '****@****';
+			default:
+				return '****';
+		}
+	}
+
+	/**
+	 * Inline JS for the "Reveal" buttons in the Sensitive data postbox
+	 * (issue #330). Rendered once per page load by render_sensitive_section
+	 * when the user is on the `reveal` tier.
+	 *
+	 * The handler POSTs to /candidates/{id}/reveal-pii with the field key,
+	 * swaps the placeholder text on success, replaces the button with a
+	 * "Hide" toggle that restores the placeholder, and surfaces any error
+	 * inline so the operator knows whether the request failed (and why)
+	 * without a page reload.
+	 *
+	 * @return void
+	 */
+	private static function render_sensitive_reveal_script(): void {
+		$rest_root  = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/candidates/' ) );
+		$nonce      = wp_create_nonce( 'wp_rest' );
+		$hide_lbl   = esc_js( __( 'Hide', 'ffcertificate' ) );
+		$reveal_lbl = esc_js( __( 'Reveal', 'ffcertificate' ) );
+		$err_lbl    = esc_js( __( 'Error', 'ffcertificate' ) );
+
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- All interpolated values are escaped via esc_url_raw / esc_js / esc_attr above; no user-controlled content.
+		echo '<script>'
+			. '(function(){'
+			. 'document.addEventListener("click",function(ev){'
+			. 'var btn=ev.target;'
+			. 'if(!btn||!btn.classList||!btn.classList.contains("ffc-pii-reveal-btn"))return;'
+			. 'ev.preventDefault();'
+			. 'var cid=btn.getAttribute("data-ffc-pii-candidate");'
+			. 'var field=btn.getAttribute("data-ffc-pii-field");'
+			. 'var ph=btn.parentNode.querySelector(\'.ffc-pii-placeholder[data-ffc-pii-field="\'+field+\'"]\');'
+			. 'if(!cid||!field||!ph)return;'
+			. 'if(btn.getAttribute("data-ffc-pii-revealed")==="1"){'
+			// Hide path — restore the saved placeholder text and reset the button label.
+			. 'ph.textContent=btn.getAttribute("data-ffc-pii-mask")||"";'
+			. 'btn.textContent="' . $reveal_lbl . '";'
+			. 'btn.removeAttribute("data-ffc-pii-revealed");'
+			. 'return;'
+			. '}'
+			. 'btn.disabled=true;'
+			. 'var fd=new FormData();fd.append("field",field);'
+			. 'fetch("' . $rest_root . '"+cid+"/reveal-pii",{'
+			. 'method:"POST",'
+			. 'headers:{"X-WP-Nonce":"' . esc_attr( $nonce ) . '"},'
+			. 'body:fd,credentials:"same-origin"'
+			. '}).then(function(r){return r.json().then(function(d){return{status:r.status,body:d};});}).then(function(o){'
+			. 'btn.disabled=false;'
+			. 'if(o.status>=200&&o.status<300&&o.body&&typeof o.body.value==="string"){'
+			. 'btn.setAttribute("data-ffc-pii-mask",ph.textContent);'
+			. 'ph.textContent=o.body.value;'
+			. 'btn.textContent="' . $hide_lbl . '";'
+			. 'btn.setAttribute("data-ffc-pii-revealed","1");'
+			. '}else{'
+			. 'var msg=(o.body&&o.body.message)?o.body.message:"' . $err_lbl . '";'
+			. 'ph.textContent="["+msg+"]";'
+			. '}'
+			. '}).catch(function(){btn.disabled=false;ph.textContent="[' . $err_lbl . ']";});'
+			. '});'
+			. '})();'
+			. '</script>';
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-candidates-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-candidates-rest-controller.php
@@ -104,6 +104,29 @@ final class RecruitmentCandidatesRestController {
 			)
 		);
 
+		// Reveal a single sensitive field on demand (issue #330). The route
+		// itself only checks "logged in" so the owner-clause inside the
+		// policy can authorise the candidate themselves; the handler then
+		// runs RecruitmentPiiAccessPolicy::resolve() to enforce the tier
+		// and writes an audit row (subject to dedup + the audit_pii_reveals
+		// setting) when the requester is on the `reveal` tier.
+		register_rest_route(
+			$ns,
+			$base . '/candidates/(?P<id>\d+)/reveal-pii',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'reveal_pii' ),
+				'permission_callback' => array( $this, 'check_logged_in' ),
+				'args'                => array(
+					'field' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+
 		// ── Candidate-self dashboard ────────────────────────────────────
 		register_rest_route(
 			$ns,
@@ -240,6 +263,83 @@ final class RecruitmentCandidatesRestController {
 			return $this->wp_error_from_envelope_with_blocked( $result, 409 );
 		}
 		return new \WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * POST /candidates/{id}/reveal-pii — return one decrypted sensitive
+	 * field after enforcing the access tier (issue #330).
+	 *
+	 * Body / param:
+	 *   field — one of `cpf`, `rf`, `email`.
+	 *
+	 * Response shape (200): `{ field: string, value: string }`.
+	 * Errors: 400 unsupported field; 403 access denied (tier=masked);
+	 *         404 candidate or encrypted column missing.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function reveal_pii( \WP_REST_Request $request ) {
+		$id        = (int) $request->get_param( 'id' );
+		$field_key = (string) $request->get_param( 'field' );
+
+		$allowed = array( 'cpf', 'rf', 'email' );
+		if ( ! in_array( $field_key, $allowed, true ) ) {
+			return new \WP_Error(
+				'recruitment_pii_field_unsupported',
+				__( 'Unsupported sensitive field.', 'ffcertificate' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$candidate = RecruitmentCandidateRepository::get_by_id( $id );
+		if ( null === $candidate ) {
+			return new \WP_Error( 'recruitment_candidate_not_found', '', array( 'status' => 404 ) );
+		}
+
+		$tier = RecruitmentPiiAccessPolicy::resolve( $candidate, get_current_user_id() );
+		if ( RecruitmentPiiAccessPolicy::TIER_MASKED === $tier ) {
+			return new \WP_Error(
+				'recruitment_pii_access_denied',
+				__( 'You do not have permission to reveal this field.', 'ffcertificate' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$column = $field_key . '_encrypted';
+		if ( empty( $candidate->{$column} ) ) {
+			return new \WP_Error( 'recruitment_pii_value_missing', '', array( 'status' => 404 ) );
+		}
+
+		$plain = Encryption::decrypt( (string) $candidate->{$column} );
+		if ( ! is_string( $plain ) || '' === $plain ) {
+			return new \WP_Error( 'recruitment_pii_decrypt_failed', '', array( 'status' => 500 ) );
+		}
+
+		// Render via DocumentFormatter so the value matches what the
+		// detail screen shows when the unmasked tier is in effect.
+		switch ( $field_key ) {
+			case 'cpf':
+				$display = DocumentFormatter::format_cpf( $plain );
+				break;
+			case 'rf':
+				$display = DocumentFormatter::format_rf( $plain );
+				break;
+			default:
+				$display = $plain;
+		}
+
+		if ( RecruitmentPiiAccessPolicy::should_audit( $candidate, get_current_user_id() ) ) {
+			RecruitmentActivityLogger::pii_revealed( $id, $field_key );
+		}
+
+		return new \WP_REST_Response(
+			array(
+				'field' => $field_key,
+				'value' => (string) $display,
+			),
+			200
+		);
 	}
 
 	// ─────────────────────────────────────────────────────────────────────

--- a/includes/recruitment/class-ffc-recruitment-pii-access-policy.php
+++ b/includes/recruitment/class-ffc-recruitment-pii-access-policy.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Recruitment PII Access Policy.
+ *
+ * Centralizes the decision of whether a given user can see the decrypted
+ * CPF / RF / email of a given candidate, and whether that view should
+ * trigger an audit-log entry. Used by the candidate detail screen and by
+ * the REST endpoint that powers the on-click "Reveal" button (issue
+ * #330).
+ *
+ * Three-tier policy:
+ *
+ *   - `unmasked` — the operator sees the plaintext value immediately, no
+ *     toggle, no audit row written. Reserved for the highest-trust roles
+ *     where every action is already assumed to be operator-driven and
+ *     the noise of a per-field log would obscure real anomalies.
+ *
+ *   - `reveal` — the operator sees a masked placeholder; clicking
+ *     "Reveal" hits the REST endpoint, which decrypts and returns the
+ *     value, and writes an audit entry (subject to dedup + the
+ *     `audit_pii_reveals` setting). This is the everyday path for
+ *     auditors / managers / the candidate themselves when they reach
+ *     the screen.
+ *
+ *   - `masked` — the operator never sees the value, even by clicking
+ *     anything. The button is not rendered.
+ *
+ * Resolution rules:
+ *
+ *   1. WordPress super-admins (`manage_options`) and members of the
+ *      `ffc_recruitment_admin` role → `unmasked`.
+ *   2. Users holding `ffc_view_recruitment_pii` (granular cap; assigned
+ *      to managers and auditors by default) → `reveal`.
+ *   3. The candidate themselves (when the row's `user_id` matches the
+ *      requester) → `reveal`. Owner of the data always has the right
+ *      to see their own information; the audit row marks the access.
+ *   4. Everyone else → `masked`.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.6.2
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves the PII access tier for a (user, candidate) pair.
+ */
+final class RecruitmentPiiAccessPolicy {
+
+	public const TIER_UNMASKED = 'unmasked';
+	public const TIER_REVEAL   = 'reveal';
+	public const TIER_MASKED   = 'masked';
+
+	/**
+	 * Resolve the access tier for the given user against the given candidate.
+	 *
+	 * The candidate row is the source of truth for the owner check (its
+	 * `user_id` column). Pass null when the candidate isn't loaded yet —
+	 * the owner clause then short-circuits to false and the cap-only path
+	 * decides.
+	 *
+	 * @param object|null $candidate Candidate row (with at least `user_id`), or null.
+	 * @param int|null    $user_id   User to check; defaults to current user.
+	 * @return string One of TIER_UNMASKED / TIER_REVEAL / TIER_MASKED.
+	 */
+	public static function resolve( ?object $candidate, ?int $user_id = null ): string {
+		$uid = $user_id ?? get_current_user_id();
+		if ( $uid <= 0 ) {
+			return self::TIER_MASKED;
+		}
+
+		if ( user_can( $uid, 'manage_options' ) ) {
+			return self::TIER_UNMASKED;
+		}
+
+		// Role check — `ffc_recruitment_admin` is the highest-trust
+		// recruitment role and shouldn't be slowed down by per-field
+		// clicks. Caps alone don't tell us the role, so we hit get_user().
+		$user = get_user_by( 'id', $uid );
+		if ( $user && in_array( 'ffc_recruitment_admin', (array) $user->roles, true ) ) {
+			return self::TIER_UNMASKED;
+		}
+
+		if ( user_can( $uid, 'ffc_view_recruitment_pii' ) ) {
+			return self::TIER_REVEAL;
+		}
+
+		// Owner clause — the candidate themselves sees their own data.
+		// Audit still fires (so the trail captures who-saw-what across
+		// the lifetime of the row).
+		if ( $candidate && isset( $candidate->user_id ) && (int) $candidate->user_id === $uid ) {
+			return self::TIER_REVEAL;
+		}
+
+		return self::TIER_MASKED;
+	}
+
+	/**
+	 * Convenience predicate: can this user reveal at all (unmasked OR reveal)?
+	 *
+	 * @param object|null $candidate Candidate row (with at least `user_id`), or null.
+	 * @param int|null    $user_id   User to check; defaults to current user.
+	 * @return bool
+	 */
+	public static function can_reveal( ?object $candidate, ?int $user_id = null ): bool {
+		$tier = self::resolve( $candidate, $user_id );
+		return self::TIER_MASKED !== $tier;
+	}
+
+	/**
+	 * Convenience predicate: does revealing fire an audit row?
+	 *
+	 * `unmasked` tier explicitly skips audit (high-trust roles, no noise).
+	 * `reveal` tier always audits (subject to dedup + setting toggle).
+	 *
+	 * @param object|null $candidate Candidate row, or null.
+	 * @param int|null    $user_id   User to check; defaults to current user.
+	 * @return bool
+	 */
+	public static function should_audit( ?object $candidate, ?int $user_id = null ): bool {
+		return self::TIER_REVEAL === self::resolve( $candidate, $user_id );
+	}
+}

--- a/includes/recruitment/class-ffc-recruitment-settings.php
+++ b/includes/recruitment/class-ffc-recruitment-settings.php
@@ -72,6 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *   notice_status_color_preliminary: string,
  *   notice_status_color_definitive:  string,
  *   notice_status_color_closed:      string,
+ *   audit_pii_reveals:               bool,
  * }
  */
 final class RecruitmentSettings {
@@ -168,6 +169,15 @@ final class RecruitmentSettings {
 			'notice_status_color_preliminary'        => '#fff3cd',
 			'notice_status_color_definitive'         => '#d4edda',
 			'notice_status_color_closed'             => '#f8d7da',
+			// Audit log toggle for the PII reveal flow (issue #330).
+			// When true, every reveal of CPF / RF / email on the candidate
+			// detail screen by a non-admin user writes a row to
+			// `ffc_activity_log` (subject to a 60s dedup window per
+			// user+candidate+field). When false, the reveal still works
+			// but no audit row is written — useful for low-trust dev
+			// environments or compliance configs that prefer external
+			// auditing tools.
+			'audit_pii_reveals'                      => true,
 		);
 	}
 
@@ -269,6 +279,14 @@ final class RecruitmentSettings {
 		$out['preview_reason_required_appeal_denied']  = ! empty( $value['preview_reason_required_appeal_denied'] );
 		$out['preview_reason_required_appeal_granted'] = ! empty( $value['preview_reason_required_appeal_granted'] );
 
+		// Audit toggle for the PII reveal flow (issue #330). Default-on
+		// when the key is absent from POST (typical for first-time saves
+		// before the new checkbox lands in the Settings UI). Once the
+		// checkbox renders, `!empty()` honors the operator's choice.
+		$out['audit_pii_reveals'] = array_key_exists( 'audit_pii_reveals', $value )
+			? ! empty( $value['audit_pii_reveals'] )
+			: (bool) $defaults['audit_pii_reveals'];
+
 		return $out;
 	}
 
@@ -346,6 +364,7 @@ final class RecruitmentSettings {
 			'notice_status_color_preliminary'        => is_string( $value['notice_status_color_preliminary'] ?? null ) ? $value['notice_status_color_preliminary'] : $defaults['notice_status_color_preliminary'],
 			'notice_status_color_definitive'         => is_string( $value['notice_status_color_definitive'] ?? null ) ? $value['notice_status_color_definitive'] : $defaults['notice_status_color_definitive'],
 			'notice_status_color_closed'             => is_string( $value['notice_status_color_closed'] ?? null ) ? $value['notice_status_color_closed'] : $defaults['notice_status_color_closed'],
+			'audit_pii_reveals'                      => is_bool( $value['audit_pii_reveals'] ?? null ) ? $value['audit_pii_reveals'] : $defaults['audit_pii_reveals'],
 		);
 	}
 

--- a/tests/Unit/RecruitmentActivityLoggerTest.php
+++ b/tests/Unit/RecruitmentActivityLoggerTest.php
@@ -217,4 +217,102 @@ class RecruitmentActivityLoggerTest extends TestCase {
 		$context = json_decode( (string) $entry['context'], true );
 		$this->assertSame( 2, $context['adjutancy_id'] );
 	}
+
+	// ------------------------------------------------------------------
+	// pii_revealed() — issue #330
+	// ------------------------------------------------------------------
+
+	/**
+	 * Override get_option to return a RecruitmentSettings array with the
+	 * `audit_pii_reveals` toggle in the requested state, and stub the
+	 * transient API with an in-memory map so dedup behavior is testable.
+	 *
+	 * @param bool                  $audit_enabled Whether audit_pii_reveals is on.
+	 * @param array<string, mixed>  $transient_state Initial transient values keyed by name.
+	 */
+	private function configure_pii_audit( bool $audit_enabled, array &$transient_state ): void {
+		// The logger reads the recruitment settings array via get_option
+		// directly (avoids the defaults() chain in tests). When audit is
+		// "enabled", we omit the key so the logger's default-on branch
+		// fires; when "disabled", we set the key to false explicitly.
+		Functions\when( 'get_option' )->alias( static function ( $key ) use ( $audit_enabled ) {
+			if ( 'ffc_recruitment_settings' === $key ) {
+				return $audit_enabled ? array() : array( 'audit_pii_reveals' => false );
+			}
+			// Activity log itself needs `enable_activity_log` on.
+			return array( 'enable_activity_log' => 1 );
+		} );
+
+		Functions\when( 'get_transient' )->alias( static function ( $name ) use ( &$transient_state ) {
+			return $transient_state[ $name ] ?? false;
+		} );
+		Functions\when( 'set_transient' )->alias( static function ( $name, $value, $ttl = 0 ) use ( &$transient_state ) {
+			$transient_state[ $name ] = $value;
+			return true;
+		} );
+	}
+
+	public function test_pii_revealed_logs_when_audit_enabled(): void {
+		$transients = array();
+		$this->configure_pii_audit( true, $transients );
+
+		$wrote = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+
+		$this->assertTrue( $wrote );
+		$entry = $this->last_buffered_entry();
+		$this->assertNotNull( $entry );
+		$this->assertSame( 'recruitment_pii_revealed', $entry['action'] );
+		// Context contains a sensitive key ('cpf' via field_key value), but
+		// the encrypted path is exercised in a different test — here we
+		// just check the action code lands and the payload is non-empty.
+		$this->assertNotEmpty( $entry['context'] ?? $entry['context_encrypted'] ?? '' );
+	}
+
+	public function test_pii_revealed_skips_log_when_audit_disabled(): void {
+		$transients = array();
+		$this->configure_pii_audit( false, $transients );
+
+		$wrote = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+
+		$this->assertFalse( $wrote );
+		$this->assertNull( $this->last_buffered_entry() );
+	}
+
+	public function test_pii_revealed_dedups_same_user_candidate_field_within_window(): void {
+		$transients = array();
+		$this->configure_pii_audit( true, $transients );
+
+		$first  = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+		$second = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+
+		$this->assertTrue( $first );
+		$this->assertFalse( $second, 'second call within window should dedup' );
+
+		// Only the first call produced a log entry.
+		$this->assertCount( 1, $this->buffer() );
+	}
+
+	public function test_pii_revealed_does_not_dedup_across_different_fields(): void {
+		$transients = array();
+		$this->configure_pii_audit( true, $transients );
+
+		$cpf = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+		$rf  = RecruitmentActivityLogger::pii_revealed( 12, 'rf' );
+
+		$this->assertTrue( $cpf );
+		$this->assertTrue( $rf, 'different field key must not be deduped' );
+		$this->assertCount( 2, $this->buffer() );
+	}
+
+	public function test_pii_revealed_does_not_dedup_across_different_candidates(): void {
+		$transients = array();
+		$this->configure_pii_audit( true, $transients );
+
+		$a = RecruitmentActivityLogger::pii_revealed( 12, 'cpf' );
+		$b = RecruitmentActivityLogger::pii_revealed( 13, 'cpf' );
+
+		$this->assertTrue( $a );
+		$this->assertTrue( $b, 'different candidate must not be deduped' );
+		$this->assertCount( 2, $this->buffer() );
+	}
 }

--- a/tests/Unit/RecruitmentCandidatesRestControllerTest.php
+++ b/tests/Unit/RecruitmentCandidatesRestControllerTest.php
@@ -85,6 +85,28 @@ class RecruitmentCandidatesRestControllerTest extends TestCase {
         $this->assertContains( '/recruitment/candidates/(?P<id>\d+)', $routes );
     }
 
+    public function test_register_routes_includes_reveal_pii_endpoint(): void {
+        $this->controller->register_routes();
+
+        $routes = array_column( $this->registered_routes, 'route' );
+        $this->assertContains( '/recruitment/candidates/(?P<id>\d+)/reveal-pii', $routes );
+
+        // Permission gate must be `check_logged_in` (the policy decides
+        // per-request whether the owner-clause applies; the route can't
+        // reject upfront on caps alone).
+        $reveal_entry = null;
+        foreach ( $this->registered_routes as $entry ) {
+            if ( '/recruitment/candidates/(?P<id>\d+)/reveal-pii' === $entry['route'] ) {
+                $reveal_entry = $entry;
+                break;
+            }
+        }
+        $this->assertNotNull( $reveal_entry );
+        $perm = $reveal_entry['args']['permission_callback'] ?? null;
+        $this->assertIsArray( $perm );
+        $this->assertSame( 'check_logged_in', $perm[1] );
+    }
+
     public function test_register_routes_includes_the_me_self_endpoint(): void {
         $this->controller->register_routes();
 

--- a/tests/Unit/RecruitmentPiiAccessPolicyTest.php
+++ b/tests/Unit/RecruitmentPiiAccessPolicyTest.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentPiiAccessPolicy;
+
+/**
+ * Tests for RecruitmentPiiAccessPolicy — the three-tier resolver that
+ * decides whether the operator sees PII unmasked, behind a click-to-
+ * reveal toggle, or never. Covers each of the four resolution rules
+ * (cap, role, granular cap, owner) plus the convenience predicates.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentPiiAccessPolicy
+ */
+class RecruitmentPiiAccessPolicyTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function setUserCapsAndRoles( int $uid, array $caps, array $roles = array() ): void {
+		Functions\when( 'get_current_user_id' )->justReturn( $uid );
+
+		// user_can( $uid, $cap ) returns true if cap is in $caps.
+		Functions\when( 'user_can' )->alias( static function ( $arg_uid, $cap ) use ( $uid, $caps ) {
+			if ( (int) $arg_uid !== $uid ) {
+				return false;
+			}
+			return in_array( $cap, $caps, true );
+		} );
+
+		// get_user_by('id', $uid) returns a stub with the given roles.
+		Functions\when( 'get_user_by' )->alias( static function ( $field, $arg_uid ) use ( $uid, $roles ) {
+			if ( 'id' !== $field || (int) $arg_uid !== $uid ) {
+				return false;
+			}
+			$stub        = new \stdClass();
+			$stub->roles = $roles;
+			return $stub;
+		} );
+	}
+
+	private function candidate( ?int $linked_user_id = null ): object {
+		$c          = new \stdClass();
+		$c->id      = 7;
+		$c->user_id = $linked_user_id;
+		return $c;
+	}
+
+	// ------------------------------------------------------------------
+	// Tier resolution
+	// ------------------------------------------------------------------
+
+	public function test_manage_options_user_gets_unmasked_tier(): void {
+		$this->setUserCapsAndRoles( 10, array( 'manage_options' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_UNMASKED,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate() )
+		);
+	}
+
+	public function test_ffc_recruitment_admin_role_gets_unmasked_tier(): void {
+		$this->setUserCapsAndRoles( 10, array(), array( 'ffc_recruitment_admin' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_UNMASKED,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate() )
+		);
+	}
+
+	public function test_user_with_granular_pii_cap_gets_reveal_tier(): void {
+		$this->setUserCapsAndRoles( 10, array( 'ffc_view_recruitment_pii' ), array( 'ffc_recruitment_manager' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_REVEAL,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate() )
+		);
+	}
+
+	public function test_candidate_owner_gets_reveal_tier_even_without_caps(): void {
+		// Owner of the data (linked WP user) — no caps, no role.
+		$this->setUserCapsAndRoles( 42, array(), array( 'subscriber' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_REVEAL,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate( 42 ) )
+		);
+	}
+
+	public function test_unrelated_user_without_caps_gets_masked_tier(): void {
+		$this->setUserCapsAndRoles( 50, array(), array( 'subscriber' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_MASKED,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate( 42 ) )
+		);
+	}
+
+	public function test_logged_out_user_gets_masked_tier(): void {
+		$this->setUserCapsAndRoles( 0, array() );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_MASKED,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate( 42 ) )
+		);
+	}
+
+	public function test_owner_check_only_fires_when_candidate_is_provided(): void {
+		// Same user (uid=42) but candidate is null — falls through to caps,
+		// no caps → masked.
+		$this->setUserCapsAndRoles( 42, array() );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_MASKED,
+			RecruitmentPiiAccessPolicy::resolve( null )
+		);
+	}
+
+	public function test_cap_path_wins_over_owner_path_for_higher_tier(): void {
+		// Owner of the record + admin role → unmasked (the higher tier wins).
+		$this->setUserCapsAndRoles( 42, array( 'manage_options' ) );
+		$this->assertSame(
+			RecruitmentPiiAccessPolicy::TIER_UNMASKED,
+			RecruitmentPiiAccessPolicy::resolve( $this->candidate( 42 ) )
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Convenience predicates
+	// ------------------------------------------------------------------
+
+	public function test_can_reveal_true_for_unmasked_and_reveal_tiers(): void {
+		$this->setUserCapsAndRoles( 10, array( 'manage_options' ) );
+		$this->assertTrue( RecruitmentPiiAccessPolicy::can_reveal( $this->candidate() ) );
+
+		$this->setUserCapsAndRoles( 10, array( 'ffc_view_recruitment_pii' ) );
+		$this->assertTrue( RecruitmentPiiAccessPolicy::can_reveal( $this->candidate() ) );
+	}
+
+	public function test_can_reveal_false_for_masked_tier(): void {
+		$this->setUserCapsAndRoles( 10, array() );
+		$this->assertFalse( RecruitmentPiiAccessPolicy::can_reveal( $this->candidate( 42 ) ) );
+	}
+
+	public function test_should_audit_true_only_for_reveal_tier(): void {
+		// unmasked → no audit (high-trust roles, no noise).
+		$this->setUserCapsAndRoles( 10, array( 'manage_options' ) );
+		$this->assertFalse( RecruitmentPiiAccessPolicy::should_audit( $this->candidate() ) );
+
+		// reveal → audit fires.
+		$this->setUserCapsAndRoles( 10, array( 'ffc_view_recruitment_pii' ) );
+		$this->assertTrue( RecruitmentPiiAccessPolicy::should_audit( $this->candidate() ) );
+
+		// masked → no reveal possible, audit moot but contract is false.
+		$this->setUserCapsAndRoles( 10, array() );
+		$this->assertFalse( RecruitmentPiiAccessPolicy::should_audit( $this->candidate( 42 ) ) );
+	}
+}


### PR DESCRIPTION
Closes #330.

## Resumo

Implementa o **toggle de reveal de PII com audit log** na tela de detalhe do candidato (`ffc_recruitment`). Resolve as 3 decisões que ficaram em aberto na sub-issue:

| Decisão | Escolha |
|---|---|
| Estado default por audience | Tier-based: `unmasked` (admin), `reveal` (cap granular ou owner), `masked` (resto) |
| Capability | Reutilizar `ffc_view_recruitment_pii` (já existente) + role `ffc_recruitment_admin` para o tier `unmasked` |
| Audit | Dedup 60s no mesmo `(user, candidate, field)`, com setting `audit_pii_reveals` (default `true`) pra desligar global |

## Arquitetura

### `RecruitmentPiiAccessPolicy` (nova classe)

`resolve($candidate, $user_id)` → `unmasked|reveal|masked`. Regras:

1. `manage_options` ou role `ffc_recruitment_admin` → `unmasked`
2. Cap granular `ffc_view_recruitment_pii` → `reveal`
3. Owner do registro (`$candidate->user_id === $user_id`) → `reveal`
4. Resto → `masked`

Predicados de conveniência: `can_reveal()` e `should_audit()`.

### `RecruitmentActivityLogger::pii_revealed($candidate_id, $field_key)` (novo)

- Lê `audit_pii_reveals` direto via `get_option()` (evita o caminho de `defaults()` que carrega `__()` em namespace, pra não complicar testes nem custar I/O à toa).
- Dedup via `set_transient` chave `ffc_pii_reveal_{user}_{candidate}_{field}` com TTL 60s.
- Loga `recruitment_pii_revealed` com payload `{candidate_id, field_key}`. `SensitiveFieldRegistry` cuida da encriptação automática se houver chave sensível no payload — aqui não há, mas a infraestrutura está pronta.

### `POST /recruitment/candidates/{id}/reveal-pii` (novo endpoint)

- Permission gate: `check_logged_in` (a policy decide per-request o tier, pra suportar o owner case sem cap admin).
- Re-roda a policy server-side (defesa em profundidade).
- Decripta via `Encryption::decrypt()`, formata via `DocumentFormatter::format_cpf|format_rf`.
- Loga se `should_audit()`.
- Retorna `{field, value}`.

### Renderer da tela de detalhe

`render_sensitive_section()` agora resolve a tier uma vez por postbox e roteia cada campo (CPF/RF) via `render_sensitive_row($tier, ...)`:

- `unmasked` → comportamento original (`render_decrypted()`).
- `reveal` → `<code class="ffc-pii-placeholder">***.***.***-**</code>` + `<button class="ffc-pii-reveal-btn">`. JS inline faz fetch → swap textContent in-place. Botão vira "Hide" no estado revelado; clique restaura placeholder (sem novo audit).
- `masked` → só o placeholder; nenhum botão.

JS inline emitido só quando tier=`reveal` (no-op nos outros).

### Setting nova

`audit_pii_reveals` (bool, default `true`) — exposto na aba Settings do Recruitment com `AdminUI::render_toggle()`. Inclui no `phpstan-type SettingsArray`, no `defaults()`, no `sanitize()` e no `migrate()`.

## Escopo / scope-down

- **Email out**: email é editável (input na seção General), não display-only. Aplicar a mesma policy lá pediria refactor de input mascarado-editável e reveal-pra-editar — fora de escopo desta PR. Anotado em comentários.
- **Owner case sem efeito imediato hoje**: a página requer `ffc_manage_recruitment` (cap maior), então o owner sem essa cap nem chega na tela. A policy resolve corretamente caso o gate seja afrouxado no futuro (ou aplicada em outra surface).

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4438/4438** (+17 cases novos)
  - `RecruitmentPiiAccessPolicyTest` (11): cobre as 4 branches + predicados.
  - `RecruitmentActivityLoggerTest` (+5): logs quando on, skip quando off, dedup mesmo tuple, no-dedup cross-field, no-dedup cross-candidate.
  - `RecruitmentCandidatesRestControllerTest` (+1): rota `/reveal-pii` registrada com `check_logged_in`.
- [x] `npm run test:js` → 885/885 (nenhum JS file novo; toda lógica nova é inline no PHP)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/recruitment/` → clean
- [x] `vendor/bin/phpstan analyze` → clean

Validação manual sugerida:
- [ ] User WP admin (manage_options) abre detalhe → CPF/RF aparecem plaintext direto, **sem** botão e **sem** linha em activity log.
- [ ] User com role `ffc_recruitment_manager` (sem admin role) → vê placeholders + botão "Reveal"; clicar mostra plaintext e gera linha `recruitment_pii_revealed`. Segundo clique no botão (que virou "Hide") restaura placeholder, sem novo audit.
- [ ] Clicar Reveal de novo dentro de 60s no mesmo campo → não duplica audit (dedup).
- [ ] Settings → "PII access audit" → off → reveal funciona mas activity log não recebe linha.
- [ ] Owner case (candidate->user_id === current user, com cap baixa) — sem teste prático hoje (gate da tela bloqueia), mas a policy resolve correto.

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_