### PR TITLE
Fix: persist original time_start on early-open + render in metabox (#350)

### DIFF
--- a/includes/admin/class-ffc-form-editor-public-csv-download-metabox.php
+++ b/includes/admin/class-ffc-form-editor-public-csv-download-metabox.php
@@ -441,6 +441,8 @@ class FormEditorPublicCsvDownloadMetabox {
 		$end_ts     = \FreeFormCertificate\Security\Geofence::get_form_end_timestamp( $post->ID );
 		$now        = time();
 		$enabled_ok = '1' === $enabled && '' !== $hash;
+		$opened_at  = (string) get_post_meta( $post->ID, \FreeFormCertificate\Frontend\EarlyOpenAction::META_OPENED_AT, true );
+		$opened_frm = (string) get_post_meta( $post->ID, \FreeFormCertificate\Frontend\EarlyOpenAction::META_OPENED_FROM, true );
 
 		// Status string mirrors the eligibility branches in EarlyOpenAction.
 		if ( ! $enabled_ok ) {
@@ -452,6 +454,13 @@ class FormEditorPublicCsvDownloadMetabox {
 		} elseif ( null === $start_ts ) {
 			$status_label = __( 'Set a start date in the Geolocation & Date/Time metabox to enable this action.', 'ffcertificate' );
 			$status_kind  = 'warning';
+		} elseif ( '' !== $opened_at ) {
+			$status_label = sprintf(
+				/* translators: %s: original time_start value (HH:MM). */
+				__( 'Already started early once for this form (was %s). Edit time_start manually below if you need to advance further.', 'ffcertificate' ),
+				'' !== $opened_frm ? $opened_frm : '—'
+			);
+			$status_kind = 'info';
 		} elseif ( null !== $end_ts && $end_ts <= $now ) {
 			$status_label = __( 'This form has already ended — early-start no longer applies.', 'ffcertificate' );
 			$status_kind  = 'info';

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -44,8 +44,8 @@ class FormEditorSaveHandler {
 		//
 		// Both `ExtendEndAction` and `EarlyOpenAction` persist a pair
 		// of metas the first time their respective action fires:
-		//   - `META_POSTPONED_AT` / `META_POSTPONED_FROM` (extend end)
-		//   - `META_OPENED_AT`    / `META_OPENED_FROM`    (early open)
+		// - `META_POSTPONED_AT` / `META_POSTPONED_FROM` (extend end)
+		// - `META_OPENED_AT`    / `META_OPENED_FROM`    (early open)
 		// — after which `is_eligible()` returns `already_postponed` /
 		// `already_opened` and the frontend button disappears.
 		//

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -42,23 +42,21 @@ class FormEditorSaveHandler {
 
 		// Reset the public-operator one-shot guards.
 		//
-		// `ExtendEndAction` persists `_ffc_csv_public_end_postponed_at`
-		// (Unix timestamp) the first time an operator postpones the
-		// close, after which `is_eligible()` returns `already_postponed`
-		// and the frontend button disappears. An admin edit of the form
-		// is the natural cycle boundary — whatever the admin is now
-		// configuring supersedes the prior operator state, so we wipe
-		// the one-shot pair and let the operator postpone again within
-		// the new window.
+		// Both `ExtendEndAction` and `EarlyOpenAction` persist a pair
+		// of metas the first time their respective action fires:
+		//   - `META_POSTPONED_AT` / `META_POSTPONED_FROM` (extend end)
+		//   - `META_OPENED_AT`    / `META_OPENED_FROM`    (early open)
+		// — after which `is_eligible()` returns `already_postponed` /
+		// `already_opened` and the frontend button disappears.
 		//
-		// `EarlyOpenAction` does NOT have a persistent flag — its
-		// "one-shot" is structural (once `date_start` moves into the
-		// past, `is_eligible()` returns `already_started`). Pushing
-		// `date_start` back into the future via the metabox naturally
-		// re-enables the early-open button without needing a reset
-		// hook here.
+		// An admin edit of the form is the natural cycle boundary —
+		// whatever the admin is now configuring supersedes the prior
+		// operator state, so we wipe both pairs and let the operator
+		// postpone / advance again within the new window.
 		delete_post_meta( $post_id, \FreeFormCertificate\Frontend\ExtendEndAction::META_POSTPONED_AT );
 		delete_post_meta( $post_id, \FreeFormCertificate\Frontend\ExtendEndAction::META_POSTPONED_FROM );
+		delete_post_meta( $post_id, \FreeFormCertificate\Frontend\EarlyOpenAction::META_OPENED_AT );
+		delete_post_meta( $post_id, \FreeFormCertificate\Frontend\EarlyOpenAction::META_OPENED_FROM );
 
 		// 1. Save Form Fields.
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- isset()/is_array() existence and type checks only.

--- a/includes/frontend/class-ffc-early-open-action.php
+++ b/includes/frontend/class-ffc-early-open-action.php
@@ -41,6 +41,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 class EarlyOpenAction {
 
 	/**
+	 * One-shot persistence. Stores the Unix timestamp of when the
+	 * early-open was applied. Presence = "already opened early once".
+	 *
+	 * Mirrors {@see ExtendEndAction::META_POSTPONED_AT} so the two
+	 * one-shot actions (advance start ↔ delay close) have symmetric
+	 * audit trails surfaced in the admin metabox (#350).
+	 *
+	 * @since 6.6.2
+	 */
+	public const META_OPENED_AT = '_ffc_csv_public_start_opened_at';
+
+	/**
+	 * Snapshot of the `time_start` value before the early-open rewrite
+	 * — kept for the audit trail surfaced in the admin metabox
+	 * ("Already started early once for this form (was %s)").
+	 *
+	 * Mirrors {@see ExtendEndAction::META_POSTPONED_FROM} (#350).
+	 *
+	 * @since 6.6.2
+	 */
+	public const META_OPENED_FROM = '_ffc_csv_public_start_opened_from';
+
+	/**
 	 * Inspect the form's current state + supplied hash and return
 	 * whether the early-open action can run.
 	 *
@@ -59,6 +82,7 @@ class EarlyOpenAction {
 	 *                                          tag for telemetry / UX
 	 *                                          (`unknown_form`, `csv_disabled`,
 	 *                                          `bad_hash`, `early_open_disabled`,
+	 *                                          `already_opened`,
 	 *                                          `datetime_disabled`, `no_start_date`,
 	 *                                          `not_today`, `already_started`,
 	 *                                          `already_ended`).
@@ -95,6 +119,18 @@ class EarlyOpenAction {
 			return array(
 				'ok'     => false,
 				'reason' => 'early_open_disabled',
+			);
+		}
+
+		// One-shot guard — matches the `already_postponed` branch in
+		// ExtendEndAction. Once the form has been opened early, the
+		// action refuses to fire again (#350); the admin can still
+		// edit `time_start` manually below if a further advance is
+		// truly needed.
+		if ( '' !== (string) get_post_meta( $form_id, self::META_OPENED_AT, true ) ) {
+			return array(
+				'ok'     => false,
+				'reason' => 'already_opened',
 			);
 		}
 
@@ -209,6 +245,14 @@ class EarlyOpenAction {
 		$new_time_start         = $now_time;
 
 		update_post_meta( $form_id, '_ffc_geofence_config', $geofence );
+
+		// Persist the snapshot so the admin metabox can render the
+		// "Already started early once (was %s)" status, and the
+		// `already_opened` eligibility guard above can short-circuit
+		// repeat triggers. Mirrors ExtendEndAction's META_POSTPONED_*
+		// pair (#350).
+		update_post_meta( $form_id, self::META_OPENED_AT, time() );
+		update_post_meta( $form_id, self::META_OPENED_FROM, $original_time_start );
 
 		// Invalidate the plugin's own object cache + page-cache plugins.
 		// The `ffc_form` CPT is registered with `'public' => false`, so

--- a/tests/Unit/EarlyOpenActionTest.php
+++ b/tests/Unit/EarlyOpenActionTest.php
@@ -303,4 +303,53 @@ class EarlyOpenActionTest extends TestCase {
         // Original geofence is untouched.
         $this->assertArrayNotHasKey( 'date_start', $this->meta_store[1]['_ffc_geofence_config'] );
     }
+
+    // ------------------------------------------------------------------
+    // META_OPENED_AT / META_OPENED_FROM snapshot — issue #350
+    // ------------------------------------------------------------------
+
+    public function test_execute_persists_opened_at_and_opened_from_metas(): void {
+        $this->configure_eligible_form( 1, 'h' );
+        $this->stub_formcache();
+
+        $r = EarlyOpenAction::execute( 1, 'h' );
+
+        $this->assertTrue( $r['ok'] );
+        // Both metas should now be set on the form row.
+        $this->assertArrayHasKey( EarlyOpenAction::META_OPENED_AT, $this->meta_store[1] );
+        $this->assertArrayHasKey( EarlyOpenAction::META_OPENED_FROM, $this->meta_store[1] );
+        $this->assertGreaterThan( 0, (int) $this->meta_store[1][ EarlyOpenAction::META_OPENED_AT ] );
+        // META_OPENED_FROM is the original `time_start` before the flip.
+        $this->assertSame( '23:00', $this->meta_store[1][ EarlyOpenAction::META_OPENED_FROM ] );
+    }
+
+    public function test_is_eligible_returns_already_opened_when_meta_set(): void {
+        $this->configure_eligible_form( 1, 'h' );
+        // Simulate a prior run by setting the META_OPENED_AT meta.
+        $this->meta_store[1][ EarlyOpenAction::META_OPENED_AT ] = time();
+
+        $r = EarlyOpenAction::is_eligible( 1, 'h' );
+
+        $this->assertFalse( $r['ok'] );
+        $this->assertSame( 'already_opened', $r['reason'] );
+    }
+
+    public function test_execute_short_circuits_when_already_opened(): void {
+        // Both opens-in-a-row should be rejected by the new guard —
+        // first one fires normally, second one returns `already_opened`
+        // without touching `time_start` again.
+        $this->configure_eligible_form( 1, 'h' );
+        $this->stub_formcache();
+
+        $first  = EarlyOpenAction::execute( 1, 'h' );
+        $this->assertTrue( $first['ok'] );
+
+        $second_time_start_before = $this->meta_store[1]['_ffc_geofence_config']['time_start'];
+        $second                   = EarlyOpenAction::execute( 1, 'h' );
+
+        $this->assertFalse( $second['ok'] );
+        $this->assertSame( 'already_opened', $second['reason'] );
+        // time_start untouched on the second call.
+        $this->assertSame( $second_time_start_before, $this->meta_store[1]['_ffc_geofence_config']['time_start'] );
+    }
 }


### PR DESCRIPTION
Corrige o bug do #350 — status "Início Antecipado" no metabox do form não mostrava o horário anterior porque `EarlyOpenAction::execute()` sobrescrevia `geofence['time_start']` sem persistir o valor pré-flip como post-meta. Só o audit log mantinha. O renderer não tinha de onde ler.

## Root cause

Assimetria entre as duas actions one-shot:

| Aspecto | `ExtendEndAction` (Fechamento Adiado) ✅ | `EarlyOpenAction` (Início Antecipado) ❌ |
|---|---|---|
| Constantes META | `META_POSTPONED_AT` + `META_POSTPONED_FROM` | ausentes |
| Persiste tempo original | sim (linha 210) | apenas audit log (linha 233) |
| Branch "já aplicado" em `is_eligible()` | linha 153 | ausente |
| Render "was %s" no metabox | linhas 525-531 | ausente |

## Mudanças (4 arquivos, simétrico ao extend-end)

### `includes/frontend/class-ffc-early-open-action.php`

- 2 constantes públicas novas:
  - `META_OPENED_AT = '_ffc_csv_public_start_opened_at'`
  - `META_OPENED_FROM = '_ffc_csv_public_start_opened_from'`
- `execute()` persiste ambos via `update_post_meta` logo após o rewrite do `time_start`
- `is_eligible()` ganha branch `already_opened` (refusa segundo trigger)
- Docblock dos reasons atualizado

### `includes/admin/class-ffc-form-editor-public-csv-download-metabox.php`

- `render_start_form_early_status()` lê os metas novos
- Branch "Already started early once for this form (was %s)..." (espelha 525-531 do extend-end)

### `includes/admin/class-ffc-form-editor-save-handler.php`

- Reset block agora apaga os 4 metas one-shot (2 do delay + 2 do early-open) no save administrativo
- Comentário que dizia "EarlyOpenAction does NOT have a persistent flag" atualizado pra refletir a nova simetria

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` → **4572/4572** verde
  - **+3 cases** em `EarlyOpenActionTest`:
    - `test_execute_persists_opened_at_and_opened_from_metas` — confirma que ambos metas ficam set após execute
    - `test_is_eligible_returns_already_opened_when_meta_set` — confirma o novo guard
    - `test_execute_short_circuits_when_already_opened` — confirma que segundo trigger não sobrescreve
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist includes/` → clean
- [x] `vendor/bin/phpstan analyze includes/` → clean

Validação manual sugerida:
- [ ] Form com `time_start='09:00'` configurado pra amanhã, no dia anterior.
- [ ] Operador antecipa hoje (via botão público) → `time_start` vira a hora atual.
- [ ] Admin reabre o form no editor → seção "Start Form Early — status" agora mostra **"Already started early once for this form (was 09:00). Edit time_start manually below if you need to advance further."**
- [ ] Botão público desaparece (guard `already_opened` no `is_eligible()`).
- [ ] Admin salva o form (qualquer save) → os metas one-shot são limpos e o botão volta a aparecer no próximo ciclo.

Fecha #350.

https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ipRSGrFLqoToWrGAZLkNt)_