### PR TITLE
Test gap: cover 9 Recruitment admin pages/renderers/managers (closes #318)

### DIFF
--- a/tests/Unit/RecruitmentAdminAssetsManagerTest.php
+++ b/tests/Unit/RecruitmentAdminAssetsManagerTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentAdminAssetsManager;
+
+/**
+ * Tests for the recruitment admin assets manager — registration of the
+ * admin_enqueue_scripts hook plus the screen-gate inside maybe_enqueue.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentAdminAssetsManager
+ */
+class RecruitmentAdminAssetsManagerTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_url_raw' )->returnArg();
+        Functions\when( 'rest_url' )->alias( fn( $p = '' ) => 'https://example.test/wp-json/' . $p );
+        Functions\when( 'wp_create_nonce' )->justReturn( 'test-nonce' );
+
+        if ( ! defined( 'FFC_PLUGIN_DIR' ) ) {
+            define( 'FFC_PLUGIN_DIR', '/tmp/ffc_recruitment_assets_test/' );
+        }
+        if ( ! defined( 'FFC_PLUGIN_URL' ) ) {
+            define( 'FFC_PLUGIN_URL', 'https://example.test/plugins/ffc/' );
+        }
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // register()
+    // ------------------------------------------------------------------
+
+    public function test_register_hooks_into_admin_enqueue_scripts(): void {
+        Actions\expectAdded( 'admin_enqueue_scripts' )
+            ->once()
+            ->with( array( RecruitmentAdminAssetsManager::class, 'maybe_enqueue' ), 10 );
+
+        RecruitmentAdminAssetsManager::register();
+    }
+
+    // ------------------------------------------------------------------
+    // maybe_enqueue() — screen gate
+    // ------------------------------------------------------------------
+
+    public function test_maybe_enqueue_no_op_on_unrelated_admin_screen(): void {
+        $style_calls  = 0;
+        $script_calls = 0;
+        Functions\when( 'wp_enqueue_style' )->alias( function () use ( &$style_calls ) { $style_calls++; } );
+        Functions\when( 'wp_enqueue_script' )->alias( function () use ( &$script_calls ) { $script_calls++; } );
+        Functions\when( 'wp_localize_script' )->justReturn( true );
+
+        RecruitmentAdminAssetsManager::maybe_enqueue( 'edit.php' );
+
+        $this->assertSame( 0, $style_calls, 'no CSS enqueue outside recruitment screen' );
+        $this->assertSame( 0, $script_calls, 'no JS enqueue outside recruitment screen' );
+    }
+
+    public function test_maybe_enqueue_enqueues_assets_on_recruitment_top_level_page(): void {
+        $enqueued_handles = array();
+        Functions\when( 'wp_enqueue_style' )->alias( function ( $handle ) use ( &$enqueued_handles ) {
+            $enqueued_handles[] = "style:$handle";
+        } );
+        Functions\when( 'wp_enqueue_script' )->alias( function ( $handle ) use ( &$enqueued_handles ) {
+            $enqueued_handles[] = "script:$handle";
+        } );
+        $localized = null;
+        Functions\when( 'wp_localize_script' )->alias( function ( $handle, $name, $data ) use ( &$localized ) {
+            $localized = compact( 'handle', 'name', 'data' );
+        } );
+
+        RecruitmentAdminAssetsManager::maybe_enqueue( 'toplevel_page_ffc-recruitment' );
+
+        $this->assertContains( 'style:' . RecruitmentAdminAssetsManager::HANDLE_CSS, $enqueued_handles );
+        $this->assertContains( 'script:' . RecruitmentAdminAssetsManager::HANDLE_JS, $enqueued_handles );
+        $this->assertSame( 'ffcRecruitmentAdmin', $localized['name'] );
+        $this->assertArrayHasKey( 'restRoot', $localized['data'] );
+        $this->assertArrayHasKey( 'nonce', $localized['data'] );
+        $this->assertSame( 'test-nonce', $localized['data']['nonce'] );
+    }
+
+    public function test_maybe_enqueue_enqueues_on_recruitment_sub_pages_too(): void {
+        $count = 0;
+        Functions\when( 'wp_enqueue_style' )->alias( function () use ( &$count ) { $count++; } );
+        Functions\when( 'wp_enqueue_script' )->alias( function () use ( &$count ) { $count++; } );
+        Functions\when( 'wp_localize_script' )->justReturn( true );
+
+        RecruitmentAdminAssetsManager::maybe_enqueue( 'ffc-recruitment_page_ffc-recruitment-some-sub' );
+
+        $this->assertGreaterThan( 0, $count, 'sub-pages of recruitment should also enqueue' );
+    }
+}

--- a/tests/Unit/RecruitmentAdminPageTest.php
+++ b/tests/Unit/RecruitmentAdminPageTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentAdminPage;
+
+/**
+ * Tests for RecruitmentAdminPage — the label/badge static helpers used
+ * across the admin surface (notice + classification status maps). The
+ * register_menu() / render_page() dispatchers are out of scope for the
+ * smoke tier — they tie into the full WP-admin runtime + tab routing.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentAdminPage
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentAdminPageTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface */
+    private $settingsMock;
+
+    /** @var \Mockery\MockInterface */
+    private $badgeMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+
+        $this->settingsMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentSettings' );
+        $this->settingsMock->shouldReceive( 'all' )->andReturn(
+            array(
+                'status_color_empty'              => '#fff',
+                'status_color_called'             => '#aaa',
+                'status_color_hired'              => '#0f0',
+                'status_color_not_shown'          => '#f00',
+                'notice_status_color_draft'       => '#ccc',
+                'notice_status_color_preliminary' => '#ff0',
+                'notice_status_color_definitive'  => '#0f0',
+                'notice_status_color_closed'      => '#999',
+            )
+        )->byDefault();
+
+        $this->badgeMock = Mockery::mock( 'alias:FreeFormCertificate\Core\BadgeHtml' );
+        $this->badgeMock->shouldReceive( 'render' )->andReturnUsing(
+            fn( $base, $cls, $color, $label ) => "[BADGE:$cls:$color:$label]"
+        );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_notice_status_label_maps_each_known_status(): void {
+        $this->assertSame( 'Draft', RecruitmentAdminPage::notice_status_label( 'draft' ) );
+        $this->assertSame( 'Preliminary', RecruitmentAdminPage::notice_status_label( 'preliminary' ) );
+        $this->assertSame( 'Definitive', RecruitmentAdminPage::notice_status_label( 'definitive' ) );
+        $this->assertSame( 'Closed', RecruitmentAdminPage::notice_status_label( 'closed' ) );
+    }
+
+    public function test_notice_status_label_falls_back_to_raw_value_for_unknown_status(): void {
+        $this->assertSame( 'bogus-status', RecruitmentAdminPage::notice_status_label( 'bogus-status' ) );
+    }
+
+    public function test_classification_status_label_maps_each_known_status(): void {
+        $this->assertSame( 'Waiting', RecruitmentAdminPage::classification_status_label( 'empty' ) );
+        $this->assertSame( 'Called', RecruitmentAdminPage::classification_status_label( 'called' ) );
+        $this->assertSame( 'Accepted', RecruitmentAdminPage::classification_status_label( 'accepted' ) );
+        $this->assertSame( 'Did not show up', RecruitmentAdminPage::classification_status_label( 'not_shown' ) );
+        $this->assertSame( 'Hired', RecruitmentAdminPage::classification_status_label( 'hired' ) );
+    }
+
+    public function test_classification_status_label_falls_back_to_raw_value_for_unknown(): void {
+        $this->assertSame( 'unknown', RecruitmentAdminPage::classification_status_label( 'unknown' ) );
+    }
+
+    public function test_classification_status_badge_delegates_to_badge_html(): void {
+        $html = RecruitmentAdminPage::classification_status_badge( 'called' );
+
+        $this->assertStringContainsString( '[BADGE:', $html );
+        $this->assertStringContainsString( 'ffc-status-called', $html );
+    }
+
+    public function test_notice_status_badge_delegates_to_badge_html(): void {
+        $html = RecruitmentAdminPage::notice_status_badge( 'preliminary' );
+
+        $this->assertStringContainsString( '[BADGE:', $html );
+        $this->assertStringContainsString( 'preliminary', $html );
+    }
+}

--- a/tests/Unit/RecruitmentClassificationFilterManagerTest.php
+++ b/tests/Unit/RecruitmentClassificationFilterManagerTest.php
@@ -1,0 +1,248 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentClassificationFilterManager;
+
+/**
+ * Tests for the recruitment classification filter manager — read_filters
+ * (GET-param normalization + CPF/RF candidate-id resolution) and
+ * apply_filters (AND-composed row filtering).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentClassificationFilterManager
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentClassificationFilterManagerTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface */
+    private $candRepoMock;
+
+    /** @var \Mockery\MockInterface */
+    private $sanitizerMock;
+
+    /** @var \Mockery\MockInterface */
+    private $encryptionMock;
+
+    /** @var \Mockery\MockInterface */
+    private $pcdHasherMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'absint' )->alias( fn( $v ) => abs( (int) $v ) );
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'sanitize_key' )->returnArg();
+        Functions\when( 'wp_unslash' )->returnArg();
+
+        $this->candRepoMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+        $this->candRepoMock->shouldReceive( 'get_by_cpf_hash' )->andReturn( null )->byDefault();
+        $this->candRepoMock->shouldReceive( 'get_by_rf_hash' )->andReturn( null )->byDefault();
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->andReturn( null )->byDefault();
+
+        $this->sanitizerMock = Mockery::mock( 'alias:FreeFormCertificate\Core\DataSanitizer' );
+        $this->sanitizerMock->shouldReceive( 'normalize_cpf_rf' )->andReturnUsing(
+            fn( $v ) => preg_replace( '/\D/', '', (string) $v )
+        );
+
+        $this->encryptionMock = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+        $this->encryptionMock->shouldReceive( 'hash' )->andReturnUsing( fn( $v ) => 'hash:' . $v );
+
+        $this->pcdHasherMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentPcdHasher' );
+        $this->pcdHasherMock->shouldReceive( 'verify' )->andReturn( false )->byDefault();
+    }
+
+    protected function tearDown(): void {
+        unset( $_GET['ffc_cls_adj'], $_GET['ffc_cls_q'], $_GET['ffc_cls_cpf'], $_GET['ffc_cls_rf'], $_GET['ffc_cls_sub'] );
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // read_filters() — defaults
+    // ------------------------------------------------------------------
+
+    public function test_read_filters_returns_zeros_when_no_get_params(): void {
+        $filters = RecruitmentClassificationFilterManager::read_filters( 42 );
+
+        $this->assertSame( 42, $filters['notice_id'] );
+        $this->assertSame( 0, $filters['adjutancy_id'] );
+        $this->assertSame( '', $filters['query'] );
+        $this->assertSame( 0, $filters['cpf_candidate_id'] );
+        $this->assertSame( 0, $filters['rf_candidate_id'] );
+        $this->assertSame( '', $filters['subscription'] );
+    }
+
+    // ------------------------------------------------------------------
+    // read_filters() — CPF resolution
+    // ------------------------------------------------------------------
+
+    public function test_read_filters_resolves_cpf_to_candidate_id_when_match_found(): void {
+        $_GET['ffc_cls_cpf'] = '123.456.789-00';
+        $this->candRepoMock->shouldReceive( 'get_by_cpf_hash' )
+            ->with( 'hash:12345678900' )
+            ->andReturn( (object) array( 'id' => 7 ) );
+
+        $filters = RecruitmentClassificationFilterManager::read_filters( 1 );
+
+        $this->assertSame( 7, $filters['cpf_candidate_id'] );
+    }
+
+    public function test_read_filters_marks_cpf_candidate_minus_one_when_no_match(): void {
+        $_GET['ffc_cls_cpf'] = '12345678900';
+        $this->candRepoMock->shouldReceive( 'get_by_cpf_hash' )->andReturn( null );
+
+        $filters = RecruitmentClassificationFilterManager::read_filters( 1 );
+
+        $this->assertSame( -1, $filters['cpf_candidate_id'] );
+    }
+
+    public function test_read_filters_normalizes_subscription_to_allowed_set(): void {
+        $_GET['ffc_cls_sub'] = 'bogus';
+
+        $filters = RecruitmentClassificationFilterManager::read_filters( 1 );
+
+        $this->assertSame( '', $filters['subscription'] );
+    }
+
+    public function test_read_filters_keeps_pcd_subscription(): void {
+        $_GET['ffc_cls_sub'] = 'pcd';
+
+        $filters = RecruitmentClassificationFilterManager::read_filters( 1 );
+
+        $this->assertSame( 'pcd', $filters['subscription'] );
+    }
+
+    // ------------------------------------------------------------------
+    // apply_filters() — early return on unresolved CPF/RF
+    // ------------------------------------------------------------------
+
+    public function test_apply_filters_returns_empty_when_cpf_unresolved(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 1 ),
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 2 ),
+        );
+        $filters = array( 'cpf_candidate_id' => -1 );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertSame( array(), $out );
+    }
+
+    public function test_apply_filters_returns_empty_when_rf_unresolved(): void {
+        $rows    = array( (object) array( 'adjutancy_id' => 1, 'candidate_id' => 1 ) );
+        $filters = array( 'rf_candidate_id' => -1 );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertSame( array(), $out );
+    }
+
+    // ------------------------------------------------------------------
+    // apply_filters() — adjutancy filter
+    // ------------------------------------------------------------------
+
+    public function test_apply_filters_keeps_only_rows_with_matching_adjutancy_id(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 10 ),
+            (object) array( 'adjutancy_id' => 2, 'candidate_id' => 20 ),
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 30 ),
+        );
+        $filters = array( 'adjutancy_id' => 1 );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertCount( 2, $out );
+        $this->assertSame( 10, $out[0]->candidate_id );
+        $this->assertSame( 30, $out[1]->candidate_id );
+    }
+
+    // ------------------------------------------------------------------
+    // apply_filters() — CPF candidate match
+    // ------------------------------------------------------------------
+
+    public function test_apply_filters_keeps_only_rows_for_resolved_cpf_candidate(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 7 ),
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 99 ),
+        );
+        $filters = array( 'cpf_candidate_id' => 7 );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertCount( 1, $out );
+        $this->assertSame( 7, $out[0]->candidate_id );
+    }
+
+    // ------------------------------------------------------------------
+    // apply_filters() — name substring search
+    // ------------------------------------------------------------------
+
+    public function test_apply_filters_name_query_is_case_insensitive_substring(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 0, 'candidate_id' => 1 ),
+            (object) array( 'adjutancy_id' => 0, 'candidate_id' => 2 ),
+        );
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->with( 1 )->andReturn( (object) array( 'name' => 'John Doe' ) );
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->with( 2 )->andReturn( (object) array( 'name' => 'Jane Smith' ) );
+
+        $filters = array( 'query' => 'doe' );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertCount( 1, $out );
+        $this->assertSame( 1, $out[0]->candidate_id );
+    }
+
+    public function test_apply_filters_drops_rows_when_candidate_lookup_fails_during_name_search(): void {
+        $rows = array( (object) array( 'adjutancy_id' => 0, 'candidate_id' => 99 ) );
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->with( 99 )->andReturn( null );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, array( 'query' => 'anything' ) );
+
+        $this->assertSame( array(), $out );
+    }
+
+    // ------------------------------------------------------------------
+    // apply_filters() — subscription filter
+    // ------------------------------------------------------------------
+
+    public function test_apply_filters_subscription_pcd_keeps_only_pcd_candidates(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 0, 'candidate_id' => 1 ),
+            (object) array( 'adjutancy_id' => 0, 'candidate_id' => 2 ),
+        );
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->with( 1 )->andReturn( (object) array( 'name' => 'A', 'pcd_hash' => 'pcd-1' ) );
+        $this->candRepoMock->shouldReceive( 'get_by_id' )->with( 2 )->andReturn( (object) array( 'name' => 'B', 'pcd_hash' => 'no-pcd-2' ) );
+        $this->pcdHasherMock->shouldReceive( 'verify' )->with( 'pcd-1', 1 )->andReturn( true );
+        $this->pcdHasherMock->shouldReceive( 'verify' )->with( 'no-pcd-2', 2 )->andReturn( false );
+
+        $filters = array( 'subscription' => 'pcd' );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, $filters );
+
+        $this->assertCount( 1, $out );
+        $this->assertSame( 1, $out[0]->candidate_id );
+    }
+
+    public function test_apply_filters_passes_through_when_no_filters_active(): void {
+        $rows = array(
+            (object) array( 'adjutancy_id' => 1, 'candidate_id' => 1 ),
+            (object) array( 'adjutancy_id' => 2, 'candidate_id' => 2 ),
+        );
+
+        $out = RecruitmentClassificationFilterManager::apply_filters( $rows, array() );
+
+        $this->assertSame( $rows, $out );
+    }
+}

--- a/tests/Unit/RecruitmentEditPagesSmokeTest.php
+++ b/tests/Unit/RecruitmentEditPagesSmokeTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentReasonEditPage;
+use FreeFormCertificate\Recruitment\RecruitmentAdjutancyEditPage;
+use FreeFormCertificate\Recruitment\RecruitmentCandidateEditPage;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeEditPage;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeEditPageRenderer;
+
+/**
+ * Smoke tests for the 4 recruitment edit-page screens + the notice
+ * edit-page renderer. Each screen exposes static register() / render() /
+ * handle_*() methods bound to the WP-admin runtime; full coverage
+ * requires the real admin context. This suite pins the register() hook
+ * contract (every page declares the admin-post action it handles) and
+ * the few pure helpers exposed on the renderer.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentReasonEditPage
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentAdjutancyEditPage
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCandidateEditPage
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeEditPage
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeEditPageRenderer
+ */
+class RecruitmentEditPagesSmokeTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // register() — admin-post action wiring
+    // ------------------------------------------------------------------
+
+    public function test_reason_edit_page_register_hooks_save_handler(): void {
+        Actions\expectAdded( 'admin_post_ffc_recruitment_save_reason' )
+            ->once()
+            ->with( array( RecruitmentReasonEditPage::class, 'handle_save' ), 10 );
+
+        RecruitmentReasonEditPage::register();
+    }
+
+    public function test_adjutancy_edit_page_register_hooks_save_handler(): void {
+        Actions\expectAdded( 'admin_post_ffc_recruitment_save_adjutancy' )
+            ->once()
+            ->with( array( RecruitmentAdjutancyEditPage::class, 'handle_save' ), 10 );
+
+        RecruitmentAdjutancyEditPage::register();
+    }
+
+    public function test_candidate_edit_page_register_hooks_all_admin_post_handlers(): void {
+        Actions\expectAdded( 'admin_post_ffc_recruitment_save_candidate' )->once();
+        Actions\expectAdded( 'admin_post_ffc_recruitment_delete_candidate' )->once();
+        Actions\expectAdded( 'admin_post_ffc_recruitment_link_candidate_user' )->once();
+        Actions\expectAdded( 'admin_post_ffc_recruitment_unlink_candidate_user' )->once();
+
+        RecruitmentCandidateEditPage::register();
+    }
+
+    public function test_notice_edit_page_register_hooks_save_transition_and_csv_handlers(): void {
+        Actions\expectAdded( 'admin_post_ffc_recruitment_save_notice' )->once();
+        Actions\expectAdded( 'admin_post_ffc_recruitment_transition_notice' )->once();
+        Actions\expectAdded( 'admin_post_ffc_recruitment_download_csv_example' )->once();
+
+        RecruitmentNoticeEditPage::register();
+    }
+
+    // ------------------------------------------------------------------
+    // RecruitmentNoticeEditPageRenderer — columns_label_map() helper
+    // ------------------------------------------------------------------
+
+    public function test_renderer_columns_label_map_covers_every_public_columns_key(): void {
+        $map = RecruitmentNoticeEditPageRenderer::columns_label_map();
+
+        $expected_keys = array(
+            'rank', 'name', 'adjutancy', 'status', 'pcd_badge',
+            'date_to_assume', 'time_to_assume', 'score', 'time_points',
+            'hab_emebs', 'cpf_masked', 'rf_masked', 'email_masked',
+            'preview_reason',
+        );
+        foreach ( $expected_keys as $key ) {
+            $this->assertArrayHasKey( $key, $map, "label missing for column: $key" );
+        }
+    }
+
+    public function test_renderer_columns_label_map_labels_are_non_empty_strings(): void {
+        $map = RecruitmentNoticeEditPageRenderer::columns_label_map();
+
+        foreach ( $map as $key => $label ) {
+            $this->assertIsString( $label, "label for '$key' must be a string" );
+            $this->assertNotSame( '', $label, "label for '$key' must not be empty" );
+        }
+    }
+}

--- a/tests/Unit/RecruitmentPublicShortcodeRendererTest.php
+++ b/tests/Unit/RecruitmentPublicShortcodeRendererTest.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentPublicShortcodeRenderer;
+
+/**
+ * Tests for the public recruitment shortcode renderer — focused on the
+ * static helpers that compose the listing HTML (msg, parse_columns_config,
+ * wrap_with_banner). The full render_section pipeline depends on the
+ * full classification + candidate runtime and is out of scope for the
+ * smoke tier.
+ *
+ * Coverage emphasises the escape paths because the renderer feeds the
+ * public shortcode output without a WordPress template wrapper — any
+ * bug here is an XSS regression vector.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentPublicShortcodeRenderer
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentPublicShortcodeRendererTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface */
+    private $settingsMock;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        // Escape stubs intentionally reflect the WP semantics so the
+        // assertions can detect missing-escape regressions.
+        Functions\when( 'esc_html' )->alias( fn( $s ) => htmlspecialchars( (string) $s, ENT_QUOTES, 'UTF-8' ) );
+        Functions\when( 'esc_attr' )->alias( fn( $s ) => htmlspecialchars( (string) $s, ENT_QUOTES, 'UTF-8' ) );
+        Functions\when( 'esc_url' )->alias( fn( $s ) => filter_var( (string) $s, FILTER_SANITIZE_URL ) ?: (string) $s );
+
+        // parse_columns_config reads RecruitmentNoticeRepository::DEFAULT_PUBLIC_COLUMNS_CONFIG
+        // (a class constant). We let the real class autoload so the constant
+        // resolves — the renderer never calls methods on the repository.
+
+        $this->settingsMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentSettings' );
+        $this->settingsMock->shouldReceive( 'all' )->andReturn(
+            array(
+                'notice_status_color_preliminary' => '#ffe066',
+                'notice_status_color_definitive'  => '#a3e0a3',
+                'notice_status_color_closed'      => '#cccccc',
+            )
+        )->byDefault();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // msg() — escape contract
+    // ------------------------------------------------------------------
+
+    public function test_msg_escapes_text_and_kind(): void {
+        $out = RecruitmentPublicShortcodeRenderer::msg( '<script>alert("x")</script>', 'info' );
+
+        $this->assertStringContainsString( 'ffc-recruitment-message-info', $out );
+        $this->assertStringNotContainsString( '<script>', $out );
+        $this->assertStringContainsString( '&lt;script&gt;', $out );
+    }
+
+    public function test_msg_escapes_quote_in_kind_attribute(): void {
+        $out = RecruitmentPublicShortcodeRenderer::msg( 'hello', 'info" onclick="alert(1)' );
+
+        // Quote in $kind must be escaped so it can't break the host
+        // class="ffc-recruitment-message-..." attribute.
+        $this->assertStringNotContainsString( '" onclick="', $out );
+    }
+
+    // ------------------------------------------------------------------
+    // parse_columns_config()
+    // ------------------------------------------------------------------
+
+    public function test_parse_columns_config_always_forces_rank_and_name_to_true(): void {
+        // Even if the operator persists explicit `false` for rank / name,
+        // the schema-level invariant flips them back to true.
+        $json = json_encode( array( 'rank' => false, 'name' => false ) );
+
+        $cols = RecruitmentPublicShortcodeRenderer::parse_columns_config( (string) $json );
+
+        $this->assertTrue( $cols['rank'] );
+        $this->assertTrue( $cols['name'] );
+    }
+
+    public function test_parse_columns_config_returns_all_known_keys(): void {
+        $cols = RecruitmentPublicShortcodeRenderer::parse_columns_config( '{}' );
+
+        $expected_keys = array(
+            'rank', 'name', 'adjutancy', 'status', 'pcd_badge', 'date_to_assume',
+            'time_to_assume', 'score', 'time_points', 'hab_emebs',
+            'cpf_masked', 'rf_masked', 'email_masked', 'preview_reason',
+        );
+        foreach ( $expected_keys as $key ) {
+            $this->assertArrayHasKey( $key, $cols, "missing key: $key" );
+        }
+    }
+
+    public function test_parse_columns_config_overrides_optional_keys_from_json(): void {
+        $json = json_encode( array( 'cpf_masked' => true, 'preview_reason' => true ) );
+
+        $cols = RecruitmentPublicShortcodeRenderer::parse_columns_config( (string) $json );
+
+        $this->assertTrue( $cols['cpf_masked'] );
+        $this->assertTrue( $cols['preview_reason'] );
+    }
+
+    public function test_parse_columns_config_tolerates_malformed_json(): void {
+        $cols = RecruitmentPublicShortcodeRenderer::parse_columns_config( 'not-json' );
+
+        // Falls back to defaults (everything optional false, mandatory true).
+        $this->assertTrue( $cols['rank'] );
+        $this->assertTrue( $cols['name'] );
+        $this->assertFalse( $cols['cpf_masked'] );
+    }
+
+    // ------------------------------------------------------------------
+    // wrap_with_banner()
+    // ------------------------------------------------------------------
+
+    public function test_wrap_with_banner_renders_preliminary_status_banner_with_color(): void {
+        $notice = (object) array(
+            'status' => 'preliminary',
+            'code'   => 'EDITAL-01',
+            'name'   => 'Concurso 2026',
+        );
+
+        $out = RecruitmentPublicShortcodeRenderer::wrap_with_banner( $notice, '<p>body</p>' );
+
+        $this->assertStringContainsString( 'ffc-recruitment-banner-preliminary', $out );
+        $this->assertStringContainsString( '#ffe066', $out );
+        $this->assertStringContainsString( 'EDITAL-01', $out );
+        $this->assertStringContainsString( 'Concurso 2026', $out );
+        $this->assertStringContainsString( '<p>body</p>', $out, 'body must follow the header' );
+    }
+
+    public function test_wrap_with_banner_renders_no_banner_when_status_unknown(): void {
+        $notice = (object) array(
+            'status' => 'draft', // not in the known status_messages map.
+            'code'   => 'EDITAL-X',
+            'name'   => 'X',
+        );
+
+        $out = RecruitmentPublicShortcodeRenderer::wrap_with_banner( $notice, 'BODY' );
+
+        $this->assertStringNotContainsString( 'ffc-recruitment-banner', $out );
+        $this->assertStringContainsString( 'EDITAL-X', $out );
+        $this->assertStringContainsString( 'BODY', $out );
+    }
+
+    public function test_wrap_with_banner_escapes_notice_code_and_name(): void {
+        $notice = (object) array(
+            'status' => 'definitive',
+            'code'   => '<script>x</script>',
+            'name'   => 'Concurso "2026"',
+        );
+
+        $out = RecruitmentPublicShortcodeRenderer::wrap_with_banner( $notice, '' );
+
+        $this->assertStringNotContainsString( '<script>', $out );
+        $this->assertStringContainsString( '&lt;script&gt;', $out );
+        $this->assertStringContainsString( '&quot;2026&quot;', $out );
+    }
+}


### PR DESCRIPTION
## Closed — redundant orphan branch

Inspection after draft-open: the single commit on this branch
(`b724e6a`) is content-identical to `df2caa9` (PR #321 — "Test gap:
cover 9 Recruitment admin pages/renderers/managers (closes #318)
(#321)"), already in `main`. `git rebase origin/main` reports
`skipped previously applied commit b724e6a`.

The branch was left on the remote after the squash-merge of #321
went through under a different head SHA. No work to ship; closing
the draft and deleting the branch.

Original PR description retained below for trail.

---

**Original draft body:**

Orphan branch found during the post-merge cleanup of #356/#357.
Single commit on the branch (`b724e6a`), no PR was opened, no
follow-up session continued the work. Opening as draft so it gets a
review path instead of sitting on the remote indefinitely.

https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn