### PR TITLE
Docblock cleanup: orphan-class status (closes #301)

### DIFF
--- a/includes/migrations/class-ffc-migration-user-profiles.php
+++ b/includes/migrations/class-ffc-migration-user-profiles.php
@@ -2,11 +2,24 @@
 /**
  * MigrationUserProfiles
  *
- * Populates ffc_user_profiles table with data from existing ffc_users.
- * Sources: wp_users.display_name, wp_usermeta.ffc_registration_date,
- * and names extracted from submissions.
+ * One-time backfill that populates `ffc_user_profiles` rows for WP
+ * users that already hold the `ffc_user` role but were created before
+ * 4.9.4 (when the profile table landed). Sources: `wp_users.display_name`
+ * and names extracted from submissions. New users get a profile
+ * automatically via `UserCreator` on registration, so this migration
+ * only matters on installs that upgraded from 4.9.3 or earlier without
+ * ever running it.
  *
- * Safe to run multiple times — skips users that already have a profile.
+ * The migration is idempotent: rows that already have a profile are
+ * skipped. Earlier versions of this docblock said the source was a
+ * table named `ffc_users` — that's wrong, the source is WP users
+ * filtered by the `ffc_user` role (`get_users(['role' => 'ffc_user'])`).
+ *
+ * Status (snapshot v6.6.1): the class is NOT registered in
+ * `MigrationStatusCalculator::get_strategies()` and the activator
+ * does not call `run()`, so it cannot be triggered from the admin
+ * UI today. Wiring it up (or formally retiring it) is tracked in
+ * #323.
  *
  * @package FreeFormCertificate\Migrations
  * @since 4.9.4
@@ -52,7 +65,7 @@ class MigrationUserProfiles {
 			);
 		}
 
-		// Get all ffc_users that don't have a profile yet.
+		// Get all WP users holding the ffc_user role that don't have a profile yet.
 		$users = get_users(
 			array(
 				'role'   => 'ffc_user',

--- a/includes/services/class-ffc-user-service.php
+++ b/includes/services/class-ffc-user-service.php
@@ -2,8 +2,18 @@
 /**
  * UserService
  *
- * Centralized service for user data retrieval and operations.
- * Single point of truth used by REST controller, PrivacyHandler, and UserCleanup.
+ * Centralized aggregator for user data retrieval and operations: merges
+ * WP core user data, the FFC `ffc_user_profiles` row, and the granted
+ * capability map into a single view-model. Designed as a single point
+ * of truth for callers that today still inline that aggregation
+ * ad-hoc (`Api\UserDataRestController`, `Privacy\PrivacyHandler`,
+ * `UserDashboard\UserCleanup`).
+ *
+ * Status (snapshot v6.6.1): the class is declared, exported via the
+ * `Services` PSR-4 mapping, and fully tested in `UserServiceTest`, but
+ * no production caller invokes it yet — the wire-up is tracked in
+ * #322 so the API stays stable while the migration happens one
+ * call-site at a time.
  *
  * @package FreeFormCertificate\Services
  * @since 4.9.7


### PR DESCRIPTION
## Closed — redundant orphan branch

Inspection after draft-open: the single commit on this branch
(`1586c17`) is content-identical to `22dd735` (PR #324 — "Docblock
cleanup: orphan-class status (closes #301) (#324)"), already in
`main`. `git rebase origin/main` reports
`skipped previously applied commit 1586c17`.

The branch was left on the remote after the squash-merge of #324
went through under a different head SHA. No work to ship; closing
the draft and deleting the branch.

Original PR description retained below for trail.

---

**Original draft body:**

Orphan branch found during the post-merge cleanup of #356/#357.
Single commit on the branch (`1586c17`), no PR was opened, no
follow-up session continued the work. Opening as draft so it gets a
review path instead of sitting on the remote indefinitely.

https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn