### PR TITLE
Centralize raw $wpdb accesses behind repositories (#340)

### DIFF
--- a/includes/admin/class-ffc-admin-user-columns.php
+++ b/includes/admin/class-ffc-admin-user-columns.php
@@ -369,7 +369,6 @@ class AdminUserColumns {
 	 */
 	private static function load_recruitment_notice_counts(): void {
 		global $wpdb;
-		$candidates_table      = $wpdb->prefix . 'ffc_recruitment_candidate';
 		$classifications_table = $wpdb->prefix . 'ffc_recruitment_classification';
 
 		if ( null === self::$recruitment_table_exists ) {
@@ -381,25 +380,7 @@ class AdminUserColumns {
 			return;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt
-				FROM %i AS cl
-				INNER JOIN %i AS c ON c.id = cl.candidate_id
-				WHERE c.user_id IS NOT NULL
-				GROUP BY c.user_id',
-				$classifications_table,
-				$candidates_table
-			),
-			ARRAY_A
-		);
-
-		if ( $results ) {
-			foreach ( $results as $row ) {
-				self::$recruitment_counts_cache[ (int) $row['user_id'] ] = (int) $row['cnt'];
-			}
-		}
+		self::$recruitment_counts_cache = \FreeFormCertificate\Recruitment\RecruitmentClassificationRepository::count_notices_grouped_by_user();
 	}
 
 	/**
@@ -464,12 +445,11 @@ class AdminUserColumns {
 
 			case 'ffc_notices':
 			default:
-				$candidates      = $wpdb->prefix . 'ffc_recruitment_candidate';
 				$classifications = $wpdb->prefix . 'ffc_recruitment_classification';
 				if ( ! self::table_exists( $classifications ) ) {
 					return;
 				}
-				$select = "(SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt FROM {$classifications} AS cl INNER JOIN {$candidates} AS c ON c.id = cl.candidate_id WHERE c.user_id IS NOT NULL GROUP BY c.user_id)";
+				$select = \FreeFormCertificate\Recruitment\RecruitmentClassificationRepository::sql_user_notice_count_subquery();
 				break;
 		}
 

--- a/includes/admin/class-ffc-admin-user-columns.php
+++ b/includes/admin/class-ffc-admin-user-columns.php
@@ -355,20 +355,7 @@ class AdminUserColumns {
 			return;
 		}
 
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT user_id, COUNT(*) AS cnt FROM %i WHERE user_id IS NOT NULL AND status != 'cancelled' GROUP BY user_id",
-				$table
-			),
-			ARRAY_A
-		);
-
-		if ( $results ) {
-			foreach ( $results as $row ) {
-				self::$appointment_counts_cache[ (int) $row['user_id'] ] = (int) $row['cnt'];
-			}
-		}
+		self::$appointment_counts_cache = ( new \FreeFormCertificate\Repositories\AppointmentRepository() )->countAllByUserGrouped( 'cancelled' );
 	}
 
 	/**

--- a/includes/admin/class-ffc-settings.php
+++ b/includes/admin/class-ffc-settings.php
@@ -217,11 +217,7 @@ class Settings {
 			return;
 		}
 
-		global $wpdb;
-		$table_name = $wpdb->prefix . 'ffc_submissions';
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$cleared = $wpdb->query( $wpdb->prepare( 'UPDATE %i SET qr_code_cache = NULL WHERE qr_code_cache IS NOT NULL', $table_name ) );
+		$cleared = ( new \FreeFormCertificate\Repositories\SubmissionRepository() )->clearQrCodeCache();
 
 		wp_safe_redirect(
 			add_query_arg(

--- a/includes/api/class-ffc-user-profile-rest-controller.php
+++ b/includes/api/class-ffc-user-profile-rest-controller.php
@@ -156,26 +156,12 @@ class UserProfileRestController {
 			}
 
 			$audience_groups = array();
-			$audiences_table = $wpdb->prefix . 'ffc_audiences';
 			$members_table   = $wpdb->prefix . 'ffc_audience_members';
 
 			if ( self::table_exists( $members_table ) ) {
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$audience_groups = $wpdb->get_results(
-					$wpdb->prepare(
-						"SELECT a.name, a.color
-                     FROM %i m
-                     INNER JOIN %i a ON a.id = m.audience_id
-                     WHERE m.user_id = %d AND a.status = 'active'
-                     ORDER BY a.name ASC",
-						$members_table,
-						$audiences_table,
-						$user_id
-					),
-					ARRAY_A
-				);
+				$audience_groups = \FreeFormCertificate\Audience\AudienceRepository::get_user_audience_badges( $user_id );
 
-				if ( ! is_array( $audience_groups ) ) {
+				if ( empty( $audience_groups ) ) {
 					$audience_groups = array();
 				}
 			}

--- a/includes/api/class-ffc-user-summary-rest-controller.php
+++ b/includes/api/class-ffc-user-summary-rest-controller.php
@@ -94,39 +94,24 @@ class UserSummaryRestController {
 
 			// Next appointment.
 			if ( $this->user_has_capability( 'ffc_view_self_scheduling', $user_id, $ctx['is_view_as'] ) ) {
-				$apt_table       = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-				$calendars_table = $wpdb->prefix . 'ffc_self_scheduling_calendars';
-
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$next = $wpdb->get_row(
-					$wpdb->prepare(
-						"SELECT a.appointment_date, a.start_time, c.title as calendar_title
-                     FROM %i a
-                     LEFT JOIN %i c ON a.calendar_id = c.id
-                     WHERE a.user_id = %d
-                       AND a.status IN ('pending', 'confirmed')
-                       AND a.appointment_date >= CURDATE()
-                     ORDER BY a.appointment_date ASC, a.start_time ASC
-                     LIMIT 1",
-						$apt_table,
-						$calendars_table,
-						$user_id
-					),
-					ARRAY_A
-				);
+				$apt_repo = new \FreeFormCertificate\Repositories\AppointmentRepository();
+				$next     = $apt_repo->findNextUpcomingForUser( $user_id );
 
 				if ( $next ) {
-					$timestamp      = strtotime( $next['appointment_date'] );
+					$timestamp      = strtotime( (string) $next['appointment_date'] );
 					$time_formatted = '';
 					if ( ! empty( $next['start_time'] ) ) {
-						$time_ts        = strtotime( $next['start_time'] );
+						$time_ts        = strtotime( (string) $next['start_time'] );
 						$time_formatted = ( false !== $time_ts ) ? \FreeFormCertificate\Core\DateFormatter::format_time( $time_ts ) : '';
 					}
 
+					$calendar      = ( new \FreeFormCertificate\Repositories\CalendarRepository() )->findById( (int) ( $next['calendar_id'] ?? 0 ) );
+					$calendar_name = is_array( $calendar ) ? (string) ( $calendar['title'] ?? '' ) : '';
+
 					$summary['next_appointment'] = array(
-						'date'  => ( false !== $timestamp ) ? \FreeFormCertificate\Core\DateFormatter::format_date( $timestamp ) : $next['appointment_date'],
+						'date'  => ( false !== $timestamp ) ? \FreeFormCertificate\Core\DateFormatter::format_date( $timestamp ) : (string) $next['appointment_date'],
 						'time'  => $time_formatted,
-						'title' => $next['calendar_title'] ?? '',
+						'title' => $calendar_name,
 					);
 				}
 			}

--- a/includes/audience/class-ffc-audience-notification-handler.php
+++ b/includes/audience/class-ffc-audience-notification-handler.php
@@ -145,16 +145,7 @@ class AudienceNotificationHandler {
 		}
 
 		// Get all affected users (from booking_users table).
-		global $wpdb;
-		$booking_users_table = $wpdb->prefix . 'ffc_audience_booking_users';
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$affected_users = $wpdb->get_col(
-			$wpdb->prepare(
-				'SELECT user_id FROM %i WHERE booking_id = %d',
-				$booking_users_table,
-				$booking_id
-			)
-		);
+		$affected_users = AudienceBookingRepository::get_booking_users( (int) $booking_id );
 
 		if ( empty( $affected_users ) ) {
 			return;

--- a/includes/audience/class-ffc-audience-repository.php
+++ b/includes/audience/class-ffc-audience-repository.php
@@ -45,6 +45,78 @@ class AudienceRepository {
 	}
 
 	/**
+	 * List every audience id regardless of status — used by callers
+	 * that need to iterate the full set without applying the public
+	 * `status='active'` filter that `get_all()` defaults to.
+	 *
+	 * Issue #340 centralization (extracted from the standard-fields
+	 * seeder's `seed_all_existing_audiences()` flow).
+	 *
+	 * @since 6.6.2
+	 * @return list<int>
+	 */
+	public static function get_all_ids(): array {
+		$wpdb  = self::db();
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Catalog scan; bounded by audience count.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT id FROM %i', $table )
+		);
+
+		return array_values( array_map( 'intval', $ids ) );
+	}
+
+	/**
+	 * Audiences (active only) the user is a member of, including only
+	 * the columns the public profile chips need: `name`, `color`. Used
+	 * by the REST `/me/profile` endpoint — keeping the column list
+	 * narrow avoids paying the SELECT * cost when only the badge
+	 * surface is rendered.
+	 *
+	 * Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WP user id.
+	 * @return list<array{name: string, color: string}>
+	 */
+	public static function get_user_audience_badges( int $user_id ): array {
+		if ( $user_id <= 0 ) {
+			return array();
+		}
+		$wpdb          = self::db();
+		$table         = self::get_table_name();
+		$members_table = self::get_members_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT a.name, a.color
+				FROM %i m
+				INNER JOIN %i a ON a.id = m.audience_id
+				WHERE m.user_id = %d AND a.status = 'active'
+				ORDER BY a.name ASC",
+				$members_table,
+				$table,
+				$user_id
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			$out[] = array(
+				'name'  => (string) ( $row['name'] ?? '' ),
+				'color' => (string) ( $row['color'] ?? '' ),
+			);
+		}
+		return $out;
+	}
+
+	/**
 	 * Get members table name
 	 *
 	 * @return string

--- a/includes/core/class-ffc-sensitive-field-registry.php
+++ b/includes/core/class-ffc-sensitive-field-registry.php
@@ -263,25 +263,11 @@ final class SensitiveFieldRegistry {
 			return $cached;
 		}
 
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_custom_fields';
-		$keys  = array();
+		$keys = array();
 
-		// The table may not exist (fresh install, tests), so guard the query.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
-		if ( $exists === $table ) {
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$rows = $wpdb->get_col(
-				$wpdb->prepare(
-					'SELECT DISTINCT field_key FROM %i WHERE is_sensitive = 1 AND is_active = 1',
-					$table
-				)
-			);
-			foreach ( (array) $rows as $field_key ) {
-				if ( is_string( $field_key ) && '' !== $field_key ) {
-					$keys[ $field_key ] = true;
-				}
+		if ( class_exists( '\\FreeFormCertificate\\Reregistration\\CustomFieldRepository' ) ) {
+			foreach ( \FreeFormCertificate\Reregistration\CustomFieldRepository::list_sensitive_field_keys() as $field_key ) {
+				$keys[ $field_key ] = true;
 			}
 		}
 

--- a/includes/frontend/class-ffc-csv-download-validator.php
+++ b/includes/frontend/class-ffc-csv-download-validator.php
@@ -254,14 +254,11 @@ final class CsvDownloadValidator {
 		}
 
 		if ( 'participants' === $mode ) {
-			global $wpdb;
 			$encryption_class = '\FreeFormCertificate\Core\Encryption';
 			$cpf_hash         = ( class_exists( $encryption_class ) && $encryption_class::is_configured() )
 				? $encryption_class::hash( $digits )
 				: hash( 'sha256', $digits );
-			$table            = $wpdb->prefix . 'ffc_submissions';
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE form_id = %d AND cpf_hash = %s', $table, $form_id, $cpf_hash ) );
+			$count            = ( new \FreeFormCertificate\Repositories\SubmissionRepository() )->countByFormAndCpfHash( $form_id, (string) $cpf_hash );
 			if ( $count <= 0 ) {
 				if ( ! $silent_audit ) {
 					$this->record_download_log_entry( $form_id, $mode, $digits, 'fail_match' );

--- a/includes/generators/class-ffc-pdf-generator.php
+++ b/includes/generators/class-ffc-pdf-generator.php
@@ -381,22 +381,14 @@ class PdfGenerator {
 	 * @return string QR code image URL or data URI
 	 */
 	public static function generate_magic_link_qr( int $submission_id, int $size = 200 ): string {
-		global $wpdb;
+		$magic_token = ( new \FreeFormCertificate\Repositories\SubmissionRepository() )->findMagicTokenById( $submission_id );
 
-		// Get submission.
-		$table = $wpdb->prefix . 'ffc_submissions';
-    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$submission = $wpdb->get_row(
-			$wpdb->prepare( 'SELECT magic_token FROM %i WHERE id = %d', $table, $submission_id ),
-			ARRAY_A
-		);
-
-		if ( ! $submission || empty( $submission['magic_token'] ) ) {
+		if ( null === $magic_token ) {
 			return '';
 		}
 
 		// Use helper to generate magic link.
-		$magic_link = \FreeFormCertificate\Generators\MagicLinkHelper::generate_magic_link( $submission['magic_token'] );
+		$magic_link = \FreeFormCertificate\Generators\MagicLinkHelper::generate_magic_link( $magic_token );
 
 		if ( empty( $magic_link ) ) {
 			return '';

--- a/includes/recruitment/class-ffc-recruitment-classification-repository.php
+++ b/includes/recruitment/class-ffc-recruitment-classification-repository.php
@@ -425,6 +425,68 @@ class RecruitmentClassificationRepository {
 	}
 
 	/**
+	 * Count distinct notices each promoted candidate participates in,
+	 * grouped by their linked `wp_users.ID`. Used by the admin Users
+	 * list "Notices" column to render the per-user count in one batch
+	 * pass (issue #340 centralization).
+	 *
+	 * Skips candidates with `user_id IS NULL` (never promoted) —
+	 * they have no WP-user surface to display the count on.
+	 *
+	 * @since 6.6.2
+	 * @return array<int, int> Map of `user_id => distinct-notice-count`.
+	 */
+	public static function count_notices_grouped_by_user(): array {
+		$wpdb            = self::db();
+		$candidates      = $wpdb->prefix . 'ffc_recruitment_candidate';
+		$classifications = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Batch aggregate for one admin-screen render; per-row caching wouldn't help.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS c
+				FROM %i AS cl
+				INNER JOIN %i AS c ON c.id = cl.candidate_id
+				WHERE c.user_id IS NOT NULL
+				GROUP BY c.user_id',
+				$classifications,
+				$candidates
+			),
+			ARRAY_A
+		);
+
+		$out = array();
+		if ( is_array( $rows ) ) {
+			foreach ( $rows as $row ) {
+				$out[ (int) $row['user_id'] ] = (int) $row['c'];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * SQL fragment for the WP_User_Query orderby rewrite that sorts
+	 * users by "distinct recruitment notices they appear in". Returns
+	 * a self-contained SELECT subquery — the caller wraps it as
+	 * `LEFT JOIN (subquery) AS {alias} ON {alias}.user_id = {wp_users}.ID`.
+	 *
+	 * Table names are baked in here so the admin layer doesn't have to
+	 * `$wpdb->prefix . 'ffc_…'` (issue #340 centralization). The output
+	 * is intentionally a raw SQL string because WP_User_Query's
+	 * `query_from` extension hook only accepts that.
+	 *
+	 * @since 6.6.2
+	 * @return string SQL subquery fragment (already including the
+	 *                surrounding parentheses).
+	 */
+	public static function sql_user_notice_count_subquery(): string {
+		$wpdb            = self::db();
+		$candidates      = $wpdb->prefix . 'ffc_recruitment_candidate';
+		$classifications = self::get_table_name();
+		return "(SELECT c.user_id AS user_id, COUNT(DISTINCT cl.notice_id) AS cnt FROM {$classifications} AS cl INNER JOIN {$candidates} AS c ON c.id = cl.candidate_id WHERE c.user_id IS NOT NULL GROUP BY c.user_id)";
+	}
+
+	/**
 	 * Swap a classification's `adjutancy_id` (issue #331 "Edit estendido").
 	 *
 	 * Pure CRUD — caller (the REST controller) is responsible for

--- a/includes/repositories/ffc-appointment-repository.php
+++ b/includes/repositories/ffc-appointment-repository.php
@@ -615,4 +615,283 @@ class AppointmentRepository extends AbstractRepository {
 
 		return $counts;
 	}
+
+	/**
+	 * Aggregate appointment counts grouped by `user_id`, optionally
+	 * excluding rows matching one status. Backs the admin Users list
+	 * "appointments" column where every row needs its own count.
+	 *
+	 * Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param string|null $exclude_status When non-null, rows with this
+	 *                                    status are filtered out (e.g.
+	 *                                    `'cancelled'`).
+	 * @return array<int, int> Map of `user_id => count`. user_id 0 / NULL
+	 *                         rows are skipped.
+	 */
+	public function countAllByUserGrouped( ?string $exclude_status = null ): array {
+		$where = 'user_id IS NOT NULL AND user_id > 0';
+		$args  = array( $this->table );
+		if ( null !== $exclude_status && '' !== $exclude_status ) {
+			$where .= ' AND status != %s';
+			$args[] = $exclude_status;
+		}
+
+		$sql = "SELECT user_id, COUNT(*) AS c FROM %i WHERE {$where} GROUP BY user_id";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where is a compile-time fragment with only known placeholders; values are bound through wpdb->prepare.
+		$rows = $this->wpdb->get_results( $this->wpdb->prepare( $sql, $args ), ARRAY_A );
+
+		$out = array();
+		if ( is_array( $rows ) ) {
+			foreach ( $rows as $row ) {
+				$out[ (int) $row['user_id'] ] = (int) $row['c'];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Delete every appointment row for a calendar. Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int $calendar_id Calendar ID.
+	 * @return int Rows deleted (0 when prepare/query fails).
+	 */
+	public function deleteByCalendar( int $calendar_id ): int {
+		if ( $calendar_id <= 0 ) {
+			return 0;
+		}
+		$sql = $this->wpdb->prepare( 'DELETE FROM %i WHERE calendar_id = %d', $this->table, $calendar_id );
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
+	 * Delete every appointment for a calendar dated strictly before
+	 * `$date` (Y-m-d). Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int    $calendar_id Calendar ID.
+	 * @param string $date        Cutoff date (`Y-m-d`).
+	 * @return int Rows deleted.
+	 */
+	public function deleteByCalendarBefore( int $calendar_id, string $date ): int {
+		if ( $calendar_id <= 0 || '' === $date ) {
+			return 0;
+		}
+		$sql = $this->wpdb->prepare(
+			'DELETE FROM %i WHERE calendar_id = %d AND appointment_date < %s',
+			$this->table,
+			$calendar_id,
+			$date
+		);
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
+	 * Delete every appointment for a calendar dated on or after `$date`
+	 * (Y-m-d). Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int    $calendar_id Calendar ID.
+	 * @param string $date        Cutoff date (`Y-m-d`).
+	 * @return int Rows deleted.
+	 */
+	public function deleteByCalendarAfter( int $calendar_id, string $date ): int {
+		if ( $calendar_id <= 0 || '' === $date ) {
+			return 0;
+		}
+		$sql = $this->wpdb->prepare(
+			'DELETE FROM %i WHERE calendar_id = %d AND appointment_date >= %s',
+			$this->table,
+			$calendar_id,
+			$date
+		);
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
+	 * Delete every appointment for a calendar matching a specific
+	 * status (e.g. `'cancelled'`). Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int    $calendar_id Calendar ID.
+	 * @param string $status      Status to delete (matches column verbatim).
+	 * @return int Rows deleted.
+	 */
+	public function deleteByCalendarAndStatus( int $calendar_id, string $status ): int {
+		if ( $calendar_id <= 0 || '' === $status ) {
+			return 0;
+		}
+		$sql = $this->wpdb->prepare(
+			'DELETE FROM %i WHERE calendar_id = %d AND status = %s',
+			$this->table,
+			$calendar_id,
+			$status
+		);
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
+	 * Count appointments for a calendar dated before `$date`. Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int    $calendar_id Calendar ID.
+	 * @param string $date        Cutoff date (`Y-m-d`).
+	 * @return int
+	 */
+	public function countByCalendarBefore( int $calendar_id, string $date ): int {
+		if ( $calendar_id <= 0 || '' === $date ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE calendar_id = %d AND appointment_date < %s',
+				$this->table,
+				$calendar_id,
+				$date
+			)
+		);
+		return null === $count ? 0 : (int) $count;
+	}
+
+	/**
+	 * Count appointments for a calendar dated on or after `$date`. Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int    $calendar_id Calendar ID.
+	 * @param string $date        Cutoff date (`Y-m-d`).
+	 * @return int
+	 */
+	public function countByCalendarAfter( int $calendar_id, string $date ): int {
+		if ( $calendar_id <= 0 || '' === $date ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE calendar_id = %d AND appointment_date >= %s',
+				$this->table,
+				$calendar_id,
+				$date
+			)
+		);
+		return null === $count ? 0 : (int) $count;
+	}
+
+	/**
+	 * Find appointments for a calendar dated on or after `$date` whose
+	 * status is in the allow-list (defaults to active states). Used by
+	 * the calendar-delete flow to know whom to notify. Issue #340.
+	 *
+	 * @since 6.6.2
+	 * @param int           $calendar_id Calendar ID.
+	 * @param string        $date        Cutoff date (`Y-m-d`).
+	 * @param array<string> $statuses    Status allow-list.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function findByCalendarAfterWithStatus( int $calendar_id, string $date, array $statuses = array( 'pending', 'confirmed' ) ): array {
+		if ( $calendar_id <= 0 || '' === $date || empty( $statuses ) ) {
+			return array();
+		}
+		$placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$args         = array_merge( array( $this->table, $calendar_id, $date ), array_values( $statuses ) );
+		$sql          = "SELECT * FROM %i WHERE calendar_id = %d AND appointment_date >= %s AND status IN ({$placeholders}) ORDER BY appointment_date ASC, start_time ASC";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a compile-time string of %s tokens whose count matches the args supplied to wpdb->prepare.
+		$rows = $this->wpdb->get_results( $this->wpdb->prepare( $sql, $args ), ARRAY_A );
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Bulk-link anonymous appointment rows (`user_id IS NULL`) to a
+	 * just-created WP user by matching a hash column (e.g. `email_hash`,
+	 * `cpf_hash`). Used by `UserCreator` after promotion. Issue #340.
+	 *
+	 * The `$hash_column` value is validated against an allow-list so it
+	 * never reaches SQL as raw operator input — only the four
+	 * `*_hash` columns the schema actually carries are accepted.
+	 *
+	 * @since 6.6.2
+	 * @param int    $user_id     Newly-created WP user id.
+	 * @param string $hash_column Hash column to match against (one of
+	 *                            `email_hash`, `cpf_hash`, `rf_hash`,
+	 *                            `ticket_hash`).
+	 * @param string $hash_value  Hash digest.
+	 * @return int Rows linked (0 when inputs invalid or no match).
+	 */
+	public function linkByIdentifierHash( int $user_id, string $hash_column, string $hash_value ): int {
+		if ( $user_id <= 0 || '' === $hash_value ) {
+			return 0;
+		}
+		$allowed = array( 'email_hash', 'cpf_hash', 'rf_hash', 'ticket_hash' );
+		if ( ! in_array( $hash_column, $allowed, true ) ) {
+			return 0;
+		}
+		$sql = $this->wpdb->prepare(
+			"UPDATE %i SET user_id = %d WHERE {$hash_column} = %s AND user_id IS NULL",
+			$this->table,
+			$user_id,
+			$hash_value
+		);
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $hash_column is verified against a fixed allow-list above; values are bound through wpdb->prepare.
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
+	 * Find the next upcoming appointment for a user — date >= today
+	 * AND status ∈ allow-list, ordered by date+time ASC, single row.
+	 * Used by the user-summary REST endpoint to surface "your next
+	 * appointment" on the dashboard. Issue #340.
+	 *
+	 * Returns just the appointment row (no calendar JOIN) — the
+	 * caller can fetch the calendar title via `CalendarRepository`
+	 * if it needs to display it, keeping this repository's queries
+	 * single-table.
+	 *
+	 * @since 6.6.2
+	 * @param int           $user_id  WP user id.
+	 * @param array<string> $statuses Status allow-list.
+	 * @return array<string, mixed>|null
+	 */
+	public function findNextUpcomingForUser( int $user_id, array $statuses = array( 'pending', 'confirmed' ) ): ?array {
+		if ( $user_id <= 0 || empty( $statuses ) ) {
+			return null;
+		}
+		$placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$args         = array_merge( array( $this->table, $user_id ), array_values( $statuses ) );
+		$sql          = "SELECT * FROM %i WHERE user_id = %d AND status IN ({$placeholders}) AND appointment_date >= CURDATE() ORDER BY appointment_date ASC, start_time ASC LIMIT 1";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a compile-time string of %s tokens whose count matches the args supplied to wpdb->prepare.
+		$row = $this->wpdb->get_row( $this->wpdb->prepare( $sql, $args ), ARRAY_A );
+		return is_array( $row ) ? $row : null;
+	}
 }

--- a/includes/repositories/ffc-submission-repository.php
+++ b/includes/repositories/ffc-submission-repository.php
@@ -675,6 +675,84 @@ class SubmissionRepository extends AbstractRepository {
 	}
 
 	/**
+	 * Fetch a single submission's `magic_token` column. Narrow read used
+	 * by the QR-code generator (`PdfGenerator::generate_magic_link_qr`)
+	 * so the caller never holds the full row in memory just to get one
+	 * field. Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param int $submission_id Submission row ID.
+	 * @return string|null `null` when the row doesn't exist or the
+	 *                     token is empty / NULL.
+	 */
+	public function findMagicTokenById( int $submission_id ): ?string {
+		if ( $submission_id <= 0 ) {
+			return null;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Narrow single-column read; caching skipped because magic_token is already cached at the full-row level when callers go through findById.
+		$token = $this->wpdb->get_var(
+			$this->wpdb->prepare( 'SELECT magic_token FROM %i WHERE id = %d', $this->table, $submission_id )
+		);
+		if ( null === $token || '' === $token ) {
+			return null;
+		}
+		return (string) $token;
+	}
+
+	/**
+	 * Count submissions matching `(form_id, cpf_hash)`. Used by the
+	 * CSV-download "participants" mode validator to decide whether the
+	 * caller (identified by CPF) actually owns a row in the form. Issue
+	 * #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param int    $form_id  Form ID.
+	 * @param string $cpf_hash SHA-256 hash of the CPF digits.
+	 * @return int Always >= 0.
+	 */
+	public function countByFormAndCpfHash( int $form_id, string $cpf_hash ): int {
+		if ( $form_id <= 0 || '' === $cpf_hash ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Existence-style count for download gating; instantaneous decision, no cache.
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE form_id = %d AND cpf_hash = %s',
+				$this->table,
+				$form_id,
+				$cpf_hash
+			)
+		);
+		return null === $count ? 0 : (int) $count;
+	}
+
+	/**
+	 * Bulk-clear the `qr_code_cache` column across every submission row
+	 * — backs the "Clear QR cache" admin button. Returns the count of
+	 * rows that actually held a cached blob (NULL rows are skipped so
+	 * the result reflects real invalidations, not the table size).
+	 * Issue #340 centralization.
+	 *
+	 * Flushes the repository's cache group at the end because the bulk
+	 * UPDATE bypasses parent::update()'s per-row cache_delete and any
+	 * full-row cache entry would otherwise keep returning the stale
+	 * `qr_code_cache` blob.
+	 *
+	 * @since 6.6.2
+	 * @return int Number of rows whose cache was dropped.
+	 */
+	public function clearQrCodeCache(): int {
+		$sql = $this->wpdb->prepare( 'UPDATE %i SET qr_code_cache = NULL WHERE qr_code_cache IS NOT NULL', $this->table );
+		if ( ! is_string( $sql ) ) {
+			return 0;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk maintenance write; per-row caches are flushed wholesale via clear_cache() below.
+		$rows = $this->wpdb->query( $sql );
+		$this->clear_cache();
+		return is_int( $rows ) ? $rows : 0;
+	}
+
+	/**
 	 * Insert a submission row and drop the status-count cache.
 	 *
 	 * @param array<string, mixed> $data Data.

--- a/includes/repositories/ffc-user-profile-repository.php
+++ b/includes/repositories/ffc-user-profile-repository.php
@@ -85,7 +85,10 @@ class UserProfileRepository extends AbstractRepository {
 		$id = $this->wpdb->get_var(
 			$this->wpdb->prepare( 'SELECT id FROM %i WHERE user_id = %d', $this->table, $user_id )
 		);
-		return null !== $id && '' !== $id;
+		// `$id` is a string ("42") in real wpdb when the row exists,
+		// or null when missing. Mocks sometimes return 0 / "0" — treat
+		// any non-positive integer interpretation as "missing".
+		return null !== $id && '' !== $id && (int) $id > 0;
 	}
 
 	/**
@@ -125,5 +128,46 @@ class UserProfileRepository extends AbstractRepository {
 		}
 		$this->clear_cache();
 		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Upsert a column slice for the supplied `user_id`. Inserts when
+	 * no row exists for the user, otherwise UPDATEs in place. Used by
+	 * `UserProfileService::update_profile_table()` to persist dynamic
+	 * column sets (which fields land here depends on the field map,
+	 * not on a fixed schema view).
+	 *
+	 * No-op when `$data` is empty.
+	 *
+	 * Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param int                  $user_id WP user id.
+	 * @param array<string, mixed> $data    Column => value slice to persist.
+	 * @return bool True on a successful write, false on failure / invalid input.
+	 */
+	public function upsertForUserId( int $user_id, array $data ): bool {
+		if ( $user_id <= 0 || empty( $data ) ) {
+			return false;
+		}
+
+		if ( $this->existsForUserId( $user_id ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row update keyed by user_id.
+			$affected = $this->wpdb->update( $this->table, $data, array( 'user_id' => $user_id ) );
+			if ( false === $affected ) {
+				return false;
+			}
+			$this->clear_cache( "user_{$user_id}" );
+			return true;
+		}
+
+		$data['user_id'] = $user_id;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper; cache invalidated below.
+		$inserted = $this->wpdb->insert( $this->table, $data );
+		if ( false === $inserted ) {
+			return false;
+		}
+		$this->clear_cache();
+		return true;
 	}
 }

--- a/includes/repositories/ffc-user-profile-repository.php
+++ b/includes/repositories/ffc-user-profile-repository.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * User Profile Repository
+ *
+ * Data access layer for the `ffc_user_profiles` table — the FFC-side
+ * extension to `wp_users` that carries the plugin's custom-field
+ * payload (display_name override, custom_data blob, etc.).
+ *
+ * Centralizes the queries that previously lived inline in
+ * `UserManager::get_profile()` and `UserCreator::create_user_profile()`
+ * (issue #340 cleanup). `UserService` is the higher-level aggregator
+ * that merges WP-core user data + this profile row + capability map
+ * into a view-model — it can layer on top of this CRUD primitive when
+ * its production wire-up lands (tracked in #322).
+ *
+ * @package FreeFormCertificate\Repositories
+ * @since   6.6.2
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Repositories;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+/**
+ * Database repository for `ffc_user_profiles` rows.
+ */
+class UserProfileRepository extends AbstractRepository {
+
+	/**
+	 * Get table name.
+	 *
+	 * @return string
+	 */
+	protected function get_table_name(): string {
+		return $this->wpdb->prefix . 'ffc_user_profiles';
+	}
+
+	/**
+	 * Cache group for the inherited cache helpers.
+	 *
+	 * @return string
+	 */
+	protected function get_cache_group(): string {
+		return 'ffc_user_profiles';
+	}
+
+	/**
+	 * Find a profile row by its WP user id.
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WordPress user ID.
+	 * @return array<string, mixed>|null
+	 */
+	public function findByUserId( int $user_id ): ?array {
+		if ( $user_id <= 0 ) {
+			return null;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row indexed lookup.
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare( 'SELECT * FROM %i WHERE user_id = %d', $this->table, $user_id ),
+			ARRAY_A
+		);
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Whether a profile row exists for the supplied user_id.
+	 * Cheaper than `findByUserId()` when the caller only needs the
+	 * boolean (no SELECT *).
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WordPress user ID.
+	 * @return bool
+	 */
+	public function existsForUserId( int $user_id ): bool {
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Existence-style lookup; pk-indexed.
+		$id = $this->wpdb->get_var(
+			$this->wpdb->prepare( 'SELECT id FROM %i WHERE user_id = %d', $this->table, $user_id )
+		);
+		return null !== $id && '' !== $id;
+	}
+
+	/**
+	 * Create a profile row for a freshly-promoted WP user. No-op when
+	 * a row already exists for the same user_id (race-safe — the call
+	 * is idempotent).
+	 *
+	 * @since 6.6.2
+	 * @param int    $user_id      WordPress user ID.
+	 * @param string $display_name Initial display_name value.
+	 * @return int|false Insert id, or false on failure / when a row
+	 *                   already existed.
+	 */
+	public function createForUser( int $user_id, string $display_name ) {
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+		if ( $this->existsForUserId( $user_id ) ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Insert via wpdb helper; cache invalidated below.
+		$inserted = $this->wpdb->insert(
+			$this->table,
+			array(
+				'user_id'      => $user_id,
+				'display_name' => $display_name,
+				'created_at'   => $now,
+				'updated_at'   => $now,
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+
+		if ( false === $inserted ) {
+			return false;
+		}
+		$this->clear_cache();
+		return (int) $this->wpdb->insert_id;
+	}
+}

--- a/includes/reregistration/class-ffc-custom-field-repository.php
+++ b/includes/reregistration/class-ffc-custom-field-repository.php
@@ -849,4 +849,107 @@ class CustomFieldRepository {
 		}
 		return is_array( $rules ) ? $rules : array();
 	}
+
+	/**
+	 * List every `field_key` that currently has `is_sensitive = 1`
+	 * AND `is_active = 1`. Used by
+	 * {@see \FreeFormCertificate\Core\SensitiveFieldRegistry::dynamic_sensitive_keys()}
+	 * to grow its sensitivity allow-list with admin-flagged fields.
+	 *
+	 * Centralizes a query that lived inline in the registry (issue #340).
+	 * Guards the table-existence via SHOW TABLES so a fresh install or
+	 * a test environment without the table degrades to an empty list
+	 * instead of throwing.
+	 *
+	 * @since 6.6.2
+	 * @return list<string> Field keys (unique, alphabetical not enforced).
+	 */
+	public static function list_sensitive_field_keys(): array {
+		global $wpdb;
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table-existence guard.
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Catalog read; caching handled at the caller (SensitiveFieldRegistry).
+		$rows = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT DISTINCT field_key FROM %i WHERE is_sensitive = 1 AND is_active = 1',
+				$table
+			)
+		);
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $field_key ) {
+			if ( is_string( $field_key ) && '' !== $field_key ) {
+				$out[] = $field_key;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Return the set of `field_key` values already present for an
+	 * audience — used by the standard-fields seeder to skip rows that
+	 * were inserted in a previous run (the seeder is idempotent).
+	 *
+	 * Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param int $audience_id Audience ID.
+	 * @return array<string, bool> Map of `field_key => true` for O(1) lookup.
+	 */
+	public static function existing_field_keys_for_audience( int $audience_id ): array {
+		if ( $audience_id <= 0 ) {
+			return array();
+		}
+		global $wpdb;
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Indexed scan by audience_id.
+		$rows = $wpdb->get_col(
+			$wpdb->prepare( 'SELECT field_key FROM %i WHERE audience_id = %d', $table, $audience_id )
+		);
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+		$keys = array();
+		foreach ( $rows as $field_key ) {
+			$key = (string) $field_key;
+			if ( '' !== $key ) {
+				$keys[ $key ] = true;
+			}
+		}
+		return $keys;
+	}
+
+	/**
+	 * INSERT a standard / dynamic field row. Wraps `$wpdb->insert()` so
+	 * the seeder doesn't have to spell out the column→format mapping.
+	 * Returns the new row id, or `false` on failure.
+	 *
+	 * Issue #340 centralization.
+	 *
+	 * @since 6.6.2
+	 * @param array<string, mixed> $data Column => value map.
+	 * @return int|false
+	 */
+	public static function insert_row( array $data ) {
+		global $wpdb;
+		$table = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row insert; format hints below kept in sync with the schema.
+		$result = $wpdb->insert(
+			$table,
+			$data,
+			array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d' )
+		);
+		return false === $result ? false : (int) $wpdb->insert_id;
+	}
 }

--- a/includes/reregistration/class-ffc-reregistration-standard-fields-seeder.php
+++ b/includes/reregistration/class-ffc-reregistration-standard-fields-seeder.php
@@ -558,22 +558,14 @@ class ReregistrationStandardFieldsSeeder {
 			return 0;
 		}
 
-		global $wpdb;
-		$audience_table = $wpdb->prefix . 'ffc_audiences';
-
-		// Get all audience IDs directly to avoid status filters.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$ids = $wpdb->get_col(
-			$wpdb->prepare( 'SELECT id FROM %i', $audience_table )
-		);
-
+		$ids = \FreeFormCertificate\Audience\AudienceRepository::get_all_ids();
 		if ( empty( $ids ) ) {
 			return 0;
 		}
 
 		$total = 0;
 		foreach ( $ids as $aud_id ) {
-			$total += self::seed_for_audience( (int) $aud_id );
+			$total += self::seed_for_audience( $aud_id );
 		}
 
 		return $total;

--- a/includes/reregistration/class-ffc-reregistration-standard-fields-seeder.php
+++ b/includes/reregistration/class-ffc-reregistration-standard-fields-seeder.php
@@ -511,20 +511,7 @@ class ReregistrationStandardFieldsSeeder {
 			return 0;
 		}
 
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_custom_fields';
-
-		// Get existing field_keys for this audience to avoid duplicates.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$existing_keys = $wpdb->get_col(
-			$wpdb->prepare(
-				'SELECT field_key FROM %i WHERE audience_id = %d',
-				$table,
-				$audience_id
-			)
-		);
-
-		$existing_keys = is_array( $existing_keys ) ? array_flip( $existing_keys ) : array();
+		$existing_keys = CustomFieldRepository::existing_field_keys_for_audience( $audience_id );
 
 		$definitions = self::get_standard_fields_definition();
 		$inserted    = 0;
@@ -551,14 +538,9 @@ class ReregistrationStandardFieldsSeeder {
 				'is_active'         => 1,
 			);
 
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$result = $wpdb->insert(
-				$table,
-				$insert_data,
-				array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d' )
-			);
+			$result = CustomFieldRepository::insert_row( $insert_data );
 
-			if ( $result ) {
+			if ( false !== $result ) {
 				++$inserted;
 			}
 		}

--- a/includes/self-scheduling/class-ffc-self-scheduling-cleanup-handler.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-cleanup-handler.php
@@ -78,18 +78,15 @@ class SelfSchedulingCleanupHandler {
 			);
 		}
 
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
 		$today = current_time( 'Y-m-d' );
+		$repo  = new \FreeFormCertificate\Repositories\AppointmentRepository();
 
 		$deleted = 0;
 
 		// Build query based on action.
 		switch ( $cleanup_action ) {
 			case 'all':
-				// Delete all appointments for this calendar.
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$deleted = $wpdb->delete( $table, array( 'calendar_id' => $calendar_id ), array( '%d' ) );
+				$deleted = $repo->deleteByCalendar( $calendar_id );
 				$message = sprintf(
 					/* translators: %d: number of deleted appointments */
 					__( 'Successfully deleted %d appointment(s).', 'ffcertificate' ),
@@ -98,16 +95,7 @@ class SelfSchedulingCleanupHandler {
 				break;
 
 			case 'old':
-				// Delete appointments before today.
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$deleted = $wpdb->query(
-					$wpdb->prepare(
-						'DELETE FROM %i WHERE calendar_id = %d AND appointment_date < %s',
-						$table,
-						$calendar_id,
-						$today
-					)
-				);
+				$deleted = $repo->deleteByCalendarBefore( $calendar_id, $today );
 				$message = sprintf(
 					/* translators: %d: number of deleted past appointments */
 					__( 'Successfully deleted %d past appointment(s).', 'ffcertificate' ),
@@ -116,16 +104,7 @@ class SelfSchedulingCleanupHandler {
 				break;
 
 			case 'future':
-				// Delete appointments today and after.
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$deleted = $wpdb->query(
-					$wpdb->prepare(
-						'DELETE FROM %i WHERE calendar_id = %d AND appointment_date >= %s',
-						$table,
-						$calendar_id,
-						$today
-					)
-				);
+				$deleted = $repo->deleteByCalendarAfter( $calendar_id, $today );
 				$message = sprintf(
 					/* translators: %d: number of deleted future appointments */
 					__( 'Successfully deleted %d future appointment(s).', 'ffcertificate' ),
@@ -134,16 +113,7 @@ class SelfSchedulingCleanupHandler {
 				break;
 
 			case 'cancelled':
-				// Delete only cancelled appointments.
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$deleted = $wpdb->delete(
-					$table,
-					array(
-						'calendar_id' => $calendar_id,
-						'status'      => 'cancelled',
-					),
-					array( '%d', '%s' )
-				);
+				$deleted = $repo->deleteByCalendarAndStatus( $calendar_id, 'cancelled' );
 				$message = sprintf(
 					/* translators: %d: number of deleted cancelled appointments */
 					__( 'Successfully deleted %d cancelled appointment(s).', 'ffcertificate' ),
@@ -208,31 +178,9 @@ class SelfSchedulingCleanupHandler {
 		// Count appointments by category.
 		$today = current_time( 'Y-m-d' );
 
-		$count_all = $appointment_repo->count( array( 'calendar_id' => $calendar_id ) );
-
-		// Count old appointments (before today).
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$count_old = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT COUNT(*) FROM %i WHERE calendar_id = %d AND appointment_date < %s',
-				$table,
-				$calendar_id,
-				$today
-			)
-		);
-
-		// Count future appointments (today and after).
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$count_future = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT COUNT(*) FROM %i WHERE calendar_id = %d AND appointment_date >= %s',
-				$table,
-				$calendar_id,
-				$today
-			)
-		);
+		$count_all    = $appointment_repo->count( array( 'calendar_id' => $calendar_id ) );
+		$count_old    = $appointment_repo->countByCalendarBefore( $calendar_id, $today );
+		$count_future = $appointment_repo->countByCalendarAfter( $calendar_id, $today );
 
 		// Count cancelled appointments.
 		$count_cancelled = $appointment_repo->count(

--- a/includes/self-scheduling/class-ffc-self-scheduling-cpt.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-cpt.php
@@ -395,32 +395,16 @@ class SelfSchedulingCPT {
 	 * @return int Number of appointments cancelled
 	 */
 	private function cancel_future_appointments( int $calendar_id, string $calendar_title ): int {
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-		$today = current_time( 'Y-m-d' );
+		$today            = current_time( 'Y-m-d' );
+		$appointment_repo = new \FreeFormCertificate\Repositories\AppointmentRepository();
 
-		// Get all future appointments (pending or confirmed).
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$future_appointments = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM %i
-             WHERE calendar_id = %d
-             AND appointment_date >= %s
-             AND status IN ('pending', 'confirmed')
-             ORDER BY appointment_date ASC",
-				$table,
-				$calendar_id,
-				$today
-			),
-			ARRAY_A
-		);
+		$future_appointments = $appointment_repo->findByCalendarAfterWithStatus( $calendar_id, $today );
 
 		if ( empty( $future_appointments ) ) {
 			return 0;
 		}
 
-		$cancelled_count  = 0;
-		$appointment_repo = new \FreeFormCertificate\Repositories\AppointmentRepository();
+		$cancelled_count = 0;
 
 		foreach ( $future_appointments as $appointment ) {
 			// Cancel the appointment.

--- a/includes/url-shortener/class-ffc-url-shortener-qr-handler.php
+++ b/includes/url-shortener/class-ffc-url-shortener-qr-handler.php
@@ -108,15 +108,7 @@ class UrlShortenerQrHandler {
 	 * @return string Base64 data or empty string.
 	 */
 	private function get_qr_cache( string $short_code ): string {
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_short_urls';
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$value = $wpdb->get_var(
-			$wpdb->prepare( 'SELECT qr_cache FROM %i WHERE short_code = %s', $table, $short_code )
-		);
-
-		return is_string( $value ) && '' !== $value ? $value : '';
+		return ( new UrlShortenerRepository() )->findQrCacheByShortCode( $short_code );
 	}
 
 	/**
@@ -126,17 +118,7 @@ class UrlShortenerQrHandler {
 	 * @param string $base64     Base64-encoded PNG.
 	 */
 	private function set_qr_cache( string $short_code, string $base64 ): void {
-		global $wpdb;
-		$table = $wpdb->prefix . 'ffc_short_urls';
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->update(
-			$table,
-			array( 'qr_cache' => $base64 ),
-			array( 'short_code' => $short_code ),
-			array( '%s' ),
-			array( '%s' )
-		);
+		( new UrlShortenerRepository() )->setQrCacheForShortCode( $short_code, $base64 );
 	}
 
 	/**

--- a/includes/url-shortener/class-ffc-url-shortener-repository.php
+++ b/includes/url-shortener/class-ffc-url-shortener-repository.php
@@ -249,4 +249,55 @@ class UrlShortenerRepository extends AbstractRepository {
 			'trashed_links' => (int) ( $row['trashed_links'] ?? 0 ),
 		);
 	}
+
+	/**
+	 * Read the cached QR PNG payload for a short code. Issue #340
+	 * centralization (replaces a raw SELECT in
+	 * `UrlShortenerQrHandler::get_qr_cache`).
+	 *
+	 * @since 6.6.2
+	 * @param string $short_code Short URL code.
+	 * @return string Base64-encoded PNG, or empty string when no
+	 *                cache row exists / column is NULL.
+	 */
+	public function findQrCacheByShortCode( string $short_code ): string {
+		if ( '' === $short_code ) {
+			return '';
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Narrow single-column lookup.
+		$value = $this->wpdb->get_var(
+			$this->wpdb->prepare( 'SELECT qr_cache FROM %i WHERE short_code = %s', $this->table, $short_code )
+		);
+		return is_string( $value ) && '' !== $value ? $value : '';
+	}
+
+	/**
+	 * Persist the cached QR PNG payload for a short code. Issue #340
+	 * centralization (replaces a raw UPDATE in
+	 * `UrlShortenerQrHandler::set_qr_cache`).
+	 *
+	 * @since 6.6.2
+	 * @param string $short_code Short URL code.
+	 * @param string $base64     Base64-encoded PNG payload to cache.
+	 * @return bool True when the UPDATE landed (or matched 0 rows
+	 *              cleanly), false on wpdb error.
+	 */
+	public function setQrCacheForShortCode( string $short_code, string $base64 ): bool {
+		if ( '' === $short_code ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row update keyed by short_code (UNIQUE).
+		$result = $this->wpdb->update(
+			$this->table,
+			array( 'qr_cache' => $base64 ),
+			array( 'short_code' => $short_code ),
+			array( '%s' ),
+			array( '%s' )
+		);
+		if ( false === $result ) {
+			return false;
+		}
+		$this->clear_cache();
+		return true;
+	}
 }

--- a/includes/user-dashboard/class-ffc-user-creator.php
+++ b/includes/user-dashboard/class-ffc-user-creator.php
@@ -190,6 +190,25 @@ class UserCreator {
 	}
 
 	/**
+	 * Hash columns to try when linking orphaned appointment rows by a
+	 * single identifier hash. Mirrors `build_hash_where_clause()` for
+	 * the per-column repository call path. Issue #340 centralization.
+	 *
+	 * @param string $identifier_type One of TYPE_CPF / TYPE_RF / TYPE_AUTO.
+	 * @return list<string>
+	 */
+	private static function hash_columns_for_type( string $identifier_type ): array {
+		switch ( $identifier_type ) {
+			case self::TYPE_CPF:
+				return array( 'cpf_hash' );
+			case self::TYPE_RF:
+				return array( 'rf_hash' );
+			default:
+				return array( 'cpf_hash', 'rf_hash' );
+		}
+	}
+
+	/**
 	 * Link orphaned records (submissions and appointments) to a user
 	 *
 	 * @since 4.9.6
@@ -220,17 +239,10 @@ class UserCreator {
 		$appointments_table  = $wpdb->prefix . 'ffc_self_scheduling_appointments';
 		$linked_appointments = 0;
 		if ( self::table_exists( $appointments_table ) ) {
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $hash_where and $hash_params built together in build_hash_* helpers with matching placeholder count.
-			$linked_appointments = $wpdb->query(
-				$wpdb->prepare(
-					"UPDATE %i SET user_id = %d WHERE ({$hash_where}) AND user_id IS NULL",
-					$appointments_table,
-					$user_id,
-					...$hash_params
-				)
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$apt_repo = new \FreeFormCertificate\Repositories\AppointmentRepository();
+			foreach ( self::hash_columns_for_type( $identifier_type ) as $column ) {
+				$linked_appointments += $apt_repo->linkByIdentifierHash( $user_id, $column, $identifier_hash );
+			}
 
 			if ( $linked_appointments > 0 ) {
 				CapabilityManager::grant_appointment_capabilities( $user_id );

--- a/includes/user-dashboard/class-ffc-user-creator.php
+++ b/includes/user-dashboard/class-ffc-user-creator.php
@@ -385,32 +385,9 @@ class UserCreator {
 			return;
 		}
 
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT id FROM %i WHERE user_id = %d',
-				$table,
-				$user_id
-			)
-		);
-
-		if ( $exists ) {
-			return;
-		}
-
 		$user         = get_userdata( $user_id );
 		$display_name = $user ? $user->display_name : '';
 
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$wpdb->insert(
-			$table,
-			array(
-				'user_id'      => $user_id,
-				'display_name' => $display_name,
-				'created_at'   => current_time( 'mysql' ),
-				'updated_at'   => current_time( 'mysql' ),
-			),
-			array( '%d', '%s', '%s', '%s' )
-		);
+		( new \FreeFormCertificate\Repositories\UserProfileRepository() )->createForUser( $user_id, $display_name );
 	}
 }

--- a/includes/user-dashboard/class-ffc-user-manager.php
+++ b/includes/user-dashboard/class-ffc-user-manager.php
@@ -275,15 +275,7 @@ class UserManager {
 		$table = $wpdb->prefix . 'ffc_user_profiles';
 
 		if ( self::table_exists( $table ) ) {
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$profile = $wpdb->get_row(
-				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d',
-					$table,
-					$user_id
-				),
-				ARRAY_A
-			);
+			$profile = ( new \FreeFormCertificate\Repositories\UserProfileRepository() )->findByUserId( $user_id );
 
 			if ( $profile ) {
 				return $profile;

--- a/includes/user-dashboard/class-ffc-user-profile-service.php
+++ b/includes/user-dashboard/class-ffc-user-profile-service.php
@@ -552,5 +552,4 @@ final class UserProfileService {
 			0
 		);
 	}
-
 }

--- a/includes/user-dashboard/class-ffc-user-profile-service.php
+++ b/includes/user-dashboard/class-ffc-user-profile-service.php
@@ -40,13 +40,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class UserProfileService {
 
 	/**
-	 * Table name cache so the class plays nice with wpdb mocks.
-	 *
-	 * @var string|null
-	 */
-	private static ?string $profile_table = null;
-
-	/**
 	 * Per-call overrides for fields that are not registered in the
 	 * static UserProfileFieldMap. Populated by write() and consumed by
 	 * resolve_spec() / resolve_hash_meta_key() inside the helpers.
@@ -267,15 +260,8 @@ final class UserProfileService {
 	 * @return array<string, mixed>
 	 */
 	private static function read_profile_table( int $user_id, array $fields ): array {
-		global $wpdb;
-		$table = self::profile_table_name();
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$row = $wpdb->get_row(
-			$wpdb->prepare( 'SELECT * FROM %i WHERE user_id = %d LIMIT 1', $table, $user_id ),
-			ARRAY_A
-		);
-		if ( ! is_array( $row ) ) {
+		$row = ( new \FreeFormCertificate\Repositories\UserProfileRepository() )->findByUserId( $user_id );
+		if ( null === $row ) {
 			$out = array();
 			foreach ( $fields as $f ) {
 				$out[ $f ] = null;
@@ -378,9 +364,6 @@ final class UserProfileService {
 	 * @return bool
 	 */
 	private static function write_profile_table( int $user_id, array $slice ): bool {
-		global $wpdb;
-		$table = self::profile_table_name();
-
 		$data = array();
 		foreach ( $slice as $field => $value ) {
 			$spec = self::resolve_spec( $field );
@@ -393,21 +376,7 @@ final class UserProfileService {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$exists = (int) $wpdb->get_var(
-			$wpdb->prepare( 'SELECT user_id FROM %i WHERE user_id = %d', $table, $user_id )
-		);
-
-		if ( $exists > 0 ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$affected = $wpdb->update( $table, $data, array( 'user_id' => $user_id ) );
-			return false !== $affected;
-		}
-
-		$data['user_id'] = $user_id;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$inserted = $wpdb->insert( $table, $data );
-		return false !== $inserted;
+		return ( new \FreeFormCertificate\Repositories\UserProfileRepository() )->upsertForUserId( $user_id, $data );
 	}
 
 	/**
@@ -584,16 +553,4 @@ final class UserProfileService {
 		);
 	}
 
-	/**
-	 * Resolve the ffc_user_profiles table name once per request.
-	 *
-	 * @return string
-	 */
-	private static function profile_table_name(): string {
-		if ( null === self::$profile_table ) {
-			global $wpdb;
-			self::$profile_table = $wpdb->prefix . 'ffc_user_profiles';
-		}
-		return self::$profile_table;
-	}
 }

--- a/tests/Unit/AdminUserColumnsTest.php
+++ b/tests/Unit/AdminUserColumnsTest.php
@@ -297,9 +297,10 @@ class AdminUserColumnsTest extends TestCase {
             ->andReturn( 'wp_ffc_recruitment_classification' )
             ->byDefault();
 
+        // COUNT() alias is `c` in the new repository method (issue #340).
         $this->wpdb->shouldReceive( 'get_results' )
             ->andReturn( array(
-                array( 'user_id' => '42', 'cnt' => '4' ),
+                array( 'user_id' => '42', 'c' => '4' ),
             ) );
 
         $output = AdminUserColumns::render_custom_column( '', 'ffc_notices', 42 );

--- a/tests/Unit/AdminUserColumnsTest.php
+++ b/tests/Unit/AdminUserColumnsTest.php
@@ -240,10 +240,11 @@ class AdminUserColumnsTest extends TestCase {
             ->andReturn( $table )
             ->byDefault();
 
-        // Batch appointment counts
+        // Batch appointment counts — AppointmentRepository::countAllByUserGrouped
+        // aliases the COUNT() column as `c` after the issue #340 centralization.
         $this->wpdb->shouldReceive( 'get_results' )
             ->andReturn( array(
-                array( 'user_id' => '42', 'cnt' => '3' ),
+                array( 'user_id' => '42', 'c' => '3' ),
             ) );
 
         $output = AdminUserColumns::render_custom_column( '', 'ffc_appointments', 42 );

--- a/tests/Unit/AppointmentRepositoryCentralizationTest.php
+++ b/tests/Unit/AppointmentRepositoryCentralizationTest.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Repositories\AppointmentRepository;
+
+/**
+ * Tests for the AppointmentRepository methods added in the issue
+ * #340 centralization sweep. Each method replaces a raw wpdb call
+ * that used to live in admin / cleanup / REST / user-creator code.
+ *
+ * @covers \FreeFormCertificate\Repositories\AppointmentRepository
+ */
+class AppointmentRepositoryCentralizationTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'wp_cache_flush' )->justReturn( true );
+		Functions\when( 'wp_cache_flush_group' )->justReturn( true );
+
+		$this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function repo(): AppointmentRepository {
+		return new AppointmentRepository();
+	}
+
+	// ------------------------------------------------------------------
+	// countAllByUserGrouped()
+	// ------------------------------------------------------------------
+
+	public function test_count_all_by_user_grouped_returns_user_id_to_count_map(): void {
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+			array(
+				array( 'user_id' => '42', 'c' => '3' ),
+				array( 'user_id' => '7', 'c' => '1' ),
+			)
+		);
+
+		$out = $this->repo()->countAllByUserGrouped( 'cancelled' );
+
+		$this->assertSame( array( 42 => 3, 7 => 1 ), $out );
+	}
+
+	public function test_count_all_by_user_grouped_returns_empty_when_no_rows(): void {
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$this->assertSame( array(), $this->repo()->countAllByUserGrouped() );
+	}
+
+	// ------------------------------------------------------------------
+	// deleteByCalendar / Before / After / AndStatus
+	// ------------------------------------------------------------------
+
+	public function test_delete_by_calendar_short_circuits_on_invalid_id(): void {
+		$this->wpdb->shouldNotReceive( 'query' );
+		$this->assertSame( 0, $this->repo()->deleteByCalendar( 0 ) );
+	}
+
+	public function test_delete_by_calendar_returns_affected_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 10 );
+		$this->assertSame( 10, $this->repo()->deleteByCalendar( 5 ) );
+	}
+
+	public function test_delete_by_calendar_before_validates_inputs(): void {
+		$this->wpdb->shouldNotReceive( 'query' );
+		$this->assertSame( 0, $this->repo()->deleteByCalendarBefore( 0, '2026-01-01' ) );
+		$this->assertSame( 0, $this->repo()->deleteByCalendarBefore( 5, '' ) );
+	}
+
+	public function test_delete_by_calendar_before_returns_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 3 );
+		$this->assertSame( 3, $this->repo()->deleteByCalendarBefore( 5, '2026-01-01' ) );
+	}
+
+	public function test_delete_by_calendar_after_returns_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 7 );
+		$this->assertSame( 7, $this->repo()->deleteByCalendarAfter( 5, '2026-01-01' ) );
+	}
+
+	public function test_delete_by_calendar_and_status_returns_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 2 );
+		$this->assertSame( 2, $this->repo()->deleteByCalendarAndStatus( 5, 'cancelled' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// countByCalendarBefore / After
+	// ------------------------------------------------------------------
+
+	public function test_count_by_calendar_before_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '12' );
+		$this->assertSame( 12, $this->repo()->countByCalendarBefore( 5, '2026-01-01' ) );
+	}
+
+	public function test_count_by_calendar_after_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '4' );
+		$this->assertSame( 4, $this->repo()->countByCalendarAfter( 5, '2026-01-01' ) );
+	}
+
+	public function test_count_by_calendar_short_circuits_on_invalid_inputs(): void {
+		$this->wpdb->shouldNotReceive( 'get_var' );
+		$this->assertSame( 0, $this->repo()->countByCalendarBefore( 0, '2026-01-01' ) );
+		$this->assertSame( 0, $this->repo()->countByCalendarAfter( 5, '' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// findByCalendarAfterWithStatus()
+	// ------------------------------------------------------------------
+
+	public function test_find_by_calendar_after_with_status_returns_rows(): void {
+		$rows = array( array( 'id' => '1', 'appointment_date' => '2026-06-01' ) );
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+		$this->assertSame( $rows, $this->repo()->findByCalendarAfterWithStatus( 5, '2026-01-01' ) );
+	}
+
+	public function test_find_by_calendar_after_with_status_short_circuits_on_empty_statuses(): void {
+		$this->wpdb->shouldNotReceive( 'get_results' );
+		$this->assertSame( array(), $this->repo()->findByCalendarAfterWithStatus( 5, '2026-01-01', array() ) );
+	}
+
+	// ------------------------------------------------------------------
+	// findNextUpcomingForUser()
+	// ------------------------------------------------------------------
+
+	public function test_find_next_upcoming_returns_row_when_found(): void {
+		$row = array( 'id' => '1', 'appointment_date' => '2026-06-15', 'start_time' => '10:30:00', 'calendar_id' => '42' );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$this->assertSame( $row, $this->repo()->findNextUpcomingForUser( 5 ) );
+	}
+
+	public function test_find_next_upcoming_returns_null_when_none(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+		$this->assertNull( $this->repo()->findNextUpcomingForUser( 5 ) );
+	}
+
+	public function test_find_next_upcoming_short_circuits_on_invalid_inputs(): void {
+		$this->wpdb->shouldNotReceive( 'get_row' );
+		$this->assertNull( $this->repo()->findNextUpcomingForUser( 0 ) );
+		$this->assertNull( $this->repo()->findNextUpcomingForUser( 5, array() ) );
+	}
+
+	// ------------------------------------------------------------------
+	// linkByIdentifierHash()
+	// ------------------------------------------------------------------
+
+	public function test_link_by_identifier_hash_returns_affected_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 4 );
+		$this->assertSame( 4, $this->repo()->linkByIdentifierHash( 5, 'cpf_hash', 'abc' ) );
+	}
+
+	public function test_link_by_identifier_hash_rejects_unknown_column(): void {
+		$this->wpdb->shouldNotReceive( 'query' );
+		$this->assertSame( 0, $this->repo()->linkByIdentifierHash( 5, 'wrong_column', 'abc' ) );
+	}
+
+	public function test_link_by_identifier_hash_rejects_invalid_inputs(): void {
+		$this->wpdb->shouldNotReceive( 'query' );
+		$this->assertSame( 0, $this->repo()->linkByIdentifierHash( 0, 'cpf_hash', 'abc' ) );
+		$this->assertSame( 0, $this->repo()->linkByIdentifierHash( 5, 'cpf_hash', '' ) );
+	}
+}

--- a/tests/Unit/AudienceRepositoryTest.php
+++ b/tests/Unit/AudienceRepositoryTest.php
@@ -1250,4 +1250,42 @@ class AudienceRepositoryTest extends TestCase {
 
         $this->assertStringContainsString('LIMIT %d', $captured_sql);
     }
+
+    // ------------------------------------------------------------------
+    // get_all_ids() / get_user_audience_badges() — issue #340
+    // ------------------------------------------------------------------
+
+    public function test_get_all_ids_returns_int_list(): void {
+        $this->wpdb->shouldReceive('prepare')->once()->andReturnUsing(fn($s) => $s);
+        $this->wpdb->shouldReceive('get_col')->once()->andReturn(['1', '2', '7']);
+
+        $this->assertSame([1, 2, 7], AudienceRepository::get_all_ids());
+    }
+
+    public function test_get_all_ids_returns_empty_when_no_rows(): void {
+        $this->wpdb->shouldReceive('prepare')->once()->andReturnUsing(fn($s) => $s);
+        $this->wpdb->shouldReceive('get_col')->once()->andReturn([]);
+
+        $this->assertSame([], AudienceRepository::get_all_ids());
+    }
+
+    public function test_get_user_audience_badges_returns_name_color_pairs(): void {
+        $this->wpdb->shouldReceive('prepare')->once()->andReturnUsing(fn($s) => $s);
+        $this->wpdb->shouldReceive('get_results')->once()->andReturn([
+            ['name' => 'VIP', 'color' => '#ff0'],
+            ['name' => 'New', 'color' => '#0f0'],
+        ]);
+
+        $badges = AudienceRepository::get_user_audience_badges(7);
+
+        $this->assertCount(2, $badges);
+        $this->assertSame('VIP', $badges[0]['name']);
+        $this->assertSame('#0f0', $badges[1]['color']);
+    }
+
+    public function test_get_user_audience_badges_short_circuits_on_invalid_user(): void {
+        $this->wpdb->shouldNotReceive('get_results');
+
+        $this->assertSame([], AudienceRepository::get_user_audience_badges(0));
+    }
 }

--- a/tests/Unit/CustomFieldRepositoryTest.php
+++ b/tests/Unit/CustomFieldRepositoryTest.php
@@ -1088,4 +1088,49 @@ class CustomFieldRepositoryTest extends TestCase {
 
         $this->assertSame([], $groups);
     }
+
+    // ------------------------------------------------------------------
+    // list_sensitive_field_keys() / existing_field_keys_for_audience() /
+    // insert_row() — issue #340 centralization
+    // ------------------------------------------------------------------
+
+    public function test_list_sensitive_field_keys_returns_empty_when_table_missing(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+        $this->assertSame( array(), CustomFieldRepository::list_sensitive_field_keys() );
+    }
+
+    public function test_list_sensitive_field_keys_returns_keys_when_table_present(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 'wp_ffc_custom_fields' );
+        $this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( 'cpf', 'rg', '' ) );
+
+        $keys = CustomFieldRepository::list_sensitive_field_keys();
+
+        $this->assertSame( array( 'cpf', 'rg' ), $keys );
+    }
+
+    public function test_existing_field_keys_for_audience_returns_lookup_map(): void {
+        $this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( 'name', 'email' ) );
+
+        $this->assertSame( array( 'name' => true, 'email' => true ), CustomFieldRepository::existing_field_keys_for_audience( 5 ) );
+    }
+
+    public function test_existing_field_keys_for_audience_short_circuits_on_zero_id(): void {
+        $this->wpdb->shouldNotReceive( 'get_col' );
+
+        $this->assertSame( array(), CustomFieldRepository::existing_field_keys_for_audience( 0 ) );
+    }
+
+    public function test_insert_row_returns_insert_id_on_success(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+        $this->wpdb->insert_id = 42;
+
+        $this->assertSame( 42, CustomFieldRepository::insert_row( array( 'audience_id' => 5 ) ) );
+    }
+
+    public function test_insert_row_returns_false_on_failure(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+        $this->assertFalse( CustomFieldRepository::insert_row( array( 'audience_id' => 5 ) ) );
+    }
 }

--- a/tests/Unit/RecruitmentClassificationRepositoryTest.php
+++ b/tests/Unit/RecruitmentClassificationRepositoryTest.php
@@ -187,4 +187,36 @@ class RecruitmentClassificationRepositoryTest extends TestCase {
 
 		$this->assertFalse( RecruitmentClassificationRepository::set_adjutancy( 42, 7 ) );
 	}
+
+	// ------------------------------------------------------------------
+	// count_notices_grouped_by_user() / sql_user_notice_count_subquery() — #340
+	// ------------------------------------------------------------------
+
+	public function test_count_notices_grouped_by_user_returns_user_count_map(): void {
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+			array(
+				array( 'user_id' => '42', 'c' => '4' ),
+				array( 'user_id' => '7',  'c' => '1' ),
+			)
+		);
+
+		$out = RecruitmentClassificationRepository::count_notices_grouped_by_user();
+
+		$this->assertSame( array( 42 => 4, 7 => 1 ), $out );
+	}
+
+	public function test_count_notices_grouped_by_user_returns_empty_when_no_promoted_candidates(): void {
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$this->assertSame( array(), RecruitmentClassificationRepository::count_notices_grouped_by_user() );
+	}
+
+	public function test_sql_user_notice_count_subquery_returns_self_contained_select(): void {
+		$sql = RecruitmentClassificationRepository::sql_user_notice_count_subquery();
+
+		$this->assertStringStartsWith( '(SELECT ', $sql );
+		$this->assertStringContainsString( 'wp_ffc_recruitment_classification', $sql );
+		$this->assertStringContainsString( 'wp_ffc_recruitment_candidate', $sql );
+		$this->assertStringContainsString( 'GROUP BY c.user_id', $sql );
+	}
 }

--- a/tests/Unit/ReregistrationStandardFieldsSeederTest.php
+++ b/tests/Unit/ReregistrationStandardFieldsSeederTest.php
@@ -30,6 +30,7 @@ class ReregistrationStandardFieldsSeederTest extends TestCase {
         $wpdb = Mockery::mock( 'wpdb' );
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error  = '';
+        $wpdb->insert_id   = 0;
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_args()[0]; } )->byDefault();
         $wpdb->shouldReceive( 'get_col' )->andReturn( array() )->byDefault();
         $wpdb->shouldReceive( 'insert' )->andReturn( 1 )->byDefault();

--- a/tests/Unit/SelfSchedulingCleanupHandlerTest.php
+++ b/tests/Unit/SelfSchedulingCleanupHandlerTest.php
@@ -74,6 +74,11 @@ class SelfSchedulingCleanupHandlerTest extends TestCase {
         Functions\when( 'FreeFormCertificate\Repositories\wp_cache_delete' )->justReturn( true );
         Functions\when( 'FreeFormCertificate\Repositories\current_user_can' )->justReturn( false );
         Functions\when( 'FreeFormCertificate\Repositories\user_can' )->justReturn( false );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'wp_cache_flush_group' )->justReturn( true );
 
         // wp_verify_nonce — use a reference so individual tests can toggle it
         $this->nonce_valid = true;
@@ -243,14 +248,10 @@ class SelfSchedulingCleanupHandlerTest extends TestCase {
         $this->setPostData( array( 'cleanup_action' => 'all' ) );
         $this->stubCalendarFound( array( 'id' => 5, 'title' => 'Test Calendar' ) );
 
-        $this->wpdb->shouldReceive( 'delete' )
-            ->once()
-            ->with(
-                'wp_ffc_self_scheduling_appointments',
-                array( 'calendar_id' => 5 ),
-                array( '%d' )
-            )
-            ->andReturn( 10 );
+        // Repository routes the DELETE through wpdb->query (with a
+        // %i-prepared DELETE statement) rather than wpdb->delete after
+        // the issue #340 centralization.
+        $this->wpdb->shouldReceive( 'query' )->once()->andReturn( 10 );
 
         try {
             $this->handler->handle_cleanup_appointments();
@@ -316,14 +317,10 @@ class SelfSchedulingCleanupHandlerTest extends TestCase {
         $this->setPostData( array( 'cleanup_action' => 'cancelled' ) );
         $this->stubCalendarFound( array( 'id' => 5, 'title' => 'Test Calendar' ) );
 
-        $this->wpdb->shouldReceive( 'delete' )
-            ->once()
-            ->with(
-                'wp_ffc_self_scheduling_appointments',
-                array( 'calendar_id' => 5, 'status' => 'cancelled' ),
-                array( '%d', '%s' )
-            )
-            ->andReturn( 2 );
+        // Repository routes the DELETE through wpdb->query (with a
+        // %i-prepared DELETE … WHERE status = %s statement) rather
+        // than wpdb->delete after the issue #340 centralization.
+        $this->wpdb->shouldReceive( 'query' )->once()->andReturn( 2 );
 
         try {
             $this->handler->handle_cleanup_appointments();

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -77,6 +77,11 @@ class SettingsTest extends TestCase {
         } );
         Functions\when( 'get_option' )->justReturn( array() );
         Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'wp_cache_flush_group' )->justReturn( true );
 
         // Stub add_action to capture registrations (constructor calls it)
         Functions\when( 'add_action' )->justReturn( true );

--- a/tests/Unit/SubmissionRepositoryCentralizationTest.php
+++ b/tests/Unit/SubmissionRepositoryCentralizationTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Repositories\SubmissionRepository;
+
+/**
+ * Tests for the three SubmissionRepository methods added in the
+ * issue #340 cleanup — `findMagicTokenById()`, `countByFormAndCpfHash()`,
+ * and `clearQrCodeCache()`. Each centralizes a call site that used to
+ * touch `wp_ffc_submissions` via raw wpdb.
+ *
+ * @covers \FreeFormCertificate\Repositories\SubmissionRepository
+ */
+class SubmissionRepositoryCentralizationTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'wp_cache_flush' )->justReturn( true );
+		Functions\when( 'wp_cache_flush_group' )->justReturn( true );
+		Functions\when( 'delete_transient' )->justReturn( true );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing( fn ( $sql ) => $sql )
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function repo(): SubmissionRepository {
+		return new SubmissionRepository();
+	}
+
+	// ------------------------------------------------------------------
+	// findMagicTokenById()
+	// ------------------------------------------------------------------
+
+	public function test_find_magic_token_returns_string_when_present(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 'tok-abc123' );
+
+		$this->assertSame( 'tok-abc123', $this->repo()->findMagicTokenById( 5 ) );
+	}
+
+	public function test_find_magic_token_returns_null_when_row_missing(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+		$this->assertNull( $this->repo()->findMagicTokenById( 5 ) );
+	}
+
+	public function test_find_magic_token_returns_null_when_token_empty_string(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '' );
+
+		$this->assertNull( $this->repo()->findMagicTokenById( 5 ) );
+	}
+
+	public function test_find_magic_token_short_circuits_on_non_positive_id(): void {
+		$this->wpdb->shouldNotReceive( 'get_var' );
+
+		$this->assertNull( $this->repo()->findMagicTokenById( 0 ) );
+		$this->assertNull( $this->repo()->findMagicTokenById( -1 ) );
+	}
+
+	// ------------------------------------------------------------------
+	// countByFormAndCpfHash()
+	// ------------------------------------------------------------------
+
+	public function test_count_by_form_and_cpf_hash_returns_int(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '3' );
+
+		$this->assertSame( 3, $this->repo()->countByFormAndCpfHash( 7, 'abc' ) );
+	}
+
+	public function test_count_by_form_and_cpf_hash_returns_zero_on_null(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+		$this->assertSame( 0, $this->repo()->countByFormAndCpfHash( 7, 'abc' ) );
+	}
+
+	public function test_count_by_form_and_cpf_hash_short_circuits_on_invalid_inputs(): void {
+		$this->wpdb->shouldNotReceive( 'get_var' );
+
+		$this->assertSame( 0, $this->repo()->countByFormAndCpfHash( 0, 'abc' ) );
+		$this->assertSame( 0, $this->repo()->countByFormAndCpfHash( 7, '' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// clearQrCodeCache()
+	// ------------------------------------------------------------------
+
+	public function test_clear_qr_code_cache_returns_affected_rows(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 12 );
+
+		$this->assertSame( 12, $this->repo()->clearQrCodeCache() );
+	}
+
+	public function test_clear_qr_code_cache_returns_zero_when_prepare_fails(): void {
+		$this->wpdb->shouldReceive( 'prepare' )->andReturn( null );
+		$this->wpdb->shouldNotReceive( 'query' );
+
+		$this->assertSame( 0, $this->repo()->clearQrCodeCache() );
+	}
+
+	public function test_clear_qr_code_cache_returns_zero_when_wpdb_query_fails(): void {
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( false );
+
+		$this->assertSame( 0, $this->repo()->clearQrCodeCache() );
+	}
+}

--- a/tests/Unit/UrlShortenerRepositoryTest.php
+++ b/tests/Unit/UrlShortenerRepositoryTest.php
@@ -309,4 +309,46 @@ class UrlShortenerRepositoryTest extends TestCase {
         $this->assertSame( 0, $stats['total_links'] );
         $this->assertSame( 0, $stats['total_clicks'] );
     }
+
+    // ------------------------------------------------------------------
+    // findQrCacheByShortCode() / setQrCacheForShortCode() — issue #340
+    // ------------------------------------------------------------------
+
+    public function test_find_qr_cache_returns_payload_when_present(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturn( 'QUERY' );
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 'data:image/png;base64,abc' );
+
+        $this->assertSame( 'data:image/png;base64,abc', $this->repo->findQrCacheByShortCode( 'ABC123' ) );
+    }
+
+    public function test_find_qr_cache_returns_empty_on_null(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->andReturn( 'QUERY' );
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+        $this->assertSame( '', $this->repo->findQrCacheByShortCode( 'ABC123' ) );
+    }
+
+    public function test_find_qr_cache_short_circuits_on_empty_code(): void {
+        $this->wpdb->shouldNotReceive( 'get_var' );
+
+        $this->assertSame( '', $this->repo->findQrCacheByShortCode( '' ) );
+    }
+
+    public function test_set_qr_cache_returns_true_on_success(): void {
+        $this->wpdb->shouldReceive( 'update' )->once()->andReturn( 1 );
+
+        $this->assertTrue( $this->repo->setQrCacheForShortCode( 'ABC123', 'payload' ) );
+    }
+
+    public function test_set_qr_cache_returns_false_on_wpdb_error(): void {
+        $this->wpdb->shouldReceive( 'update' )->once()->andReturn( false );
+
+        $this->assertFalse( $this->repo->setQrCacheForShortCode( 'ABC123', 'payload' ) );
+    }
+
+    public function test_set_qr_cache_short_circuits_on_empty_code(): void {
+        $this->wpdb->shouldNotReceive( 'update' );
+
+        $this->assertFalse( $this->repo->setQrCacheForShortCode( '', 'payload' ) );
+    }
 }

--- a/tests/Unit/UserManagerTest.php
+++ b/tests/Unit/UserManagerTest.php
@@ -38,6 +38,8 @@ class UserManagerTest extends TestCase {
         Functions\when( 'wp_cache_get' )->justReturn( false );
         Functions\when( 'wp_cache_set' )->justReturn( true );
         Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'wp_cache_flush_group' )->justReturn( true );
         Functions\when( '__' )->returnArg();
         Functions\when( 'wp_parse_args' )->alias( function ( $args, $defaults = array() ) {
             return array_merge( $defaults, $args );

--- a/tests/Unit/UserProfileRepositoryTest.php
+++ b/tests/Unit/UserProfileRepositoryTest.php
@@ -106,4 +106,43 @@ class UserProfileRepositoryTest extends TestCase {
 
 		$this->assertFalse( $this->repo()->createForUser( 7, 'Alice' ) );
 	}
+
+	// ------------------------------------------------------------------
+	// upsertForUserId() — full UserProfileService write path
+	// ------------------------------------------------------------------
+
+	public function test_upsert_for_user_id_updates_when_row_exists(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturn( 1 );
+
+		$this->assertTrue( $this->repo()->upsertForUserId( 7, array( 'display_name' => 'Bob' ) ) );
+	}
+
+	public function test_upsert_for_user_id_inserts_when_row_missing(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+
+		$this->assertTrue( $this->repo()->upsertForUserId( 7, array( 'display_name' => 'Bob' ) ) );
+	}
+
+	public function test_upsert_for_user_id_returns_false_when_update_fails(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturn( false );
+
+		$this->assertFalse( $this->repo()->upsertForUserId( 7, array( 'display_name' => 'Bob' ) ) );
+	}
+
+	public function test_upsert_for_user_id_short_circuits_on_empty_data(): void {
+		$this->wpdb->shouldNotReceive( 'update' );
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$this->assertFalse( $this->repo()->upsertForUserId( 7, array() ) );
+	}
+
+	public function test_upsert_for_user_id_short_circuits_on_invalid_user(): void {
+		$this->wpdb->shouldNotReceive( 'update' );
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$this->assertFalse( $this->repo()->upsertForUserId( 0, array( 'display_name' => 'Bob' ) ) );
+	}
 }

--- a/tests/Unit/UserProfileRepositoryTest.php
+++ b/tests/Unit/UserProfileRepositoryTest.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Repositories\UserProfileRepository;
+
+/**
+ * Tests for UserProfileRepository — issue #340 centralization of the
+ * `ffc_user_profiles` table access points that lived inline in
+ * UserManager + UserCreator.
+ *
+ * @covers \FreeFormCertificate\Repositories\UserProfileRepository
+ */
+class UserProfileRepositoryTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb            = Mockery::mock( 'wpdb' );
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = 0;
+		$this->wpdb      = $wpdb;
+
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'wp_cache_flush' )->justReturn( true );
+		Functions\when( 'wp_cache_flush_group' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-19 10:00:00' );
+
+		$this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function repo(): UserProfileRepository {
+		return new UserProfileRepository();
+	}
+
+	public function test_find_by_user_id_returns_row_when_present(): void {
+		$row = array( 'id' => '1', 'user_id' => '7', 'display_name' => 'Alice' );
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+
+		$this->assertSame( $row, $this->repo()->findByUserId( 7 ) );
+	}
+
+	public function test_find_by_user_id_returns_null_when_missing(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+		$this->assertNull( $this->repo()->findByUserId( 7 ) );
+	}
+
+	public function test_find_by_user_id_short_circuits_on_invalid_input(): void {
+		$this->wpdb->shouldNotReceive( 'get_row' );
+		$this->assertNull( $this->repo()->findByUserId( 0 ) );
+	}
+
+	public function test_exists_for_user_id_true_when_row_present(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+		$this->assertTrue( $this->repo()->existsForUserId( 7 ) );
+	}
+
+	public function test_exists_for_user_id_false_when_no_row(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$this->assertFalse( $this->repo()->existsForUserId( 7 ) );
+	}
+
+	public function test_create_for_user_returns_insert_id_on_success(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		$this->wpdb->insert_id = 99;
+
+		$this->assertSame( 99, $this->repo()->createForUser( 7, 'Alice' ) );
+	}
+
+	public function test_create_for_user_is_idempotent_when_row_exists(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+		$this->wpdb->shouldNotReceive( 'insert' );
+
+		$this->assertFalse( $this->repo()->createForUser( 7, 'Alice' ) );
+	}
+
+	public function test_create_for_user_short_circuits_on_non_positive_id(): void {
+		$this->wpdb->shouldNotReceive( 'insert' );
+		$this->assertFalse( $this->repo()->createForUser( 0, 'Alice' ) );
+	}
+
+	public function test_create_for_user_returns_false_when_insert_fails(): void {
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+		$this->assertFalse( $this->repo()->createForUser( 7, 'Alice' ) );
+	}
+}

--- a/tests/Unit/UserProfileServiceTest.php
+++ b/tests/Unit/UserProfileServiceTest.php
@@ -66,6 +66,11 @@ class UserProfileServiceTest extends TestCase {
         Functions\when( 'current_time' )->justReturn( '2026-04-23 12:00:00' );
         Functions\when( 'get_current_user_id' )->justReturn( 7 );
         Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'wp_cache_flush_group' )->justReturn( true );
 
         // Stateful get/update/delete_user_meta backed by $usermeta_store.
         $store =& $this->usermeta_store;

--- a/tests/Unit/UserSummaryRestControllerTest.php
+++ b/tests/Unit/UserSummaryRestControllerTest.php
@@ -211,17 +211,29 @@ class UserSummaryRestControllerTest extends TestCase {
         Functions\when( 'current_user_can' )->alias( function( $cap ) {
             return $cap === 'manage_options';
         });
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
 
         // Certificates count
         $this->wpdb->shouldReceive( 'get_var' )->andReturn( '0' );
 
-        // Next appointment query returns a row
-        $appointment_row = array(
-            'appointment_date' => '2026-06-15',
-            'start_time'       => '10:30:00',
-            'calendar_title'   => 'Main Calendar',
+        // The next-appointment lookup now goes through
+        // AppointmentRepository::findNextUpcomingForUser() and the
+        // calendar title is fetched separately via CalendarRepository
+        // (issue #340 centralization). Two get_row() returns: first the
+        // appointment row, then the calendar row.
+        $this->wpdb->shouldReceive( 'get_row' )->andReturn(
+            array(
+                'id'               => 1,
+                'appointment_date' => '2026-06-15',
+                'start_time'       => '10:30:00',
+                'calendar_id'      => 42,
+            ),
+            array(
+                'id'    => 42,
+                'title' => 'Main Calendar',
+            )
         );
-        $this->wpdb->shouldReceive( 'get_row' )->andReturn( $appointment_row );
 
         Functions\when( 'get_option' )->alias( function( $key, $default = false ) {
             if ( $key === 'ffc_settings' ) {


### PR DESCRIPTION
PR única abarcando os 7 sprints do #340 (1 commit por sprint) + 1 commit final de audit catch.

## Estrutura

| Sprint | Tabela | Sites | Repo / Service alvo |
|---|---|---|---|
| 1 | `ffc_submissions` | 3 | `SubmissionRepository` (3 métodos novos) |
| 2 | `ffc_self_scheduling_appointments` | 8 (5 saneados, 3 UNIONs deferidos) | `AppointmentRepository` (10 métodos novos) |
| 3 | `ffc_recruitment_*` admin columns | 4 | `RecruitmentClassificationRepository` (2 métodos novos) |
| 4 | `ffc_user_profiles` | 2 | **novo** `UserProfileRepository` |
| 5 | `ffc_short_urls` QR handler | 2 | `UrlShortenerRepository` (2 métodos novos) |
| 6 | `ffc_custom_fields*` seeder + sensitive registry | 2 | `CustomFieldRepository` (3 métodos novos) |
| 7 | `ffc_audience_*` (parcial) | 3 (de 6) | `AudienceRepository` (2 métodos novos) + `AudienceBookingRepository` reuso |
| **audit** | UserProfileService bypass + test stubs | 1 | Catch da varredura final |

Cada commit é auto-contido (build verde + testes próprios), seguindo a regra "1 sprint = 1 commit".

## O que muda (visão geral)

### Novos métodos públicos em repositories existentes
- **`SubmissionRepository`** — `findMagicTokenById`, `countByFormAndCpfHash`, `clearQrCodeCache`
- **`AppointmentRepository`** — `countAllByUserGrouped`, `deleteByCalendar{,Before,After,AndStatus}`, `countByCalendar{Before,After}`, `findByCalendarAfterWithStatus`, `findNextUpcomingForUser`, `linkByIdentifierHash`
- **`RecruitmentClassificationRepository`** — `count_notices_grouped_by_user`, `sql_user_notice_count_subquery` (fragmento SQL pro WP_User_Query orderby)
- **`UrlShortenerRepository`** — `findQrCacheByShortCode`, `setQrCacheForShortCode`
- **`CustomFieldRepository`** — `list_sensitive_field_keys`, `existing_field_keys_for_audience`, `insert_row`
- **`AudienceRepository`** — `get_all_ids`, `get_user_audience_badges`

### Nova classe
- **`UserProfileRepository`** (`includes/repositories/ffc-user-profile-repository.php`) — wrapper CRUD do `ffc_user_profiles` (4 métodos: `findByUserId`, `existsForUserId`, `createForUser`, `upsertForUserId`)

### Call sites refatorados
- `admin/class-ffc-settings.php` — QR cache clear
- `generators/class-ffc-pdf-generator.php` — magic-link QR
- `frontend/class-ffc-csv-download-validator.php` — participants gate
- `admin/class-ffc-admin-user-columns.php` — recruitment + appointment column loaders + orderby
- `self-scheduling/class-ffc-self-scheduling-cleanup-handler.php` — 4 ações de delete + 2 contagens
- `self-scheduling/class-ffc-self-scheduling-cpt.php` — cancel future appointments
- `api/class-ffc-user-summary-rest-controller.php` — next appointment lookup (2-step em vez de JOIN inline)
- `user-dashboard/class-ffc-user-creator.php` — link orphaned appointments por hash
- `user-dashboard/class-ffc-user-manager.php` — get profile
- `user-dashboard/class-ffc-user-profile-service.php` — read/write profile table (achado na auditoria final)
- `url-shortener/class-ffc-url-shortener-qr-handler.php` — get/set QR cache
- `core/class-ffc-sensitive-field-registry.php` — dynamic sensitive keys
- `reregistration/class-ffc-reregistration-standard-fields-seeder.php` — seed por audiência + all-audiences
- `api/class-ffc-user-profile-rest-controller.php` — user audience badges
- `audience/class-ffc-audience-notification-handler.php` — booking users

## Deferidos (documentados pra novas issues, NÃO regressões)

Três grupos identificados como leaks pelo audit final mas **fora do escopo de "centralização" simples**:

1. **`UserManager` UNION queries** (3 sites: `get_user_cpfs_masked`, `get_user_identifiers_masked`, `get_user_emails`) — atravessam `ffc_submissions` ⊕ `ffc_self_scheduling_appointments`. Não cabem em um repository single-table. Belong em um `UserIdentifiersQueryService` aggregator.

2. **`UserAudienceRestController` + `UserSummaryRestController` heavy JOINs** (4 sites) — joins de 4-7 tabelas audience (`bookings + booking_users + booking_audiences + members + environments + schedules`). Belong em um `AudienceQueryService` read aggregator.

3. **Admin Users list ORDERBY rewrites para `ffc_submissions` e `ffc_self_scheduling_appointments`** (2 sites) — são **fragmentos SQL** para o hook `query_from` do `WP_User_Query`, não execuções de query. Mantidos inline por design (única coisa que esse hook aceita é string SQL).

Sprint 3 já consolidou um desses fragmentos via `RecruitmentClassificationRepository::sql_user_notice_count_subquery()`. Submissões e appointments podem seguir o mesmo padrão em PRs futuras (cada uma traz pouco isolado).

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4545/4545** (+87 cases novos espalhados pelos sprints)
  - SubmissionRepositoryCentralizationTest: 10
  - AppointmentRepositoryCentralizationTest: 19
  - UserProfileRepositoryTest: 14 (5 da auditoria final)
  - RecruitmentClassificationRepositoryTest: +3
  - UrlShortenerRepositoryTest: +6
  - CustomFieldRepositoryTest: +6
  - AudienceRepositoryTest: +4
  - Tests existentes atualizados pra novos paths: SelfSchedulingCleanupHandlerTest, UserSummaryRestControllerTest, AdminUserColumnsTest, ReregistrationStandardFieldsSeederTest, UserProfileServiceTest, UserManagerTest, SettingsTest (apenas stubs de `wp_cache_flush*`)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean
- [x] Auditoria final (`grep -rn "\$wpdb->prefix \. 'ffc_" includes/`) confirma que tudo remanescente é OWNER ou LEGITIMATE-POLICY ou um dos 3 grupos documentados acima

## Critério de aceite (do #340)

- [x] Cada novo método tem cobertura unitária
- [ ] `grep` retorna apenas linhas em classes-camada ou centralizações legítimas — **parcial**: as 3 categorias deferidas acima ainda têm raw `$wpdb`, mas estão fora do escopo de "centralização" tradicional e merecem PRs próprias

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_