### PR TITLE
6.6.7 — add missing ffc-core dep to 4 public-facing JS enqueues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.7] (2026-05-21)
+
+Follow-up to the PR #352 (6.6.2) dependency cleanup. Four public-facing JS enqueues never had `ffc-core` listed as a dependency, so any page combining their script via a JS-combining cache plugin (LiteSpeed JS Combine, WP Rocket Combine, etc.) ended up with `FFC is not defined` and a non-functional widget. Reported on `dresaomiguel.com.br/avaliacoes-e-provas/` where `[ffc_audience schedule_id="1"]` failed to render the calendar.
+
+### Fixed
+
+- **`[ffc_audience]` shortcode: calendar fails to load events when JS is combined.** `ffc-audience.js` calls `FFC.request()` once (search-users path) but its enqueue declared only `['jquery']` as dependency. Added `ffc-core` so WordPress (and downstream cache plugins) preserve load order.
+- **`[ffc_self_scheduling]` shortcode: same root cause on two siblings.** `ffc-frontend-helpers.js` (3 FFC call sites) and `ffc-calendar-core.js` (1 FFC call site) were enqueued with only `['jquery']`. Both now list `ffc-core`.
+- **Public form pre-flight pipeline: `ffc-geofence-frontend.js` enqueue missing `ffc-core` dependency.** This file gained 6 `FFC.request` call sites across 6.6.4 / follow-up (geofence telemetry, cookie sanity, GPS pre-check) but the original 6.6.4 enqueue still declared only `['jquery']`. Without a JS combiner this worked because `ffc-frontend-js` (enqueued one line above) already pulls `ffc-core`, but combiners that flatten dependencies dropped `ffc-core` from the bundle.
+
+### Why these escaped 6.6.2
+
+PR #352 walked the 5 public shortcodes that existed at the time and added `ffc-core` to each. `ffc-audience` (Audience module), `ffc-frontend-helpers` / `ffc-calendar-core` (Self-Scheduling module), and `ffc-geofence-frontend` (Frontend) all gained `FFC.request` call sites in *later* releases (6.6.4 for geofence; 6.5.x for the calendar siblings) without their enqueues being updated. The fix is mechanical (4 × `array('jquery')` → `array('jquery', 'ffc-core')`) and has no behavioural effect on installs that don't combine JS.
+
+---
+
 ## [6.6.6] (2026-05-21)
 
 Two production-reported fixes surfaced by enabling WP_DEBUG_LOG on a 6.6.5 install.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.6
+ * Version:            6.6.7
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.6' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.7' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/audience/class-ffc-audience-loader.php
+++ b/includes/audience/class-ffc-audience-loader.php
@@ -284,11 +284,13 @@ class AudienceLoader {
 			FFC_VERSION
 		);
 
-		// Frontend JS.
+		// Frontend JS. `ffc-core` provides window.FFC.request() used by
+		// ffc-audience.js — without it, the AJAX call near the bottom of
+		// the file throws `FFC is not defined` and breaks the calendar.
 		wp_enqueue_script(
 			'ffc-audience',
 			FFC_PLUGIN_URL . "assets/js/ffc-audience{$s}.js",
-			array( 'jquery' ),
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/frontend/class-ffc-frontend.php
+++ b/includes/frontend/class-ffc-frontend.php
@@ -184,7 +184,8 @@ class Frontend {
 
 			wp_enqueue_script( 'ffc-frontend-js', FFC_PLUGIN_URL . "assets/js/ffc-frontend{$s}.js", array( 'jquery', 'ffc-core', 'ffc-pdf-generator', 'ffc-rate-limit' ), FFC_VERSION, true );
 
-			wp_enqueue_script( 'ffc-geofence-frontend', FFC_PLUGIN_URL . "assets/js/ffc-geofence-frontend{$s}.js", array( 'jquery' ), FFC_VERSION, true );
+			// ffc-core dep: ffc-geofence-frontend.js calls FFC.request() (6 sites incl. the pre-flight telemetry endpoint added in 6.6.4 follow-up).
+			wp_enqueue_script( 'ffc-geofence-frontend', FFC_PLUGIN_URL . "assets/js/ffc-geofence-frontend{$s}.js", array( 'jquery', 'ffc-core' ), FFC_VERSION, true );
 
 			// Pass geofence configurations to frontend.
 			$this->localize_geofence_config();

--- a/includes/self-scheduling/class-ffc-self-scheduling-shortcode.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-shortcode.php
@@ -96,19 +96,21 @@ class SelfSchedulingShortcode {
 		);
 
 		// Enqueue FFC frontend helpers (for CPF/RF mask).
+		// ffc-core dep: ffc-frontend-helpers.js calls FFC.request() internally.
 		wp_enqueue_script(
 			'ffc-frontend-helpers',
 			FFC_PLUGIN_URL . "assets/js/ffc-frontend-helpers{$s}.js",
-			array( 'jquery' ),
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);
 
 		// Enqueue shared calendar core component.
+		// ffc-core dep: ffc-calendar-core.js calls FFC.request() internally.
 		wp_enqueue_script(
 			'ffc-calendar-core',
 			FFC_PLUGIN_URL . "assets/js/ffc-calendar-core{$s}.js",
-			array( 'jquery' ),
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.6
+Stable tag: 6.6.7
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

Production-reported on `dresaomiguel.com.br/avaliacoes-e-provas/`: `[ffc_audience schedule_id="1"]` failed to render the calendar. LiteSpeed Cache JS Combine produced a bundle that referenced `window.FFC` before `ffc-core.js` defined it, throwing `FFC is not defined`.

Root cause: PR #352 (6.6.2) walked the 5 public shortcodes that existed at the time and added `ffc-core` as dep. Four siblings gained `FFC.request` call sites in later releases without their enqueues being updated:

| Script | Module | FFC sites | Added in |
|---|---|---|---|
| `ffc-audience` | Audience | 1 | 6.5.x |
| `ffc-frontend-helpers` | Self-Scheduling | 3 | 6.5.x |
| `ffc-calendar-core` | Self-Scheduling | 1 | 6.5.x |
| `ffc-geofence-frontend` | Frontend | 6 | 6.6.4 / follow-up |

Without a JS combiner this worked by accident on most pages because a *sibling* enqueue on the same hook already pulled `ffc-core` into the page. Combiners that flatten the dependency tree dropped `ffc-core` from the bundle, exposing the bug.

Fix is mechanical: `array('jquery')` → `array('jquery', 'ffc-core')` in each of the four call sites. No behaviour change on installs that don't combine JS.

## Test plan

- [ ] On a site with LiteSpeed Cache JS Combine ON: `[ffc_audience]` calendar loads dates/events again
- [ ] Other 3 fixes (self-scheduling, geofence) also resolve their respective `FFC is not defined` cases when combiner is on
- [ ] Sites without JS combiner: zero regression (deps already resolved by other means)
- [ ] CI green (no PHP/test changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DoW27oCksZLmDUrtD5CfLn)_