### PR TITLE
Recruitment admin: candidate hard-delete dialog with row context (#331 hard-delete)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Recruitment;
 
+use FreeFormCertificate\Core\DateFormatter;
 use FreeFormCertificate\Core\DocumentFormatter;
 use FreeFormCertificate\Core\Encryption;
 
@@ -543,13 +544,18 @@ final class RecruitmentCandidateEditPage {
 
 		echo '<p>' . esc_html__( 'Removes the candidate row permanently. The linked WordPress user (if any) is preserved untouched. ActivityLog entries are kept (with sensitive payloads already redacted).', 'ffcertificate' ) . '</p>';
 
+		// Issue #331 asked for `last_classification_at` / `last_call_at`
+		// in the dialog. With the current §7-bis gate (`classification_count
+		// === 0`) those are always null by construction — the candidate
+		// can't be deleted while any classification still references it,
+		// and calls hang off classifications. So we surface the timestamps
+		// that ARE always meaningful (and that the operator actually wants
+		// before a destructive action): when the row was created and when
+		// it was last touched. Plus the WP user link, if any — the modal
+		// already says "preserved untouched" but seeing the actual login
+		// helps the operator confirm they're looking at the right row.
 		$hard_delete_consequences = wp_json_encode(
-			array(
-				__( 'The candidate row is removed permanently.', 'ffcertificate' ),
-				__( 'The linked WordPress user (if any) is preserved untouched.', 'ffcertificate' ),
-				__( 'ActivityLog entries are kept (with sensitive payloads already redacted).', 'ffcertificate' ),
-				__( 'This cannot be undone.', 'ffcertificate' ),
-			)
+			self::build_delete_consequences( $candidate )
 		);
 		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '"'
 			. ' data-ffc-confirm'
@@ -557,16 +563,85 @@ final class RecruitmentCandidateEditPage {
 			. ' data-ffc-confirm-body="' . esc_attr__( 'You are about to permanently delete this candidate record.', 'ffcertificate' ) . '"'
 			. ' data-ffc-confirm-consequences="' . esc_attr( (string) $hard_delete_consequences ) . '"'
 			. ' data-ffc-confirm-cta="' . esc_attr__( 'Delete permanently', 'ffcertificate' ) . '"'
-			. ' data-ffc-confirm-style="destructive">';
+			. ' data-ffc-confirm-style="destructive"'
+			. ' data-ffc-confirm-reason-label="' . esc_attr__( 'Reason (logged):', 'ffcertificate' ) . '">';
 		echo '<input type="hidden" name="action" value="ffc_recruitment_delete_candidate">';
 		echo '<input type="hidden" name="candidate_id" value="' . esc_attr( (string) $id ) . '">';
 		wp_nonce_field( $nonce_action );
-		echo '<p><label for="ffc-cand-delete-reason">' . esc_html__( 'Reason (logged):', 'ffcertificate' ) . '</label><br>';
-		echo '<input id="ffc-cand-delete-reason" type="text" class="large-text" name="reason" required></p>';
+		// No-JS fallback: a plain reason input that submits with the form
+		// when the modal interceptor (assets/js/ffc-recruitment-admin.js)
+		// hasn't loaded. When JS is on, the modal injects its own hidden
+		// `reason` input after this one — the appended value wins in PHP's
+		// `$_POST` parsing, so the operator's modal-typed reason takes
+		// precedence and the inline field becomes a no-JS safety net.
+		echo '<noscript><p>'
+			. '<label for="ffc-cand-delete-reason">' . esc_html__( 'Reason (logged):', 'ffcertificate' ) . '</label><br>'
+			. '<input id="ffc-cand-delete-reason" type="text" class="large-text" name="reason" required>'
+			. '</p></noscript>';
 		submit_button( __( 'Delete permanently', 'ffcertificate' ), 'delete' );
 		echo '</form>';
 
 		echo '</div></div>';
+	}
+
+	/**
+	 * Build the consequences-bullet list for the hard-delete confirm
+	 * modal. Issue #331: front-loads the candidate-row context (created /
+	 * last-updated timestamps + linked WP user) so the operator sees
+	 * actionable details BEFORE the standard "what will happen" lines.
+	 *
+	 * Returned as a `list<string>` ready to feed into wp_json_encode for
+	 * the `data-ffc-confirm-consequences` attribute.
+	 *
+	 * @since 6.6.2
+	 * @param object $candidate Candidate row.
+	 * @phpstan-param CandidateRow $candidate
+	 * @return list<string>
+	 */
+	private static function build_delete_consequences( object $candidate ): array {
+		$context = array();
+
+		$created_at = (string) $candidate->created_at;
+		if ( '' !== $created_at ) {
+			$context[] = sprintf(
+				/* translators: %s — formatted datetime when the candidate row was created */
+				__( 'Created on %s.', 'ffcertificate' ),
+				DateFormatter::format_datetime( $created_at )
+			);
+		}
+
+		$updated_at = (string) $candidate->updated_at;
+		if ( '' !== $updated_at && $updated_at !== $created_at ) {
+			$context[] = sprintf(
+				/* translators: %s — formatted datetime when the candidate row was last touched */
+				__( 'Last updated on %s.', 'ffcertificate' ),
+				DateFormatter::format_datetime( $updated_at )
+			);
+		}
+
+		$user_id = (int) ( $candidate->user_id ?? 0 );
+		if ( $user_id > 0 ) {
+			$user = get_userdata( $user_id );
+			if ( false !== $user ) {
+				$context[] = sprintf(
+					/* translators: %s — linked WordPress user login */
+					__( 'Linked WP user: @%s (preserved untouched on delete).', 'ffcertificate' ),
+					(string) $user->user_login
+				);
+			}
+		}
+
+		// Standard "what will happen" lines — same vocabulary as before
+		// #331, appended after the context block so the operator reads
+		// "row state → action consequences" top-down.
+		return array_merge(
+			$context,
+			array(
+				__( 'The candidate row is removed permanently.', 'ffcertificate' ),
+				__( 'ActivityLog entries are kept (with sensitive payloads already redacted).', 'ffcertificate' ),
+				__( 'This cannot be undone.', 'ffcertificate' ),
+			)
+		);
 	}
 
 	/**

--- a/tests/Unit/RecruitmentEditPagesSmokeTest.php
+++ b/tests/Unit/RecruitmentEditPagesSmokeTest.php
@@ -108,4 +108,97 @@ class RecruitmentEditPagesSmokeTest extends TestCase {
             $this->assertNotSame( '', $label, "label for '$key' must not be empty" );
         }
     }
+
+    // ------------------------------------------------------------------
+    // RecruitmentCandidateEditPage::build_delete_consequences() — #331
+    // ------------------------------------------------------------------
+
+    /**
+     * Reflect into the private static helper since it has no public
+     * surface and rendering the whole delete section pulls in repository
+     * + DateFormatter stubs that would clutter this smoke suite.
+     *
+     * @param object $candidate Candidate row stub.
+     * @return list<string>
+     */
+    private function invoke_build_delete_consequences( object $candidate ): array {
+        $ref = new \ReflectionMethod( RecruitmentCandidateEditPage::class, 'build_delete_consequences' );
+        $ref->setAccessible( true );
+        /** @var list<string> $out */
+        $out = $ref->invoke( null, $candidate );
+        return $out;
+    }
+
+    public function test_build_delete_consequences_prepends_created_on_line(): void {
+        Functions\when( 'get_userdata' )->justReturn( false );
+        // DateFormatter is fully namespaced, but format_datetime is a
+        // static method on the helper class — stub the WordPress
+        // primitives it relies on so we exercise the formatter for
+        // real (it falls back to the input string when wp_date /
+        // wp_timezone are unavailable in test, which is fine for
+        // assertion purposes).
+        Functions\when( 'wp_date' )->returnArg();
+        Functions\when( 'wp_timezone' )->justReturn( new \DateTimeZone( 'UTC' ) );
+        Functions\when( 'get_option' )->justReturn( array() );
+
+        $candidate = (object) array(
+            'id'         => 5,
+            'user_id'    => null,
+            'created_at' => '2026-05-10 12:00:00',
+            'updated_at' => '2026-05-10 12:00:00',
+        );
+
+        $lines = $this->invoke_build_delete_consequences( $candidate );
+
+        $this->assertNotEmpty( $lines );
+        $this->assertStringStartsWith( 'Created on ', $lines[0] );
+        $this->assertCount( 4, $lines, 'created + 3 standard consequences when updated_at == created_at' );
+    }
+
+    public function test_build_delete_consequences_separates_created_and_updated_when_different(): void {
+        Functions\when( 'get_userdata' )->justReturn( false );
+        Functions\when( 'wp_date' )->returnArg();
+        Functions\when( 'wp_timezone' )->justReturn( new \DateTimeZone( 'UTC' ) );
+        Functions\when( 'get_option' )->justReturn( array() );
+
+        $candidate = (object) array(
+            'id'         => 5,
+            'user_id'    => null,
+            'created_at' => '2026-05-10 12:00:00',
+            'updated_at' => '2026-05-12 09:30:00',
+        );
+
+        $lines = $this->invoke_build_delete_consequences( $candidate );
+
+        $this->assertStringStartsWith( 'Created on ', $lines[0] );
+        $this->assertStringStartsWith( 'Last updated on ', $lines[1] );
+        $this->assertCount( 5, $lines, 'created + last-updated + 3 standard consequences' );
+    }
+
+    public function test_build_delete_consequences_surfaces_linked_user_when_promoted(): void {
+        $wp_user             = new \stdClass();
+        $wp_user->user_login = 'alice';
+        Functions\when( 'get_userdata' )->justReturn( $wp_user );
+        Functions\when( 'wp_date' )->returnArg();
+        Functions\when( 'wp_timezone' )->justReturn( new \DateTimeZone( 'UTC' ) );
+        Functions\when( 'get_option' )->justReturn( array() );
+
+        $candidate = (object) array(
+            'id'         => 5,
+            'user_id'    => 99,
+            'created_at' => '2026-05-10 12:00:00',
+            'updated_at' => '2026-05-10 12:00:00',
+        );
+
+        $lines = $this->invoke_build_delete_consequences( $candidate );
+
+        $found_user_line = false;
+        foreach ( $lines as $line ) {
+            if ( str_contains( $line, '@alice' ) ) {
+                $found_user_line = true;
+                break;
+            }
+        }
+        $this->assertTrue( $found_user_line, 'expected the linked user line to surface @alice' );
+    }
 }


### PR DESCRIPTION
Terceira PR de #331 (de 4). Cobre a frente **Hard-delete dialog context**.

## Estado anterior

Quando fui mapear o flow, o hard-delete **já usa o modal compartilhado** (migração do nativo `confirm()` aconteceu em #332). A frase no checklist da issue está desatualizada nessa parte. Os gaps reais são:

1. Modal não mostra **contexto da row** antes do destrutivo
2. Reason ainda usa `<input required>` inline em vez do gating do modal

## Decisão de escopo: `last_classification_at` / `last_call_at`

A spec da issue pede `last_classification_at` e `last_call_at` no diálogo. Sob o gate §7-bis atual (`classification_count = 0` requirido pra deletar), esses dois valores são **sempre null** por construção — o gate impede delete enquanto qualquer classification ainda referencia o candidato, e calls dependem de classifications.

Substituí por timestamps **da row do candidato** (`created_at` / `updated_at`) + **linked WP user** se promovido. São os campos que sempre existem e que o operador precisa antes do destrutivo. Deviação documentada inline no código.

## O que muda

### `render_delete_section()`

- **Novo helper** privado `build_delete_consequences(CandidateRow): list<string>` que monta a lista de bullets do modal:
  - "Created on {datetime}." — sempre
  - "Last updated on {datetime}." — só quando `updated_at != created_at` (evita duplicação em rows recém-criadas)
  - "Linked WP user: @{login} (preserved untouched on delete)." — só quando `user_id` resolve para um WP_User válido
  - Seguido das 3 linhas standard pré-existentes ("removed permanently", "ActivityLog kept", "cannot be undone")

- **`data-ffc-confirm-reason-label="Reason (logged):"`** no `<form>` — o modal passa a renderizar e gatear o input de reason (igual #332 / #335).

- **Inline reason vira `<noscript>` fallback**: o `<input name="reason" required>` antigo é movido pra dentro de `<noscript>`. Com JS ligado, o modal injeta um hidden `reason` que vence o parsing de `$_POST` (last-wins). Com JS desligado, o `<noscript>` força o operador a digitar antes do submit. Sem conflito de double-submit.

### Texto introdutório

O `<p>` que precede o form mantém o resumo do que vai acontecer. As linhas detalhadas ficam no modal (onde o operador efetivamente para antes de confirmar).

## Aceite (do checklist da issue)

- [x] Endpoint já existe via `DeleteService` — sem mudança
- [x] UI usa modal (já migrado em #332) — agora com **reason gating** próprio do modal
- [x] Mostrar contexto pré-deleção — substituí `last_classification_at`/`last_call_at` (sempre null sob o gate atual) por `created_at`/`updated_at` + linked WP user

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/RecruitmentEditPagesSmokeTest.php` → **9/9** (+3 cases novos via `ReflectionMethod` no helper privado)
  - "Created on …" como primeira linha de consequences quando há `created_at`
  - "Created on …" + "Last updated on …" quando os dois timestamps diferem
  - Linha `@login` quando `user_id` resolve a um WP_User
- [x] `vendor/bin/phpunit --testsuite=unit` → **4459/4459**
- [x] `npx vitest run tests/js/recruitment-admin.test.js` → 27/27 (modal JS preservada)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/recruitment/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] Candidato sem classifications e sem WP user linkado → clicar Delete → modal abre mostrando Created on / Last updated on + linhas standard, input de reason gating o CTA.
- [ ] Candidato com `user_id` → modal mostra linha extra com `@login`.
- [ ] Candidato recém-criado (created_at == updated_at) → modal mostra só uma linha "Created on" sem a redundante "Last updated".
- [ ] JS desligado (`<noscript>` fallback) → input de reason inline aparece e bloqueia submit sem valor.
- [ ] Confirmar deleção → reason chega em `$_POST` e é gravado no ActivityLog (`recruitment_candidate_deleted` com `reason`).

## #331 checklist

- [x] Search → #337 (merged)
- [x] Edit estendido → #338 (merged)
- [x] **Hard-delete dialog context** → esta PR
- [ ] History panel (próxima — última)

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_