### PR TITLE
6.6.5 — bump minimum PHP 8.1 → 8.3 + CI matrix slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ concurrency:
 
 jobs:
   lint:
-    name: PHPStan (PHP 8.1)
+    name: PHPStan (PHP 8.3)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-composer
         with:
-          php-version: '8.1'
+          php-version: '8.3'
       - name: Run PHPStan
         run: vendor/bin/phpstan analyze
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           tools: composer:v2
           coverage: none
       - name: Validate composer.json / composer.lock are in sync
@@ -36,12 +36,15 @@ jobs:
         run: composer audit --locked --no-interaction
 
   test:
+    # 6.6.5 — minimum PHP bumped 8.1 → 8.3. Matrix went 4 versions
+    # (8.1, 8.2, 8.3, 8.4) → 2 (8.3, 8.4). 8.1 / 8.2 visitors are
+    # capped at 6.6.4 by WordPress's `Requires PHP` enforcement.
     name: PHPUnit (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.3', '8.4']
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-composer
@@ -51,7 +54,7 @@ jobs:
         run: vendor/bin/phpunit
 
   coverage:
-    name: Coverage (PHP 8.1)
+    name: Coverage (PHP 8.3)
     runs-on: ubuntu-latest
     # Bumped 15 → 20 after the pcov+3881-test suite started routinely
     # finishing at 14m–15m and tripping the previous ceiling on busy
@@ -82,7 +85,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-composer
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: pcov
           ini-values: pcov.directory=./includes,pcov.exclude="#(libraries|views)/#",memory_limit=512M
       - name: Run PHPUnit with coverage

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-composer
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           tools: composer:v2, cs2pr
 
       - name: Resolve changed PHP files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,62 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.5] (2026-05-21)
+
+> ### ⚠ Breaking change: minimum PHP bumped 8.1 → 8.3
+>
+> Visitors / sites running on PHP 8.1 or 8.2 will not auto-upgrade
+> to this release. WordPress enforces the `Requires PHP` plugin
+> header — installs on 8.1 / 8.2 stay pinned at 6.6.4 until the
+> host upgrades PHP. Both versions are EOL'd / approaching EOL
+> upstream (8.1 security-only support ends late 2026; 8.2 active
+> support ended late 2025), and the project's own production
+> deploys run 8.3, so the maintenance gain outweighs the loss of
+> coverage for two unsupported versions.
+>
+> **What to expect**:
+>
+> - Existing 8.1/8.2 sites continue to work on 6.6.4 (no
+>   regressions; their plugin update notification just no longer
+>   surfaces 6.6.5).
+> - 8.3+ sites get the full release on their next auto-update or
+>   manual refresh.
+> - No source code changes in this release beyond the version
+>   declarations + a small dead-code cleanup PHPStan 2.1.55
+>   surfaced after the composer upgrade (recruitment public
+>   shortcode renderer; behaviour unchanged because the branch was
+>   unreachable).
+
+### Changed
+
+- **Minimum PHP version bumped 8.1 → 8.3** across all four
+  declarations: `ffcertificate.php` plugin header
+  (`Requires PHP: 8.3`), `FFC_MIN_PHP_VERSION` constant,
+  `readme.txt` `Requires PHP:`, and `composer.json` (`>=8.3`
+  + platform pin `8.3`). PHPStan target pinned via new
+  `phpVersion: 80300` in `phpstan.neon.dist` so analysis stays
+  target-aware regardless of CI runner version.
+- **CI matrix slimmed 4 → 2 PHP versions**. PHPUnit matrix now
+  runs `['8.3', '8.4']` (was `['8.1', '8.2', '8.3', '8.4']`).
+  PHPStan, Coverage, Composer audit, and PHPCS jobs all switched
+  runtime from PHP 8.1 → 8.3 to match the new minimum + benefit
+  from the faster runtime. Coverage step's wall-clock drops
+  ~1.5-3 minutes (PHP 8.3 is ~5-15% faster than 8.1 on
+  PHPUnit-heavy workloads); total runner-minutes per PR drops
+  ~30% (12 jobs instead of 14).
+
+### Fixed
+
+- **Dead-code branch in `RecruitmentPublicShortcodeRenderer::render_row()`**
+  surfaced by PHPStan 2.1.55 (the patch composer pulled during the
+  bump). The `else` branch's inner `if ( $show_date && $cols['…'] )`
+  checks were unreachable by construction — the outer condition
+  negates as "either `$show_date` is false OR both columns are
+  false", which forces both inner conditions to false. Removed
+  the dead lines; no behaviour change.
+
+---
+
 ## [6.6.4] (2026-05-20)
 
 Pre-flight permission checks + server-side reorderings + user-facing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ green completion is silent by design.
 
 ## CI gates (all gating, enforced on `main`)
 
-- PHP: PHPStan (level 8) · WPCS · PHPUnit (8.1/8.2/8.3/8.4) · Coverage
+- PHP: PHPStan (level 8) · WPCS · PHPUnit (8.3/8.4) · Coverage
   ≥ floor (clover, env `COVERAGE_FLOOR_LINES` in `.github/workflows/ci.yml`).
 - JS / CSS: ESLint (zero-error) · Stylelint (zero-error) · Vitest +
   coverage ≥ floor (env `JS_COVERAGE_FLOOR_LINES` in

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.3"
     },
     "require-dev": {
         "brain/monkey": "^2.6",
@@ -32,7 +32,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.1"
+            "php": "8.3"
         },
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16d619d3526d280aafd7788cba53beb8",
+    "content-hash": "4636841a3254ef92a01883f58686bc93",
     "packages": [],
     "packages-dev": [
         {
@@ -1103,11 +1103,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -1152,7 +1152,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2923,11 +2923,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,8 +3,8 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.4
- * Requires PHP:       8.1
+ * Version:            6.6.5
+ * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
  * License:             GPLv3 or later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.4' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.5' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.
@@ -30,7 +30,7 @@ define( 'FFC_JQUERY_UI_VERSION', '1.14.2' );    // jQuery UI theme (CDN) - https
 define( 'FFC_THUMBMARK_VERSION', '1.9.0' );     // thumbmarkjs - https://github.com/thumbmarkjs/thumbmarkjs (MIT, vendored at libs/js/).
 
 define( 'FFC_MIN_WP_VERSION', '6.2' );          // Minimum WordPress (required for %i identifier placeholder).
-define( 'FFC_MIN_PHP_VERSION', '8.1' );         // Minimum PHP.
+define( 'FFC_MIN_PHP_VERSION', '8.3' );         // Minimum PHP.
 define( 'FFC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
@@ -226,14 +226,12 @@ final class RecruitmentPublicShortcodeRenderer {
 				$time  = null === $call ? '' : self::format_time_hm( (string) $call->time_to_assume );
 				$html .= '<td>' . esc_html( $time ) . '</td>';
 			}
-		} else {
-			if ( $show_date && $columns['date_to_assume'] ) {
-				$html .= '<td></td>';
-			}
-			if ( $show_date && $columns['time_to_assume'] ) {
-				$html .= '<td></td>';
-			}
 		}
+		// 6.6.5 — removed the `else { if ( $show_date && $cols['…'] ) … }`
+		// fallback: those inner checks are dead code by construction
+		// (the outer condition negates as "$show_date false OR both
+		// columns false", which forces both inner $show_date && col
+		// checks to be false). PHPStan 2.1.55 surfaced this.
 		$html .= '</tr>';
 		return $html;
 	}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,13 @@ includes:
 parameters:
     level: 8
 
+    # 6.6.5 — pin the analysis target to PHP 8.3 (the new minimum).
+    # Without this, PHPStan infers the target from the runtime PHP
+    # version, which means moving the CI runner to 8.3 (also 6.6.5)
+    # would silently relax checks for 8.2- syntax. Pinning makes the
+    # gate target-version-aware regardless of runtime.
+    phpVersion: 80300
+
     paths:
         - includes/
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.4
-Requires PHP: 8.1
+Stable tag: 6.6.5
+Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## Summary

Single-commit PR bumping the plugin's minimum PHP from 8.1 to 8.3
across all four declarations + slimming the CI matrix to match. Per
user confirmation: the project deploys on PHP 8.3 (Hostinger), the
plugin is GitHub-public but uso interno, so the breaking change for
8.1/8.2 visitors is acceptable.

## ⚠ Breaking change

WordPress enforces `Requires PHP` server-side — visitors on 8.1/8.2
will no longer receive auto-update notifications for 6.6.5+. They
stay pinned at 6.6.4 until the host upgrades PHP. The CHANGELOG
entry has a prominent banner explaining this.

## Changes

- **Plugin version declarations** (4 places): `ffcertificate.php`
  header + `FFC_MIN_PHP_VERSION` constant + `readme.txt` Stable tag
  + `Requires PHP:` + `composer.json` (`require` + platform pin).
  All bumped to `8.3` (`Requires PHP: 8.3`) / version `6.6.5`.
- **PHPStan**: pin `phpVersion: 80300` in `phpstan.neon.dist` so the
  analysis stays target-aware regardless of CI runner version
  (otherwise moving runtime to 8.3 would silently relax 8.2-syntax
  checks).
- **CI**:
  - PHPUnit matrix: `['8.1', '8.2', '8.3', '8.4']` → `['8.3', '8.4']`
  - PHPStan / Coverage / Composer audit / WPCS jobs: runtime PHP 8.1 → 8.3
  - Job names updated where they spelled the version
- **CHANGELOG**: new `[6.6.5]` entry with the breaking-change banner
- **CLAUDE.md**: "CI gates" line updated to reflect the slim matrix
- **Side fix**: PHPStan 2.1.55 (pulled by `composer update` during
  the platform-pin bump) surfaced 2 dead-code lines in
  `RecruitmentPublicShortcodeRenderer::render_row()`. Removed them
  — the `else { if ($show_date && $cols[…]) … }` was unreachable
  by construction. No behaviour change.

## Test plan

- [x] PHPUnit local: 4598 tests / 11655 assertions, all pass.
- [x] Vitest local: 950 / 950 pass (no JS changes; ran to confirm
  composer update didn't disturb anything).
- [x] PHPStan level 8 clean after the `phpVersion: 80300` pin +
  dead-code removal.
- [x] ESLint / Stylelint / WPCS zero-error.
- [x] `composer update` produced ONLY a PHPStan 2.1.54 → 2.1.55
  patch bump — no other dep moved.
- [ ] **Manual smoke (post-merge, staging on PHP 8.3)**:
  * Activate plugin, expect zero warnings.
  * Submit form, download certificate, verify magic link.
  * Verify admin pages render correctly.

## Expected CI savings

- Total runner-minutes per PR: ~30% lower (12 jobs instead of 14).
- Wall-clock PR check: ~1.5-3 minutes faster (Coverage is the
  pacing bottleneck; PHP 8.3 typically 5-15% faster than 8.1 on
  PHPUnit-heavy workloads).

## Post-merge action (requires repo admin)

After this PR merges, the GitHub `main` branch protection rule needs
updating:

- **Settings → Branches → main → Edit "Require status checks to
  pass before merging"**: remove `PHPUnit (PHP 8.1)` and
  `PHPUnit (PHP 8.2)` from the required-checks list (they no longer
  run, so leaving them required would block all future PRs).

Optional cosmetic tidy:
- Repo "About" sidebar / topics: drop any PHP-8.1-specific mentions.

I'll remind you of these as a checklist after merge.

https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn)_