### PR TITLE
6.7.0 — Schedule exception per submission (WIP, #366)

### DIFF
--- a/includes/class-ffc-activator.php
+++ b/includes/class-ffc-activator.php
@@ -483,86 +483,99 @@ class Activator {
 		$table_name = \FreeFormCertificate\Core\Utils::get_submissions_table();
 
 		$columns = array(
-			'user_id'           => array(
+			'user_id'                 => array(
 				'type'  => 'BIGINT(20) UNSIGNED DEFAULT NULL',
 				'after' => 'form_id',
 				'index' => 'user_id',
 			),
-			'magic_token'       => array(
+			'magic_token'             => array(
 				'type'  => 'VARCHAR(32) DEFAULT NULL',
 				'after' => 'status',
 				'index' => 'magic_token',
 			),
-			'auth_code'         => array(
+			'auth_code'               => array(
 				'type'  => 'VARCHAR(20) DEFAULT NULL',
 				'after' => 'magic_token',
 				'index' => 'auth_code',
 			),
-			'email_encrypted'   => array(
+			'email_encrypted'         => array(
 				'type'  => 'TEXT NULL DEFAULT NULL',
 				'after' => 'auth_code',
 			),
-			'email_hash'        => array(
+			'email_hash'              => array(
 				'type'  => 'VARCHAR(64) NULL DEFAULT NULL',
 				'after' => 'email_encrypted',
 				'index' => 'email_hash',
 			),
-			'cpf_encrypted'     => array(
+			'cpf_encrypted'           => array(
 				'type'  => 'TEXT NULL DEFAULT NULL',
 				'after' => 'email_hash',
 			),
-			'cpf_hash'          => array(
+			'cpf_hash'                => array(
 				'type'  => 'VARCHAR(64) NULL DEFAULT NULL',
 				'after' => 'cpf_encrypted',
 				'index' => 'cpf_hash',
 			),
-			'rf_encrypted'      => array(
+			'rf_encrypted'            => array(
 				'type'  => 'TEXT NULL DEFAULT NULL',
 				'after' => 'cpf_hash',
 			),
-			'rf_hash'           => array(
+			'rf_hash'                 => array(
 				'type'  => 'VARCHAR(64) NULL DEFAULT NULL',
 				'after' => 'rf_encrypted',
 				'index' => 'rf_hash',
 			),
-			'ticket_hash'       => array(
+			'ticket_hash'             => array(
 				'type'  => 'VARCHAR(64) NULL DEFAULT NULL',
 				'after' => 'rf_hash',
 				'index' => 'ticket_hash',
 			),
-			'user_ip_encrypted' => array(
+			'user_ip_encrypted'       => array(
 				'type'  => 'TEXT NULL DEFAULT NULL',
 				'after' => 'ticket_hash',
 			),
-			'data_encrypted'    => array(
+			'data_encrypted'          => array(
 				'type'  => 'LONGTEXT NULL DEFAULT NULL',
 				'after' => 'user_ip_encrypted',
 			),
-			'consent_given'     => array(
+			'consent_given'           => array(
 				'type'  => 'TINYINT(1) DEFAULT 0',
 				'after' => 'data_encrypted',
 			),
 			// Category A instant since 6.6.0 (#249 sub-escopo d) — unix UTC.
-			'consent_date'      => array(
+			'consent_date'            => array(
 				'type'  => 'BIGINT UNSIGNED DEFAULT NULL',
 				'after' => 'consent_given',
 			),
-			'consent_text'      => array(
+			'consent_text'            => array(
 				'type'  => 'TEXT DEFAULT NULL',
 				'after' => 'consent_date',
 			),
-			'qr_code_cache'     => array(
+			'qr_code_cache'           => array(
 				'type'  => 'LONGTEXT DEFAULT NULL',
 				'after' => 'consent_text',
 			),
 			// Category A instant since 6.6.0 (#249 sub-escopo d) — unix UTC.
-			'edited_at'         => array(
+			'edited_at'               => array(
 				'type'  => 'BIGINT UNSIGNED DEFAULT NULL',
 				'after' => 'qr_code_cache',
 			),
-			'edited_by'         => array(
+			'edited_by'               => array(
 				'type'  => 'BIGINT(20) UNSIGNED NULL DEFAULT NULL',
 				'after' => 'edited_at',
+			),
+			// Category B wall-clock TIMEs for the operator-driven schedule
+			// exception (#366). NULL means "no override — use the form/geofence
+			// baseline at render time". Stored as literal HH:MM:SS, never
+			// converted across TZs. See CLAUDE.md "Date / time storage
+			// convention".
+			'schedule_start_override' => array(
+				'type'  => 'TIME NULL DEFAULT NULL',
+				'after' => 'edited_by',
+			),
+			'schedule_end_override'   => array(
+				'type'  => 'TIME NULL DEFAULT NULL',
+				'after' => 'schedule_start_override',
 			),
 		);
 

--- a/includes/core/class-ffc-activity-log.php
+++ b/includes/core/class-ffc-activity-log.php
@@ -54,6 +54,17 @@ class ActivityLog {
 	const LEVEL_DEBUG   = 'debug';
 
 	/**
+	 * Action types for the schedule-override-per-submission feature (#366).
+	 * The submission handler emits both rows whenever an operator-driven
+	 * exception is consumed: SCHEDULE_OVERRIDE_CREATED carries the full
+	 * before/after range + operator + participant context, and
+	 * OPERATOR_IP_BYPASS records that the IP rate-limit gate was bypassed
+	 * for that submission.
+	 */
+	const ACTION_SCHEDULE_OVERRIDE_CREATED = 'schedule_override_created';
+	const ACTION_OPERATOR_IP_BYPASS        = 'operator_ip_bypass';
+
+	/**
 	 * Cache for table columns (performance optimization)
 	 * Prevents repeated DESCRIBE queries on each log
 	 *

--- a/tests/Unit/ActivatorTest.php
+++ b/tests/Unit/ActivatorTest.php
@@ -318,4 +318,77 @@ class ActivatorTest extends TestCase {
         $this->assertArrayHasKey( 'ffc_submissions_db_version', $updated_options );
         $this->assertSame( FFC_VERSION, $updated_options['ffc_submissions_db_version'] );
     }
+
+    // ==================================================================
+    // add_columns() — schedule override columns (#366)
+    // ==================================================================
+
+    public function test_maybe_add_columns_emits_schedule_override_columns(): void {
+        // Force the version gate to "out of date" so add_columns() actually runs.
+        Functions\when( 'get_option' )->justReturn( '1.0.0' );
+
+        // Default get_results stub returns [], so column_exists() reports
+        // every column as missing — every column gets an ALTER TABLE.
+        $queries = [];
+        $this->wpdb->shouldReceive( 'query' )
+            ->andReturnUsing( function ( $sql ) use ( &$queries ) {
+                $queries[] = $sql;
+                return 1;
+            } );
+
+        Activator::maybe_add_columns();
+
+        $start_added = array_filter( $queries, function ( $sql ) {
+            return stripos( $sql, 'schedule_start_override' ) !== false
+                && stripos( $sql, 'TIME' ) !== false
+                && stripos( $sql, 'ADD COLUMN' ) !== false;
+        } );
+        $end_added = array_filter( $queries, function ( $sql ) {
+            return stripos( $sql, 'schedule_end_override' ) !== false
+                && stripos( $sql, 'TIME' ) !== false
+                && stripos( $sql, 'ADD COLUMN' ) !== false;
+        } );
+
+        $this->assertNotEmpty( $start_added, 'schedule_start_override TIME column should be added by the migration' );
+        $this->assertNotEmpty( $end_added, 'schedule_end_override TIME column should be added by the migration' );
+    }
+
+    public function test_maybe_add_columns_skips_schedule_override_columns_when_already_present(): void {
+        Functions\when( 'get_option' )->justReturn( '1.0.0' );
+
+        // Make column_exists() return true for the two override columns so
+        // add_column_if_missing() short-circuits without issuing ALTER TABLE.
+        $this->wpdb->shouldReceive( 'get_results' )
+            ->andReturnUsing( function ( $query ) {
+                if ( stripos( $query, 'SHOW COLUMNS' ) !== false
+                    && (
+                        stripos( $query, 'schedule_start_override' ) !== false
+                        || stripos( $query, 'schedule_end_override' ) !== false
+                    )
+                ) {
+                    return [ (object) [ 'Field' => 'present' ] ];
+                }
+                return [];
+            } );
+
+        $queries = [];
+        $this->wpdb->shouldReceive( 'query' )
+            ->andReturnUsing( function ( $sql ) use ( &$queries ) {
+                $queries[] = $sql;
+                return 1;
+            } );
+
+        Activator::maybe_add_columns();
+
+        foreach ( $queries as $sql ) {
+            $this->assertFalse(
+                stripos( $sql, 'ADD COLUMN' ) !== false
+                    && (
+                        stripos( $sql, 'schedule_start_override' ) !== false
+                        || stripos( $sql, 'schedule_end_override' ) !== false
+                    ),
+                'ALTER TABLE ADD COLUMN should not be issued for already-present override columns'
+            );
+        }
+    }
 }

--- a/tests/Unit/ActivityLogTest.php
+++ b/tests/Unit/ActivityLogTest.php
@@ -164,6 +164,11 @@ class ActivityLogTest extends TestCase {
         $this->assertSame('debug', ActivityLog::LEVEL_DEBUG);
     }
 
+    public function test_schedule_override_action_constants_are_defined(): void {
+        $this->assertSame('schedule_override_created', ActivityLog::ACTION_SCHEDULE_OVERRIDE_CREATED);
+        $this->assertSame('operator_ip_bypass', ActivityLog::ACTION_OPERATOR_IP_BYPASS);
+    }
+
     public function test_buffer_threshold_constant(): void {
         $ref = new \ReflectionClass(ActivityLog::class);
         $constants = $ref->getConstants();


### PR DESCRIPTION
Implements the operator-driven, hash-protected schedule-exception feature spec'd in #366.

This PR will accumulate 10 sequential sprints — each landing as one commit on this branch — and only lift out of draft after Sprint 10 (i18n + CHANGELOG + version bump). Auto-merge will be enabled at that point per `CLAUDE.md`.

## Sprint progress

- [x] **Sprint 1** — Schema (2 nullable TIME columns on `ffc_submissions`) + `ActivityLog::ACTION_SCHEDULE_OVERRIDE_CREATED` / `ACTION_OPERATOR_IP_BYPASS` constants.
- [ ] Sprint 2 — Admin metabox extension + form duplication propagates the 3 new form metas.
- [ ] Sprint 3 — `ScheduleExceptionSession` (signed cookie + HMAC token, 30 min, one-use).
- [ ] Sprint 4 — Operator modal in `[ffc_csv_download]` + `wp_ajax_nopriv_ffc_schedule_exception_create`.
- [ ] Sprint 5 — Form-render side: read cookie, embed signed token + hidden inputs, render banner, clear cookie.
- [ ] Sprint 6 — Submission handler: verify token, persist override columns, bypass IP rate-limit, emit 2 audit rows.
- [ ] Sprint 7 — `DateFormatter::format_schedule()` + `format_schedule_total()` + `{schedule}` / `{schedule_total}` placeholders on cert + email pipelines.
- [ ] Sprint 8 — `/valid` "Entrada/saída diferenciada" block.
- [ ] Sprint 9 — Activity Log admin renderer + filter dropdown for the 2 new action types.
- [ ] Sprint 10 — i18n (.po / .l10n.php / .mo), `CHANGELOG` under `[6.7.0]`, version bump 6.6.7 → 6.7.0, `npm run build:js` if any JS is new.

## Out-of-scope (registered in the issue, not in this PR)

GPS/geofence bypass · re-edit of an existing exception · per-CPF token binding · admin list filter for exceptional submissions.

## Test plan

- [ ] PHPUnit (8.3 + 8.4) green
- [ ] PHPStan level 8 green
- [ ] WPCS + ESLint + Stylelint + Vitest green
- [ ] Coverage ≥ floor (lines)
- [ ] Manual: create exception in dev, verify cert renders override, verify `/valid` block, verify audit log entries

Closes #366 (on merge).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7grqE9h5TssSekVW74DFF)_