### PR TITLE
6.6.3 (cont.) — extend stale-nonce auto-recovery to verification endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,29 @@ just stale code in the client.
 
 ### Fixed
 
-- **Server-side stale-nonce auto-recovery on form submission.** When
-  `wp_verify_nonce()` rejects the submitted nonce, the response now
-  includes `refresh_nonce: true` + `new_nonce: '<fresh>'` alongside
-  the existing error message. The fresh nonce is bound to the
-  visitor's current session cookie via `wp_create_nonce()`, so an
-  attacker who can't present a valid cookie can't use it.
+- **Server-side stale-nonce auto-recovery on form submission AND
+  certificate verification.** When `wp_verify_nonce()` rejects, both
+  `FormProcessor::handle_submission_ajax()` and
+  `VerificationHandler::handle_verification_ajax()` now respond with
+  `refresh_nonce: true` + `new_nonce: '<fresh>'` alongside the
+  existing error message. Both endpoints share the same
+  `ffc_frontend_nonce` action and the same iOS / cache failure modes,
+  so they get the same treatment. (Verification also switches from
+  `check_ajax_referer()` — which `wp_die()`s with 403 on failure —
+  to explicit `wp_verify_nonce()` so the client can read the
+  structured error.) The fresh nonce is bound to the visitor's
+  current session cookie via `wp_create_nonce()`, so an attacker
+  who can't present a valid cookie can't use it.
 - **Client-side single-retry on FFC.request.** When a request comes
   back with `refresh_nonce` flagged, `FFC.request` updates
   `window.ffc_ajax.nonce` (the live-getter from 6.6.2 picks it up
   automatically) and re-issues the same call exactly once. An
   `options._ffcNonceRetried` guard prevents ping-pong. The user
   never sees the "Security check failed" message in the common
-  recoverable cases.
+  recoverable cases. Generic: every endpoint that responds with
+  `refresh_nonce` benefits — adding the treatment to other nonce
+  checks (self-scheduling AJAX, public CSV download) is now a
+  server-side-only change.
 
 ### Why this safety net is needed even after the 6.6.2.1 cache-bust
 
@@ -62,9 +72,11 @@ one applies.
   pinning the retry contract (updates `ffc_ajax.nonce`, retries
   once, no retry without `refresh_nonce`, no retry without
   `new_nonce`, preserves the final error payload).
-- PHPUnit: `FormProcessorNonceRecoveryTest` asserts the server
-  payload includes `refresh_nonce: true` + a non-empty `new_nonce`
-  when `wp_verify_nonce()` returns false.
+- PHPUnit: `FormProcessorNonceRecoveryTest` +
+  `VerificationHandlerNonceRecoveryTest` each assert that the
+  server payload includes `refresh_nonce: true` + a non-empty
+  `new_nonce` when `wp_verify_nonce()` returns false on the
+  respective endpoint.
 
 ---
 

--- a/includes/frontend/class-ffc-verification-handler.php
+++ b/includes/frontend/class-ffc-verification-handler.php
@@ -747,9 +747,27 @@ class VerificationHandler {
 	 * Handle certificate verification via AJAX (manual - with captcha)
 	 */
 	public function handle_verification_ajax(): void {
-		check_ajax_referer( 'ffc_frontend_nonce', 'nonce' );
+		// 6.6.3 — explicit wp_verify_nonce with stale-nonce auto-recovery.
+		// Was check_ajax_referer( 'ffc_frontend_nonce', 'nonce' ), which
+		// wp_die()s with a 403 on stale-nonce — leaving cached-HTML / iOS
+		// Safari visitors stuck. Same root causes as the form-submission
+		// path covered in form-processor.php: cached page nonces from
+		// another visitor, Safari ITP / Private Relay rotating cookies,
+		// ffc-dynamic-fragments silently failing to refresh. The fresh
+		// nonce is keyed to the current session cookie, so FFC.request
+		// can transparently retry once via its existing refresh_nonce
+		// branch.
+		if ( ! wp_verify_nonce( Utils::get_post_string( 'nonce' ), 'ffc_frontend_nonce' ) ) {
+			wp_send_json_error(
+				array(
+					'message'       => __( 'Security check failed. Please refresh the page.', 'ffcertificate' ),
+					'refresh_nonce' => true,
+					'new_nonce'     => wp_create_nonce( 'ffc_frontend_nonce' ),
+				)
+			);
+		}
 
-        // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above via check_ajax_referer.
+        // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above via wp_verify_nonce.
 
 		// Validate honeypot + captcha via centralised service.
 		$security_check = \FreeFormCertificate\Core\SecurityService::validate_security_fields( $_POST );

--- a/tests/Unit/VerificationHandlerNonceRecoveryTest.php
+++ b/tests/Unit/VerificationHandlerNonceRecoveryTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Frontend\VerificationHandler;
+use FreeFormCertificate\Submissions\SubmissionHandler;
+
+/**
+ * 6.6.3 — pins the stale-nonce auto-recovery contract on the
+ * verification AJAX endpoint. Same shape as form-processor: when
+ * wp_verify_nonce() rejects, the response MUST include
+ * `refresh_nonce: true` + `new_nonce: '<hash>'` so the client
+ * (FFC.request in ffc-core.js) can transparently retry once.
+ *
+ * Without this, cached pages / iOS Safari sessions / failed
+ * dynamic-fragments would all leave the certificate-verification
+ * shortcode stuck at "Security check failed" — same symptom that
+ * the form submission flow hit, same root causes.
+ *
+ * @runClassInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class VerificationHandlerNonceRecoveryTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var VerificationHandler */
+    private $handler;
+
+    /** @var array<string, mixed>|null Captured payload from wp_send_json_error. */
+    private $captured_error = null;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'wp_unslash' )->returnArg();
+
+        // The nonce path under test fails.
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        // Server-issued replacement nonce — must be non-empty.
+        Functions\when( 'wp_create_nonce' )->justReturn( 'fresh-nonce-verify-xyz' );
+
+        // Capture wp_send_json_error payload and throw so the handler short-circuits.
+        $captured = &$this->captured_error;
+        Functions\when( 'wp_send_json_error' )->alias( static function ( $payload ) use ( &$captured ) {
+            $captured = $payload;
+            throw new \RuntimeException( 'wp_send_json_error called' );
+        } );
+
+        $mock_handler  = Mockery::mock( SubmissionHandler::class );
+        $this->handler = new VerificationHandler( $mock_handler );
+
+        $_POST = array(
+            'action' => 'ffc_verify_certificate',
+            'nonce'  => 'stale-or-mismatched',
+        );
+    }
+
+    protected function tearDown(): void {
+        $_POST = array();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_nonce_failure_returns_refresh_nonce_with_fresh_value(): void {
+        $this->expectException( \RuntimeException::class );
+
+        try {
+            $this->handler->handle_verification_ajax();
+        } finally {
+            $this->assertIsArray( $this->captured_error, 'wp_send_json_error must be called' );
+            $this->assertArrayHasKey( 'message', $this->captured_error );
+            $this->assertArrayHasKey( 'refresh_nonce', $this->captured_error );
+            $this->assertArrayHasKey( 'new_nonce', $this->captured_error );
+            $this->assertTrue( $this->captured_error['refresh_nonce'] );
+            $this->assertSame( 'fresh-nonce-verify-xyz', $this->captured_error['new_nonce'] );
+            $this->assertNotSame( '', $this->captured_error['new_nonce'] );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Stacked on PR #356.** Same stale-nonce safety net applied to the
public certificate verification endpoint
(`ffc_verify_certificate`). Both endpoints sign with the same
`ffc_frontend_nonce` action and share every root cause from #356
(cached HTML, iOS Safari ITP cookie rotation, dynamic-fragments
silently failing), so if one of them is hitting the issue the other
almost certainly is too.

## Changes

- **`VerificationHandler::handle_verification_ajax()`**: swap
  `check_ajax_referer('ffc_frontend_nonce', 'nonce')` for an explicit
  `wp_verify_nonce()` check that returns
  `refresh_nonce: true` + `new_nonce: '<fresh>'` on failure. The old
  call `wp_die()`'d with a generic 403, leaving the client no path
  to recover.
- **Client-side**: no change. `FFC.request`'s `refresh_nonce` retry
  branch (added in #356) is endpoint-agnostic — it fires on any
  response that carries the flag, regardless of which AJAX endpoint
  sent it.
- **CHANGELOG**: 6.6.3 entry extended to mention both endpoints and
  note that adding the same treatment to other nonce-protected AJAX
  endpoints (self-scheduling, public CSV download) is now a
  server-side-only one-block change.

## Test plan

- [x] **PHPUnit** `tests/Unit/VerificationHandlerNonceRecoveryTest.php`
  (1 test, 8 assertions): asserts the server payload includes
  `refresh_nonce: true` + a non-empty `new_nonce` when
  `wp_verify_nonce()` returns false.
- [x] Vitest 920 pass (unchanged — no JS touched).
- [x] PHPStan level 8 clean, WPCS clean on
  `class-ffc-verification-handler.php`.
- [ ] **Manual smoke (post-merge)**: open `[ffc_verification]`
  shortcode on a cached page, paste an auth code, expect verify
  to succeed instead of "Security check failed".

## Stacking

Base branch is set to `claude/auto-recover-stale-nonce` (PR #356) so
the diff here shows only the new changes. When #356 merges, this
PR's base auto-retargets to `main` (or I'll do it manually). No
version bump needed — both PRs land as 6.6.3.

## Roadmap (deferred)

Endpoints that ALSO carry the same vulnerability but were not
included in this PR (reactive: ship when symptom is reproduced):

- `class-ffc-self-scheduling-appointment-ajax-handler.php` (4
  `check_ajax_referer` sites on `ffc_self_scheduling_nonce`)
- `class-ffc-public-csv-download.php` + `-exporter.php` (7 sites on
  `_ffc_pcd_nonce`)

Pattern is identical: swap `check_ajax_referer` for
`wp_verify_nonce` + `refresh_nonce` response.

https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn)_