### PR TITLE
Recruitment admin: candidate-edit audit + classification adjutancy swap (#331 edit)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-activity-logger.php
+++ b/includes/recruitment/class-ffc-recruitment-activity-logger.php
@@ -261,6 +261,70 @@ final class RecruitmentActivityLogger {
 	}
 
 	/**
+	 * Candidate "General" fields edited (name / phone / notes / email)
+	 * via the admin edit page — issue #331 "Edit estendido" frontend.
+	 *
+	 * `$changes` carries only the keys whose value actually changed;
+	 * the caller computes the diff against the pre-update row. Each
+	 * entry is `['old' => mixed, 'new' => mixed]`. For the `email`
+	 * field the values are the SHA-256 hash digests of the addresses
+	 * (not the plaintext), so the audit row is safe to display even
+	 * if the operator viewing it doesn't hold the PII-reveal tier;
+	 * the other three (name / phone / notes) live unencrypted in the
+	 * candidate table by design (§12) and are logged as-is.
+	 *
+	 * Returns false (no-op) when `$changes` is empty — the save
+	 * handler still calls this method, the no-diff branch just short-
+	 * circuits so we don't write `{}` rows when the operator hits
+	 * "Save" without touching anything.
+	 *
+	 * @since 6.6.2
+	 * @param int                                                      $candidate_id Candidate row ID.
+	 * @param array<string, array{old: scalar|null, new: scalar|null}> $changes      Per-field old/new pairs.
+	 * @return bool True if a log entry was written.
+	 */
+	public static function candidate_fields_edited( int $candidate_id, array $changes ): bool {
+		if ( empty( $changes ) ) {
+			return false;
+		}
+		ActivityLog::log(
+			'recruitment_candidate_fields_edited',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'candidate_id' => $candidate_id,
+				'changes'      => $changes,
+			),
+			get_current_user_id()
+		);
+		return true;
+	}
+
+	/**
+	 * Classification's `adjutancy_id` swapped via the candidate edit
+	 * page (issue #331). Validation that the new adjutancy is attached
+	 * to the classification's notice happens in the REST controller —
+	 * by the time this fires the swap has already committed.
+	 *
+	 * @since 6.6.2
+	 * @param int $classification_id Classification ID.
+	 * @param int $from              Previous adjutancy_id.
+	 * @param int $to                New adjutancy_id.
+	 * @return void
+	 */
+	public static function classification_adjutancy_changed( int $classification_id, int $from, int $to ): void {
+		ActivityLog::log(
+			'recruitment_classification_adjutancy_changed',
+			ActivityLog::LEVEL_INFO,
+			array(
+				'classification_id' => $classification_id,
+				'from'              => $from,
+				'to'                => $to,
+			),
+			get_current_user_id()
+		);
+	}
+
+	/**
 	 * Candidate hard-deleted (gate already checked by RecruitmentDeleteService).
 	 *
 	 * @param int         $candidate_id Candidate ID (the row no longer exists at log time).

--- a/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
@@ -424,6 +424,13 @@ final class RecruitmentCandidateEditPage {
 			$classification_ids = array_map( static fn( $c ) => (int) $c->id, $classifications );
 			$calls_by_class     = self::group_calls_by_classification( $classification_ids );
 
+			// Pre-compute the set of adjutancies attached to each
+			// distinct notice referenced by this candidate's rows, so
+			// the per-row <select> renders only the junction-attached
+			// options (anything else would be rejected by the REST
+			// endpoint and lead to a confusing UX).
+			$adjutancies_by_notice = self::adjutancies_per_notice_for_rows( $classifications );
+
 			echo '<table class="widefat striped"><thead><tr>';
 			echo '<th>' . esc_html__( 'Notice', 'ffcertificate' ) . '</th>';
 			echo '<th>' . esc_html__( 'Adjutancy', 'ffcertificate' ) . '</th>';
@@ -435,13 +442,12 @@ final class RecruitmentCandidateEditPage {
 			echo '</tr></thead><tbody>';
 
 			foreach ( $classifications as $c ) {
-				$notice_obj    = RecruitmentNoticeRepository::get_by_id( (int) $c->notice_id );
-				$adjutancy_obj = RecruitmentAdjutancyRepository::get_by_id( (int) $c->adjutancy_id );
-				$call_count    = isset( $calls_by_class[ (int) $c->id ] ) ? count( $calls_by_class[ (int) $c->id ] ) : 0;
+				$notice_obj = RecruitmentNoticeRepository::get_by_id( (int) $c->notice_id );
+				$call_count = isset( $calls_by_class[ (int) $c->id ] ) ? count( $calls_by_class[ (int) $c->id ] ) : 0;
 
 				echo '<tr>';
 				echo '<td>' . esc_html( null !== $notice_obj ? (string) $notice_obj->code : '#' . (int) $c->notice_id ) . '</td>';
-				echo '<td><code>' . esc_html( null !== $adjutancy_obj ? (string) $adjutancy_obj->slug : '#' . (int) $c->adjutancy_id ) . '</code></td>';
+				echo '<td>' . self::render_adjutancy_cell( $c, $adjutancies_by_notice ) . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_adjutancy_cell returns pre-escaped HTML.
 				echo '<td>' . esc_html( (string) $c->list_type ) . '</td>';
 				echo '<td>' . esc_html( (string) $c->rank ) . '</td>';
 				echo '<td>' . esc_html( (string) $c->score ) . '</td>';
@@ -450,6 +456,7 @@ final class RecruitmentCandidateEditPage {
 				echo '</tr>';
 			}
 			echo '</tbody></table>';
+			self::render_adjutancy_swap_script();
 
 			// Render an inline calls table per classification that has any calls.
 			foreach ( $classifications as $c ) {
@@ -584,6 +591,12 @@ final class RecruitmentCandidateEditPage {
 		$phone = isset( $_POST['phone'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['phone'] ) ) : '';
 		$notes = isset( $_POST['notes'] ) ? sanitize_textarea_field( wp_unslash( (string) $_POST['notes'] ) ) : '';
 
+		// Read the pre-update row so we can audit-log the diff after the
+		// repository write lands. Done BEFORE the update because the
+		// repository's update method invalidates the cache key but
+		// returns the wpdb int affected-rows, not the updated row.
+		$before = RecruitmentCandidateRepository::get_by_id( $id );
+
 		$update = array(
 			'name'  => $name,
 			'phone' => '' === $phone ? null : $phone,
@@ -603,7 +616,67 @@ final class RecruitmentCandidateEditPage {
 
 		RecruitmentCandidateRepository::update( $id, $update );
 
+		if ( null !== $before ) {
+			$changes = self::diff_general_fields( $before, $name, $phone, $notes, $email );
+			RecruitmentActivityLogger::candidate_fields_edited( $id, $changes );
+		}
+
 		self::redirect_with_notice( $id, 'saved' );
+	}
+
+	/**
+	 * Diff the four General-section fields against the pre-update row,
+	 * returning the entries that actually changed. Used by handle_save()
+	 * to feed the audit logger — empty diff means "operator pressed
+	 * Save without changing anything" and the logger short-circuits.
+	 *
+	 * The `email` field is reported as the SHA-256 hash digests of the
+	 * old / new addresses (never plaintext); the other three live
+	 * unencrypted in the candidate table by design (§12) and are
+	 * logged as-is.
+	 *
+	 * @since 6.6.2
+	 * @param object $before  Pre-update candidate row.
+	 * @phpstan-param CandidateRow $before
+	 * @param string $name    New name.
+	 * @param string $phone   New phone (empty string means "clear").
+	 * @param string $notes   New notes (empty string means "clear").
+	 * @param string $email   New email (empty string means "clear").
+	 * @return array<string, array{old: scalar|null, new: scalar|null}>
+	 */
+	private static function diff_general_fields( object $before, string $name, string $phone, string $notes, string $email ): array {
+		$old_name       = (string) ( $before->name ?? '' );
+		$old_phone      = null === $before->phone ? '' : (string) $before->phone;
+		$old_notes      = null === $before->notes ? '' : (string) $before->notes;
+		$old_email_hash = null === $before->email_hash ? '' : (string) $before->email_hash;
+		$new_email_hash = '' === $email ? '' : (string) Encryption::hash( $email );
+
+		$changes = array();
+		if ( $old_name !== $name ) {
+			$changes['name'] = array(
+				'old' => $old_name,
+				'new' => $name,
+			);
+		}
+		if ( $old_phone !== $phone ) {
+			$changes['phone'] = array(
+				'old' => $old_phone,
+				'new' => $phone,
+			);
+		}
+		if ( $old_notes !== $notes ) {
+			$changes['notes'] = array(
+				'old' => $old_notes,
+				'new' => $notes,
+			);
+		}
+		if ( $old_email_hash !== $new_email_hash ) {
+			$changes['email_hash'] = array(
+				'old' => $old_email_hash,
+				'new' => $new_email_hash,
+			);
+		}
+		return $changes;
 	}
 
 	/**
@@ -754,5 +827,121 @@ final class RecruitmentCandidateEditPage {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Build a `notice_id => list<adjutancy_id>` map for the unique
+	 * notices referenced by the candidate's classifications. Used by
+	 * the per-row Adjutancy <select> so the operator only sees options
+	 * the notice_adjutancy junction would actually accept.
+	 *
+	 * @since 6.6.2
+	 * @param array<int, object> $classifications Candidate's classification rows.
+	 * @phpstan-param array<int, ClassificationRow> $classifications
+	 * @return array<int, list<int>>
+	 */
+	private static function adjutancies_per_notice_for_rows( array $classifications ): array {
+		$out  = array();
+		$seen = array();
+		foreach ( $classifications as $c ) {
+			$notice_id = (int) $c->notice_id;
+			if ( isset( $seen[ $notice_id ] ) ) {
+				continue;
+			}
+			$seen[ $notice_id ] = true;
+			$out[ $notice_id ]  = array_values( array_map( 'intval', RecruitmentNoticeAdjutancyRepository::get_adjutancy_ids_for_notice( $notice_id ) ) );
+		}
+		return $out;
+	}
+
+	/**
+	 * Render the Adjutancy table cell for a single classification row
+	 * — either an inline <select> + Save button (when the notice has
+	 * >1 adjutancy attached) or the read-only `<code>` slug rendered
+	 * before #331 (when 0 or 1 alternatives exist, swap would be a
+	 * no-op or rejected). Issue #331 "Edit estendido".
+	 *
+	 * The returned HTML is already escaped and safe to echo directly.
+	 *
+	 * @since 6.6.2
+	 * @param object                $c                     Classification row.
+	 * @phpstan-param ClassificationRow $c
+	 * @param array<int, list<int>> $adjutancies_by_notice  Pre-fetched map.
+	 * @return string
+	 */
+	private static function render_adjutancy_cell( object $c, array $adjutancies_by_notice ): string {
+		$current_adj_id = (int) $c->adjutancy_id;
+		$notice_id      = (int) $c->notice_id;
+		$candidates     = $adjutancies_by_notice[ $notice_id ] ?? array();
+		$current_obj    = RecruitmentAdjutancyRepository::get_by_id( $current_adj_id );
+		$current_label  = null !== $current_obj ? (string) $current_obj->slug : '#' . $current_adj_id;
+
+		if ( count( $candidates ) < 2 ) {
+			return '<code>' . esc_html( $current_label ) . '</code>';
+		}
+
+		$html  = '<span class="ffc-adjutancy-swap" data-ffc-cls-id="' . esc_attr( (string) (int) $c->id ) . '">';
+		$html .= '<select class="ffc-adjutancy-swap-select">';
+		foreach ( $candidates as $aid ) {
+			$obj   = RecruitmentAdjutancyRepository::get_by_id( (int) $aid );
+			$label = null !== $obj ? (string) $obj->slug : '#' . (int) $aid;
+			$sel   = (int) $aid === $current_adj_id ? ' selected' : '';
+			$html .= '<option value="' . esc_attr( (string) (int) $aid ) . '"' . esc_attr( $sel ) . '>' . esc_html( $label ) . '</option>';
+		}
+		$html .= '</select> ';
+		$html .= '<button type="button" class="button button-small ffc-adjutancy-swap-btn">' . esc_html__( 'Save', 'ffcertificate' ) . '</button>';
+		$html .= ' <span class="ffc-adjutancy-swap-msg" aria-live="polite"></span>';
+		$html .= '</span>';
+		return $html;
+	}
+
+	/**
+	 * Inline JS for the per-row Adjutancy swap button. Issue #331.
+	 *
+	 * On click: PATCH /classifications/{id}/adjutancy with the selected
+	 * option, surface success or the WP_Error message inline (the REST
+	 * controller emits a stable `code` field per failure mode so we
+	 * could branch on it for richer messaging later — for now we just
+	 * show whatever the server returned).
+	 *
+	 * @since 6.6.2
+	 * @return void
+	 */
+	private static function render_adjutancy_swap_script(): void {
+		$rest_root = esc_url_raw( rest_url( 'ffcertificate/v1/recruitment/classifications/' ) );
+		$nonce     = wp_create_nonce( 'wp_rest' );
+		$ok_lbl    = esc_js( __( 'Saved', 'ffcertificate' ) );
+		$err_lbl   = esc_js( __( 'Error', 'ffcertificate' ) );
+
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- All interpolated values escaped via esc_url_raw / esc_js above.
+		echo '<script>'
+			. '(function(){'
+			. 'document.addEventListener("click",function(ev){'
+			. 'var btn=ev.target;'
+			. 'if(!btn||!btn.classList||!btn.classList.contains("ffc-adjutancy-swap-btn"))return;'
+			. 'ev.preventDefault();'
+			. 'var wrap=btn.closest(".ffc-adjutancy-swap");'
+			. 'if(!wrap)return;'
+			. 'var cid=wrap.getAttribute("data-ffc-cls-id");'
+			. 'var sel=wrap.querySelector(".ffc-adjutancy-swap-select");'
+			. 'var msg=wrap.querySelector(".ffc-adjutancy-swap-msg");'
+			. 'if(!cid||!sel||!msg)return;'
+			. 'msg.textContent="";'
+			. 'btn.disabled=true;'
+			. 'fetch("' . $rest_root . '"+encodeURIComponent(cid)+"/adjutancy",{'
+			. 'method:"PATCH",'
+			. 'credentials:"same-origin",'
+			. 'headers:{"Content-Type":"application/json","X-WP-Nonce":"' . esc_js( $nonce ) . '"},'
+			. 'body:JSON.stringify({adjutancy_id:parseInt(sel.value,10)})'
+			. '}).then(function(r){return r.json().then(function(b){return{ok:r.ok,body:b};});})'
+			. '.then(function(res){'
+			. 'btn.disabled=false;'
+			. 'if(res.ok&&res.body&&res.body.success){msg.textContent="' . $ok_lbl . '";msg.style.color="#1a7f37";}'
+			. 'else{msg.textContent="' . $err_lbl . ': "+((res.body&&res.body.message)||"");msg.style.color="#b91c1c";}'
+			. '}).catch(function(){btn.disabled=false;msg.textContent="' . $err_lbl . '";msg.style.color="#b91c1c";});'
+			. '});'
+			. '})();'
+			. '</script>';
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/includes/recruitment/class-ffc-recruitment-classification-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-repository.php
@@ -425,6 +425,48 @@ class RecruitmentClassificationRepository {
 	}
 
 	/**
+	 * Swap a classification's `adjutancy_id` (issue #331 "Edit estendido").
+	 *
+	 * Pure CRUD — caller (the REST controller) is responsible for
+	 * validating that the new adjutancy is attached to the classification's
+	 * notice via the `notice_adjutancy` junction. Without that gate the
+	 * classification would silently become orphaned from the notice's
+	 * effective adjutancy set, which breaks the read-side queries that
+	 * filter classifications by `(notice_id, adjutancy_id)` against the
+	 * junction.
+	 *
+	 * Returns false when the row doesn't exist or the UPDATE fails;
+	 * returns true even when the new value matches the current one
+	 * (no-op write — wpdb returns 0 affected rows but no error).
+	 *
+	 * @since 6.6.2
+	 * @param int $id               Classification ID.
+	 * @param int $new_adjutancy_id Adjutancy ID to swap in.
+	 * @return bool
+	 */
+	public static function set_adjutancy( int $id, int $new_adjutancy_id ): bool {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row update keyed by PK.
+		$result = $wpdb->update(
+			$table,
+			array( 'adjutancy_id' => $new_adjutancy_id ),
+			array( 'id' => $id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		static::cache_delete( "id_{$id}" );
+
+		if ( false !== $result ) {
+			do_action( 'ffc_recruitment_public_cache_dirty' );
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Hard-delete a single classification row.
 	 *
 	 * Deletion gating (`status='empty'` + notice in `draft`/`preliminary`)

--- a/includes/recruitment/class-ffc-recruitment-classifications-rest-controller.php
+++ b/includes/recruitment/class-ffc-recruitment-classifications-rest-controller.php
@@ -177,6 +177,23 @@ final class RecruitmentClassificationsRestController {
 
 		register_rest_route(
 			$ns,
+			$base . '/classifications/(?P<id>\d+)/adjutancy',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'change_classification_adjutancy' ),
+				'permission_callback' => array( $this, 'check_admin_cap' ),
+				'args'                => array(
+					'adjutancy_id' => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$ns,
 			$base . '/classifications/(?P<id>\d+)',
 			array(
 				'methods'             => \WP_REST_Server::DELETABLE,
@@ -471,6 +488,69 @@ final class RecruitmentClassificationsRestController {
 		}
 
 		return new \WP_REST_Response( RecruitmentClassificationRepository::get_by_id( $id ), 200 );
+	}
+
+	/**
+	 * PATCH /classifications/{id}/adjutancy — swap a classification's
+	 * adjutancy_id. Issue #331 "Edit estendido".
+	 *
+	 * Validates:
+	 *   - the classification exists
+	 *   - the new adjutancy exists AND is attached to the classification's
+	 *     notice via the `notice_adjutancy` junction (otherwise we'd
+	 *     orphan the classification from the notice's effective set)
+	 *   - the new adjutancy differs from the current one (no-op detected
+	 *     upfront so we don't emit a misleading audit row)
+	 *
+	 * Surfaces failures as WP_Error with 4xx + a stable code so the
+	 * frontend can branch on the reason.
+	 *
+	 * @since 6.6.2
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function change_classification_adjutancy( \WP_REST_Request $request ) {
+		$id               = (int) $request->get_param( 'id' );
+		$new_adjutancy_id = (int) $request->get_param( 'adjutancy_id' );
+
+		if ( $new_adjutancy_id <= 0 ) {
+			return new \WP_Error( 'ffc_invalid_adjutancy', __( 'A valid adjutancy_id is required.', 'ffcertificate' ), array( 'status' => 400 ) );
+		}
+
+		$cls = RecruitmentClassificationRepository::get_by_id( $id );
+		if ( null === $cls ) {
+			return new \WP_Error( 'ffc_classification_not_found', __( 'Classification not found.', 'ffcertificate' ), array( 'status' => 404 ) );
+		}
+
+		$current_adjutancy = (int) $cls->adjutancy_id;
+		if ( $current_adjutancy === $new_adjutancy_id ) {
+			return new \WP_Error( 'ffc_classification_adjutancy_unchanged', __( 'New adjutancy is the same as the current one.', 'ffcertificate' ), array( 'status' => 409 ) );
+		}
+
+		$notice_id = (int) $cls->notice_id;
+		if ( ! RecruitmentNoticeAdjutancyRepository::is_attached( $notice_id, $new_adjutancy_id ) ) {
+			return new \WP_Error(
+				'ffc_classification_adjutancy_not_attached_to_notice',
+				__( 'The selected adjutancy is not attached to this notice.', 'ffcertificate' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( ! RecruitmentClassificationRepository::set_adjutancy( $id, $new_adjutancy_id ) ) {
+			return new \WP_Error( 'ffc_classification_adjutancy_update_failed', __( 'Could not update the classification.', 'ffcertificate' ), array( 'status' => 500 ) );
+		}
+
+		RecruitmentActivityLogger::classification_adjutancy_changed( $id, $current_adjutancy, $new_adjutancy_id );
+
+		return new \WP_REST_Response(
+			array(
+				'success'           => true,
+				'classification_id' => $id,
+				'from'              => $current_adjutancy,
+				'to'                => $new_adjutancy_id,
+			),
+			200
+		);
 	}
 
 	/**

--- a/tests/Unit/RecruitmentActivityLoggerTest.php
+++ b/tests/Unit/RecruitmentActivityLoggerTest.php
@@ -315,4 +315,60 @@ class RecruitmentActivityLoggerTest extends TestCase {
 		$this->assertTrue( $b, 'different candidate must not be deduped' );
 		$this->assertCount( 2, $this->buffer() );
 	}
+
+	// ------------------------------------------------------------------
+	// candidate_fields_edited() + classification_adjutancy_changed() — #331
+	// ------------------------------------------------------------------
+
+	public function test_candidate_fields_edited_logs_diff(): void {
+		$wrote = RecruitmentActivityLogger::candidate_fields_edited(
+			42,
+			array(
+				'name'  => array( 'old' => 'Alice', 'new' => 'Alicia' ),
+				'notes' => array( 'old' => '', 'new' => 'some note' ),
+			)
+		);
+
+		$this->assertTrue( $wrote );
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_candidate_fields_edited', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 42, $context['candidate_id'] );
+		$this->assertArrayHasKey( 'changes', $context );
+		$this->assertSame( 'Alicia', $context['changes']['name']['new'] );
+	}
+
+	public function test_candidate_fields_edited_auto_encrypts_when_diff_carries_sensitive_keys(): void {
+		// `phone` is a registered sensitive field — when it appears in the
+		// audit payload (even nested under `changes`), the ActivityLog
+		// auto-encrypt path drops the plaintext `context` column and only
+		// writes `context_encrypted`. Verify the protection actually fires.
+		RecruitmentActivityLogger::candidate_fields_edited(
+			42,
+			array( 'phone' => array( 'old' => '', 'new' => '11999999999' ) )
+		);
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_candidate_fields_edited', $entry['action'] );
+		$this->assertNull( $entry['context'], 'plaintext context must be dropped' );
+		$this->assertNotNull( $entry['context_encrypted'], 'context_encrypted must be populated' );
+	}
+
+	public function test_candidate_fields_edited_short_circuits_on_empty_diff(): void {
+		$wrote = RecruitmentActivityLogger::candidate_fields_edited( 42, array() );
+
+		$this->assertFalse( $wrote );
+		$this->assertSame( array(), $this->buffer() );
+	}
+
+	public function test_classification_adjutancy_changed_logs_from_to(): void {
+		RecruitmentActivityLogger::classification_adjutancy_changed( 7, 3, 5 );
+
+		$entry = $this->last_buffered_entry();
+		$this->assertSame( 'recruitment_classification_adjutancy_changed', $entry['action'] );
+		$context = json_decode( (string) $entry['context'], true );
+		$this->assertSame( 7, $context['classification_id'] );
+		$this->assertSame( 3, $context['from'] );
+		$this->assertSame( 5, $context['to'] );
+	}
 }

--- a/tests/Unit/RecruitmentClassificationRepositoryTest.php
+++ b/tests/Unit/RecruitmentClassificationRepositoryTest.php
@@ -161,4 +161,30 @@ class RecruitmentClassificationRepositoryTest extends TestCase {
 		$result = RecruitmentClassificationRepository::get_for_notice( 1, 'definitive', 2 );
 		$this->assertCount( 2, $result );
 	}
+
+	// ------------------------------------------------------------------
+	// set_adjutancy() — issue #331 "Edit estendido"
+	// ------------------------------------------------------------------
+
+	public function test_set_adjutancy_returns_true_on_successful_update(): void {
+		Functions\when( 'do_action' )->justReturn( null );
+		$this->wpdb->shouldReceive( 'update' )
+			->once()
+			->with(
+				'wp_ffc_recruitment_classification',
+				array( 'adjutancy_id' => 7 ),
+				array( 'id' => 42 ),
+				array( '%d' ),
+				array( '%d' )
+			)
+			->andReturn( 1 );
+
+		$this->assertTrue( RecruitmentClassificationRepository::set_adjutancy( 42, 7 ) );
+	}
+
+	public function test_set_adjutancy_returns_false_when_wpdb_update_fails(): void {
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturn( false );
+
+		$this->assertFalse( RecruitmentClassificationRepository::set_adjutancy( 42, 7 ) );
+	}
 }

--- a/tests/Unit/RecruitmentClassificationsRestControllerTest.php
+++ b/tests/Unit/RecruitmentClassificationsRestControllerTest.php
@@ -81,9 +81,9 @@ class RecruitmentClassificationsRestControllerTest extends TestCase {
     public function test_register_routes_registers_classification_route_groups(): void {
         $this->controller->register_routes();
 
-        // 9 register_rest_route calls: list/item/import/promote/call/bulk-call/
-        // status/preview-status/cancel-call.
-        $this->assertCount( 9, $this->registered_routes );
+        // 10 register_rest_route calls: list/item/import/promote/call/bulk-call/
+        // status/preview-status/cancel-call/adjutancy.
+        $this->assertCount( 10, $this->registered_routes );
     }
 
     public function test_register_routes_includes_classifications_and_import_routes(): void {
@@ -142,5 +142,82 @@ class RecruitmentClassificationsRestControllerTest extends TestCase {
         $this->assertInstanceOf( \WP_Error::class, $result );
         $this->assertSame( 'recruitment_csv_file_missing', $result->get_error_code() );
         $this->assertSame( 400, $result->get_error_data()['status'] );
+    }
+
+    // ------------------------------------------------------------------
+    // change_classification_adjutancy() — issue #331 "Edit estendido"
+    // ------------------------------------------------------------------
+
+    public function test_change_classification_adjutancy_returns_400_when_id_zero(): void {
+        $result = $this->controller->change_classification_adjutancy(
+            $this->make_request( array( 'id' => 7, 'adjutancy_id' => 0 ) )
+        );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'ffc_invalid_adjutancy', $result->get_error_code() );
+        $this->assertSame( 400, $result->get_error_data()['status'] );
+    }
+
+    public function test_change_classification_adjutancy_returns_404_when_row_missing(): void {
+        $this->clsRepoMock->shouldReceive( 'get_by_id' )->with( 7 )->andReturn( null );
+
+        $result = $this->controller->change_classification_adjutancy(
+            $this->make_request( array( 'id' => 7, 'adjutancy_id' => 5 ) )
+        );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'ffc_classification_not_found', $result->get_error_code() );
+    }
+
+    public function test_change_classification_adjutancy_returns_409_when_unchanged(): void {
+        $this->clsRepoMock->shouldReceive( 'get_by_id' )->with( 7 )
+            ->andReturn( (object) array( 'id' => '7', 'notice_id' => '1', 'adjutancy_id' => '5' ) );
+
+        $result = $this->controller->change_classification_adjutancy(
+            $this->make_request( array( 'id' => 7, 'adjutancy_id' => 5 ) )
+        );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'ffc_classification_adjutancy_unchanged', $result->get_error_code() );
+    }
+
+    public function test_change_classification_adjutancy_rejects_when_not_attached_to_notice(): void {
+        $this->clsRepoMock->shouldReceive( 'get_by_id' )->with( 7 )
+            ->andReturn( (object) array( 'id' => '7', 'notice_id' => '1', 'adjutancy_id' => '3' ) );
+
+        $naMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository' );
+        $naMock->shouldReceive( 'is_attached' )->with( 1, 9 )->andReturn( false );
+
+        $result = $this->controller->change_classification_adjutancy(
+            $this->make_request( array( 'id' => 7, 'adjutancy_id' => 9 ) )
+        );
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'ffc_classification_adjutancy_not_attached_to_notice', $result->get_error_code() );
+        $this->assertSame( 409, $result->get_error_data()['status'] );
+    }
+
+    public function test_change_classification_adjutancy_success_path_returns_envelope(): void {
+        $this->clsRepoMock->shouldReceive( 'get_by_id' )->with( 7 )
+            ->andReturn( (object) array( 'id' => '7', 'notice_id' => '1', 'adjutancy_id' => '3' ) );
+        $this->clsRepoMock->shouldReceive( 'set_adjutancy' )->with( 7, 9 )->andReturn( true );
+
+        $naMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository' );
+        $naMock->shouldReceive( 'is_attached' )->with( 1, 9 )->andReturn( true );
+
+        $loggerMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+        $loggerMock->shouldReceive( 'classification_adjutancy_changed' )->once()->with( 7, 3, 9 );
+
+        $response = $this->controller->change_classification_adjutancy(
+            $this->make_request( array( 'id' => 7, 'adjutancy_id' => 9 ) )
+        );
+
+        $this->assertNotInstanceOf( \WP_Error::class, $response );
+        $this->assertSame( 200, $response->get_status() );
+        $data = $response->get_data();
+        $this->assertTrue( $data['success'] );
+        $this->assertSame( 7, $data['classification_id'] );
+        $this->assertSame( 3, $data['from'] );
+        $this->assertSame( 9, $data['to'] );
     }
 }


### PR DESCRIPTION
Segunda PR de #331 (de 4). Cobre a frente **Edit estendido**.

## Decisão de escopo (confirmada com o user antes de codar)

A issue lista dois itens em Edit:
- "Permitir editar `custom_fields` decriptados (com audit — ver #330)"
- "Permitir alterar `adjutancy_id` (com validação que não desclassifica)"

Descobertas durante o mapeamento:
- **`custom_fields` não existe no schema do candidato** — as tabelas `ffc_custom_fields*` listadas no CLAUDE.md são do módulo audience/user-profile, não wired a recruitment. Construir do zero seria PR isolada.
- **`adjutancy_id` não existe na coluna do candidato** — relação fica em `ffc_recruitment_classification`. A interpretação plausível é swap da `classification.adjutancy_id`, validando contra a junction `notice_adjutancy`.

User confirmou as duas frentes que vão nesta PR:
1. **Audit log nos edits existentes** (name/phone/notes/email) reusando #330.
2. **Classification adjutancy swap** com validação na junction.

`custom_fields` e edit de CPF/RF ficam pra issues separadas.

## O que muda

### Audit log

`RecruitmentActivityLogger` ganha dois métodos:

| Método | Função |
|---|---|
| `candidate_fields_edited(int $candidate_id, array $changes): bool` | Diff per-field old/new. Short-circuit em `$changes = []`. `email` é logado como SHA-256 hash digests (nunca plaintext — o `email_hash` já existe). `phone` em plaintext nas changes dispara o auto-encrypt do `SensitiveFieldRegistry` automaticamente (walking de chaves aninhadas). |
| `classification_adjutancy_changed(int $cls_id, int $from, int $to): void` | Fires no commit do swap. |

### Repository

`RecruitmentClassificationRepository::set_adjutancy(int $id, int $new): bool` — CRUD primitive, sem validação. Caller é responsável pelo notice junction check. Invalida cache + dispara `ffc_recruitment_public_cache_dirty`.

### REST endpoint

**`PATCH /classifications/{id}/adjutancy`** com body `{adjutancy_id: int}`. Failure modes com códigos estáveis:

| Status | Code | Quando |
|---|---|---|
| 400 | `ffc_invalid_adjutancy` | `adjutancy_id <= 0` |
| 404 | `ffc_classification_not_found` | id não resolve |
| 409 | `ffc_classification_adjutancy_unchanged` | no-op upfront |
| 409 | `ffc_classification_adjutancy_not_attached_to_notice` | junction check falha |
| 500 | `ffc_classification_adjutancy_update_failed` | wpdb update returned false |

Success → `{success: true, classification_id, from, to}` + audit.

### Candidate edit page

- `handle_save()` lê a row pré-update via `get_by_id`, diffa os 4 campos da General section, chama `candidate_fields_edited()` (helper privado `diff_general_fields()` extraído pra manter o request-handling enxuto). Email comparado via hash.
- **Classifications section** — coluna Adjutancy deixa de ser `<code>` estático. Quando o notice tem 2+ adjutancies attached, renderiza `<select>` + Save button; quando 0/1, mantém o `<code>` (swap seria no-op/rejeitado). JS per-row PATCHes o endpoint, mensagem inline com `aria-live="polite"`. Set de adjutancies attached é pré-fetchado uma vez por notice distinto.

## Aceite (do checklist da issue)

- [x] Edit completo de `custom_fields` com audit → **deferido** (sem schema; documentado no commit)
- [x] **Audit nos edits existentes** (reusing #330 infra)
- [x] **Alterar adjutancy_id sem desclassificar** (interpretado como classification.adjutancy_id + junction validation)

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4456/4456** (+11 cases novos)
  - `RecruitmentActivityLoggerTest`: candidate_fields_edited (diff feliz / short-circuit / auto-encrypt em sensitive nested) + classification_adjutancy_changed
  - `RecruitmentClassificationRepositoryTest`: set_adjutancy happy + falha do wpdb
  - `RecruitmentClassificationsRestControllerTest`: route count 9→10, 4 failure modes, happy path com envelope + audit
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/recruitment/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] Candidate com classification em notice que tem 2+ adjutancies attached → trocar adjutancy via select+Save → row reflete a nova adjutancy + audit log mostra `recruitment_classification_adjutancy_changed`.
- [ ] Mesmo flow tentando uma adjutancy NÃO attached à notice (impossível via UI, mas testável via curl direto na REST) → 409 + code estável.
- [ ] Editar name → audit log mostra `recruitment_candidate_fields_edited` com `{changes: {name: {old, new}}}` em plaintext.
- [ ] Editar phone → audit log mostra `context_encrypted` populated (plaintext em `context` null).
- [ ] Save sem mudar nada → nenhuma entry de audit é escrita.

## #331 checklist

- [x] **Search** → PR #337 (merged)
- [x] **Edit estendido** → esta PR
- [ ] Hard-delete dialog context (próxima)
- [ ] History panel (última)

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_