### PR TITLE
6.6.6 — fix 500 on certificate reprint + activity_log schema heal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,21 @@ jobs:
       - name: Validate composer.json / composer.lock are in sync
         run: composer validate --strict --no-check-publish
       - name: Run composer audit
-        run: composer audit --locked --no-interaction
+        # `composer audit` hits packagist.org/api/security-advisories/.
+        # That endpoint has occasional 10-second DNS timeouts from
+        # GitHub Actions runners (curl error 28). Retry up to 3 times
+        # before failing the job — the audit is read-only, retrying
+        # is safe.
+        run: |
+          for attempt in 1 2 3; do
+            if composer audit --locked --no-interaction; then
+              exit 0
+            fi
+            echo "::warning::composer audit attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::composer audit failed after 3 attempts"
+          exit 1
 
   test:
     # 6.6.5 — minimum PHP bumped 8.1 → 8.3. Matrix went 4 versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.6] (2026-05-21)
+
+Two production-reported fixes surfaced by enabling WP_DEBUG_LOG on a 6.6.5 install.
+
+### Fixed
+
+- **`Uncaught TypeError` on every certificate reprint** (`Utils::generate_success_html()`). The 6.6.0 schema migration switched `submissions.submission_date` from MySQL DATETIME string to BIGINT UNSIGNED unix int. The reprint branch in `FormProcessor::handle_submission_ajax` passes that int through, but `generate_success_html()` still declared `string $submission_date` — every reprint threw a fatal that the AJAX layer surfaced as a generic 500. Fresh submissions kept working because they pass a `current_time('mysql')` string. Fix: signature now accepts `int|string`; `DateFormatter::format_datetime()` already accepted both internally.
+- **`Unknown column 'action'` on the form-editor pre-flight stats metabox** for installs whose `ffc_activity_log` table was created in a pre-`action`-column plugin version. The legacy `create_table()` early-returned on `table_exists()`, so dbDelta never ran to add columns added in later releases. New `ActivityLog::maybe_create_table()` (mirrors `RateLimitActivator::maybe_create_tables()` pattern) compares a stored `ffc_activity_log_db_version` option against the code's expected version and re-runs dbDelta once on legacy installs. Wired into `Loader::on_plugins_loaded` alongside the rate-limit equivalent.
+
+---
+
 ## [6.6.5] (2026-05-21)
 
 > ### ⚠ Breaking change: minimum PHP bumped 8.1 → 8.3

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.5
+ * Version:            6.6.6
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.5' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.6' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -193,6 +193,15 @@ class Loader {
 			\FreeFormCertificate\Security\RateLimitActivator::maybe_create_tables();
 		}
 
+		// Ensure activity_log schema is healed. Installs created in a
+		// pre-`action`-column plugin version skipped dbDelta on every
+		// upgrade because create_table() used to early-return on
+		// `table_exists`. Without this, PreflightStatsService queries
+		// fail with `Unknown column 'action'`.
+		if ( class_exists( '\FreeFormCertificate\Core\ActivityLog' ) ) {
+			\FreeFormCertificate\Core\ActivityLog::maybe_create_table();
+		}
+
 		// In-place plugin updates (drop new files via `wp-admin/plugins.php`'s
 		// "Update" button) DO NOT fire `register_activation_hook`. Re-register
 		// the canonical FFC role + the 6.2.0 module-manager / recruitment-tier

--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -259,8 +259,24 @@ class ActivityLog {
 	}
 
 	/**
+	 * Expected schema version. Bumped whenever this class's CREATE TABLE
+	 * statement changes shape (new columns, new indexes, etc.).
+	 * Read by maybe_create_table() to decide if dbDelta needs to run on an
+	 * existing install.
+	 */
+	private const DB_VERSION = '2.0.0';
+
+	/**
 	 * Create activity log table
-	 * Called during plugin activation
+	 * Called during plugin activation and from maybe_create_table() on
+	 * in-place upgrades.
+	 *
+	 * 6.6.6: removed the early-return on `table_exists()`. The old guard
+	 * meant installs whose table was created in a pre-`action` schema
+	 * (pre-4.6.x) never got dbDelta'd to add the `action` column, and
+	 * every PreflightStatsService query hit `Unknown column 'action'`.
+	 * dbDelta is idempotent — letting it run on every call lets it heal
+	 * legacy schemas without breaking fresh installs.
 	 *
 	 * @return bool Success
 	 */
@@ -268,11 +284,6 @@ class ActivityLog {
 		global $wpdb;
 		$table_name      = $wpdb->prefix . 'ffc_activity_log';
 		$charset_collate = $wpdb->get_charset_collate();
-
-		// Check if table already exists.
-		if ( self::table_exists( $table_name ) ) {
-			return true;
-		}
 
 		$sql = "CREATE TABLE {$table_name} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -295,6 +306,20 @@ class ActivityLog {
 		dbDelta( $sql );
 
 		return true;
+	}
+
+	/**
+	 * Run create_table() once when the stored db version is older than the
+	 * code's expected version. Mirrors RateLimitActivator::maybe_create_tables()
+	 * — covers in-place plugin upgrades that don't fire register_activation_hook.
+	 */
+	public static function maybe_create_table(): void {
+		$stored = get_option( 'ffc_activity_log_db_version', '' );
+		if ( self::DB_VERSION === $stored ) {
+			return;
+		}
+		self::create_table();
+		update_option( 'ffc_activity_log_db_version', self::DB_VERSION );
 	}
 
 	// =====================================================================.

--- a/includes/core/class-ffc-utils.php
+++ b/includes/core/class-ffc-utils.php
@@ -646,13 +646,15 @@ class Utils {
 	 * @since 2.9.16
 	 * @param array<string, mixed> $submission_data Submission data.
 	 * @param int                  $form_id Form ID.
-	 * @param string               $submission_date Submission date.
+	 * @param int|string           $submission_date Submission date — unix UTC int (since 6.6.0, reprint flow)
+	 *                                              or MySQL `Y-m-d H:i:s` string (fresh submission via `current_time('mysql')`).
+	 *                                              DateFormatter::format_datetime accepts both.
 	 * @param string               $success_message Success message.
 	 * @param int                  $submission_id Submission ID (used to surface the magic link in the success card; 0 to skip).
 	 * @param object|null          $submission_handler Handler that knows how to ensure/load the submission's magic token.
 	 * @return string HTML content
 	 */
-	public static function generate_success_html( array $submission_data, int $form_id, string $submission_date, string $success_message = '', int $submission_id = 0, ?object $submission_handler = null ): string {
+	public static function generate_success_html( array $submission_data, int $form_id, int|string $submission_date, string $success_message = '', int $submission_id = 0, ?object $submission_handler = null ): string {
 		// Get form configuration.
 		$form_config = get_post_meta( $form_id, '_ffc_form_config', true );
 		if ( ! is_array( $form_config ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.5
+Stable tag: 6.6.6
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

Two production-reported fixes surfaced by enabling `WP_DEBUG_LOG` on a 6.6.5 install (`dresaomiguel.com.br`). Patch bump 6.6.5 → 6.6.6.

### Bug 1 — Every certificate reprint hit a generic 500

`Utils::generate_success_html()` declared `string $submission_date`, but after the 6.6.0 schema migration `submissions.submission_date` became `BIGINT UNSIGNED` (unix int). The reprint branch in `FormProcessor::handle_submission_ajax` passes that int verbatim — fresh submissions still pass a `current_time('mysql')` string. Result:

```
Uncaught TypeError: Utils::generate_success_html():
Argument #3 ($submission_date) must be of type string, int given,
called in .../class-ffc-form-processor.php on line 707
```

**Fix** (`bb44543`): signature accepts `int|string`. `DateFormatter::format_datetime()` already handled both internally.

### Bug 2 — `Unknown column 'action'` on form-editor pre-flight stats

Installs whose `ffc_activity_log` table was created in a pre-`action`-column plugin version never got the new columns — `create_table()` early-returned on `table_exists()`, so `dbDelta` never ran. Every `PreflightStatsService` query threw `Unknown column 'action'`.

**Fix** (`173bc81`): mirrors the `RateLimitActivator::maybe_create_tables()` pattern. New `ActivityLog::maybe_create_table()` compares a stored `ffc_activity_log_db_version` option against the code's expected version and re-runs `dbDelta` once on legacy installs. Wired into `Loader::on_plugins_loaded` alongside the rate-limit equivalent. `create_table()`'s early-return is removed since `dbDelta` is idempotent on identical schemas.

### Commits

- `bb44543` — Fix: Utils::generate_success_html() rejected int submission_date (reprint flow)
- `173bc81` — Fix: ffc_activity_log schema heal on legacy installs
- `6217c7c` — 6.6.6 — bump version + CHANGELOG

## Test plan

- [ ] Production reprint reproduces a `200 OK` instead of `500`
- [ ] Form editor metabox loads without `Unknown column 'action'` in debug.log
- [ ] Fresh installs (current schema) unaffected — `dbDelta` is a no-op when schema matches
- [ ] Existing tests stay green


---
_Generated by [Claude Code](https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn)_