### PR TITLE
6.6.8 — fix geofence shortcode regex + URL Shortener ffc-core dep

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -2,7 +2,7 @@ name: Asset Build Verification
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 # Path filters were removed because branch protection requires this
 # check on every PR. Skipped runs (path-filtered) never report status
 # and leave PRs in mergeable_state: blocked. With npm cache + npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # `release/**` so 6.6.x hotfix PRs (and any future minor-line
+    # maintenance branch) get the same PHPStan + PHPUnit + WPCS +
+    # coverage-floor gates as PRs targeting `main`. Without this,
+    # hotfix PRs were merging with zero CI signal.
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   schedule:
     # Weekly catch-all run so newly-disclosed query packs surface on
     # unchanged code too. Monday 03:00 UTC keeps it off business hours.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,7 +2,7 @@ name: PHPCS
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.8] (2026-05-22)
+
+Hotfix on the 6.6.x maintenance branch. Two production-reported bugs surfaced by an admin who configured "Hide form completely" on a form's date/time restrictions and saw the form still rendering, and by the QR Code download buttons silently doing nothing on a site that combines JS through a cache plugin.
+
+### Fixed
+
+- **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax.** `Frontend::localize_geofence_config()` matched form IDs with a hand-rolled regex (`/\[ffc_form\s+id=['"](\d+)['"]\]/`) that **required** the `id` attribute to be wrapped in quotes AND to be the LAST attribute before the closing bracket. WordPress's shortcode parser accepts `[ffc_form id=42]` (unquoted shorthand) and `[ffc_form id="42" class="ffc-custom"]` (extra attributes) as valid — admins who used either format saw the form render with no geofence at all because the localization step silently dropped them. Symptom on the user side: setting *"Display before opening" → "Hide form completely"* in the admin had no effect — the form remained visible before its start date. Fix: replace the hand-rolled regex with `get_shortcode_regex(['ffc_form'])` and parse attributes via `shortcode_parse_atts()`, the WP-canonical helpers that handle every quoting variant the platform parser accepts.
+- **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS.** `ffc-url-shortener-admin.js` declared only `['jquery']` as a script dependency but the click handlers call `FFC.request()`, which lives on `ffc-core`. WordPress loads both scripts on the page, but JS combiners (LiteSpeed JS Combine, WP Rocket Combine, etc.) flatten the dependency tree — without `ffc-core` in the declared chain, the combined bundle can execute the URL Shortener script before `window.FFC` is defined, throwing `TypeError: FFC.request is undefined` and aborting the click handler silently. Same fix shape as 6.6.7 (#367) applied to the four public-facing sites; this admin site was missed in that pass. Both enqueues (post-edit metabox + admin list page) now list `ffc-core`.
+
+### Tests
+
+- 3 new PHPUnit cases in `FrontendTest` covering the regex switch: quoted, unquoted, and extra-attributes shortcode shapes all land in `ffcGeofenceConfig` with the correct form ID.
+
+### Notes
+
+- This release branches off `release/6.6.x` rather than `main` so it can ship while the 6.7.0 feature (Schedule exception per submission, #366) is still in testing.
+- The fixes will be forward-ported to `main` so 6.7.0 also carries them.
+
+---
+
 ## [6.6.7] (2026-05-21)
 
 Follow-up to the PR #352 (6.6.2) dependency cleanup. Four public-facing JS enqueues never had `ffc-core` listed as a dependency, so any page combining their script via a JS-combining cache plugin (LiteSpeed JS Combine, WP Rocket Combine, etc.) ended up with `FFC is not defined` and a non-functional widget. Reported on `dresaomiguel.com.br/avaliacoes-e-provas/` where `[ffc_audience schedule_id="1"]` failed to render the calendar.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.7
+ * Version:            6.6.8
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.7' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.8' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/frontend/class-ffc-frontend.php
+++ b/includes/frontend/class-ffc-frontend.php
@@ -484,8 +484,8 @@ class Frontend {
 		// `[ffc_form id="42"]` (double-quoted) and `[ffc_form id='42']`
 		// (single-quoted). It silently missed two WP-valid formats that
 		// are common in the wild:
-		//   - `[ffc_form id=42]` — quotes are optional in shortcode atts
-		//   - `[ffc_form id="42" class="extra"]` — additional attributes
+		// `[ffc_form id=42]` (quotes are optional in shortcode atts) and
+		// `[ffc_form id="42" class="extra"]` (additional attributes).
 		// When the regex missed, `wp_localize_script` was never called
 		// for that form, so the JS geofence layer never received its
 		// config, never validated the datetime window, and the form

--- a/includes/frontend/class-ffc-frontend.php
+++ b/includes/frontend/class-ffc-frontend.php
@@ -479,17 +479,46 @@ class Frontend {
 		}
 
 		// Find all form IDs in post content.
-		preg_match_all( '/\[ffc_form\s+id=[\'"](\d+)[\'"]\]/', $post->post_content, $matches );
+		//
+		// Pre-6.6.8 used a hand-rolled regex that ONLY matched
+		// `[ffc_form id="42"]` (double-quoted) and `[ffc_form id='42']`
+		// (single-quoted). It silently missed two WP-valid formats that
+		// are common in the wild:
+		//   - `[ffc_form id=42]` — quotes are optional in shortcode atts
+		//   - `[ffc_form id="42" class="extra"]` — additional attributes
+		// When the regex missed, `wp_localize_script` was never called
+		// for that form, so the JS geofence layer never received its
+		// config, never validated the datetime window, and the form
+		// rendered as if no geofence existed. Users would set
+		// "hide before start" in admin and still see the form on the
+		// public page.
+		//
+		// Fix: use `get_shortcode_regex(['ffc_form'])`, the canonical
+		// WP helper, then parse atts via `shortcode_parse_atts()` which
+		// handles all the quoting variants WP's own parser accepts.
+		$form_ids = array();
+		$pattern  = get_shortcode_regex( array( 'ffc_form' ) );
+		if ( preg_match_all( '/' . $pattern . '/', $post->post_content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				// $match[3] holds the raw attribute string in WP's
+				// get_shortcode_regex layout (group 3).
+				$atts_raw = isset( $match[3] ) ? (string) $match[3] : '';
+				$atts     = shortcode_parse_atts( $atts_raw );
+				$id       = isset( $atts['id'] ) ? (int) $atts['id'] : 0;
+				if ( $id > 0 ) {
+					$form_ids[] = $id;
+				}
+			}
+		}
 
-		if ( empty( $matches[1] ) ) {
+		if ( empty( $form_ids ) ) {
 			return;
 		}
 
 		$geofence_configs = array();
 
-		foreach ( $matches[1] as $form_id ) {
-			$form_id_int = (int) $form_id;
-			$config      = \FreeFormCertificate\Security\Geofence::get_frontend_config( $form_id_int );
+		foreach ( array_unique( $form_ids ) as $form_id_int ) {
+			$config = \FreeFormCertificate\Security\Geofence::get_frontend_config( $form_id_int );
 
 			if ( null !== $config ) {
 				$geofence_configs[ $form_id_int ] = $config;

--- a/includes/url-shortener/class-ffc-url-shortener-admin-page.php
+++ b/includes/url-shortener/class-ffc-url-shortener-admin-page.php
@@ -86,7 +86,14 @@ class UrlShortenerAdminPage {
 		wp_enqueue_script(
 			'ffc-url-shortener-admin',
 			FFC_PLUGIN_URL . 'assets/js/ffc-url-shortener-admin.js',
-			array( 'jquery' ),
+			// `ffc-core` carries `window.FFC.request()` which the QR-download
+			// click handler calls. Declaring it as a dep makes the load
+			// order survive JS-combining cache plugins (LiteSpeed Combine,
+			// WP Rocket Combine, etc.) that flatten the bundle and would
+			// otherwise drop `ffc-core` for not being in the chain. Same
+			// fix shape as 6.6.7 (#367) applied to the 4 public-facing
+			// sites; admin sites missed that pass.
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/url-shortener/class-ffc-url-shortener-meta-box.php
+++ b/includes/url-shortener/class-ffc-url-shortener-meta-box.php
@@ -230,7 +230,14 @@ class UrlShortenerMetaBox {
 		wp_enqueue_script(
 			'ffc-url-shortener-admin',
 			FFC_PLUGIN_URL . 'assets/js/ffc-url-shortener-admin.js',
-			array( 'jquery' ),
+			// `ffc-core` carries `window.FFC.request()` which the QR-download
+			// click handler calls. Declaring it as a dep makes the load
+			// order survive JS-combining cache plugins (LiteSpeed Combine,
+			// WP Rocket Combine, etc.) that flatten the bundle and would
+			// otherwise drop `ffc-core` for not being in the chain. Same
+			// fix shape as 6.6.7 (#367) applied to the 4 public-facing
+			// sites; admin sites missed that pass.
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.7
+Stable tag: 6.6.8
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/FrontendTest.php
+++ b/tests/Unit/FrontendTest.php
@@ -43,6 +43,25 @@ class FrontendTest extends TestCase {
             }
             return $defaults;
         } );
+        // Stubs for the WP shortcode helpers used by
+        // localize_geofence_config() since the 6.6.8 fix. Default
+        // regex pattern matches `[ffc_form ...]` and captures the
+        // attribute string in group 3 (WP's actual layout).
+        Functions\when( 'get_shortcode_regex' )->justReturn(
+            '\[(\[?)(ffc_form)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)'
+        );
+        Functions\when( 'shortcode_parse_atts' )->alias( function ( $text ) {
+            $atts    = array();
+            $pattern = '/(\w+)\s*=\s*"([^"]*)"|(\w+)\s*=\s*\'([^\']*)\'|(\w+)\s*=\s*([^\s\]]+)/';
+            if ( preg_match_all( $pattern, (string) $text, $m, PREG_SET_ORDER ) ) {
+                foreach ( $m as $row ) {
+                    $key            = $row[1] !== '' ? $row[1] : ( $row[3] !== '' ? $row[3] : $row[5] );
+                    $val            = $row[1] !== '' ? $row[2] : ( $row[3] !== '' ? $row[4] : $row[6] );
+                    $atts[ $key ] = $val;
+                }
+            }
+            return $atts;
+        } );
 
         // PublicCsvDownload::register_hooks() instantiates PublicCsvExporter,
         // whose SubmissionRepository constructor reads $wpdb->prefix.
@@ -229,5 +248,81 @@ class FrontendTest extends TestCase {
         // Geofence config should be localized
         $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
         $this->assertArrayHasKey( '_global', $localized['ffcGeofenceConfig'] );
+    }
+
+    /**
+     * Stub `get_shortcode_regex` + `shortcode_parse_atts` with simplified
+     * WP-shape implementations so the production regex switch (#XXX 6.6.8)
+     * can be driven through both quoted and unquoted attribute formats.
+     * Returns the captured `wp_localize_script` payload bag.
+     *
+     * @param string $post_content Raw `$post->post_content` to drive.
+     * @return array<string, mixed>
+     */
+    private function capture_geofence_for_content( string $post_content ): array {
+        global $post;
+        $post = Mockery::mock( 'WP_Post' );
+        $post->post_content = $post_content;
+
+        Functions\when( 'has_shortcode' )->justReturn( true );
+
+        // Alias Geofence so we don't have to wire up get_post_meta /
+        // settings / option reads — we're testing the regex+atts path,
+        // not the config builder.
+        $geofence_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\Geofence' );
+        $geofence_mock->shouldReceive( 'get_frontend_config' )
+            ->andReturnUsing( static fn( $id ) => array( 'formId' => (int) $id, 'datetime' => array( 'enabled' => true ) ) );
+
+        $localized = array();
+        Functions\when( 'wp_localize_script' )->alias( function ( $handle, $name, $data ) use ( &$localized ) {
+            $localized[ $name ] = $data;
+        } );
+
+        $handler  = $this->makeSubmissionHandlerMock();
+        $frontend = new Frontend( $handler );
+        $frontend->frontend_assets();
+
+        return $localized;
+    }
+
+    public function test_localize_geofence_accepts_quoted_id(): void {
+        $localized = $this->capture_geofence_for_content( '[ffc_form id="42"]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        // Form id was extracted — `_global` PLUS the per-form key share the array.
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ) );
+    }
+
+    public function test_localize_geofence_accepts_unquoted_id(): void {
+        // The bug fixed in 6.6.8: pre-fix regex required quotes around
+        // the id attribute, so `[ffc_form id=42]` (WP-valid unquoted
+        // shorthand) silently failed to localize and the JS geofence
+        // never received its config. The form rendered as if no
+        // datetime restriction existed.
+        $localized = $this->capture_geofence_for_content( '[ffc_form id=42]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ), 'unquoted id MUST localize too' );
+    }
+
+    public function test_localize_geofence_accepts_extra_attributes(): void {
+        // Same root cause, second failing shape: pre-fix regex required
+        // `id=...` to be the LAST attribute before the closing bracket.
+        $localized = $this->capture_geofence_for_content( '[ffc_form id="42" class="ffc-custom"]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ), 'extra attributes MUST NOT block localize' );
     }
 }


### PR DESCRIPTION
Hotfix on the 6.6.x maintenance line — does not pull in 6.7.0 (still in testing).

## Bugs

### 1. "Hide form completely before opening" não oculta o form

**Root cause**: `Frontend::localize_geofence_config()` extraía form IDs do `post_content` com regex hand-rolled `/\[ffc_form\s+id=['"](\d+)['"]\]/`. Esse regex EXIGE aspas e que `id` seja o único atributo.

- `[ffc_form id="42"]` ✅ casa
- `[ffc_form id=42]` ❌ não casa (shorthand WP-válido)
- `[ffc_form id="42" class="x"]` ❌ não casa (atributos extras)

Quando não casa, `wp_localize_script('ffcGeofenceConfig', …)` nunca é chamado → `window.ffcGeofenceConfig` indefinido no client → JS `init()` aborta na primeira linha → nada de validação datetime, nada de `handleBlocked()`, form renderiza como se não houvesse geofence.

**Fix**: substituir o regex por `get_shortcode_regex(['ffc_form'])` + `shortcode_parse_atts()` (canônicos do WP — aceitam todos os formatos válidos).

### 2. QR download / regenerate / copy buttons no URL Shortener admin não funcionam em sites com JS combine

**Root cause**: `ffc-url-shortener-admin.js` declarava apenas `['jquery']` como dep, mas o handler de click chama `FFC.request()` que vive em `ffc-core`. Em sites sem combiner, ambos scripts carregam na ordem certa por sorte. Em sites com LiteSpeed Combine / WP Rocket Combine, o bundle achata a chain e pode executar o URL Shortener antes de `window.FFC` existir — handler morre silenciosamente com `TypeError`.

Mesmo padrão da fix do 6.6.7 (#367) que cobriu 4 sites public-facing. Os 2 sites admin do URL Shortener ficaram de fora desse pass.

**Fix**: adicionar `'ffc-core'` à dep array de ambos enqueues (metabox + admin page).

## Test plan

- [x] PHPUnit (4601 testes) — verde local.
- [x] PHPCS WPCS — clean.
- [x] PHPStan level 8 — clean.
- [ ] Manual: criar form `[ffc_form id=42]` (sem aspas), configurar "Hide form completely" antes da janela, abrir frontend → form não aparece.
- [ ] Manual: form `[ffc_form id="42" class="ffc-custom"]` — mesmo cenário.
- [ ] Manual: site com LiteSpeed JS Combine ON, edit ffc_form, clicar "Download QR PNG" → arquivo baixa.

## Notes

- Base: `release/6.6.x` (NÃO `main` — main carrega 6.7.0 em testes).
- Forward-port pra `main` vai sair em PR separada depois deste merge, pra que 6.7.0 também carregue as duas fixes.
- Bump 6.6.7 → 6.6.8 (patch — fix-only).

Closes (hotfix workflow, sem ligação direta a issue).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7grqE9h5TssSekVW74DFF)_