### PR TITLE
Group A (#343): UserIdentifiersQueryService for the UserManager UNIONs

### DIFF
--- a/includes/services/class-ffc-user-identifiers-query-service.php
+++ b/includes/services/class-ffc-user-identifiers-query-service.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * UserIdentifiersQueryService
+ *
+ * Cross-table aggregator for the user-level identifiers (CPF, RF, email)
+ * that live encrypted on `wp_ffc_submissions` and
+ * `wp_ffc_self_scheduling_appointments`. Concentrates the UNION ALL
+ * queries that used to be inlined in `UserManager` (#343 group A).
+ *
+ * Rationale (from #343's body): the UNIONs straddle two tables owned
+ * by different repositories (`SubmissionRepository` and
+ * `AppointmentRepository`). Pushing the cross-table SQL into either
+ * repo would break single-table ownership. A dedicated query service
+ * sits at the right layer — read-only, scoped to "user identifiers",
+ * and easy to test in isolation.
+ *
+ * @package FreeFormCertificate\Services
+ * @since   6.6.2
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+/**
+ * Stateless service. Public API mirrors what `UserManager` exposed
+ * pre-#343 group A — callers route through here now.
+ */
+final class UserIdentifiersQueryService {
+
+	/**
+	 * Return every masked CPF / RF the user appears with, deduped.
+	 * Each row is decrypted, the CPF takes precedence when both
+	 * columns are populated, and the resulting plaintext is masked
+	 * through `DocumentFormatter::mask_cpf()`.
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WordPress user ID.
+	 * @return array<int, string>
+	 */
+	public static function get_cpfs_masked_for_user( int $user_id ): array {
+		$rows = self::fetch_encrypted_cpf_rf_rows( $user_id );
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			try {
+				$plain = null;
+				if ( ! empty( $row['cpf_encrypted'] ) ) {
+					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['cpf_encrypted'] );
+				} elseif ( ! empty( $row['rf_encrypted'] ) ) {
+					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['rf_encrypted'] );
+				}
+
+				if ( ! empty( $plain ) ) {
+					$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
+					if ( ! empty( $masked ) && ! in_array( $masked, $out, true ) ) {
+						$out[] = $masked;
+					}
+				}
+			} catch ( \Exception $e ) {
+				if ( class_exists( '\FreeFormCertificate\Core\Debug' ) ) {
+					\FreeFormCertificate\Core\Debug::log_user_manager(
+						'Failed to decrypt CPF/RF',
+						array(
+							'user_id' => $user_id,
+							'error'   => $e->getMessage(),
+						)
+					);
+				}
+				continue;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Return the user's masked identifiers split by type — `cpfs` and
+	 * `rfs` keys. Decryption + masking match
+	 * {@see self::get_cpfs_masked_for_user()}; the difference is the
+	 * shape (typed buckets rather than a flat list).
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WordPress user ID.
+	 * @return array{cpfs: array<int, string>, rfs: array<int, string>}
+	 */
+	public static function get_typed_identifiers_for_user( int $user_id ): array {
+		$rows = self::fetch_encrypted_cpf_rf_rows( $user_id );
+
+		$cpfs = array();
+		$rfs  = array();
+
+		foreach ( $rows as $row ) {
+			try {
+				if ( ! empty( $row['cpf_encrypted'] ) ) {
+					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['cpf_encrypted'] );
+					if ( ! empty( $plain ) ) {
+						$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
+						if ( ! empty( $masked ) && ! in_array( $masked, $cpfs, true ) ) {
+							$cpfs[] = $masked;
+						}
+					}
+				} elseif ( ! empty( $row['rf_encrypted'] ) ) {
+					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['rf_encrypted'] );
+					if ( ! empty( $plain ) ) {
+						$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
+						if ( ! empty( $masked ) && ! in_array( $masked, $rfs, true ) ) {
+							$rfs[] = $masked;
+						}
+					}
+				}
+			} catch ( \Exception $e ) {
+				continue;
+			}
+		}
+
+		return array(
+			'cpfs' => $cpfs,
+			'rfs'  => $rfs,
+		);
+	}
+
+	/**
+	 * Return every distinct email the user appears with — across
+	 * submissions, appointments, AND the WP account itself. Decryption
+	 * is best-effort; rows whose blob doesn't decrypt to a valid email
+	 * are silently dropped. The WP account email is appended last so
+	 * it's always included when valid.
+	 *
+	 * @since 6.6.2
+	 * @param int $user_id WordPress user ID.
+	 * @return array<int, string>
+	 */
+	public static function get_emails_for_user( int $user_id ): array {
+		$encrypted_emails = self::fetch_encrypted_emails( $user_id );
+
+		if ( empty( $encrypted_emails ) ) {
+			$user = get_user_by( 'id', $user_id );
+			return $user ? array( $user->user_email ) : array();
+		}
+
+		$emails = array();
+		foreach ( $encrypted_emails as $encrypted ) {
+			try {
+				$email = \FreeFormCertificate\Core\Encryption::decrypt( $encrypted );
+				if ( is_string( $email ) && is_email( $email ) ) {
+					$emails[] = $email;
+				}
+			} catch ( \Exception $e ) {
+				continue;
+			}
+		}
+
+		$user = get_user_by( 'id', $user_id );
+		if ( $user && is_email( $user->user_email ) ) {
+			$emails[] = $user->user_email;
+		}
+
+		return array_values( array_unique( $emails ) );
+	}
+
+	/**
+	 * UNION ALL across `ffc_submissions` ⊕ `ffc_self_scheduling_appointments`
+	 * returning every row carrying a CPF or RF blob for the supplied
+	 * user. Used by both
+	 * {@see self::get_cpfs_masked_for_user()} and
+	 * {@see self::get_typed_identifiers_for_user()} — the only
+	 * difference between those two is how they shape the decrypted
+	 * output, so the SQL stays single-source.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return list<array{cpf_encrypted: ?string, rf_encrypted: ?string}>
+	 */
+	private static function fetch_encrypted_cpf_rf_rows( int $user_id ): array {
+		global $wpdb;
+		$submissions_table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
+		$appointments_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cross-table UNION; bounded by (user_id) filter on both halves.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT cpf_encrypted, rf_encrypted FROM %i
+				WHERE user_id = %d
+				AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)
+				UNION ALL
+				SELECT cpf_encrypted, rf_encrypted FROM %i
+				WHERE user_id = %d
+				AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)',
+				$submissions_table,
+				$user_id,
+				$appointments_table,
+				$user_id
+			),
+			ARRAY_A
+		);
+
+		return is_array( $rows ) ? array_values( $rows ) : array();
+	}
+
+	/**
+	 * UNION ALL across `ffc_submissions` ⊕ `ffc_self_scheduling_appointments`
+	 * returning every encrypted-email blob the user appears with.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return list<string>
+	 */
+	private static function fetch_encrypted_emails( int $user_id ): array {
+		global $wpdb;
+		$submissions_table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
+		$appointments_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cross-table UNION; bounded by (user_id) filter on both halves.
+		$rows = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT email_encrypted FROM %i
+				WHERE user_id = %d
+				AND email_encrypted IS NOT NULL
+				AND email_encrypted != ''
+				UNION ALL
+				SELECT email_encrypted FROM %i
+				WHERE user_id = %d
+				AND email_encrypted IS NOT NULL
+				AND email_encrypted != ''",
+				$submissions_table,
+				$user_id,
+				$appointments_table,
+				$user_id
+			)
+		);
+
+		return is_array( $rows ) ? array_values( array_map( 'strval', $rows ) ) : array();
+	}
+}

--- a/includes/user-dashboard/class-ffc-user-manager.php
+++ b/includes/user-dashboard/class-ffc-user-manager.php
@@ -471,67 +471,7 @@ class UserManager {
 	 * @return array<int, string> Array of masked CPF/RF values
 	 */
 	public static function get_user_cpfs_masked( int $user_id ): array {
-		global $wpdb;
-		$submissions_table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
-		$appointments_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-
-		// Query both submissions and appointments tables so users who only.
-		// have self-scheduling appointments still get their CPF/RF displayed.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT cpf_encrypted, rf_encrypted FROM %i
-             WHERE user_id = %d
-             AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)
-             UNION ALL
-             SELECT cpf_encrypted, rf_encrypted FROM %i
-             WHERE user_id = %d
-             AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)',
-				$submissions_table,
-				$user_id,
-				$appointments_table,
-				$user_id
-			),
-			ARRAY_A
-		);
-
-		if ( empty( $rows ) ) {
-			return array();
-		}
-
-		$cpfs_masked = array();
-
-		foreach ( $rows as $row ) {
-			try {
-				// Prefer split columns.
-				$plain = null;
-				if ( ! empty( $row['cpf_encrypted'] ) ) {
-					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['cpf_encrypted'] );
-				} elseif ( ! empty( $row['rf_encrypted'] ) ) {
-					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['rf_encrypted'] );
-				}
-
-				if ( ! empty( $plain ) ) {
-					$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
-					if ( ! empty( $masked ) && ! in_array( $masked, $cpfs_masked, true ) ) {
-						$cpfs_masked[] = $masked;
-					}
-				}
-			} catch ( \Exception $e ) {
-				if ( class_exists( '\FreeFormCertificate\Core\Debug' ) ) {
-					\FreeFormCertificate\Core\Debug::log_user_manager(
-						'Failed to decrypt CPF/RF',
-						array(
-							'user_id' => $user_id,
-							'error'   => $e->getMessage(),
-						)
-					);
-				}
-				continue;
-			}
-		}
-
-		return $cpfs_masked;
+		return \FreeFormCertificate\Services\UserIdentifiersQueryService::get_cpfs_masked_for_user( $user_id );
 	}
 
 	/**
@@ -542,67 +482,7 @@ class UserManager {
 	 * @return array{cpfs: array<int, string>, rfs: array<int, string>}
 	 */
 	public static function get_user_identifiers_masked( int $user_id ): array {
-		global $wpdb;
-		$submissions_table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
-		$appointments_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-
-		// Query both submissions and appointments tables.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT cpf_encrypted, rf_encrypted FROM %i
-             WHERE user_id = %d
-             AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)
-             UNION ALL
-             SELECT cpf_encrypted, rf_encrypted FROM %i
-             WHERE user_id = %d
-             AND (cpf_encrypted IS NOT NULL OR rf_encrypted IS NOT NULL)',
-				$submissions_table,
-				$user_id,
-				$appointments_table,
-				$user_id
-			),
-			ARRAY_A
-		);
-
-		$cpfs = array();
-		$rfs  = array();
-
-		if ( empty( $rows ) ) {
-			return array(
-				'cpfs' => $cpfs,
-				'rfs'  => $rfs,
-			);
-		}
-
-		foreach ( $rows as $row ) {
-			try {
-				if ( ! empty( $row['cpf_encrypted'] ) ) {
-					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['cpf_encrypted'] );
-					if ( ! empty( $plain ) ) {
-						$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
-						if ( ! empty( $masked ) && ! in_array( $masked, $cpfs, true ) ) {
-							$cpfs[] = $masked;
-						}
-					}
-				} elseif ( ! empty( $row['rf_encrypted'] ) ) {
-					$plain = \FreeFormCertificate\Core\Encryption::decrypt( $row['rf_encrypted'] );
-					if ( ! empty( $plain ) ) {
-						$masked = \FreeFormCertificate\Core\DocumentFormatter::mask_cpf( $plain );
-						if ( ! empty( $masked ) && ! in_array( $masked, $rfs, true ) ) {
-							$rfs[] = $masked;
-						}
-					}
-				}
-			} catch ( \Exception $e ) {
-				continue;
-			}
-		}
-
-		return array(
-			'cpfs' => $cpfs,
-			'rfs'  => $rfs,
-		);
+		return \FreeFormCertificate\Services\UserIdentifiersQueryService::get_typed_identifiers_for_user( $user_id );
 	}
 
 	/**
@@ -612,54 +492,7 @@ class UserManager {
 	 * @return array<int, string> Array of emails
 	 */
 	public static function get_user_emails( int $user_id ): array {
-		global $wpdb;
-		$submissions_table  = \FreeFormCertificate\Core\Utils::get_submissions_table();
-		$appointments_table = $wpdb->prefix . 'ffc_self_scheduling_appointments';
-
-		// Query both submissions and appointments tables.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$encrypted_emails = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT email_encrypted FROM %i
-             WHERE user_id = %d
-             AND email_encrypted IS NOT NULL
-             AND email_encrypted != ''
-             UNION ALL
-             SELECT email_encrypted FROM %i
-             WHERE user_id = %d
-             AND email_encrypted IS NOT NULL
-             AND email_encrypted != ''",
-				$submissions_table,
-				$user_id,
-				$appointments_table,
-				$user_id
-			)
-		);
-
-		if ( empty( $encrypted_emails ) ) {
-			$user = get_user_by( 'id', $user_id );
-			return $user ? array( $user->user_email ) : array();
-		}
-
-		$emails = array();
-
-		foreach ( $encrypted_emails as $encrypted ) {
-			try {
-				$email = \FreeFormCertificate\Core\Encryption::decrypt( $encrypted );
-				if ( is_string( $email ) && is_email( $email ) ) {
-					$emails[] = $email;
-				}
-			} catch ( \Exception $e ) {
-				continue;
-			}
-		}
-
-		$user = get_user_by( 'id', $user_id );
-		if ( $user && is_email( $user->user_email ) ) {
-			$emails[] = $user->user_email;
-		}
-
-		return array_unique( $emails );
+		return \FreeFormCertificate\Services\UserIdentifiersQueryService::get_emails_for_user( $user_id );
 	}
 
 	/**

--- a/tests/Unit/UserIdentifiersQueryServiceTest.php
+++ b/tests/Unit/UserIdentifiersQueryServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Services\UserIdentifiersQueryService;
+
+/**
+ * Focused tests for `UserIdentifiersQueryService` — the cross-table
+ * aggregator for user-level CPF / RF / email identifiers introduced
+ * in issue #343 group A. Existing UserManagerTest coverage already
+ * exercises every public method transitively (UserManager delegates
+ * to this service post-#343 group A); these cases pin the public
+ * service contract directly for greppability + as a smoke check.
+ *
+ * @covers \FreeFormCertificate\Services\UserIdentifiersQueryService
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class UserIdentifiersQueryServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$this->wpdb   = $wpdb;
+
+		Functions\when( 'is_email' )->alias( function ( $v ) {
+			return is_string( $v ) && false !== strpos( $v, '@' );
+		} );
+
+		$this->wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
+
+		// Default Utils stub: the service calls get_submissions_table().
+		$utilsMock = Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' );
+		$utilsMock->shouldReceive( 'get_submissions_table' )->andReturn( 'wp_ffc_submissions' )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_cpfs_masked_for_user_decrypts_and_masks(): void {
+		$encMock = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$encMock->shouldReceive( 'decrypt' )->andReturn( '12345678901' );
+
+		$fmtMock = Mockery::mock( 'alias:FreeFormCertificate\Core\DocumentFormatter' );
+		$fmtMock->shouldReceive( 'mask_cpf' )->andReturn( '123.***.***-01' );
+
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+			array( array( 'cpf_encrypted' => 'cipher', 'rf_encrypted' => null ) )
+		);
+
+		$out = UserIdentifiersQueryService::get_cpfs_masked_for_user( 42 );
+
+		$this->assertSame( array( '123.***.***-01' ), $out );
+	}
+
+	public function test_get_cpfs_masked_for_user_returns_empty_when_no_rows(): void {
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$this->assertSame( array(), UserIdentifiersQueryService::get_cpfs_masked_for_user( 42 ) );
+	}
+
+	public function test_get_typed_identifiers_separates_cpfs_and_rfs(): void {
+		$encMock = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$encMock->shouldReceive( 'decrypt' )->andReturnUsing( fn ( $v ) => 'plain-' . $v );
+
+		$fmtMock = Mockery::mock( 'alias:FreeFormCertificate\Core\DocumentFormatter' );
+		$fmtMock->shouldReceive( 'mask_cpf' )->andReturnUsing( fn ( $v ) => 'mask:' . $v );
+
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+			array(
+				array( 'cpf_encrypted' => 'c1',  'rf_encrypted' => null ),
+				array( 'cpf_encrypted' => null,  'rf_encrypted' => 'r1' ),
+			)
+		);
+
+		$out = UserIdentifiersQueryService::get_typed_identifiers_for_user( 42 );
+
+		$this->assertSame( array( 'mask:plain-c1' ), $out['cpfs'] );
+		$this->assertSame( array( 'mask:plain-r1' ), $out['rfs'] );
+	}
+
+	public function test_get_emails_for_user_falls_back_to_wp_account_when_no_encrypted_rows(): void {
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array() );
+
+		$user              = new \stdClass();
+		$user->user_email  = 'wp@example.com';
+		Functions\when( 'get_user_by' )->justReturn( $user );
+
+		$this->assertSame( array( 'wp@example.com' ), UserIdentifiersQueryService::get_emails_for_user( 42 ) );
+	}
+
+	public function test_get_emails_for_user_decrypts_and_dedups_against_wp_account(): void {
+		$encMock = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$encMock->shouldReceive( 'decrypt' )->andReturn( 'alice@example.com' );
+
+		$this->wpdb->shouldReceive( 'get_col' )->once()->andReturn( array( 'cipher-1', 'cipher-2' ) );
+
+		$user              = new \stdClass();
+		$user->user_email  = 'alice@example.com';
+		Functions\when( 'get_user_by' )->justReturn( $user );
+
+		$out = UserIdentifiersQueryService::get_emails_for_user( 42 );
+
+		// Two decrypted hits + one wp account email — but array_unique
+		// dedups them to one.
+		$this->assertSame( array( 'alice@example.com' ), $out );
+	}
+}


### PR DESCRIPTION
Fecha o **Grupo A** do #343 — 3 queries `UNION ALL` que atravessavam `ffc_submissions` ⊕ `ffc_self_scheduling_appointments`, inline no `UserManager`.

## Decisão de design

Per #343 opção A: **UNION inline no service** (vs opção B que faria duas queries separadas via repositories e merge em PHP). Justificativa:

- Cross-table UNION é o **propósito** do service. Manter a UNION ALL num só lugar é mais honesto que esconder atrás de 2 queries + dedup PHP.
- Não dobra round-trips ao DB.
- A dependência cross-table fica **explícita** na assinatura do service, não escondida.

## O que muda

### Novo arquivo
`includes/services/class-ffc-user-identifiers-query-service.php` (PSR-4: `FreeFormCertificate\Services\UserIdentifiersQueryService`) — 3 métodos estáticos públicos:

| Método | Substitui | Comportamento |
|---|---|---|
| `get_cpfs_masked_for_user(int): list<string>` | `UserManager::get_user_cpfs_masked()` | Lista flat dedupada de CPF/RF mascarados. CPF tem precedência, fallback RF. |
| `get_typed_identifiers_for_user(int): array{cpfs, rfs}` | `UserManager::get_user_identifiers_masked()` | Mesma UNION, response separada em `cpfs` + `rfs`. |
| `get_emails_for_user(int): list<string>` | `UserManager::get_user_emails()` | UNION dos `email_encrypted` de ambas tabelas, decrypted + filtrado via `is_email()`, com email do WP account appendado pra cobrir usuários sem interação FFC. |

UNION SQL extraída em 2 helpers privados (`fetch_encrypted_cpf_rf_rows` / `fetch_encrypted_emails`) — os 2 entry points de CPF/RF compartilham fonte única.

### UserManager
Os 3 métodos viram delegações de uma linha. Assinaturas públicas **inalteradas** — todos os callers existentes continuam funcionando sem modificação.

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4555/4555** verde
  - **+5 cases novos** em `UserIdentifiersQueryServiceTest` (happy paths de cada método + 2 edge cases: empty / WP fallback dedup)
  - Pre-existing `UserManagerTest` (10+ cases nos 3 métodos) continua verde via delegação — cobre indiretamente o service também
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] `GET /me/profile` autenticado → fields `cpfs_masked`, `identifiers`, `emails` idênticos ao pré-merge (REST chama UserManager → service).
- [ ] Admin recruitment edit page → seção Sensitive data continua mostrando CPF/RF/email do usuário linkado.

## #343 status

- [x] **Grupo C** (ORDERBY fragments) — #346
- [x] **Grupo A** (UserManager UNIONs) — esta PR
- [ ] **Grupo B** (Audience REST heavy JOINs → `AudienceQueryService`) — maior, precisa de design discussion antes da implementação

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_