### PR TITLE
Recruitment admin: candidate-search filters (email, status, combinable) (#331 search)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-candidate-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-repository.php
@@ -423,6 +423,189 @@ class RecruitmentCandidateRepository {
 	}
 
 	/**
+	 * Return every candidate row whose `email_hash` matches the given
+	 * digest. Used by the list-table when the operator types an email
+	 * into the search box — the column is non-unique so multiple
+	 * candidates can legitimately share it (family members, etc.).
+	 *
+	 * @since 6.6.2
+	 * @param string $email_hash Hash produced by `Encryption::hash()`.
+	 * @return list<int> Candidate IDs matching the hash (empty array on no match).
+	 */
+	public static function get_ids_by_email_hash( string $email_hash ): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed (non-unique) lookup.
+		$rows = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT id FROM %i WHERE email_hash = %s', $table, $email_hash )
+		);
+
+		return array_values( array_map( 'intval', $rows ) );
+	}
+
+	/**
+	 * Paginated candidates with combinable filters (issue #331 search frontend).
+	 *
+	 * All filters are AND-ed:
+	 *   - `$name_search`     — LIKE on the `name` column when non-empty.
+	 *   - `$id_constraint`   — array of candidate IDs the result is
+	 *     limited to (used by CPF / RF / email matches resolved upfront).
+	 *     `null` means "no constraint"; an empty array means "no
+	 *     candidates match" and the method short-circuits to `[]`.
+	 *   - `$adjutancy_id`    — `>0` joins on the classifications table
+	 *     and limits to candidates with at least one classification in
+	 *     that adjutancy.
+	 *   - `$status`          — one of `empty|called|accepted|not_shown|hired`
+	 *     joins on the classifications table (list_type='definitive')
+	 *     and limits to candidates whose at-least-one definitive
+	 *     classification is in that status.
+	 *
+	 * When both `$adjutancy_id` and `$status` are set, the JOIN is
+	 * combined (same row must match both) — matches the operator's
+	 * mental model of "candidates currently called in adjutancy X".
+	 *
+	 * @since 6.6.2
+	 * @param string         $name_search   Optional substring filter on name.
+	 * @param list<int>|null $id_constraint Optional candidate-id constraint set.
+	 * @param int            $adjutancy_id  Optional adjutancy id; 0 = no filter.
+	 * @param string         $status        Optional classification status; '' = no filter.
+	 * @param int            $limit         Page size (capped at 200).
+	 * @param int            $offset        Page offset.
+	 * @return list<CandidateRow>
+	 */
+	public static function get_paginated_filtered(
+		string $name_search,
+		?array $id_constraint,
+		int $adjutancy_id,
+		string $status,
+		int $limit,
+		int $offset
+	): array {
+		if ( is_array( $id_constraint ) && empty( $id_constraint ) ) {
+			return array();
+		}
+
+		$wpdb      = self::db();
+		$table     = self::get_table_name();
+		$cls_table = $wpdb->prefix . 'ffc_recruitment_classification';
+
+		$limit  = max( 1, min( 200, $limit ) );
+		$offset = max( 0, $offset );
+
+		$where          = array();
+		$where_a        = array();
+		$needs_cls_join = $adjutancy_id > 0 || '' !== $status;
+
+		if ( '' !== $name_search ) {
+			$where[]   = 'c.name LIKE %s';
+			$where_a[] = '%' . $wpdb->esc_like( $name_search ) . '%';
+		}
+		if ( is_array( $id_constraint ) ) {
+			$ids     = array_values( array_unique( array_map( 'intval', $id_constraint ) ) );
+			$where[] = 'c.id IN (' . implode( ',', array_fill( 0, count( $ids ), '%d' ) ) . ')';
+			$where_a = array_merge( $where_a, $ids );
+		}
+		if ( $adjutancy_id > 0 ) {
+			$where[]   = 'cls.adjutancy_id = %d';
+			$where_a[] = $adjutancy_id;
+		}
+		if ( '' !== $status ) {
+			$where[]   = 'cls.status = %s';
+			$where_a[] = $status;
+			$where[]   = "cls.list_type = 'definitive'";
+		}
+
+		$sql_args = array( $table );
+		$select   = 'SELECT DISTINCT c.* FROM %i c';
+		if ( $needs_cls_join ) {
+			$select    .= ' INNER JOIN %i cls ON cls.candidate_id = c.id';
+			$sql_args[] = $cls_table;
+		}
+		if ( ! empty( $where ) ) {
+			$select  .= ' WHERE ' . implode( ' AND ', $where );
+			$sql_args = array_merge( $sql_args, $where_a );
+		}
+		$select    .= ' ORDER BY c.created_at DESC LIMIT %d OFFSET %d';
+		$sql_args[] = $limit;
+		$sql_args[] = $offset;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- $select is assembled from compile-time fragments with %s/%d placeholders matching $sql_args one-to-one.
+		$results = $wpdb->get_results( $wpdb->prepare( $select, $sql_args ) );
+
+		/**
+		 * Typed shape cast.
+		 *
+		 * @var list<CandidateRow>|null $results
+		 */
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
+	 * Companion count for {@see self::get_paginated_filtered()}.
+	 *
+	 * @since 6.6.2
+	 * @param string         $name_search   Optional substring filter on name.
+	 * @param list<int>|null $id_constraint Optional candidate-id constraint set.
+	 * @param int            $adjutancy_id  Optional adjutancy id; 0 = no filter.
+	 * @param string         $status        Optional classification status; '' = no filter.
+	 * @return int
+	 */
+	public static function count_paginated_filtered(
+		string $name_search,
+		?array $id_constraint,
+		int $adjutancy_id,
+		string $status
+	): int {
+		if ( is_array( $id_constraint ) && empty( $id_constraint ) ) {
+			return 0;
+		}
+
+		$wpdb      = self::db();
+		$table     = self::get_table_name();
+		$cls_table = $wpdb->prefix . 'ffc_recruitment_classification';
+
+		$where          = array();
+		$where_a        = array();
+		$needs_cls_join = $adjutancy_id > 0 || '' !== $status;
+
+		if ( '' !== $name_search ) {
+			$where[]   = 'c.name LIKE %s';
+			$where_a[] = '%' . $wpdb->esc_like( $name_search ) . '%';
+		}
+		if ( is_array( $id_constraint ) ) {
+			$ids     = array_values( array_unique( array_map( 'intval', $id_constraint ) ) );
+			$where[] = 'c.id IN (' . implode( ',', array_fill( 0, count( $ids ), '%d' ) ) . ')';
+			$where_a = array_merge( $where_a, $ids );
+		}
+		if ( $adjutancy_id > 0 ) {
+			$where[]   = 'cls.adjutancy_id = %d';
+			$where_a[] = $adjutancy_id;
+		}
+		if ( '' !== $status ) {
+			$where[]   = 'cls.status = %s';
+			$where_a[] = $status;
+			$where[]   = "cls.list_type = 'definitive'";
+		}
+
+		$sql_args = array( $table );
+		$select   = 'SELECT COUNT(DISTINCT c.id) FROM %i c';
+		if ( $needs_cls_join ) {
+			$select    .= ' INNER JOIN %i cls ON cls.candidate_id = c.id';
+			$sql_args[] = $cls_table;
+		}
+		if ( ! empty( $where ) ) {
+			$select  .= ' WHERE ' . implode( ' AND ', $where );
+			$sql_args = array_merge( $sql_args, $where_a );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- $select assembled from compile-time fragments; placeholders match $sql_args.
+		$total = $wpdb->get_var( $wpdb->prepare( $select, $sql_args ) );
+
+		return null === $total ? 0 : (int) $total;
+	}
+
+	/**
 	 * Insert a new candidate row.
 	 *
 	 * Required keys: `name`, `pcd_hash`. At least one of `cpf_hash` or

--- a/includes/recruitment/class-ffc-recruitment-candidates-list-table.php
+++ b/includes/recruitment/class-ffc-recruitment-candidates-list-table.php
@@ -40,6 +40,16 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 	private const MAX_PER_PAGE     = 100;
 
 	/**
+	 * Classification statuses the operator can filter by from the
+	 * Candidates tab toolbar. Mirrors the §5.2 state machine vocabulary.
+	 * Any other value typed into `?status=` is rejected and treated as
+	 * "no filter".
+	 *
+	 * @var list<string>
+	 */
+	private const ALLOWED_STATUSES = array( 'empty', 'called', 'accepted', 'not_shown', 'hired' );
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -242,41 +252,46 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$cpf = isset( $_REQUEST['cpf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['cpf'] ) ) : '';
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$rf = isset( $_REQUEST['rf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['rf'] ) ) : '';
-
-		// CPF / RF lookup short-circuits everything else.
-		if ( '' !== $cpf || '' !== $rf ) {
-			$candidate   = self::lookup_by_cpf_rf( $cpf, $rf );
-			$rows        = null === $candidate ? array() : array( self::convert_row( $candidate ) );
-			$this->items = $rows;
-			$this->set_pagination_args(
-				array(
-					'total_items' => count( $rows ),
-					'per_page'    => 1,
-					'total_pages' => 1,
-				)
-			);
-			return;
-		}
-
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$email = isset( $_REQUEST['email'] ) ? sanitize_email( wp_unslash( (string) $_REQUEST['email'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$search = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['s'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$adjutancy_id = isset( $_REQUEST['adjutancy_id'] ) ? absint( wp_unslash( (string) $_REQUEST['adjutancy_id'] ) ) : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$status_raw = isset( $_REQUEST['status'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['status'] ) ) : '';
+		$status     = in_array( $status_raw, self::ALLOWED_STATUSES, true ) ? $status_raw : '';
+
+		// Resolve CPF / RF / email to a candidate-id constraint set.
+		// Each is independently optional; when all three are absent the
+		// constraint is `null` (no narrowing). Otherwise we intersect
+		// the matches — typing CPF + email means "the candidate with
+		// this CPF AND this email", not the union. If any of the three
+		// resolves to zero matches we short-circuit to an empty result
+		// without hitting the main paginated query.
+		$id_constraint = self::resolve_id_constraint( $cpf, $rf, $email );
 
 		$per_page     = $this->get_items_per_page( 'ffc_recruitment_candidates_per_page', self::DEFAULT_PER_PAGE );
 		$per_page     = min( max( 1, $per_page ), self::MAX_PER_PAGE );
 		$current_page = max( 1, $this->get_pagenum() );
 		$offset       = ( $current_page - 1 ) * $per_page;
 
-		if ( $adjutancy_id > 0 ) {
-			$total_items = RecruitmentCandidateRepository::count_paginated_for_adjutancy( $search, $adjutancy_id );
-			$raw_rows    = RecruitmentCandidateRepository::get_paginated_for_adjutancy( $search, $adjutancy_id, $per_page, $offset );
-		} else {
-			$total_items = RecruitmentCandidateRepository::count_paginated( $search );
-			$raw_rows    = RecruitmentCandidateRepository::get_paginated( $search, $per_page, $offset );
-		}
+		$total_items = RecruitmentCandidateRepository::count_paginated_filtered(
+			$search,
+			$id_constraint,
+			$adjutancy_id,
+			$status
+		);
+		$raw_rows    = RecruitmentCandidateRepository::get_paginated_filtered(
+			$search,
+			$id_constraint,
+			$adjutancy_id,
+			$status,
+			$per_page,
+			$offset
+		);
 
 		$this->items = array_map( array( self::class, 'convert_row' ), $raw_rows );
 
@@ -352,18 +367,24 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$cpf = isset( $_REQUEST['cpf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['cpf'] ) ) : '';
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$rf = isset( $_REQUEST['rf'] ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['rf'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$email = isset( $_REQUEST['email'] ) ? sanitize_email( wp_unslash( (string) $_REQUEST['email'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
 		$adjutancy_id = isset( $_REQUEST['adjutancy_id'] ) ? absint( wp_unslash( (string) $_REQUEST['adjutancy_id'] ) ) : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$status_raw = isset( $_REQUEST['status'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['status'] ) ) : '';
+		$status     = in_array( $status_raw, self::ALLOWED_STATUSES, true ) ? $status_raw : '';
 
 		echo '<div class="alignleft actions">';
 		echo '<input type="text" name="cpf" value="' . esc_attr( $cpf ) . '" placeholder="' . esc_attr__( 'CPF (digits only)', 'ffcertificate' ) . '" size="15">';
 		echo ' <input type="text" name="rf" value="' . esc_attr( $rf ) . '" placeholder="' . esc_attr__( 'RF (digits only)', 'ffcertificate' ) . '" size="10">';
+		echo ' <input type="email" name="email" value="' . esc_attr( $email ) . '" placeholder="' . esc_attr__( 'Email (exact)', 'ffcertificate' ) . '" size="22">';
 
 		// Adjutancy dropdown — limits the result set to candidates with at
-		// least one classification in the selected adjutancy. Independent
-		// of the CPF/RF lookup, which short-circuits everything else.
+		// least one classification in the selected adjutancy. Combinable
+		// with every other filter via the unified paginated query.
 		$adjutancies = RecruitmentAdjutancyRepository::get_all();
 		if ( ! empty( $adjutancies ) ) {
 			echo ' <select name="adjutancy_id">';
@@ -376,34 +397,92 @@ class RecruitmentCandidatesListTable extends \WP_List_Table {
 			echo '</select>';
 		}
 
+		// Status dropdown — limits to candidates with at least one
+		// definitive classification in the selected status (§5.2 enum).
+		echo ' <select name="status">';
+		echo '<option value="">' . esc_html__( 'All statuses', 'ffcertificate' ) . '</option>';
+		$status_labels = array(
+			'empty'     => __( 'Waiting', 'ffcertificate' ),
+			'called'    => __( 'Called', 'ffcertificate' ),
+			'accepted'  => __( 'Accepted', 'ffcertificate' ),
+			'not_shown' => __( 'Did not show up', 'ffcertificate' ),
+			'hired'     => __( 'Hired', 'ffcertificate' ),
+		);
+		foreach ( $status_labels as $value => $label ) {
+			$is_selected = $value === $status ? ' selected' : '';
+			echo '<option value="' . esc_attr( $value ) . '"' . esc_attr( $is_selected ) . '>' . esc_html( $label ) . '</option>';
+		}
+		echo '</select>';
+
 		echo ' <input type="submit" class="button" value="' . esc_attr__( 'Filter', 'ffcertificate' ) . '">';
 		echo '</div>';
 	}
 
 	/**
-	 * Resolve a single candidate by CPF or RF (digits-only input).
+	 * Resolve CPF / RF / email search inputs into a candidate-id
+	 * constraint set the paginated query can use as a `c.id IN (...)`
+	 * narrowing. The three filters are AND-ed (intersection).
 	 *
-	 * @param string $cpf Operator-typed CPF.
-	 * @param string $rf  Operator-typed RF.
-	 * @return object|null
-	 * @phpstan-return CandidateRow|null
+	 * Returns:
+	 *   - `null` when none of the three is set (no narrowing applied).
+	 *   - empty `array()` when at least one is set but no candidate
+	 *     matches that input (caller should short-circuit to 0 rows).
+	 *   - non-empty `list<int>` otherwise.
+	 *
+	 * @since 6.6.2
+	 * @param string $cpf   Operator-typed CPF (digits or formatted).
+	 * @param string $rf    Operator-typed RF (digits or formatted).
+	 * @param string $email Operator-typed email (post-sanitize_email).
+	 * @return list<int>|null
 	 */
-	private static function lookup_by_cpf_rf( string $cpf, string $rf ): ?object {
+	private static function resolve_id_constraint( string $cpf, string $rf, string $email ): ?array {
+		$sets = array();
+
 		if ( '' !== $cpf ) {
-			$digits = \FreeFormCertificate\Core\DataSanitizer::normalize_cpf_rf( $cpf );
-			if ( '' !== $digits ) {
-				$hash = (string) Encryption::hash( $digits );
-				return RecruitmentCandidateRepository::get_by_cpf_hash( $hash );
-			}
+			$sets[] = self::resolve_cpf_or_rf_to_ids( $cpf, 'cpf' );
 		}
 		if ( '' !== $rf ) {
-			$digits = \FreeFormCertificate\Core\DataSanitizer::normalize_cpf_rf( $rf );
-			if ( '' !== $digits ) {
-				$hash = (string) Encryption::hash( $digits );
-				return RecruitmentCandidateRepository::get_by_rf_hash( $hash );
+			$sets[] = self::resolve_cpf_or_rf_to_ids( $rf, 'rf' );
+		}
+		if ( '' !== $email ) {
+			$hash   = (string) Encryption::hash( $email );
+			$sets[] = '' === $hash ? array() : RecruitmentCandidateRepository::get_ids_by_email_hash( $hash );
+		}
+
+		if ( empty( $sets ) ) {
+			return null;
+		}
+
+		// Intersect every non-null set. Any empty set propagates → no
+		// candidate matches all the filters typed by the operator.
+		$intersection = array_shift( $sets );
+		foreach ( $sets as $next ) {
+			$intersection = array_values( array_intersect( $intersection, $next ) );
+			if ( empty( $intersection ) ) {
+				return array();
 			}
 		}
-		return null;
+		return $intersection;
+	}
+
+	/**
+	 * Resolve a single CPF or RF input to the matching candidate-id
+	 * list (size 0 or 1 — the columns are UNIQUE).
+	 *
+	 * @param string $value Operator-typed value (digits or formatted).
+	 * @param string $kind  Either `'cpf'` or `'rf'`.
+	 * @return list<int>
+	 */
+	private static function resolve_cpf_or_rf_to_ids( string $value, string $kind ): array {
+		$digits = \FreeFormCertificate\Core\DataSanitizer::normalize_cpf_rf( $value );
+		if ( '' === $digits ) {
+			return array();
+		}
+		$hash = (string) Encryption::hash( $digits );
+		$row  = 'cpf' === $kind
+			? RecruitmentCandidateRepository::get_by_cpf_hash( $hash )
+			: RecruitmentCandidateRepository::get_by_rf_hash( $hash );
+		return null === $row ? array() : array( (int) $row->id );
 	}
 
 	/**

--- a/tests/Unit/RecruitmentCandidateRepositoryTest.php
+++ b/tests/Unit/RecruitmentCandidateRepositoryTest.php
@@ -195,4 +195,94 @@ class RecruitmentCandidateRepositoryTest extends TestCase {
 
 		$this->assertTrue( RecruitmentCandidateRepository::delete( 5 ) );
 	}
+
+	// ------------------------------------------------------------------
+	// get_ids_by_email_hash() — issue #331 search frontend
+	// ------------------------------------------------------------------
+
+	public function test_get_ids_by_email_hash_returns_all_matches(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( '1', '7', '12' ) );
+
+		$ids = RecruitmentCandidateRepository::get_ids_by_email_hash( 'fakehash' );
+
+		$this->assertSame( array( 1, 7, 12 ), $ids );
+	}
+
+	public function test_get_ids_by_email_hash_returns_empty_when_no_match(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+
+		$ids = RecruitmentCandidateRepository::get_ids_by_email_hash( 'fakehash' );
+
+		$this->assertSame( array(), $ids );
+	}
+
+	// ------------------------------------------------------------------
+	// get_paginated_filtered() / count_paginated_filtered() — #331
+	// ------------------------------------------------------------------
+
+	public function test_get_paginated_filtered_short_circuits_on_empty_id_constraint(): void {
+		// id_constraint=[] means "at least one filter matched zero rows".
+		// The query should never run.
+		$this->wpdb->shouldNotReceive( 'get_results' );
+
+		$rows = RecruitmentCandidateRepository::get_paginated_filtered( '', array(), 0, '', 20, 0 );
+
+		$this->assertSame( array(), $rows );
+	}
+
+	public function test_count_paginated_filtered_short_circuits_on_empty_id_constraint(): void {
+		$this->wpdb->shouldNotReceive( 'get_var' );
+
+		$total = RecruitmentCandidateRepository::count_paginated_filtered( '', array(), 0, '' );
+
+		$this->assertSame( 0, $total );
+	}
+
+	public function test_get_paginated_filtered_executes_query_when_unconstrained(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$this->wpdb->shouldReceive( 'get_results' )
+			->once()
+			->andReturn( array( (object) array( 'id' => '5', 'name' => 'Alice' ) ) );
+
+		$rows = RecruitmentCandidateRepository::get_paginated_filtered( '', null, 0, '', 20, 0 );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( '5', $rows[0]->id );
+	}
+
+	public function test_get_paginated_filtered_joins_when_status_filter_present(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+
+		// Capture the SQL passed to prepare() so we can assert the JOIN
+		// + WHERE clauses fire as expected.
+		$captured_sql = null;
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				function ( $sql ) use ( &$captured_sql ) {
+					if ( null === $captured_sql ) {
+						$captured_sql = $sql;
+					}
+					return $sql;
+				}
+			);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		RecruitmentCandidateRepository::get_paginated_filtered( '', null, 0, 'called', 20, 0 );
+
+		$this->assertNotNull( $captured_sql );
+		$this->assertStringContainsString( 'INNER JOIN', (string) $captured_sql );
+		$this->assertStringContainsString( "cls.list_type = 'definitive'", (string) $captured_sql );
+		$this->assertStringContainsString( 'cls.status = %s', (string) $captured_sql );
+	}
+
+	public function test_count_paginated_filtered_returns_int_total(): void {
+		$this->wpdb->shouldReceive( 'esc_like' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+
+		$total = RecruitmentCandidateRepository::count_paginated_filtered( 'Alice', null, 0, '' );
+
+		$this->assertSame( 42, $total );
+	}
 }


### PR DESCRIPTION
Primeira PR de #331 (de 4): cobre a frente **Search** do backlog per-candidate.

## Estado anterior

A aba Candidates já tinha:
- Search por nome (`?s=`) via LIKE
- CPF (`?cpf=`) e RF (`?rf=`) por hash exato — porém **curto-circuitando** todos os outros filtros
- Filtro por adjutancy (`?adjutancy_id=`) via INNER JOIN

Faltavam:
- Email
- Status de classificação
- Tornar os filtros **combináveis** (hoje CPF ignora adjutancy, status, etc.)

## O que muda

### Repository (`RecruitmentCandidateRepository`)

| Método novo | Função |
|---|---|
| `get_ids_by_email_hash($hash): list<int>` | Email é non-unique no schema (família compartilha) — retorna todos os matches em vez do primeiro. |
| `get_paginated_filtered($name, $id_constraint, $adjutancy_id, $status, $limit, $offset): list<CandidateRow>` | Query unificada com filtros combináveis (AND). `$id_constraint = []` curto-circuita sem hit ao DB. |
| `count_paginated_filtered(...): int` | Companion count. |

O `INNER JOIN` na classifications só dispara quando `adjutancy_id > 0` **ou** `status != ''`. Status filtra com `list_type='definitive'` (preview rows são sempre `empty` por invariante §5.2 — incluí-las quebraria o filtro).

### List table (`RecruitmentCandidatesListTable`)

- `prepare_items()` colapsa os 3 caminhos antigos (CPF short-circuit / adjutancy+name / plain-name) numa única chamada à query unificada.
- Novo helper `resolve_id_constraint($cpf, $rf, $email)` que resolve CPF/RF/email em set de candidate-ids e **intersecta** os matches — `CPF + email` significa "o candidato que tem ambos", não a união.
- `extra_tablenav()` ganha input `email` e select `status` (todas as 5 status da §5.2 + "All statuses").
- Nova const `ALLOWED_STATUSES` pinned na vocabulary; `?status=junk` é rejeitado.

## Aceite (do checklist da issue)

- [x] Search por **Nome** — já existia, mantido
- [x] Search por **CPF** (hash exato) — já existia, agora combinável
- [x] Search por **RF** (hash exato) — já existia, agora combinável
- [x] Search por **E-mail** (hash exato — partial não é possível em coluna encrypted/hash) — **novo**
- [x] Search por **Adjutancy** — já existia, agora combinável
- [x] Search por **Status** — **novo**
- [x] **Filtros combináveis** — nova query unificada com AND

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4445/4445** (+7 cases novos em `RecruitmentCandidateRepositoryTest`)
  - `get_ids_by_email_hash` retorna ints / array vazio
  - `get_paginated_filtered` curto-circuita em `id_constraint=[]`
  - mesma coisa pro count
  - query sem constraint dispara normalmente
  - SQL ganha `INNER JOIN` + `list_type='definitive'` + placeholder de status quando status filter setado
  - count retorna int
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/recruitment/` → clean
- [x] `vendor/bin/phpstan analyze` → clean

Validação manual sugerida:
- [ ] Aba Candidates → filtrar por status "Hired" → só candidatos com pelo menos uma classificação definitiva em hired aparecem.
- [ ] CPF + adjutancy combinados → match só se o candidato com aquele CPF tem classificação na adjutancy escolhida.
- [ ] CPF + email combinados (do mesmo candidato) → 1 row; CPF + email (de pessoas diferentes) → 0 rows.
- [ ] Sem filtros → comportamento idêntico ao anterior (`get_paginated`/`count_paginated` antigos não foram tocados — ficam disponíveis caso outro consumidor exista).

## #331 checklist (esta umbrella)

- [x] **Search** — esta PR
- [ ] Edit estendido (custom_fields + adjutancy_id)
- [ ] Hard-delete dialog context
- [ ] History panel

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_