### PR TITLE
Recruitment admin: per-candidate History panel + activity-log indirection (#331 history)

### DIFF
--- a/includes/admin/class-ffc-admin-activity-log-page.php
+++ b/includes/admin/class-ffc-admin-activity-log-page.php
@@ -266,20 +266,13 @@ class AdminActivityLogPage {
 	}
 
 	/**
-	 * Get unique actions from database
+	 * Get unique actions from database (delegates to ActivityLogQuery
+	 * so the read path stays centralized — see #331 follow-up).
 	 *
 	 * @return array<int, string>
 	 */
 	private function get_unique_actions(): array {
-		global $wpdb;
-		$table_name = $wpdb->prefix . 'ffc_activity_log';
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$actions = $wpdb->get_col(
-			$wpdb->prepare( 'SELECT DISTINCT action FROM %i ORDER BY action ASC', $table_name )
-		);
-
-		return $actions;
+		return \FreeFormCertificate\Core\ActivityLogQuery::distinct_actions();
 	}
 
 	/**

--- a/includes/core/class-ffc-activity-log-query.php
+++ b/includes/core/class-ffc-activity-log-query.php
@@ -38,6 +38,7 @@ class ActivityLogQuery {
 			'offset'    => 0,
 			'level'     => null,
 			'action'    => null,
+			'action_in' => null,
 			'user_id'   => null,
 			'user_ip'   => null,
 			'date_from' => null,
@@ -56,6 +57,15 @@ class ActivityLogQuery {
 		}
 		if ( $args['action'] ) {
 			$where[] = $wpdb->prepare( 'action = %s', sanitize_text_field( $args['action'] ) );
+		}
+		if ( is_array( $args['action_in'] ) && ! empty( $args['action_in'] ) ) {
+			// Sanitized + bounded — each value passes through
+			// sanitize_text_field and the SET is built from a fixed-count
+			// `%s` placeholder run that matches $sanitized one-for-one.
+			$sanitized    = array_values( array_unique( array_map( 'sanitize_text_field', $args['action_in'] ) ) );
+			$placeholders = implode( ',', array_fill( 0, count( $sanitized ), '%s' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is a compile-time `%s,%s,...` string whose count matches $sanitized one-for-one; values are bound by wpdb->prepare.
+			$where[] = $wpdb->prepare( "action IN ({$placeholders})", $sanitized );
 		}
 		if ( $args['user_id'] ) {
 			$where[] = $wpdb->prepare( 'user_id = %d', absint( $args['user_id'] ) );
@@ -98,6 +108,77 @@ class ActivityLogQuery {
 		}
 
 		return $results;
+	}
+
+	/**
+	 * List every distinct `action` ever written to the activity log,
+	 * ordered alphabetically. Used by the admin-side filter dropdown
+	 * — and by any caller that needs to enumerate the action vocabulary
+	 * present in this installation. Replaces a raw `SELECT DISTINCT
+	 * action` query that previously sat in the admin page (issue #331
+	 * "candidate history service" cleanup).
+	 *
+	 * @since 6.6.2
+	 * @return list<string>
+	 */
+	public static function distinct_actions(): array {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'ffc_activity_log';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Catalog lookup; %i used for the table identifier.
+		$actions = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT DISTINCT action FROM %i ORDER BY action ASC', $table_name )
+		);
+		if ( ! is_array( $actions ) ) {
+			return array();
+		}
+		return array_values( array_map( 'strval', $actions ) );
+	}
+
+	/**
+	 * Privacy / user-cleanup helper — `SET user_id = NULL` on every log
+	 * row that referenced the supplied wp_user, so the audit trail
+	 * survives a user deletion without leaking the orphaned numeric ID
+	 * via foreign-key joins. Returns the row count that was rewritten,
+	 * or `0` when the table doesn't exist (legacy installs that never
+	 * ran the activator).
+	 *
+	 * Centralizes a query that was duplicated in
+	 * {@see \FreeFormCertificate\Privacy\PrivacyHandler} and
+	 * {@see \FreeFormCertificate\UserDashboard\UserCleanup} — both
+	 * callsites now route through here.
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WP user ID to redact.
+	 * @return int Number of log rows whose `user_id` was nulled.
+	 */
+	public static function redact_user_id( int $user_id ): int {
+		global $wpdb;
+		if ( $user_id <= 0 ) {
+			return 0;
+		}
+		$table_name = $wpdb->prefix . 'ffc_activity_log';
+
+		// Mirror the existing callers' table-existence guard so legacy
+		// pre-activator installs degrade quietly. Follows the same
+		// shape as DatabaseHelperTrait::table_exists() (SHOW TABLES
+		// LIKE %s; %s already handles LIKE-escape — the table name is
+		// internal, never operator-supplied).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+		if ( $exists !== $table_name ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Privacy redaction; surface area kept narrow (single WHERE on user_id).
+		$rows = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET user_id = NULL WHERE user_id = %d',
+				$table_name,
+				$user_id
+			)
+		);
+		return is_int( $rows ) ? $rows : 0;
 	}
 
 	/**

--- a/includes/privacy/class-ffc-privacy-handler.php
+++ b/includes/privacy/class-ffc-privacy-handler.php
@@ -683,16 +683,7 @@ class PrivacyHandler {
 		}
 
 		// 7. Activity log: SET user_id = NULL.
-		$activity_table = $wpdb->prefix . 'ffc_activity_log';
-		if ( self::table_exists( $activity_table ) ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					'UPDATE %i SET user_id = NULL WHERE user_id = %d',
-					$activity_table,
-					$user_id
-				)
-			);
-		}
+		\FreeFormCertificate\Core\ActivityLogQuery::redact_user_id( $user_id );
 
 		// 8. ffc_* user meta: DELETE.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-edit-page.php
@@ -95,6 +95,7 @@ final class RecruitmentCandidateEditPage {
 		self::render_general_section( $candidate );
 		self::render_sensitive_section( $candidate );
 		self::render_classifications_section( $candidate );
+		self::render_history_section( $candidate );
 		self::render_delete_section( $candidate );
 	}
 
@@ -517,7 +518,88 @@ final class RecruitmentCandidateEditPage {
 	}
 
 	/**
-	 * Section 4: Hard-delete with reason (gated per §7-bis).
+	 * Section 4: per-candidate activity log feed (issue #331 "History").
+	 *
+	 * Surfaces every recruitment event that references this candidate
+	 * — direct (`candidate_id` in context) or indirect (`classification_id`
+	 * in context, matched against the candidate's current classifications).
+	 * Delegates the cross-table lookup + decryption to
+	 * {@see RecruitmentCandidateHistoryService::get_for_candidate()}.
+	 *
+	 * Rendered ABOVE the hard-delete postbox so the operator can scan
+	 * the audit trail before committing a destructive action.
+	 *
+	 * @since 6.6.2
+	 * @param object $candidate Candidate row.
+	 * @phpstan-param CandidateRow $candidate
+	 * @return void
+	 */
+	private static function render_history_section( object $candidate ): void {
+		$entries = RecruitmentCandidateHistoryService::get_for_candidate( (int) $candidate->id );
+
+		echo '<div class="postbox" style="margin-top:20px;">';
+		echo '<h2 class="hndle"><span>' . esc_html__( 'History', 'ffcertificate' ) . '</span></h2>';
+		echo '<div class="inside">';
+
+		if ( empty( $entries ) ) {
+			echo '<p><em>' . esc_html__( '(no activity recorded for this candidate)', 'ffcertificate' ) . '</em></p>';
+			echo '</div></div>';
+			return;
+		}
+
+		echo '<p class="description">' . esc_html__( 'Most recent first. Pulled from the activity log for events referencing this candidate or any of its classifications.', 'ffcertificate' ) . '</p>';
+		echo '<table class="widefat striped"><thead><tr>';
+		echo '<th>' . esc_html__( 'When', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Who', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Event', 'ffcertificate' ) . '</th>';
+		echo '</tr></thead><tbody>';
+		foreach ( $entries as $entry ) {
+			$action  = (string) ( $entry['action'] ?? '' );
+			$context = is_array( $entry['context'] ?? null ) ? $entry['context'] : array();
+			$when    = (string) ( $entry['created_at'] ?? '' );
+			$uid     = (int) ( $entry['user_id'] ?? 0 );
+
+			echo '<tr>';
+			echo '<td>' . esc_html( '' === $when ? '—' : DateFormatter::format_datetime( $when ) ) . '</td>';
+			echo '<td>' . esc_html( self::render_history_actor( $uid ) ) . '</td>';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- summarize_event() returns pre-escaped HTML.
+			echo '<td>' . RecruitmentCandidateHistoryService::summarize_event( $action, $context ) . '</td>';
+			echo '</tr>';
+		}
+		echo '</tbody></table>';
+
+		echo '</div></div>';
+	}
+
+	/**
+	 * Resolve a user_id to a display string for the History table.
+	 *
+	 * Mirrors the convention used by the global activity-log admin
+	 * page: real users → "Display Name (login)"; deleted users → the
+	 * row keeps its trace via "User #N (deleted)"; system events
+	 * (user_id 0, e.g. cron-driven cleanups) → "System".
+	 *
+	 * @since 6.6.2
+	 * @param int $uid `wp_users.ID`, or 0 for system events.
+	 * @return string Plain text, NOT yet escaped (caller wraps in esc_html).
+	 */
+	private static function render_history_actor( int $uid ): string {
+		if ( $uid <= 0 ) {
+			return __( 'System', 'ffcertificate' );
+		}
+		$user = get_userdata( $uid );
+		if ( false === $user ) {
+			return sprintf(
+				/* translators: %d — orphaned WP user id */
+				__( 'User #%d (deleted)', 'ffcertificate' ),
+				$uid
+			);
+		}
+		return sprintf( '%s (%s)', (string) $user->display_name, (string) $user->user_login );
+	}
+
+	/**
+	 * Section 5: Hard-delete with reason (gated per §7-bis).
 	 *
 	 * @param object $candidate Candidate row.
 	 * @phpstan-param CandidateRow $candidate

--- a/includes/recruitment/class-ffc-recruitment-candidate-history-service.php
+++ b/includes/recruitment/class-ffc-recruitment-candidate-history-service.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Recruitment Candidate History Service
+ *
+ * Per-candidate audit-trail aggregator. Cross-references the recruitment
+ * action vocabulary (see {@see RecruitmentActivityLogger}) against the
+ * candidate's classifications so the operator sees every activity-log
+ * entry that touches "this candidate" on one screen — status changes,
+ * calls (issued / cancelled), PII reveals, field edits, adjutancy swaps,
+ * classification deletions, promotion to WP user.
+ *
+ * Filter strategy:
+ *
+ *   1. SELECT activity log rows where `action IN (...)` for the recruitment
+ *      action codes that can reference a candidate (directly or via a
+ *      classification). Bounded by a generous LIMIT so the per-candidate
+ *      view stays performant even on a system with millions of total
+ *      activity rows.
+ *
+ *   2. Resolve `context` via `ActivityLogQuery::resolve_context()` so
+ *      encrypted rows (those carrying sensitive keys per
+ *      `SensitiveFieldRegistry`) are decoded transparently.
+ *
+ *   3. Filter in PHP: keep rows whose context references this candidate
+ *      directly (`candidate_id`), via a classification this candidate
+ *      currently owns (`classification_id`), or via the bulk-call array
+ *      (`classification_ids`). Classifications that were hard-deleted
+ *      before this fetch are lost — acceptable tradeoff for v1; the
+ *      delete event itself still lands via the direct-id path when it
+ *      carried a `candidate_id`.
+ *
+ * @package FreeFormCertificate\Recruitment
+ * @since   6.6.2
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Recruitment;
+
+use FreeFormCertificate\Core\ActivityLogQuery;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stateless service. Issue #331 "History" frontend.
+ */
+final class RecruitmentCandidateHistoryService {
+
+	/**
+	 * Activity log action codes that may reference a candidate. Kept
+	 * in sync with the §13 vocabulary in {@see RecruitmentActivityLogger}.
+	 * Codes that never name a candidate (notice / adjutancy / CSV
+	 * pipeline level) are deliberately omitted — they would just
+	 * inflate the SELECT before the PHP-side filter rejects them.
+	 *
+	 * @var list<string>
+	 */
+	private const RELEVANT_ACTIONS = array(
+		'recruitment_candidate_promoted',
+		'recruitment_candidate_fields_edited',
+		'recruitment_pii_revealed',
+		'recruitment_classification_status_changed',
+		'recruitment_classification_adjutancy_changed',
+		'recruitment_classification_deleted',
+		'recruitment_call_created',
+		'recruitment_bulk_call_created',
+		'recruitment_call_cancelled',
+	);
+
+	/**
+	 * Pre-filter SELECT cap. Over-fetched so the PHP-side filter has
+	 * room to drop unrelated entries and still surface a useful page.
+	 */
+	private const SELECT_CEILING = 400;
+
+	/**
+	 * Return every activity-log entry that references the candidate,
+	 * sorted by `created_at DESC` (most recent first).
+	 *
+	 * Each entry mirrors the shape `ActivityLogQuery::get_activities()`
+	 * returns: `id`, `action`, `level`, `context` (resolved/decoded),
+	 * `user_id`, `user_ip`, `created_at`.
+	 *
+	 * @param int $candidate_id Candidate row ID.
+	 * @param int $limit        Page size (max 200).
+	 * @return list<array<string, mixed>>
+	 */
+	public static function get_for_candidate( int $candidate_id, int $limit = 50 ): array {
+		if ( $candidate_id <= 0 ) {
+			return array();
+		}
+		$limit = max( 1, min( 200, $limit ) );
+
+		$classifications = RecruitmentClassificationRepository::get_for_candidate( $candidate_id );
+		$cls_ids         = array_map( static fn( $c ) => (int) $c->id, $classifications );
+
+		// Delegate the SELECT to ActivityLogQuery so the read path stays
+		// centralized (context resolution + decrypt + json_decode happen
+		// inside `get_activities()` once, for every consumer). Over-fetch
+		// vs $limit because we still need to filter in PHP — the action
+		// codes themselves don't carry candidate identity, only their
+		// context does.
+		$rows = ActivityLogQuery::get_activities(
+			array(
+				'action_in' => self::RELEVANT_ACTIONS,
+				'orderby'   => 'created_at',
+				'order'     => 'DESC',
+				'limit'     => self::SELECT_CEILING,
+			)
+		);
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			if ( self::matches_candidate( $row, $candidate_id, $cls_ids ) ) {
+				$out[] = $row;
+				if ( count( $out ) >= $limit ) {
+					break;
+				}
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Decide whether a resolved log row references the candidate.
+	 *
+	 * Accepts:
+	 *   - direct `candidate_id` match (candidate_promoted, fields_edited,
+	 *     pii_revealed)
+	 *   - `classification_id` ∈ candidate's current classifications
+	 *   - any of `classification_ids[]` ∈ candidate's current classifications
+	 *     (covers `recruitment_bulk_call_created`)
+	 *
+	 * @param array<string, mixed> $row          Resolved activity log row.
+	 * @param int                  $candidate_id Candidate ID.
+	 * @param array                $cls_ids      Candidate's classification IDs.
+	 * @phpstan-param list<int>    $cls_ids
+	 * @return bool
+	 */
+	public static function matches_candidate( array $row, int $candidate_id, array $cls_ids ): bool {
+		$ctx = $row['context'] ?? array();
+		if ( ! is_array( $ctx ) ) {
+			return false;
+		}
+
+		if ( isset( $ctx['candidate_id'] ) && (int) $ctx['candidate_id'] === $candidate_id ) {
+			return true;
+		}
+
+		if ( isset( $ctx['classification_id'] ) && in_array( (int) $ctx['classification_id'], $cls_ids, true ) ) {
+			return true;
+		}
+
+		if ( isset( $ctx['classification_ids'] ) && is_array( $ctx['classification_ids'] ) ) {
+			foreach ( $ctx['classification_ids'] as $cid ) {
+				if ( in_array( (int) $cid, $cls_ids, true ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Render-side summary string for an event row. Returns a short
+	 * single-line, already-escaped description suitable for direct
+	 * `echo` from the candidate-edit history table.
+	 *
+	 * Unknown action codes fall back to the action code itself — keeps
+	 * the panel forward-compatible when new recruitment events ship
+	 * before this method learns about them.
+	 *
+	 * @param string               $action  Action code.
+	 * @param array<string, mixed> $context Resolved context.
+	 * @return string Escaped HTML.
+	 */
+	public static function summarize_event( string $action, array $context ): string {
+		switch ( $action ) {
+			case 'recruitment_candidate_promoted':
+				return esc_html(
+					sprintf(
+						/* translators: %d — WP user ID */
+						__( 'Promoted to WordPress user #%d.', 'ffcertificate' ),
+						(int) ( $context['user_id'] ?? 0 )
+					)
+				);
+
+			case 'recruitment_candidate_fields_edited':
+				$changes = isset( $context['changes'] ) && is_array( $context['changes'] ) ? array_keys( $context['changes'] ) : array();
+				return esc_html(
+					sprintf(
+						/* translators: %s — comma-separated list of field names */
+						__( 'Fields edited: %s.', 'ffcertificate' ),
+						implode( ', ', $changes )
+					)
+				);
+
+			case 'recruitment_pii_revealed':
+				return esc_html(
+					sprintf(
+						/* translators: %s — PII field key (cpf / rf / email) */
+						__( 'PII revealed: %s.', 'ffcertificate' ),
+						(string) ( $context['field_key'] ?? '?' )
+					)
+				);
+
+			case 'recruitment_classification_status_changed':
+				$base = sprintf(
+					/* translators: 1 — classification ID, 2 — previous status, 3 — new status */
+					__( 'Classification #%1$d status: %2$s → %3$s.', 'ffcertificate' ),
+					(int) ( $context['classification_id'] ?? 0 ),
+					(string) ( $context['from'] ?? '?' ),
+					(string) ( $context['to'] ?? '?' )
+				);
+				return esc_html( self::append_reason( $base, $context ) );
+
+			case 'recruitment_classification_adjutancy_changed':
+				return esc_html(
+					sprintf(
+						/* translators: 1 — classification ID, 2 — previous adjutancy id, 3 — new adjutancy id */
+						__( 'Classification #%1$d adjutancy: #%2$d → #%3$d.', 'ffcertificate' ),
+						(int) ( $context['classification_id'] ?? 0 ),
+						(int) ( $context['from'] ?? 0 ),
+						(int) ( $context['to'] ?? 0 )
+					)
+				);
+
+			case 'recruitment_classification_deleted':
+				$base = sprintf(
+					/* translators: %d — classification id */
+					__( 'Classification #%d deleted.', 'ffcertificate' ),
+					(int) ( $context['classification_id'] ?? 0 )
+				);
+				return esc_html( self::append_reason( $base, $context ) );
+
+			case 'recruitment_call_created':
+				$ooo_flag = ( isset( $context['out_of_order'] ) && 1 === (int) $context['out_of_order'] ) ? ' (out-of-order)' : '';
+				return esc_html(
+					sprintf(
+						/* translators: 1 — call ID, 2 — classification ID, 3 — out-of-order flag suffix */
+						__( 'Call #%1$d issued on classification #%2$d%3$s.', 'ffcertificate' ),
+						(int) ( $context['call_id'] ?? 0 ),
+						(int) ( $context['classification_id'] ?? 0 ),
+						$ooo_flag
+					)
+				);
+
+			case 'recruitment_bulk_call_created':
+				return esc_html(
+					sprintf(
+						/* translators: %d — total count of classifications convocated in the bulk call */
+						__( 'Bulk call issued for %d classifications.', 'ffcertificate' ),
+						(int) ( $context['count'] ?? 0 )
+					)
+				);
+
+			case 'recruitment_call_cancelled':
+				$base = sprintf(
+					/* translators: 1 — call ID, 2 — classification ID */
+					__( 'Call #%1$d cancelled on classification #%2$d.', 'ffcertificate' ),
+					(int) ( $context['call_id'] ?? 0 ),
+					(int) ( $context['classification_id'] ?? 0 )
+				);
+				return esc_html( self::append_reason( $base, $context ) );
+
+			default:
+				return esc_html( $action );
+		}
+	}
+
+	/**
+	 * Append the `reason` clause to an event summary when the context
+	 * carries one. Pure formatting helper extracted so the `__()` calls
+	 * with placeholders sit next to their `translators:` annotation per
+	 * the WPCS I18n rule.
+	 *
+	 * @param string               $base    Already-formatted base summary.
+	 * @param array<string, mixed> $context Resolved log context.
+	 * @return string Plain text (caller wraps in esc_html).
+	 */
+	private static function append_reason( string $base, array $context ): string {
+		$reason = (string) ( $context['reason'] ?? '' );
+		if ( '' === $reason ) {
+			return $base;
+		}
+		return $base . ' ' . sprintf(
+			/* translators: %s — operator-supplied reason text */
+			__( '(reason: %s)', 'ffcertificate' ),
+			$reason
+		);
+	}
+}

--- a/includes/user-dashboard/class-ffc-user-cleanup.php
+++ b/includes/user-dashboard/class-ffc-user-cleanup.php
@@ -79,18 +79,9 @@ class UserCleanup {
 		}
 
 		// 3. Activity log: SET user_id = NULL (preserve audit trail)
-		$activity_table = $wpdb->prefix . 'ffc_activity_log';
-		if ( self::table_exists( $activity_table ) ) {
-			$rows = $wpdb->query(
-				$wpdb->prepare(
-					'UPDATE %i SET user_id = NULL WHERE user_id = %d',
-					$activity_table,
-					$user_id
-				)
-			);
-			if ( $rows > 0 ) {
-				$anonymized['activity_log'] = $rows;
-			}
+		$rows = \FreeFormCertificate\Core\ActivityLogQuery::redact_user_id( $user_id );
+		if ( $rows > 0 ) {
+			$anonymized['activity_log'] = $rows;
 		}
 
 		// 4. Audience members: DELETE.

--- a/tests/Unit/ActivityLogQueryTest.php
+++ b/tests/Unit/ActivityLogQueryTest.php
@@ -351,4 +351,93 @@ class ActivityLogQueryTest extends TestCase {
         $deleted = ActivityLogQuery::run_cleanup();
         $this->assertSame( 5, $deleted );
     }
+
+    // ------------------------------------------------------------------
+    // action_in filter — issue #331 history service consumer
+    // ------------------------------------------------------------------
+
+    public function test_get_activities_accepts_action_in_array(): void {
+        $captured = null;
+        $this->wpdb->shouldReceive( 'prepare' )
+            ->andReturnUsing(
+                function ( $sql ) use ( &$captured ) {
+                    if ( null === $captured && str_contains( $sql, 'action IN' ) ) {
+                        $captured = $sql;
+                    }
+                    return $sql;
+                }
+            );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() );
+
+        ActivityLogQuery::get_activities(
+            array( 'action_in' => array( 'recruitment_call_created', 'recruitment_call_cancelled' ) )
+        );
+
+        $this->assertNotNull( $captured );
+        $this->assertStringContainsString( 'action IN', (string) $captured );
+    }
+
+    public function test_get_activities_ignores_empty_action_in(): void {
+        $captured_sqls = array();
+        $this->wpdb->shouldReceive( 'prepare' )
+            ->andReturnUsing(
+                function ( $sql ) use ( &$captured_sqls ) {
+                    $captured_sqls[] = $sql;
+                    return $sql;
+                }
+            );
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() );
+
+        ActivityLogQuery::get_activities( array( 'action_in' => array() ) );
+
+        $combined = implode( ' ', $captured_sqls );
+        $this->assertStringNotContainsString( 'action IN', $combined );
+    }
+
+    // ------------------------------------------------------------------
+    // distinct_actions() — admin filter dropdown delegate
+    // ------------------------------------------------------------------
+
+    public function test_distinct_actions_returns_string_list(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql );
+        $this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( 'recruitment_call_created', 'submission_received' ) );
+
+        $actions = ActivityLogQuery::distinct_actions();
+
+        $this->assertSame( array( 'recruitment_call_created', 'submission_received' ), $actions );
+    }
+
+    public function test_distinct_actions_returns_empty_array_when_no_rows(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql );
+        $this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+
+        $this->assertSame( array(), ActivityLogQuery::distinct_actions() );
+    }
+
+    // ------------------------------------------------------------------
+    // redact_user_id() — privacy / user-cleanup delegate
+    // ------------------------------------------------------------------
+
+    public function test_redact_user_id_short_circuits_on_non_positive(): void {
+        $this->wpdb->shouldNotReceive( 'query' );
+
+        $this->assertSame( 0, ActivityLogQuery::redact_user_id( 0 ) );
+        $this->assertSame( 0, ActivityLogQuery::redact_user_id( -5 ) );
+    }
+
+    public function test_redact_user_id_returns_zero_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql );
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+        $this->wpdb->shouldNotReceive( 'query' );
+
+        $this->assertSame( 0, ActivityLogQuery::redact_user_id( 42 ) );
+    }
+
+    public function test_redact_user_id_runs_update_when_table_present(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql );
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 'wp_ffc_activity_log' );
+        $this->wpdb->shouldReceive( 'query' )->once()->andReturn( 3 );
+
+        $this->assertSame( 3, ActivityLogQuery::redact_user_id( 42 ) );
+    }
 }

--- a/tests/Unit/RecruitmentCandidateHistoryServiceTest.php
+++ b/tests/Unit/RecruitmentCandidateHistoryServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCandidateHistoryService;
+
+/**
+ * Tests for RecruitmentCandidateHistoryService — verifies the candidate
+ * matcher predicate (direct candidate_id / classification_id /
+ * bulk classification_ids) plus the per-action summary formatter. The
+ * end-to-end `get_for_candidate()` path that hits wpdb is exercised
+ * separately by the integration suite; here we pin the pure logic.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCandidateHistoryService
+ */
+class RecruitmentCandidateHistoryServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// matches_candidate()
+	// ------------------------------------------------------------------
+
+	public function test_matches_direct_candidate_id(): void {
+		$row = array( 'action' => 'recruitment_candidate_fields_edited', 'context' => array( 'candidate_id' => 42 ) );
+
+		$this->assertTrue( RecruitmentCandidateHistoryService::matches_candidate( $row, 42, array() ) );
+	}
+
+	public function test_does_not_match_when_candidate_id_differs(): void {
+		$row = array( 'action' => 'recruitment_candidate_fields_edited', 'context' => array( 'candidate_id' => 7 ) );
+
+		$this->assertFalse( RecruitmentCandidateHistoryService::matches_candidate( $row, 42, array() ) );
+	}
+
+	public function test_matches_when_classification_id_in_set(): void {
+		$row = array( 'action' => 'recruitment_classification_status_changed', 'context' => array( 'classification_id' => 100 ) );
+
+		$this->assertTrue( RecruitmentCandidateHistoryService::matches_candidate( $row, 42, array( 100, 101 ) ) );
+	}
+
+	public function test_does_not_match_when_classification_id_outside_set(): void {
+		$row = array( 'action' => 'recruitment_classification_status_changed', 'context' => array( 'classification_id' => 999 ) );
+
+		$this->assertFalse( RecruitmentCandidateHistoryService::matches_candidate( $row, 42, array( 100, 101 ) ) );
+	}
+
+	public function test_matches_when_bulk_classification_ids_intersects(): void {
+		$row = array(
+			'action'  => 'recruitment_bulk_call_created',
+			'context' => array( 'classification_ids' => array( 50, 51, 100 ) ),
+		);
+
+		$this->assertTrue( RecruitmentCandidateHistoryService::matches_candidate( $row, 42, array( 100, 101 ) ) );
+	}
+
+	public function test_does_not_match_when_context_missing(): void {
+		$this->assertFalse( RecruitmentCandidateHistoryService::matches_candidate( array(), 42, array( 100 ) ) );
+		$this->assertFalse( RecruitmentCandidateHistoryService::matches_candidate( array( 'context' => 'not-an-array' ), 42, array( 100 ) ) );
+	}
+
+	// ------------------------------------------------------------------
+	// summarize_event() — every supported action code
+	// ------------------------------------------------------------------
+
+	public function test_summarize_candidate_promoted_mentions_user_id(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event( 'recruitment_candidate_promoted', array( 'user_id' => 99 ) );
+
+		$this->assertStringContainsString( '#99', $out );
+	}
+
+	public function test_summarize_fields_edited_lists_changed_field_names(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_candidate_fields_edited',
+			array( 'changes' => array( 'name' => array( 'old' => 'A', 'new' => 'B' ), 'phone' => array() ) )
+		);
+
+		$this->assertStringContainsString( 'name', $out );
+		$this->assertStringContainsString( 'phone', $out );
+	}
+
+	public function test_summarize_pii_revealed_shows_field_key(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event( 'recruitment_pii_revealed', array( 'field_key' => 'cpf' ) );
+
+		$this->assertStringContainsString( 'cpf', $out );
+	}
+
+	public function test_summarize_status_changed_includes_from_to_and_reason(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_classification_status_changed',
+			array( 'classification_id' => 17, 'from' => 'empty', 'to' => 'called', 'reason' => 'urgência' )
+		);
+
+		$this->assertStringContainsString( '#17', $out );
+		$this->assertStringContainsString( 'empty', $out );
+		$this->assertStringContainsString( 'called', $out );
+		$this->assertStringContainsString( 'urgência', $out );
+	}
+
+	public function test_summarize_status_changed_without_reason_omits_clause(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_classification_status_changed',
+			array( 'classification_id' => 17, 'from' => 'empty', 'to' => 'called' )
+		);
+
+		$this->assertStringNotContainsString( 'reason:', $out );
+	}
+
+	public function test_summarize_adjutancy_changed_shows_both_ids(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_classification_adjutancy_changed',
+			array( 'classification_id' => 17, 'from' => 3, 'to' => 5 )
+		);
+
+		$this->assertStringContainsString( '#3', $out );
+		$this->assertStringContainsString( '#5', $out );
+	}
+
+	public function test_summarize_call_created_flags_out_of_order(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_call_created',
+			array( 'call_id' => 8, 'classification_id' => 17, 'out_of_order' => 1 )
+		);
+
+		$this->assertStringContainsString( 'out-of-order', $out );
+	}
+
+	public function test_summarize_call_created_in_order_has_no_flag(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_call_created',
+			array( 'call_id' => 8, 'classification_id' => 17, 'out_of_order' => 0 )
+		);
+
+		$this->assertStringNotContainsString( 'out-of-order', $out );
+	}
+
+	public function test_summarize_bulk_call_includes_count(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event( 'recruitment_bulk_call_created', array( 'count' => 12 ) );
+
+		$this->assertStringContainsString( '12', $out );
+	}
+
+	public function test_summarize_call_cancelled_includes_reason(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event(
+			'recruitment_call_cancelled',
+			array( 'call_id' => 8, 'classification_id' => 17, 'reason' => 'duplicado' )
+		);
+
+		$this->assertStringContainsString( 'duplicado', $out );
+	}
+
+	public function test_summarize_unknown_action_falls_back_to_code(): void {
+		$out = RecruitmentCandidateHistoryService::summarize_event( 'recruitment_some_future_event', array() );
+
+		$this->assertSame( 'recruitment_some_future_event', $out );
+	}
+}


### PR DESCRIPTION
Última PR de #331 (de 4). Cobre a frente **History panel** + uma limpeza colateral solicitada pelo reviewer durante o build.

## Per-candidate History panel

Novo serviço `RecruitmentCandidateHistoryService` que agrega cada entrada de activity log referenciando o candidato, ordenada DESC por `created_at`. Cross-references o vocabulário §13 contra as classifications atuais do candidato — pega tanto eventos com `candidate_id` direto (`promoted`, `fields_edited`, `pii_revealed`) quanto eventos chave-via-classification (`status_changed`, `call_created/cancelled`, `adjutancy_changed`, `classification_deleted`, `bulk_call_created` via array de classification_ids).

`summarize_event($action, $context)` emite uma linha humana por código de ação com as anotações `translators:` que o sniff de I18n requer. Fallback pro action code raw mantém forward-compat com eventos futuros.

UI: nova postbox "History" renderizada entre Classifications e Hard-delete, com colunas When / Who / Event. "Who" segue a convenção do `AdminActivityLogPage` (real user → "Display (login)", deleted → "User #N (deleted)", system → "System").

## Limpeza colateral (acesso direto ao `ffc_activity_log`)

O `RecruitmentCandidateHistoryService` começou usando `$wpdb->get_results()` raw contra `ffc_activity_log`. Reviewer apontou que o plugin já centraliza essa tabela no `ActivityLogQuery` e pediu auditoria dos outros locais com o mesmo problema.

Três call sites migrados nessa PR:

| Site | Antes | Depois |
|---|---|---|
| `RecruitmentCandidateHistoryService` (novo) | `SELECT … WHERE action IN (…)` raw | `ActivityLogQuery::get_activities(['action_in' => …])` |
| `AdminActivityLogPage::get_unique_actions()` | `SELECT DISTINCT action` raw | `ActivityLogQuery::distinct_actions()` |
| `PrivacyHandler::erase_user_data` + `UserCleanup::anonymize` | `UPDATE … SET user_id = NULL WHERE user_id = X` duplicado | `ActivityLogQuery::redact_user_id($user_id)` (guarda de table-existence preservada dentro do helper) |

`ActivityLogQuery` ganha 3 métodos públicos novos:
- `get_activities([action_in => list<string>])` — extensão da API existente; placeholders `%s,%s,…` montados em compile-time, valores ligados via `wpdb->prepare`.
- `distinct_actions(): list<string>` — catálogo de actions distintas.
- `redact_user_id(int $user_id): int` — write helper LGPD que retorna o count de linhas redatadas.

O audit do restante do codebase achou **~25 outros leaks similares em 7 tabelas** (submissions, appointments, recruitment, audience, custom_fields, short_urls, user_profiles). Mapeei tudo em **#340** como tracking pra trabalhar incrementalmente — fora do escopo desta PR.

## Aceite (do checklist da issue)

- [x] Painel mostrando mudanças de status (de/para, quando, por quem, motivo se houver)
- [x] Calls emitidos (issued com flag out-of-order) + cancelled com reason
- [x] Edits de campo (referenciando `recruitment_candidate_fields_edited`)
- [x] Cobertura de testes

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4483/4483** (+24 cases novos)
  - `RecruitmentCandidateHistoryServiceTest` (17): predicate (direct id / classification_id / bulk array / misses / context malformado) + summarizer por ação (promoted, fields_edited, pii_revealed, status_changed com/sem reason, adjutancy_changed, call_created in-order/out-of-order, bulk_call, call_cancelled, unknown fallback)
  - `ActivityLogQueryTest` (7): `action_in` happy + empty short-circuit; `distinct_actions` row/empty; `redact_user_id` non-positive/missing-table/present-table
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] Candidato com 2-3 classifications ativas → abrir edit page → seção History lista os eventos relevantes (status changes nas classifications, calls, edits do próprio candidato, PII reveals).
- [ ] Candidato com 0 classifications atuais → só os eventos `candidate_id`-diretos aparecem; classification-keyed antigos (já deletados) somem (acceptable tradeoff — documentado no docblock do serviço).
- [ ] Admin activity log filter dropdown (page=ffc-activity-log) continua populando com as actions distintas.
- [ ] Deletar um WP user pelo admin → entries antigas no activity log que ele autorou ficam com `user_id = NULL` (preservando trail).

## #331 checklist (umbrella fechada com esta PR)

- [x] **Search** → #337 (merged)
- [x] **Edit estendido** → #338 (merged)
- [x] **Hard-delete dialog context** → #339 (merged)
- [x] **History panel** → esta PR

## Follow-up

- #340 (novo): mapeamento dos ~25 outros leaks de acesso direto a tabelas plugin-owned para serem saneados em PRs incrementais por agrupamento de tabela.

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_