### PR TITLE
Per-read rate-limit pool for public Calendar REST endpoints (#259)

### DIFF
--- a/includes/api/class-ffc-calendar-rest-controller.php
+++ b/includes/api/class-ffc-calendar-rest-controller.php
@@ -24,6 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class CalendarRestController {
 
+	use ReadRateLimitGuardTrait;
+
+
 	/**
 	 * API namespace
 	 *
@@ -109,39 +112,27 @@ class CalendarRestController {
 	}
 
 	/**
-	 * Reject the request when the caller's IP has already tripped the
-	 * rate-limit pool (typically populated by failed/abusive form
-	 * submissions from the same IP). Returns null on green light.
+	 * Per-endpoint rate-limit guard.
 	 *
-	 * Rationale: the calendar GET routes are public-by-design — the
+	 * The Calendar GET routes are public-by-design — the
 	 * `[ffc_self_scheduling]` shortcode hits them anonymously to build
-	 * the booking UI. Behind `__return_true` they had no defence at
-	 * all against a scraper polling `/slots` to enumerate the working
-	 * hours of every calendar on a site. This guard is a circuit
-	 * breaker, not a per-read limiter: it shares the IP pool with
-	 * submit/verify, so an actor caught flooding submissions also
-	 * gets blocked from these reads. A per-read pool is a follow-up.
+	 * the booking UI. Issue #259 replaced the previous shared-IP-pool
+	 * circuit breaker with a dedicated per-read pool (per-endpoint
+	 * thresholds in `settings['read']['endpoints']`) so a scraper that
+	 * never submits forms doesn't bypass the protection.
+	 *
+	 * Logic lives in {@see ReadRateLimitGuardTrait::guard_read()} —
+	 * the three calendar endpoints just pass their endpoint key.
 	 *
 	 * @since 6.4.1
+	 * @param string $endpoint_key Endpoint identifier.
 	 * @return \WP_Error|null `WP_Error` (status 429) when blocked, null when allowed.
 	 */
-	private function rate_limit_guard() {
+	private function rate_limit_guard( string $endpoint_key ) {
 		if ( ! class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
 			return null;
 		}
-		$ip       = \FreeFormCertificate\Core\Utils::get_user_ip();
-		$ip_check = \FreeFormCertificate\Security\RateLimiter::check_ip_limit( $ip );
-		if ( ! empty( $ip_check['allowed'] ) ) {
-			return null;
-		}
-		return new \WP_Error(
-			'rate_limit_exceeded',
-			isset( $ip_check['message'] ) ? (string) $ip_check['message'] : __( 'Too many requests. Please try again later.', 'ffcertificate' ),
-			array(
-				'status'       => 429,
-				'wait_seconds' => isset( $ip_check['wait_seconds'] ) ? (int) $ip_check['wait_seconds'] : 60,
-			)
-		);
+		return $this->guard_read( $endpoint_key );
 	}
 
 	/**
@@ -153,7 +144,7 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendars( $request ) {
-		$blocked = $this->rate_limit_guard();
+		$blocked = $this->rate_limit_guard( 'calendar_list' );
 		if ( $blocked instanceof \WP_Error ) {
 			return $blocked;
 		}
@@ -223,7 +214,7 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendar( $request ) {
-		$blocked = $this->rate_limit_guard();
+		$blocked = $this->rate_limit_guard( 'calendar_detail' );
 		if ( $blocked instanceof \WP_Error ) {
 			return $blocked;
 		}
@@ -308,7 +299,7 @@ class CalendarRestController {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_calendar_slots( $request ) {
-		$blocked = $this->rate_limit_guard();
+		$blocked = $this->rate_limit_guard( 'calendar_slots' );
 		if ( $blocked instanceof \WP_Error ) {
 			return $blocked;
 		}

--- a/includes/api/class-ffc-read-rate-limit-guard-trait.php
+++ b/includes/api/class-ffc-read-rate-limit-guard-trait.php
@@ -79,14 +79,14 @@ trait ReadRateLimitGuardTrait {
 
 		$result = RateLimiter::check_read_limit( $ip, $endpoint_key );
 
-		if ( false === ( $result['allowed'] ?? false ) ) {
+		if ( ! $result['allowed'] ) {
 			$identifier = $ip . '|' . $endpoint_key;
-			$reason     = (string) ( $result['reason'] ?? 'read_limit' );
+			$reason     = isset( $result['reason'] ) ? (string) $result['reason'] : 'read_limit';
 
 			RateLimitLogger::log_attempt( 'read', $identifier, 'blocked', $reason, null );
 
-			$wait    = (int) ( $result['wait_seconds'] ?? 60 );
-			$message = (string) ( $result['message'] ?? __( 'Too many requests. Please slow down.', 'ffcertificate' ) );
+			$wait    = isset( $result['wait_seconds'] ) ? (int) $result['wait_seconds'] : 60;
+			$message = isset( $result['message'] ) ? (string) $result['message'] : __( 'Too many requests. Please slow down.', 'ffcertificate' );
 
 			return new \WP_Error(
 				'rate_limit_exceeded',

--- a/includes/api/class-ffc-read-rate-limit-guard-trait.php
+++ b/includes/api/class-ffc-read-rate-limit-guard-trait.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Read Rate-Limit Guard Trait
+ *
+ * Reusable guard for public GET endpoints that need their own
+ * rate-limit pool — see issue #259 for the threat model (scrapers
+ * that never submit forms bypass the IP pool's circuit breaker
+ * because that pool is only fed by submit/verify activity).
+ *
+ * Consumers attach the trait and call `guard_read( $endpoint_key )`
+ * at the top of every public read handler. Returns `null` on green
+ * light (caller continues) or a `WP_Error` 429 on block (caller
+ * just returns the error — the trait already shaped the response
+ * to match what the rest of the plugin does for rate-limit blocks).
+ *
+ * Endpoint keys are arbitrary strings the admin configures via the
+ * Rate Limit settings tab; the trait validates the supplied key
+ * exists in the settings and short-circuits to "allowed" when the
+ * specific endpoint is disabled (so adoption stays opt-in per
+ * endpoint).
+ *
+ * @package FreeFormCertificate\API
+ * @since   6.6.2
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\API;
+
+use FreeFormCertificate\Core\Utils;
+use FreeFormCertificate\Security\RateLimiter;
+use FreeFormCertificate\Security\RateLimitChecker;
+use FreeFormCertificate\Security\RateLimitLogger;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared guard for read-only public REST endpoints.
+ */
+trait ReadRateLimitGuardTrait {
+
+	/**
+	 * Gate the current request against the per-endpoint rate-limit
+	 * pool. Returns null when the caller is clear (and increments
+	 * the counter); returns a `WP_Error` 429 with `Retry-After`
+	 * header data otherwise.
+	 *
+	 * Resolution order matches the existing plugin convention:
+	 *   1. `settings['read']['respect_whitelist']` — when on AND the
+	 *      caller IP is in `settings['whitelist']['ips']`, bypass.
+	 *   2. `settings['read']['bypass_logged_in']` — when on AND the
+	 *      caller is `is_user_logged_in()`, bypass.
+	 *   3. `RateLimiter::check_read_limit()` — check counters.
+	 *      Block → log via `RateLimitLogger`, return 429.
+	 *      Allow → `record_read_attempt()`, return null.
+	 *
+	 * @since 6.6.2
+	 * @param string $endpoint_key Endpoint identifier matching the
+	 *                             `settings['read']['endpoints'][$key]`
+	 *                             slot (e.g. `calendar_slots`).
+	 * @return \WP_Error|null
+	 */
+	protected function guard_read( string $endpoint_key ): ?\WP_Error {
+		$ip       = Utils::get_user_ip();
+		$settings = RateLimiter::get_settings();
+		$read     = is_array( $settings['read'] ?? null ) ? $settings['read'] : array();
+
+		// Bypass 1 — IP whitelist.
+		if ( ! empty( $read['respect_whitelist'] ) && RateLimitChecker::is_ip_whitelisted( $ip ) ) {
+			return null;
+		}
+
+		// Bypass 2 — logged-in users (staff / kiosks signed in to WP).
+		if ( ! empty( $read['bypass_logged_in'] ) && is_user_logged_in() ) {
+			return null;
+		}
+
+		$result = RateLimiter::check_read_limit( $ip, $endpoint_key );
+
+		if ( false === ( $result['allowed'] ?? false ) ) {
+			$identifier = $ip . '|' . $endpoint_key;
+			$reason     = (string) ( $result['reason'] ?? 'read_limit' );
+
+			RateLimitLogger::log_attempt( 'read', $identifier, 'blocked', $reason, null );
+
+			$wait    = (int) ( $result['wait_seconds'] ?? 60 );
+			$message = (string) ( $result['message'] ?? __( 'Too many requests. Please slow down.', 'ffcertificate' ) );
+
+			return new \WP_Error(
+				'rate_limit_exceeded',
+				$message,
+				array(
+					'status'  => 429,
+					'headers' => array(
+						'Retry-After' => max( 1, $wait ),
+					),
+				)
+			);
+		}
+
+		RateLimiter::record_read_attempt( $ip, $endpoint_key );
+		return null;
+	}
+}

--- a/includes/security/class-ffc-rate-limit-checker.php
+++ b/includes/security/class-ffc-rate-limit-checker.php
@@ -1164,6 +1164,22 @@ final class RateLimitChecker {
 	}
 
 	/**
+	 * Public IP-only whitelist check. The internal `is_whitelisted()`
+	 * accepts email + CPF too; this thin wrapper exposes just the IP
+	 * branch for consumers that only have an IP to test (the read
+	 * trait, future webhook handlers, etc.). Issue #259.
+	 *
+	 * @since 6.6.2
+	 * @param string $ip Client IP.
+	 * @return bool
+	 */
+	public static function is_ip_whitelisted( string $ip ): bool {
+		$wl = self::get_settings()['whitelist'] ?? array();
+		$ips = is_array( $wl ) && isset( $wl['ips'] ) && is_array( $wl['ips'] ) ? $wl['ips'] : array();
+		return in_array( $ip, $ips, true );
+	}
+
+	/**
 	 * Read the `settings['read']['endpoints'][$key]` slot, or `null`
 	 * when the endpoint isn't configured. Centralizes the lookup so
 	 * `check_read_limit` + future read methods share the schema shape.

--- a/includes/security/class-ffc-rate-limit-checker.php
+++ b/includes/security/class-ffc-rate-limit-checker.php
@@ -1174,7 +1174,7 @@ final class RateLimitChecker {
 	 * @return bool
 	 */
 	public static function is_ip_whitelisted( string $ip ): bool {
-		$wl = self::get_settings()['whitelist'] ?? array();
+		$wl  = self::get_settings()['whitelist'] ?? array();
 		$ips = is_array( $wl ) && isset( $wl['ips'] ) && is_array( $wl['ips'] ) ? $wl['ips'] : array();
 		return in_array( $ip, $ips, true );
 	}

--- a/includes/security/class-ffc-rate-limit-checker.php
+++ b/includes/security/class-ffc-rate-limit-checker.php
@@ -1070,4 +1070,117 @@ final class RateLimitChecker {
 
 		return array( 'allowed' => true );
 	}
+
+	/**
+	 * Check the per-read rate limit for a given (IP, endpoint_key) pair.
+	 * Issue #259 — public read endpoints (Calendar REST) need their own
+	 * pool so a scraper that never submits forms doesn't bypass the
+	 * IP-pool circuit breaker.
+	 *
+	 * Thresholds are looked up from `settings['read']['endpoints'][$endpoint_key]`.
+	 * When the endpoint is disabled (or absent from settings) the call
+	 * short-circuits to `allowed=true` so feature stays opt-in per endpoint.
+	 *
+	 * Algorithm matches the existing IP path: minute window via object
+	 * cache + hour window via DB. Cache TTLs mirror the window length
+	 * (60 / 3600 seconds).
+	 *
+	 * @since 6.6.2
+	 * @param string $ip            Client IP.
+	 * @param string $endpoint_key  Endpoint identifier (e.g. `calendar_slots`).
+	 * @return array{allowed: bool, message?: string, reason?: string, wait_seconds?: int}
+	 */
+	public static function check_read_limit( string $ip, string $endpoint_key ): array {
+		$s        = self::get_settings();
+		$endpoint = self::read_endpoint_settings( $s, $endpoint_key );
+		if ( null === $endpoint || empty( $endpoint['enabled'] ) ) {
+			return array( 'allowed' => true );
+		}
+
+		$max_min  = (int) ( $endpoint['max_per_minute'] ?? 0 );
+		$max_hour = (int) ( $endpoint['max_per_hour'] ?? 0 );
+		$message  = (string) ( $s['read']['message'] ?? __( 'Too many requests. Please wait {time}.', 'ffcertificate' ) );
+
+		if ( $max_min > 0 ) {
+			$mk     = 'ffc_rate_read_' . md5( $ip . '|' . $endpoint_key ) . '_minute';
+			$cached = wp_cache_get( $mk, RateLimiter::CACHE_GROUP );
+			$mc     = false !== $cached ? (int) $cached : 0;
+			if ( $mc >= $max_min ) {
+				return array(
+					'allowed'      => false,
+					'reason'       => 'read_minute_limit',
+					'message'      => self::format_message( $message, array( 'time' => __( '1 minute', 'ffcertificate' ) ) ),
+					'wait_seconds' => 60,
+				);
+			}
+		}
+
+		if ( $max_hour > 0 ) {
+			$hk     = 'ffc_rate_read_' . md5( $ip . '|' . $endpoint_key ) . '_hour';
+			$cached = wp_cache_get( $hk, RateLimiter::CACHE_GROUP );
+			$hc     = false !== $cached ? (int) $cached : 0;
+			if ( $hc >= $max_hour ) {
+				return array(
+					'allowed'      => false,
+					'reason'       => 'read_hour_limit',
+					'message'      => self::format_message( $message, array( 'time' => __( '1 hour', 'ffcertificate' ) ) ),
+					'wait_seconds' => 3600,
+				);
+			}
+		}
+
+		return array( 'allowed' => true );
+	}
+
+	/**
+	 * Record a successful read against the per-endpoint counters.
+	 * Increments both the minute and hour cache buckets keyed by
+	 * `(ip, endpoint_key)` plus the underlying `ffc_rate_limits` row
+	 * (via `record_attempt`) so historical scans and the admin log
+	 * tab pick up the same audit trail other rate-limit types use.
+	 *
+	 * @since 6.6.2
+	 * @param string $ip           Client IP.
+	 * @param string $endpoint_key Endpoint identifier.
+	 * @return void
+	 */
+	public static function record_read_attempt( string $ip, string $endpoint_key ): void {
+		$identifier = $ip . '|' . $endpoint_key;
+
+		$mk     = 'ffc_rate_read_' . md5( $identifier ) . '_minute';
+		$cached = wp_cache_get( $mk, RateLimiter::CACHE_GROUP );
+		wp_cache_set( $mk, ( false !== $cached ? (int) $cached : 0 ) + 1, RateLimiter::CACHE_GROUP, 60 );
+
+		$hk     = 'ffc_rate_read_' . md5( $identifier ) . '_hour';
+		$cached = wp_cache_get( $hk, RateLimiter::CACHE_GROUP );
+		wp_cache_set( $hk, ( false !== $cached ? (int) $cached : 0 ) + 1, RateLimiter::CACHE_GROUP, 3600 );
+
+		// Persist the day counter too so the admin "rate-limit log" tab
+		// surfaces read activity alongside the other types. `record_attempt`
+		// already knows the global / ip / email / cpf branches — passing
+		// `'read'` short-circuits all of them and reuses just the day
+		// counter persistence at the end.
+		self::record_attempt( 'read', $identifier );
+	}
+
+	/**
+	 * Read the `settings['read']['endpoints'][$key]` slot, or `null`
+	 * when the endpoint isn't configured. Centralizes the lookup so
+	 * `check_read_limit` + future read methods share the schema shape.
+	 *
+	 * @param array<string, mixed> $settings     Full rate-limit settings array.
+	 * @param string               $endpoint_key Endpoint identifier.
+	 * @return array<string, mixed>|null
+	 */
+	private static function read_endpoint_settings( array $settings, string $endpoint_key ): ?array {
+		$read = $settings['read'] ?? array();
+		if ( ! is_array( $read ) ) {
+			return null;
+		}
+		$endpoints = $read['endpoints'] ?? array();
+		if ( ! is_array( $endpoints ) || ! isset( $endpoints[ $endpoint_key ] ) || ! is_array( $endpoints[ $endpoint_key ] ) ) {
+			return null;
+		}
+		return $endpoints[ $endpoint_key ];
+	}
 }

--- a/includes/security/class-ffc-rate-limiter.php
+++ b/includes/security/class-ffc-rate-limiter.php
@@ -168,6 +168,30 @@ class RateLimiter {
 	}
 
 	/**
+	 * Forwards to {@see RateLimitChecker::check_read_limit()}.
+	 *
+	 * @since 6.6.2
+	 * @param string $ip           Client IP.
+	 * @param string $endpoint_key Endpoint identifier (e.g. `calendar_slots`).
+	 * @return array{allowed: bool, message?: string, reason?: string, wait_seconds?: int}
+	 */
+	public static function check_read_limit( string $ip, string $endpoint_key ): array {
+		return RateLimitChecker::check_read_limit( $ip, $endpoint_key );
+	}
+
+	/**
+	 * Forwards to {@see RateLimitChecker::record_read_attempt()}.
+	 *
+	 * @since 6.6.2
+	 * @param string $ip           Client IP.
+	 * @param string $endpoint_key Endpoint identifier.
+	 * @return void
+	 */
+	public static function record_read_attempt( string $ip, string $endpoint_key ): void {
+		RateLimitChecker::record_read_attempt( $ip, $endpoint_key );
+	}
+
+	/**
 	 * Forwards to {@see RateLimitChecker::check_user_limit()}.
 	 *
 	 * @param int    $user_id WordPress user ID.

--- a/includes/settings/tabs/class-ffc-tab-rate-limit.php
+++ b/includes/settings/tabs/class-ffc-tab-rate-limit.php
@@ -215,6 +215,12 @@ class TabRateLimit extends SettingsTab {
 				'max_per_hour'   => absint( wp_unslash( $_POST['global_max_per_hour'] ?? 1000 ) ),
 				'message'        => sanitize_textarea_field( wp_unslash( $_POST['global_message'] ?? '' ) ),
 			),
+			'read'      => array(
+				'respect_whitelist' => isset( $_POST['read_respect_whitelist'] ),
+				'bypass_logged_in'  => isset( $_POST['read_bypass_logged_in'] ),
+				'message'           => sanitize_textarea_field( wp_unslash( $_POST['read_message'] ?? '' ) ),
+				'endpoints'         => $this->parse_read_endpoints_post(),
+			),
 			'device'    => array(
 				'enabled'                   => isset( $_POST['device_enabled'] ),
 				'max_per_form'              => max( 1, absint( wp_unslash( $_POST['device_max_per_form'] ?? 1 ) ) ),
@@ -269,5 +275,33 @@ class TabRateLimit extends SettingsTab {
         // phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		update_option( 'ffc_rate_limit_settings', $settings );
+	}
+
+	/**
+	 * Parse the per-endpoint read-rate-limit POST fields into the
+	 * `endpoints` sub-array shape `get_settings()` documents. Keys
+	 * are the known endpoint identifiers — anything else POST'd is
+	 * silently ignored (defence in depth against a tampered form).
+	 *
+	 * Each endpoint stores `{enabled, max_per_minute, max_per_hour}`.
+	 * `max_per_minute` / `max_per_hour` accept `0` (= "no per-window
+	 * cap on this axis"); the checker treats `<=0` as "skip this gate".
+	 *
+	 * @since 6.6.2
+	 * @return array<string, array{enabled: bool, max_per_minute: int, max_per_hour: int}>
+	 */
+	private function parse_read_endpoints_post(): array {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified by save_settings() caller.
+		$known = array( 'calendar_slots', 'calendar_list', 'calendar_detail' );
+		$out   = array();
+		foreach ( $known as $key ) {
+			$out[ $key ] = array(
+				'enabled'        => isset( $_POST[ 'read_endpoint_' . $key . '_enabled' ] ),
+				'max_per_minute' => absint( wp_unslash( $_POST[ 'read_endpoint_' . $key . '_max_per_minute' ] ?? 0 ) ),
+				'max_per_hour'   => absint( wp_unslash( $_POST[ 'read_endpoint_' . $key . '_max_per_hour' ] ?? 0 ) ),
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		return $out;
 	}
 }

--- a/includes/settings/tabs/class-ffc-tab-rate-limit.php
+++ b/includes/settings/tabs/class-ffc-tab-rate-limit.php
@@ -128,6 +128,33 @@ class TabRateLimit extends SettingsTab {
 				'show_wait_time'  => true,
 				'countdown_timer' => true,
 			),
+			'read'      => array(
+				'respect_whitelist' => true,
+				'bypass_logged_in'  => true,
+				'message'           => __( 'Too many requests. Please wait {time}.', 'ffcertificate' ),
+				// Per-endpoint thresholds (#259). Keys match the
+				// `endpoint_key` strings the ReadRateLimitGuardTrait
+				// passes through; defaults below are calibrated for the
+				// 3 calendar GETs but new endpoints can append their
+				// own sub-array following the same shape.
+				'endpoints'         => array(
+					'calendar_slots'  => array(
+						'enabled'        => true,
+						'max_per_minute' => 60,
+						'max_per_hour'   => 1000,
+					),
+					'calendar_list'   => array(
+						'enabled'        => true,
+						'max_per_minute' => 30,
+						'max_per_hour'   => 500,
+					),
+					'calendar_detail' => array(
+						'enabled'        => true,
+						'max_per_minute' => 60,
+						'max_per_hour'   => 1000,
+					),
+				),
+			),
 		);
 		return wp_parse_args( get_option( 'ffc_rate_limit_settings', array() ), $defaults );
 	}

--- a/includes/settings/views/ffc-tab-rate-limit.php
+++ b/includes/settings/views/ffc-tab-rate-limit.php
@@ -181,6 +181,74 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 </div>
 
 <div class="card">
+	<h2 class="ffc-icon-shield"><?php esc_html_e( 'Read Endpoints (Public GET)', 'ffcertificate' ); ?></h2>
+	<p class="description">
+		<?php esc_html_e( 'Per-endpoint rate limit for public GET endpoints (e.g. the Calendar shortcode\'s /slots lookup). Prevents scraping while leaving submission limits independent.', 'ffcertificate' ); ?>
+	</p>
+	<table class="form-table" role="presentation"><tbody>
+		<tr><th><?php esc_html_e( 'Respect IP whitelist', 'ffcertificate' ); ?></th><td>
+			<?php
+			\FreeFormCertificate\Admin\AdminUI::render_toggle(
+				array(
+					'name'    => 'read_respect_whitelist',
+					'id'      => 'read_respect_whitelist',
+					'checked' => (bool) ( $ffcertificate_s['read']['respect_whitelist'] ?? true ),
+					'label'   => __( 'IPs listed in the global Whitelist below bypass the read limit', 'ffcertificate' ),
+					'data'    => array( 'ffc-autosave-key' => 'read_respect_whitelist' ),
+				)
+			);
+			?>
+		</td></tr>
+		<tr><th><?php esc_html_e( 'Bypass for logged-in users', 'ffcertificate' ); ?></th><td>
+			<?php
+			\FreeFormCertificate\Admin\AdminUI::render_toggle(
+				array(
+					'name'    => 'read_bypass_logged_in',
+					'id'      => 'read_bypass_logged_in',
+					'checked' => (bool) ( $ffcertificate_s['read']['bypass_logged_in'] ?? true ),
+					'label'   => __( 'Any logged-in WordPress user bypasses the read limit (staff / kiosks signed in to WP)', 'ffcertificate' ),
+					'data'    => array( 'ffc-autosave-key' => 'read_bypass_logged_in' ),
+				)
+			);
+			?>
+		</td></tr>
+		<tr><th><?php esc_html_e( 'Block message', 'ffcertificate' ); ?></th><td>
+			<textarea name="read_message" rows="2" class="large-text" data-ffc-autosave-key="read_message" data-ffc-autosave-debounce="800"><?php echo esc_textarea( (string) ( $ffcertificate_s['read']['message'] ?? '' ) ); ?></textarea>
+			<p class="description"><?php esc_html_e( 'Shown to blocked callers in the 429 response. {time} is replaced with the wait window.', 'ffcertificate' ); ?></p>
+		</td></tr>
+	</tbody></table>
+
+	<?php
+	$ffc_read_endpoints = array(
+		'calendar_slots'  => __( 'Calendar — Slots (GET /calendars/{id}/slots)', 'ffcertificate' ),
+		'calendar_list'   => __( 'Calendar — List (GET /calendars)', 'ffcertificate' ),
+		'calendar_detail' => __( 'Calendar — Detail (GET /calendars/{id})', 'ffcertificate' ),
+	);
+	foreach ( $ffc_read_endpoints as $ffc_ep_key => $ffc_ep_label ) :
+		$ffc_ep = $ffcertificate_s['read']['endpoints'][ $ffc_ep_key ] ?? array( 'enabled' => false, 'max_per_minute' => 0, 'max_per_hour' => 0 );
+		?>
+		<h3 style="margin-top:1.5em;"><?php echo esc_html( $ffc_ep_label ); ?></h3>
+		<table class="form-table" role="presentation"><tbody>
+			<tr><th><?php esc_html_e( 'Enable', 'ffcertificate' ); ?></th><td>
+				<?php
+				\FreeFormCertificate\Admin\AdminUI::render_toggle(
+					array(
+						'name'    => 'read_endpoint_' . $ffc_ep_key . '_enabled',
+						'id'      => 'read_endpoint_' . $ffc_ep_key . '_enabled',
+						'checked' => (bool) $ffc_ep['enabled'],
+						'label'   => __( 'Enforce limit on this endpoint', 'ffcertificate' ),
+						'data'    => array( 'ffc-autosave-key' => 'read_endpoint_' . $ffc_ep_key . '_enabled' ),
+					)
+				);
+				?>
+			</td></tr>
+			<tr><th><?php esc_html_e( 'Max per minute', 'ffcertificate' ); ?></th><td><input type="number" name="read_endpoint_<?php echo esc_attr( $ffc_ep_key ); ?>_max_per_minute" value="<?php echo esc_attr( (string) (int) $ffc_ep['max_per_minute'] ); ?>" min="0" data-ffc-autosave-key="read_endpoint_<?php echo esc_attr( $ffc_ep_key ); ?>_max_per_minute"></td></tr>
+			<tr><th><?php esc_html_e( 'Max per hour', 'ffcertificate' ); ?></th><td><input type="number" name="read_endpoint_<?php echo esc_attr( $ffc_ep_key ); ?>_max_per_hour" value="<?php echo esc_attr( (string) (int) $ffc_ep['max_per_hour'] ); ?>" min="0" data-ffc-autosave-key="read_endpoint_<?php echo esc_attr( $ffc_ep_key ); ?>_max_per_hour"></td></tr>
+		</tbody></table>
+	<?php endforeach; ?>
+</div>
+
+<div class="card">
 	<h2 class="ffc-icon-shield"><?php esc_html_e( 'Device Fingerprint', 'ffcertificate' ); ?></h2>
 	<p class="description"><?php esc_html_e( 'Limit submissions from the same physical device by combining a persistent cookie with multiple browser signals. The "N of M" rule treats two visits as the same device when at least the configured number of non-cookie signals match.', 'ffcertificate' ); ?></p>
 	<p>

--- a/includes/settings/views/ffc-tab-rate-limit.php
+++ b/includes/settings/views/ffc-tab-rate-limit.php
@@ -225,7 +225,11 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 		'calendar_detail' => __( 'Calendar — Detail (GET /calendars/{id})', 'ffcertificate' ),
 	);
 	foreach ( $ffc_read_endpoints as $ffc_ep_key => $ffc_ep_label ) :
-		$ffc_ep = $ffcertificate_s['read']['endpoints'][ $ffc_ep_key ] ?? array( 'enabled' => false, 'max_per_minute' => 0, 'max_per_hour' => 0 );
+		$ffc_ep = $ffcertificate_s['read']['endpoints'][ $ffc_ep_key ] ?? array(
+			'enabled'        => false,
+			'max_per_minute' => 0,
+			'max_per_hour'   => 0,
+		);
 		?>
 		<h3 style="margin-top:1.5em;"><?php echo esc_html( $ffc_ep_label ); ?></h3>
 		<table class="form-table" role="presentation"><tbody>

--- a/tests/Unit/CalendarRestControllerTest.php
+++ b/tests/Unit/CalendarRestControllerTest.php
@@ -68,9 +68,29 @@ class CalendarRestControllerTest extends TestCase {
         $utils_mock->shouldReceive( 'get_user_ip' )->andReturn( '127.0.0.1' )->byDefault();
 
         // RateLimiter alias: every test gets a green light by default.
-        // Individual cases can re-stub `check_ip_limit` via the property.
+        // Individual cases can re-stub `check_read_limit` via the property.
+        // Post-#259 the calendar controller delegates to the per-endpoint
+        // read pool via ReadRateLimitGuardTrait — that path calls
+        // `get_settings()` (for the whitelist/bypass toggles) and
+        // `check_read_limit` (for the actual gate); both stubbed here.
         $this->rate_limiter_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
         $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->andReturn( array( 'allowed' => true ) )->byDefault();
+        $this->rate_limiter_mock->shouldReceive( 'check_read_limit' )->andReturn( array( 'allowed' => true ) )->byDefault();
+        $this->rate_limiter_mock->shouldReceive( 'record_read_attempt' )->byDefault();
+        $this->rate_limiter_mock->shouldReceive( 'get_settings' )->andReturn(
+            array(
+                'whitelist' => array( 'ips' => array() ),
+                'read'      => array( 'respect_whitelist' => true, 'bypass_logged_in' => true ),
+            )
+        )->byDefault();
+        Functions\when( 'is_user_logged_in' )->justReturn( false );
+
+        // The trait also reaches RateLimitChecker::is_ip_whitelisted and
+        // RateLimitLogger::log_attempt — alias-stub both to no-op.
+        $checker_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimitChecker' );
+        $checker_mock->shouldReceive( 'is_ip_whitelisted' )->andReturn( false )->byDefault();
+        $logger_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimitLogger' );
+        $logger_mock->shouldReceive( 'log_attempt' )->byDefault();
     }
 
     protected function tearDown(): void {
@@ -133,12 +153,15 @@ class CalendarRestControllerTest extends TestCase {
     // ------------------------------------------------------------------
 
     public function test_get_calendars_returns_429_when_rate_limit_blocks(): void {
-        $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->once()->andReturn( array(
-            'allowed'      => false,
-            'reason'       => 'ip_hour_limit',
-            'message'      => 'Slow down.',
-            'wait_seconds' => 3600,
-        ) );
+        $this->rate_limiter_mock->shouldReceive( 'check_read_limit' )
+            ->with( Mockery::any(), 'calendar_list' )
+            ->once()
+            ->andReturn( array(
+                'allowed'      => false,
+                'reason'       => 'read_hour_limit',
+                'message'      => 'Slow down.',
+                'wait_seconds' => 3600,
+            ) );
 
         $ctrl    = new CalendarRestController( 'ffc/v1' );
         $request = $this->make_request();
@@ -151,11 +174,14 @@ class CalendarRestControllerTest extends TestCase {
     }
 
     public function test_get_calendar_slots_returns_429_when_rate_limit_blocks(): void {
-        $this->rate_limiter_mock->shouldReceive( 'check_ip_limit' )->once()->andReturn( array(
-            'allowed' => false,
-            'reason'  => 'ip_day_limit',
-            'message' => 'Daily limit reached.',
-        ) );
+        $this->rate_limiter_mock->shouldReceive( 'check_read_limit' )
+            ->with( Mockery::any(), 'calendar_slots' )
+            ->once()
+            ->andReturn( array(
+                'allowed' => false,
+                'reason'  => 'read_minute_limit',
+                'message' => 'Daily limit reached.',
+            ) );
 
         $ctrl    = new CalendarRestController( 'ffc/v1' );
         $request = $this->make_request( array( 'id' => 1, 'date' => '2026-05-20' ) );

--- a/tests/Unit/ReadRateLimitTest.php
+++ b/tests/Unit/ReadRateLimitTest.php
@@ -1,0 +1,196 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Security\RateLimitChecker;
+
+/**
+ * Tests for the per-read rate-limit infrastructure added in #259:
+ *   - RateLimitChecker::check_read_limit() / record_read_attempt()
+ *   - RateLimitChecker::is_ip_whitelisted()
+ *
+ * The trait `ReadRateLimitGuardTrait` is exercised indirectly via
+ * `CalendarRestControllerTest` (which already mocks the public API
+ * the trait delegates to); this file pins the underlying checker
+ * methods.
+ *
+ * @covers \FreeFormCertificate\Security\RateLimitChecker::check_read_limit
+ * @covers \FreeFormCertificate\Security\RateLimitChecker::record_read_attempt
+ * @covers \FreeFormCertificate\Security\RateLimitChecker::is_ip_whitelisted
+ */
+class ReadRateLimitTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var array<string, int> */
+	private array $cache;
+
+	/** @var array<string, mixed> */
+	private array $settings;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->cache    = array();
+		$this->settings = array(
+			'whitelist' => array( 'ips' => array(), 'emails' => array(), 'email_domains' => array(), 'cpfs' => array() ),
+			'read'      => array(
+				'message'   => 'Too many requests. Please wait {time}.',
+				'endpoints' => array(
+					'calendar_slots' => array( 'enabled' => true, 'max_per_minute' => 2, 'max_per_hour' => 10 ),
+					'calendar_list'  => array( 'enabled' => false, 'max_per_minute' => 100, 'max_per_hour' => 1000 ),
+				),
+			),
+		);
+
+		$cache    =& $this->cache;
+		$settings =& $this->settings;
+
+		Functions\when( 'wp_cache_get' )->alias( function ( $key, $group = '' ) use ( &$cache ) {
+			return $cache[ $group . '|' . $key ] ?? false;
+		} );
+		Functions\when( 'wp_cache_set' )->alias( function ( $key, $value, $group = '' ) use ( &$cache ) {
+			$cache[ $group . '|' . $key ] = $value;
+			return true;
+		} );
+		Functions\when( 'get_option' )->alias( function ( $name, $default_value = false ) use ( &$settings ) {
+			if ( 'ffc_rate_limit_settings' === $name ) {
+				return $settings;
+			}
+			return $default_value;
+		} );
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'wp_parse_args' )->alias( function ( $args, $defaults ) {
+			return array_merge( $defaults, is_array( $args ) ? $args : array() );
+		} );
+		Functions\when( 'current_time' )->justReturn( '2026-05-20 12:00:00' );
+		Functions\when( 'absint' )->alias( fn ( $v ) => abs( (int) $v ) );
+
+		// Reset the static settings cache so each test sees its own
+		// `$this->settings` (the checker memoizes the first lookup).
+		$ref = new \ReflectionProperty( RateLimitChecker::class, 'settings_cache' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, null );
+
+		// Minimal wpdb stub — record_read_attempt → record_attempt
+		// → increment_counter writes one row per (type, identifier, day).
+		global $wpdb;
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
+		$wpdb->shouldReceive( 'get_row' )->andReturn( null )->byDefault();
+		$wpdb->shouldReceive( 'get_var' )->andReturn( null )->byDefault();
+		$wpdb->shouldReceive( 'insert' )->andReturn( 1 )->byDefault();
+		$wpdb->shouldReceive( 'query' )->andReturn( 1 )->byDefault();
+		$wpdb->shouldReceive( 'update' )->andReturn( 1 )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// check_read_limit()
+	// ------------------------------------------------------------------
+
+	public function test_check_read_limit_allows_when_endpoint_disabled(): void {
+		$result = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_list' );
+
+		$this->assertTrue( $result['allowed'] );
+	}
+
+	public function test_check_read_limit_allows_when_endpoint_key_unknown(): void {
+		$result = RateLimitChecker::check_read_limit( '1.1.1.1', 'nonexistent_key' );
+
+		$this->assertTrue( $result['allowed'] );
+	}
+
+	public function test_check_read_limit_allows_below_threshold(): void {
+		$result = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_slots' );
+
+		$this->assertTrue( $result['allowed'] );
+	}
+
+	public function test_check_read_limit_blocks_at_minute_threshold(): void {
+		// Two prior hits → next one trips the per-minute cap (= 2).
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+
+		$result = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_slots' );
+
+		$this->assertFalse( $result['allowed'] );
+		$this->assertSame( 'read_minute_limit', $result['reason'] );
+		$this->assertSame( 60, $result['wait_seconds'] );
+	}
+
+	public function test_check_read_limit_isolates_per_endpoint_key(): void {
+		// Saturating slots shouldn't affect a (hypothetically enabled) detail key.
+		$this->settings['read']['endpoints']['calendar_detail'] = array( 'enabled' => true, 'max_per_minute' => 5, 'max_per_hour' => 100 );
+
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+
+		$slots_result  = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_slots' );
+		$detail_result = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_detail' );
+
+		$this->assertFalse( $slots_result['allowed'] );
+		$this->assertTrue( $detail_result['allowed'] );
+	}
+
+	public function test_check_read_limit_isolates_per_ip(): void {
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+		RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+
+		$blocked_for_a = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_slots' );
+		$allowed_for_b = RateLimitChecker::check_read_limit( '2.2.2.2', 'calendar_slots' );
+
+		$this->assertFalse( $blocked_for_a['allowed'] );
+		$this->assertTrue( $allowed_for_b['allowed'] );
+	}
+
+	public function test_check_read_limit_skips_minute_gate_when_threshold_zero(): void {
+		// max_per_minute=0 means "no per-minute cap"; the hour gate still applies.
+		$this->settings['read']['endpoints']['calendar_slots']['max_per_minute'] = 0;
+
+		// 12 attempts shouldn't trip the (disabled) minute gate; would trip
+		// the per-hour cap (10) on the 11th.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimitChecker::record_read_attempt( '1.1.1.1', 'calendar_slots' );
+		}
+
+		$result = RateLimitChecker::check_read_limit( '1.1.1.1', 'calendar_slots' );
+
+		$this->assertFalse( $result['allowed'] );
+		$this->assertSame( 'read_hour_limit', $result['reason'] );
+	}
+
+	// ------------------------------------------------------------------
+	// is_ip_whitelisted()
+	// ------------------------------------------------------------------
+
+	public function test_is_ip_whitelisted_returns_false_when_not_listed(): void {
+		$this->settings['whitelist']['ips'] = array( '10.0.0.1' );
+
+		$this->assertFalse( RateLimitChecker::is_ip_whitelisted( '1.1.1.1' ) );
+	}
+
+	public function test_is_ip_whitelisted_returns_true_when_listed(): void {
+		$this->settings['whitelist']['ips'] = array( '10.0.0.1', '1.1.1.1' );
+
+		$this->assertTrue( RateLimitChecker::is_ip_whitelisted( '1.1.1.1' ) );
+	}
+
+	public function test_is_ip_whitelisted_returns_false_when_list_missing(): void {
+		unset( $this->settings['whitelist'] );
+
+		$this->assertFalse( RateLimitChecker::is_ip_whitelisted( '1.1.1.1' ) );
+	}
+}


### PR DESCRIPTION
Implementa o per-read rate-limit pool conforme as 7 decisões de design tomadas em #259.

## Decisões implementadas

| # | Decisão | Implementação |
|---|---|---|
| 1 | Trait extensível | `ReadRateLimitGuardTrait::guard_read($endpoint_key)` em `includes/api/` |
| 2 | Settings-driven | Nova seção "Read Endpoints" na tab Rate Limit; defaults sensatos no `defaults()` |
| 3 | Fixed-window | Reusa pattern do IP path: minute cache (TTL=60s) + hour cache (TTL=3600s) |
| 4 | 429 + Retry-After + log | WP_Error com `status=429` e `headers.Retry-After`; entry em `ffc_rate_limit_logs` via `RateLimitLogger::log_attempt('read', …, 'blocked', …)` |
| 5 | `type='read'` em `ffc_rate_limits` | Sem migration — coluna já é VARCHAR(20) |
| 6 | Tier por endpoint | 3 endpoint keys (`calendar_slots`/`calendar_list`/`calendar_detail`) cada com `enabled`/`max_per_minute`/`max_per_hour` |
| 7 | Tudo configurável | `respect_whitelist` (toggle global) + `bypass_logged_in` (toggle global) + thresholds per-endpoint + message |

## Defaults (admin pode ajustar no UI)

| Endpoint | per minute | per hour |
|---|---:|---:|
| `calendar_slots` (alvo principal de scraping) | 60 | 1000 |
| `calendar_list` | 30 | 500 |
| `calendar_detail` | 60 | 1000 |

`respect_whitelist=true` + `bypass_logged_in=true` por default — kiosks com refresh curto + IPs whitelisted ficam de fora.

## Estrutura — 5 commits

1. **Settings: defaults** — `class-ffc-tab-rate-limit.php::get_settings()` ganha a chave `'read'` com os 3 endpoint slots.
2. **Checker: API** — `RateLimitChecker::check_read_limit($ip, $endpoint_key)` + `record_read_attempt($ip, $endpoint_key)`. Facade `RateLimiter::check_read_limit()`/`record_read_attempt()`.
3. **Trait: `ReadRateLimitGuardTrait`** + `RateLimitChecker::is_ip_whitelisted(string $ip): bool` (public IP-only branch do whitelist helper interno).
4. **Wire-up: `CalendarRestController`** — `use ReadRateLimitGuardTrait;` e os 3 endpoints passam endpoint keys distintos pro `rate_limit_guard()`. O `rate_limit_guard()` antigo (que só lia o IP pool sem alimentar) foi substituído.
5. **UI + tests** — nova card "Read Endpoints (Public GET)" no settings view com toggles + thresholds per-endpoint + parser `parse_read_endpoints_post()`. 10 cases em `ReadRateLimitTest`.

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4569/4569** verde
  - **+10 cases novos** em `ReadRateLimitTest`:
    - check_read_limit: allows quando disabled / key desconhecida / abaixo do threshold
    - blocks no minute threshold (com reason + wait_seconds corretos)
    - isolation per-endpoint key + per-IP
    - skip do minute gate quando max=0 (cap apenas hourly)
    - is_ip_whitelisted: false sem match / true com match / false sem lista
  - 4 cases em `CalendarRestControllerTest` atualizados pra novo nome (`check_read_limit` em vez de `check_ip_limit`); restante intocado.
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] Settings > Rate Limit → card "Read Endpoints" aparece, toggles + thresholds gravam via autosave.
- [ ] `curl /calendars/1/slots?date=...` repetido > 60 vezes em 1 minuto → 429 com `Retry-After: 60`.
- [ ] Logged in (admin) → mesmo flood não bloqueia (bypass_logged_in=true por default).
- [ ] IP em settings.whitelist.ips → flood não bloqueia.
- [ ] Disable um endpoint individual → flood naquele endpoint não bloqueia (mas outros continuam protegidos).

## Critério de aceite (do #259)

- [x] 7 decisões batidas
- [x] Implementação não-breaking (calendar continua respondendo green para tráfego legítimo nos thresholds default)
- [x] Cobertura de testes
- [x] Independente de outros bundles

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_