### PR TITLE
6.6.2.1 — cache-bust-only release after #353 + #354 (4th-segment convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [6.6.3] (2026-05-20)
+## [6.6.2.1] (2026-05-20)
 
-Patch release. Bumps `FFC_VERSION` so the asset cache key `?ver=…`
-changes and browsers / CDNs re-download the `.min.js` and `.min.css`
-that were modified by PRs #353 (stale-nonce fix) and #354 (success
-card auth-code wrap + PT-BR translations).
+Cache-bust-only release — no source code changes. Bumps `FFC_VERSION`
+so the asset cache key `?ver=…` rotates and browsers / CDNs re-download
+the `.min.js` and `.min.css` that were modified by PRs #353
+(stale-nonce fix) and #354 (success-card auth-code wrap + PT-BR
+translations) without their own version bumps.
+
+**Versioning convention introduced here**: when a release exists only
+to invalidate asset caches (no functional change beyond what the
+previous version already shipped on disk), append a 4th segment to
+the prior version instead of consuming a fresh patch number. So a
+"real" patch goes `6.6.2 → 6.6.3`, but a cache-bust-only sibling of
+6.6.2 goes `6.6.2 → 6.6.2.1`. Future cache-bust-only siblings of
+6.6.3 would be `6.6.3.1`, `6.6.3.2`, etc.
 
 ### Fixed
 
@@ -25,9 +34,9 @@ card auth-code wrap + PT-BR translations).
   the query string is invisible to those caches, so visitors kept
   hitting the original snapshot-nonce code path and seeing
   "A verificação de segurança falhou." even though the source on
-  disk had the getter fix. Bumping `FFC_VERSION` to `6.6.3` flips
-  every enqueued script and stylesheet to `?ver=6.6.3` and forces a
-  re-fetch.
+  disk had the getter fix. Bumping `FFC_VERSION` to `6.6.2.1` flips
+  every enqueued script and stylesheet to `?ver=6.6.2.1` and forces
+  a re-fetch.
 - **Same applies to PR #354's CSS / template / translation changes**
   — `ffc-frontend.min.css` and the success-card layout would
   otherwise stay broken on cached clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.3] (2026-05-20)
+
+Patch release. Bumps `FFC_VERSION` so the asset cache key `?ver=…`
+changes and browsers / CDNs re-download the `.min.js` and `.min.css`
+that were modified by PRs #353 (stale-nonce fix) and #354 (success
+card auth-code wrap + PT-BR translations).
+
+### Fixed
+
+- **Stale-nonce fix from PR #353 wasn't reaching cached clients** —
+  iOS Safari (and CDN edges in front of LiteSpeed / Varnish / WP
+  Rocket) keep `ffc-core.min.js?ver=6.6.2` pinned in their HTTP
+  cache. Re-saving the file content on the origin without changing
+  the query string is invisible to those caches, so visitors kept
+  hitting the original snapshot-nonce code path and seeing
+  "A verificação de segurança falhou." even though the source on
+  disk had the getter fix. Bumping `FFC_VERSION` to `6.6.3` flips
+  every enqueued script and stylesheet to `?ver=6.6.3` and forces a
+  re-fetch.
+- **Same applies to PR #354's CSS / template / translation changes**
+  — `ffc-frontend.min.css` and the success-card layout would
+  otherwise stay broken on cached clients.
+
+---
+
 ## [6.6.2] (2026-05-20)
 
 Public certificate form — user-messaging sweep (PR #352). Six-sprint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,44 @@ Use `claude/<short-kebab-description>`. Examples in main history:
 `claude/csv-import-normalize-cpf-rf`. The remote refuses pushes to
 `main` directly; always go through a PR.
 
+## Versioning
+
+Three places carry the plugin version and must stay in sync:
+
+1. `ffcertificate.php` plugin header — `* Version: X.Y.Z`. Parsed by
+   WordPress core BEFORE PHP runs, so it must be a literal string.
+2. `ffcertificate.php` PHP constant — `define( 'FFC_VERSION', 'X.Y.Z' )`.
+   Source of `?ver=…` on every `wp_enqueue_*` call.
+3. `readme.txt` `Stable tag: X.Y.Z`. Parsed by WordPress.org before
+   PHP runs; also a literal string.
+
+When changing the version, update all three in the same commit.
+
+### Patch vs. cache-bust-only releases
+
+- A "real" patch release (any source-code change) consumes the next
+  patch number: `6.6.2 → 6.6.3`.
+- A **cache-bust-only release** (no functional change — exists purely
+  to rotate the `?ver=…` asset cache key after a prior PR shipped an
+  updated `.min.js` / `.min.css` without bumping the version) uses a
+  4th segment appended to the prior version: `6.6.2 → 6.6.2.1`. The
+  next cache-bust sibling of the same minor would be `6.6.2.2`, and
+  so on. WordPress's `version_compare()` and the plugin update flow
+  both handle 4-segment versions without special-casing.
+- Reason for the convention: a cache-bust release carries no new
+  user-visible behavior, only a key rotation. Burning a real patch
+  number on it would imply meaningful changes that aren't there.
+
+### When to bump
+
+Any PR that touches a bundled asset file (`assets/**/*.min.js`,
+`assets/**/*.min.css`, `templates/**.php`, or
+`languages/*.l10n.php` / `.mo`) MUST bump `FFC_VERSION` in the same
+PR — otherwise iOS Safari, LiteSpeed / Varnish / WP Rocket, and CDN
+edges keep serving the pre-PR bundle from cache. The
+"Verify minified assets are up to date" CI job catches build
+freshness but does NOT enforce the version bump.
+
 ## What not to do
 
 - Do not amend or rewrite published commits (force-push reserved for

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.2
+ * Version:            6.6.3
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.2' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.3' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.3
+ * Version:            6.6.2.1
  * Requires PHP:       8.1
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.3' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.2.1' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.2
+Stable tag: 6.6.3
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.3
+Stable tag: 6.6.2.1
 Requires PHP: 8.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

iOS Safari visitor reported that the "Security check failed" fix from
PR #353 was not taking effect — the symptom persisted on mobile. After
investigation, the bug is in the source AND fixed in the source, but
the cache key didn't change so cached clients keep getting served the
pre-fix `.min.js`:

```php
wp_enqueue_script('ffc-core', URL, deps, FFC_VERSION, true);
// → ffc-core.min.js?ver=6.6.2
```

Both PR #353 and PR #354 modified bundled assets (`ffc-core.min.js`,
`ffc-frontend.min.css`, `submission-success.php`, the .po / .mo /
.l10n.php trio) but neither bumped `FFC_VERSION`. The `?ver=` query
string IS the cache key for every browser HTTP cache, every CDN edge,
and every page-cache plugin. Without a bump:

- iOS Safari pins `ffc-core.min.js?ver=6.6.2` aggressively, even
  across hard reloads;
- LiteSpeed / Varnish / WP Rocket / hosting CDNs treat the same
  query string as a stable key and only refresh on TTL expiry;
- bfcache replays the cached DOM + scripts.

Bumping the version flips every `wp_enqueue_*` call to a brand-new
URL → mandatory re-fetch → fresh `ffc-core.min.js` with the getter,
fresh `ffc-frontend.min.css` with the unwrapped auth code, fresh
PT-BR translations.

## Versioning convention introduced (per user feedback)

This release exists solely to rotate the asset cache key — no source
code change beyond what 6.6.2 already shipped on disk. A "real" patch
would consume `6.6.2 → 6.6.3`, but a cache-bust-only sibling of 6.6.2
gets a 4th segment instead: `6.6.2 → 6.6.2.1`. Next cache-bust sibling
would be `6.6.2.2`, etc. WordPress's `version_compare()` handles
4-segment versions natively (`'6.6.2.1' > '6.6.2'` and `'6.6.2.1' <
'6.6.3'`).

The convention is documented in CLAUDE.md so future PRs follow the
same pattern, alongside a new contract: **any PR that touches a
bundled asset file must bump the version in the same PR** (the
"Verify minified assets are up to date" CI job catches build
freshness but not the version-bump-on-change rule).

**No source code changes.** Plugin header + `FFC_VERSION` + readme.txt
stable tag + CHANGELOG + CLAUDE.md only.

## Test plan

- [x] PHPUnit / Vitest unchanged from main (915 / 4579 pass).
- [x] PHPCS clean on `ffcertificate.php`.
- [x] CHANGELOG: new `## [6.6.2.1]` section documenting both the
      cache-busting patch and the new versioning convention.
- [x] `version_compare()` sanity-check: `6.6.2.1 > 6.6.2`,
      `6.6.2.1 < 6.6.3`.
- [ ] Post-merge in iOS Safari: open the form on a previously-visited
      site, submit, expect success.

## Possible follow-up

Collapse the 3 version sources to 2 by auto-deriving `FFC_VERSION`
from the plugin header via `get_file_data()`. Discussion in the
PR #355 comment thread — adds a tiny boot-time file read, so left
as a separate decision rather than bundled here.

https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn