### PR TITLE
Forward-port 6.6.8 + 6.6.9 + 6.6.10 hotfixes to main

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -2,7 +2,7 @@ name: Asset Build Verification
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 # Path filters were removed because branch protection requires this
 # check on every PR. Skipped runs (path-filtered) never report status
 # and leave PRs in mergeable_state: blocked. With npm cache + npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # `release/**` so 6.6.x hotfix PRs (and any future minor-line
+    # maintenance branch) get the same PHPStan + PHPUnit + WPCS +
+    # coverage-floor gates as PRs targeting `main`. Without this,
+    # hotfix PRs were merging with zero CI signal.
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   schedule:
     # Weekly catch-all run so newly-disclosed query packs surface on
     # unchanged code too. Monday 03:00 UTC keeps it off business hours.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,7 +2,7 @@ name: PHPCS
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,16 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - **`ffc_submissions` schema.** Two new nullable `TIME` columns added through the existing `Activator::maybe_add_columns()` migration. NULL means "no override — use the baseline at render time". Category B wall-clock per CLAUDE.md.
 - **`ActivityLog` action vocabulary.** Two new constants (`ACTION_SCHEDULE_OVERRIDE_CREATED`, `ACTION_OPERATOR_IP_BYPASS`). The constant values are also inlined as literals in `FormProcessor::persist_schedule_exception()` so the test harness can spy on `ActivityLog::log()` via a Mockery alias without booting the real wpdb-backed class.
 
+### Fixed (forward-ported from 6.6.8)
+
+- **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax.** `Frontend::localize_geofence_config()` matched form IDs with a hand-rolled regex (`/\[ffc_form\s+id=['"](\d+)['"]\]/`) that **required** the `id` attribute to be wrapped in quotes AND to be the LAST attribute before the closing bracket. WordPress's shortcode parser accepts `[ffc_form id=42]` (unquoted shorthand) and `[ffc_form id="42" class="ffc-custom"]` (extra attributes) as valid — admins who used either format saw the form render with no geofence at all because the localization step silently dropped them. Symptom on the user side: setting *"Display before opening" → "Hide form completely"* in the admin had no effect — the form remained visible before its start date. Fix: replace the hand-rolled regex with `get_shortcode_regex(['ffc_form'])` and parse attributes via `shortcode_parse_atts()`, the WP-canonical helpers that handle every quoting variant the platform parser accepts.
+- **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS.** `ffc-url-shortener-admin.js` declared only `['jquery']` as a script dependency but the click handlers call `FFC.request()`, which lives on `ffc-core`. WordPress loads both scripts on the page, but JS combiners (LiteSpeed JS Combine, WP Rocket Combine, etc.) flatten the dependency tree — without `ffc-core` in the declared chain, the combined bundle can execute the URL Shortener script before `window.FFC` is defined, throwing `TypeError: FFC.request is undefined` and aborting the click handler silently. Same fix shape as 6.6.7 (#367) applied to the four public-facing sites; this admin site was missed in that pass. Both enqueues (post-edit metabox + admin list page) now list `ffc-core`.
+
 ### Tests
 
 - 65+ new PHPUnit cases across 8 files covering: schema migration idempotency, the action gate cascade and override-validation matrix, the session crypto round-trip (tamper / expiry / version / form-id-mismatch rejection), cookie attribute correctness, form-render embed + clear, submission handler persistence + audit emit, placeholder formatter / resolver, `/valid` block assembly, and the admin renderer.
 - 7 new Vitest cases for the operator modal (render gating, modal open with baseline pre-fill, client-side validation, AJAX success → CTA swap, AJAX failure → button re-enabled + error visible, Escape closes).
+- 3 additional PHPUnit cases in `FrontendTest` covering the regex switch from the forward-ported 6.6.8 fix: quoted, unquoted, and extra-attributes shortcode shapes all land in `ffcGeofenceConfig`.
 
 ### i18n
 
@@ -44,6 +50,21 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - Re-edit of an existing exception — current contract is one-use, admin must delete the submission and operator recreates.
 - Restriction of an exception to a specific participant CPF — current contract trusts the operator to hand the tablet to the right person within the 30-minute window.
 - Admin list filter for "exceptional submissions only" — explicitly out per the issue spec ("sem badge na lista de submissões").
+
+---
+
+## [6.6.8] (2026-05-22)
+
+Hotfix on the 6.6.x maintenance branch. See `release/6.6.x` for the shipped tag; the same two fixes are forward-ported into 6.7.0 above so installs on `main` carry them too.
+
+### Fixed
+
+- **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax.** See the "Fixed (forward-ported from 6.6.8)" entry under 6.7.0 for the full diagnosis.
+- **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS.** Same scope as the forward-port note in 6.7.0.
+
+### Notes
+
+- This release branches off `release/6.6.x` rather than `main` so it could ship while the 6.7.0 feature (Schedule exception per submission, #366) was still in testing.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,18 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - **`ffc_submissions` schema.** Two new nullable `TIME` columns added through the existing `Activator::maybe_add_columns()` migration. NULL means "no override — use the baseline at render time". Category B wall-clock per CLAUDE.md.
 - **`ActivityLog` action vocabulary.** Two new constants (`ACTION_SCHEDULE_OVERRIDE_CREATED`, `ACTION_OPERATOR_IP_BYPASS`). The constant values are also inlined as literals in `FormProcessor::persist_schedule_exception()` so the test harness can spy on `ActivityLog::log()` via a Mockery alias without booting the real wpdb-backed class.
 
-### Fixed (forward-ported from 6.6.8)
+### Fixed (forward-ported from 6.6.8 / 6.6.9)
 
-- **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax.** `Frontend::localize_geofence_config()` matched form IDs with a hand-rolled regex (`/\[ffc_form\s+id=['"](\d+)['"]\]/`) that **required** the `id` attribute to be wrapped in quotes AND to be the LAST attribute before the closing bracket. WordPress's shortcode parser accepts `[ffc_form id=42]` (unquoted shorthand) and `[ffc_form id="42" class="ffc-custom"]` (extra attributes) as valid — admins who used either format saw the form render with no geofence at all because the localization step silently dropped them. Symptom on the user side: setting *"Display before opening" → "Hide form completely"* in the admin had no effect — the form remained visible before its start date. Fix: replace the hand-rolled regex with `get_shortcode_regex(['ffc_form'])` and parse attributes via `shortcode_parse_atts()`, the WP-canonical helpers that handle every quoting variant the platform parser accepts.
-- **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS.** `ffc-url-shortener-admin.js` declared only `['jquery']` as a script dependency but the click handlers call `FFC.request()`, which lives on `ffc-core`. WordPress loads both scripts on the page, but JS combiners (LiteSpeed JS Combine, WP Rocket Combine, etc.) flatten the dependency tree — without `ffc-core` in the declared chain, the combined bundle can execute the URL Shortener script before `window.FFC` is defined, throwing `TypeError: FFC.request is undefined` and aborting the click handler silently. Same fix shape as 6.6.7 (#367) applied to the four public-facing sites; this admin site was missed in that pass. Both enqueues (post-edit metabox + admin list page) now list `ffc-core`.
+- **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax** (6.6.8). `Frontend::localize_geofence_config()` matched form IDs with a hand-rolled regex (`/\[ffc_form\s+id=['"](\d+)['"]\]/`) that **required** the `id` attribute to be wrapped in quotes AND to be the LAST attribute before the closing bracket. WordPress's shortcode parser accepts `[ffc_form id=42]` (unquoted shorthand) and `[ffc_form id="42" class="ffc-custom"]` (extra attributes) as valid — admins who used either format saw the form render with no geofence at all because the localization step silently dropped them. Symptom on the user side: setting *"Display before opening" → "Hide form completely"* in the admin had no effect — the form remained visible before its start date. Fix: replace the hand-rolled regex with `get_shortcode_regex(['ffc_form'])` and parse attributes via `shortcode_parse_atts()`, the WP-canonical helpers that handle every quoting variant the platform parser accepts.
+- **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS** (6.6.8). `ffc-url-shortener-admin.js` declared only `['jquery']` as a script dependency but the click handlers call `FFC.request()`, which lives on `ffc-core`. WordPress loads both scripts on the page, but JS combiners (LiteSpeed JS Combine, WP Rocket Combine, etc.) flatten the dependency tree — without `ffc-core` in the declared chain, the combined bundle can execute the URL Shortener script before `window.FFC` is defined, throwing `TypeError: FFC.request is undefined` and aborting the click handler silently. Same fix shape as 6.6.7 (#367) applied to the four public-facing sites; this admin site was missed in that pass. Both enqueues (post-edit metabox + admin list page) now list `ffc-core`.
+- **URL Shortener admin: same buttons still inert on regular post/page edit screens (Gutenberg)** (6.6.9). 6.6.8 declared `'ffc-core'` as a dep but assumed the handle was already registered. That holds on FFC-owned pages (`post_type === 'ffc_form'` or `page=ffc-*`), but the URL Shortener metabox also renders on regular post / page edit screens when the post type is enabled — and on those screens `AdminAssetsManager::is_ffc_page()` returns false, so `ffc-core` was never registered for the request. WordPress's enqueue path silently dropped the unknown dep, `window.FFC` stayed undefined, and the QR PNG / SVG / Regenerate / Copy buttons still failed silently. Reported on the production site (Gutenberg post edit, standard `post` post type, URL Shortener metabox visible in the sidebar). Fix: register `ffc-core` early on every `admin_enqueue_scripts` request via a new `Loader::register_admin_core_assets()` hook (priority 1, before any module enqueues run). Idempotent — guarded by `wp_script_is('ffc-core', 'registered')` so it's a no-op on FFC pages where `AdminAssetsManager` already registered the handle. Mirrors the frontend `register_frontend_assets()` pattern.
 
 ### Tests
 
 - 65+ new PHPUnit cases across 8 files covering: schema migration idempotency, the action gate cascade and override-validation matrix, the session crypto round-trip (tamper / expiry / version / form-id-mismatch rejection), cookie attribute correctness, form-render embed + clear, submission handler persistence + audit emit, placeholder formatter / resolver, `/valid` block assembly, and the admin renderer.
 - 7 new Vitest cases for the operator modal (render gating, modal open with baseline pre-fill, client-side validation, AJAX success → CTA swap, AJAX failure → button re-enabled + error visible, Escape closes).
 - 3 additional PHPUnit cases in `FrontendTest` covering the regex switch from the forward-ported 6.6.8 fix: quoted, unquoted, and extra-attributes shortcode shapes all land in `ffcGeofenceConfig`.
+- 3 additional PHPUnit cases in `LoaderTest` for the 6.6.9 admin-side `ffc-core` registration: constructor wires the `admin_enqueue_scripts` hook at priority 1; method registers `ffc-core` when not yet registered; method is a no-op when `AdminAssetsManager` already registered it.
 
 ### i18n
 
@@ -50,6 +52,16 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - Re-edit of an existing exception — current contract is one-use, admin must delete the submission and operator recreates.
 - Restriction of an exception to a specific participant CPF — current contract trusts the operator to hand the tablet to the right person within the 30-minute window.
 - Admin list filter for "exceptional submissions only" — explicitly out per the issue spec ("sem badge na lista de submissões").
+
+---
+
+## [6.6.9] (2026-05-22)
+
+Follow-up to the URL Shortener half of 6.6.8 (#370 → release/6.6.x). See `release/6.6.x` for the shipped tag; the fix is forward-ported into 6.7.0 above.
+
+### Fixed
+
+- **URL Shortener admin: QR PNG / SVG / Regenerate / Copy buttons still inert on non-FFC admin screens.** See the third bullet of the "Fixed (forward-ported from 6.6.8 / 6.6.9)" entry under 6.7.0 for the full diagnosis.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - **`ffc_submissions` schema.** Two new nullable `TIME` columns added through the existing `Activator::maybe_add_columns()` migration. NULL means "no override — use the baseline at render time". Category B wall-clock per CLAUDE.md.
 - **`ActivityLog` action vocabulary.** Two new constants (`ACTION_SCHEDULE_OVERRIDE_CREATED`, `ACTION_OPERATOR_IP_BYPASS`). The constant values are also inlined as literals in `FormProcessor::persist_schedule_exception()` so the test harness can spy on `ActivityLog::log()` via a Mockery alias without booting the real wpdb-backed class.
 
-### Fixed (forward-ported from 6.6.8 / 6.6.9)
+### Fixed (forward-ported from 6.6.8 / 6.6.9 / 6.6.10)
 
 - **`[ffc_form]` shortcode: geofence config not localized when the shortcode uses unquoted or extra-attribute syntax** (6.6.8). `Frontend::localize_geofence_config()` matched form IDs with a hand-rolled regex (`/\[ffc_form\s+id=['"](\d+)['"]\]/`) that **required** the `id` attribute to be wrapped in quotes AND to be the LAST attribute before the closing bracket. WordPress's shortcode parser accepts `[ffc_form id=42]` (unquoted shorthand) and `[ffc_form id="42" class="ffc-custom"]` (extra attributes) as valid — admins who used either format saw the form render with no geofence at all because the localization step silently dropped them. Symptom on the user side: setting *"Display before opening" → "Hide form completely"* in the admin had no effect — the form remained visible before its start date. Fix: replace the hand-rolled regex with `get_shortcode_regex(['ffc_form'])` and parse attributes via `shortcode_parse_atts()`, the WP-canonical helpers that handle every quoting variant the platform parser accepts.
 - **URL Shortener admin: QR download / regenerate / copy buttons fail silently on sites that combine JS** (6.6.8). `ffc-url-shortener-admin.js` declared only `['jquery']` as a script dependency but the click handlers call `FFC.request()`, which lives on `ffc-core`. WordPress loads both scripts on the page, but JS combiners (LiteSpeed JS Combine, WP Rocket Combine, etc.) flatten the dependency tree — without `ffc-core` in the declared chain, the combined bundle can execute the URL Shortener script before `window.FFC` is defined, throwing `TypeError: FFC.request is undefined` and aborting the click handler silently. Same fix shape as 6.6.7 (#367) applied to the four public-facing sites; this admin site was missed in that pass. Both enqueues (post-edit metabox + admin list page) now list `ffc-core`.
 - **URL Shortener admin: same buttons still inert on regular post/page edit screens (Gutenberg)** (6.6.9). 6.6.8 declared `'ffc-core'` as a dep but assumed the handle was already registered. That holds on FFC-owned pages (`post_type === 'ffc_form'` or `page=ffc-*`), but the URL Shortener metabox also renders on regular post / page edit screens when the post type is enabled — and on those screens `AdminAssetsManager::is_ffc_page()` returns false, so `ffc-core` was never registered for the request. WordPress's enqueue path silently dropped the unknown dep, `window.FFC` stayed undefined, and the QR PNG / SVG / Regenerate / Copy buttons still failed silently. Reported on the production site (Gutenberg post edit, standard `post` post type, URL Shortener metabox visible in the sidebar). Fix: register `ffc-core` early on every `admin_enqueue_scripts` request via a new `Loader::register_admin_core_assets()` hook (priority 1, before any module enqueues run). Idempotent — guarded by `wp_script_is('ffc-core', 'registered')` so it's a no-op on FFC pages where `AdminAssetsManager` already registered the handle. Mirrors the frontend `register_frontend_assets()` pattern.
+- **Form duplication: four CSV-public-download sub-feature toggles missed by `CPT::handle_form_duplication()`** (6.6.10). `_ffc_csv_public_download_enabled`, `_ffc_csv_public_preview_enabled`, `_ffc_csv_public_start_early_enabled`, and `_ffc_csv_public_extend_end_enabled` are persisted by `FormEditorSaveHandler::save_form_data()` whenever the admin saves the form's "CSV Download público" section. The 6.5.6 → 6.5.12 sprints that introduced each toggle never added it to the duplicator's hard-coded `$config_metas` list, so a duplicate had empty meta on all four — and empty meta reads as the FormEditorSaveHandler default at metabox render time ('1' for download / preview / start_early, '0' for extend_end). Net effect: any admin who had disabled the download / preview / start_early sub-toggle on the original saw it silently re-enabled on the duplicate; any admin who had enabled extend_end saw it silently disabled. Fix: add the four keys to `$config_metas`. The hash + counter exclusions stay — those are still intentionally not copied.
 
 ### Tests
 
@@ -41,6 +42,7 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - 7 new Vitest cases for the operator modal (render gating, modal open with baseline pre-fill, client-side validation, AJAX success → CTA swap, AJAX failure → button re-enabled + error visible, Escape closes).
 - 3 additional PHPUnit cases in `FrontendTest` covering the regex switch from the forward-ported 6.6.8 fix: quoted, unquoted, and extra-attributes shortcode shapes all land in `ffcGeofenceConfig`.
 - 3 additional PHPUnit cases in `LoaderTest` for the 6.6.9 admin-side `ffc-core` registration: constructor wires the `admin_enqueue_scripts` hook at priority 1; method registers `ffc-core` when not yet registered; method is a no-op when `AdminAssetsManager` already registered it.
+- 1 additional PHPUnit case in `CptTest` (`test_handle_form_duplication_copies_all_per_form_metas`) for the 6.6.10 duplicator fix: every persisted per-form meta key copied verbatim; hash + counter exclusions preserved. Acts as the regression lock for future sub-feature toggles.
 
 ### i18n
 
@@ -52,6 +54,16 @@ Per-submission **schedule exception** flow (#366). When a participant misses a c
 - Re-edit of an existing exception — current contract is one-use, admin must delete the submission and operator recreates.
 - Restriction of an exception to a specific participant CPF — current contract trusts the operator to hand the tablet to the right person within the 30-minute window.
 - Admin list filter for "exceptional submissions only" — explicitly out per the issue spec ("sem badge na lista de submissões").
+
+---
+
+## [6.6.10] (2026-05-22)
+
+Hotfix on the 6.6.x maintenance branch (#373 → release/6.6.x). See `release/6.6.x` for the shipped tag; the fix is forward-ported into 6.7.0 above.
+
+### Fixed
+
+- **Form duplication: four CSV-public-download sub-feature toggles missed by `CPT::handle_form_duplication()`.** See the fourth bullet of the "Fixed (forward-ported from 6.6.8 / 6.6.9 / 6.6.10)" entry under 6.7.0 for the full diagnosis.
 
 ---
 

--- a/includes/admin/class-ffc-cpt.php
+++ b/includes/admin/class-ffc-cpt.php
@@ -168,8 +168,19 @@ class CPT {
 			'_ffc_form_config',
 			'_ffc_form_bg',
 			'_ffc_geofence_config',
-			// Public CSV Download (enabled + sub-settings only).
+			// Public CSV Download (enabled flag + sub-feature toggles + sub-settings).
+			// 6.6.10 — the four `*_enabled` sub-feature toggles below were
+			// missing from the pre-6.6.10 list, so a duplicated form lost
+			// the admin's choice on download / preview / start-early /
+			// extend-end. Empty meta reads as the FormEditorSaveHandler
+			// default ('1' for the first three, '0' for extend-end), so
+			// the silent loss flipped the duplicate's behaviour either
+			// direction depending on which toggle the admin had touched.
 			'_ffc_csv_public_enabled',
+			'_ffc_csv_public_download_enabled',
+			'_ffc_csv_public_preview_enabled',
+			'_ffc_csv_public_start_early_enabled',
+			'_ffc_csv_public_extend_end_enabled',
 			'_ffc_csv_public_limit',
 			'_ffc_csv_public_cpf_mode',
 			'_ffc_csv_public_cpf_whitelist',

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -159,6 +159,18 @@ class Loader {
 	public function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'init_plugin' ), 10 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_assets' ) );
+		// Mirror the frontend register_frontend_assets pattern in admin.
+		// `ffc-core` carries `window.FFC.request()` and is used by several
+		// admin enqueues (URL Shortener metabox, etc.). Pre-6.6.9 it was
+		// only registered when AdminAssetsManager decided the current page
+		// was an FFC page (post_type === 'ffc_form' OR page === 'ffc-*').
+		// On regular post/page admin screens where the URL Shortener
+		// metabox is rendered, that gate failed and the dep silently
+		// dropped, leaving `window.FFC` undefined and the QR download /
+		// regenerate / copy buttons inert. Registering early on every
+		// admin request makes `ffc-core` resolvable as a dep regardless
+		// of post type. Enqueue happens elsewhere; this is register-only.
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_core_assets' ), 1 );
 		$this->define_activation_hooks();
 	}
 
@@ -504,6 +516,45 @@ class Loader {
 			'ffcDynamic',
 			array(
 				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			)
+		);
+	}
+
+	/**
+	 * Register `ffc-core` on every admin request.
+	 *
+	 * Sibling of register_frontend_assets() for the admin side. Other
+	 * admin enqueues (URL Shortener metabox, etc.) declare `ffc-core` as
+	 * a dependency — when this script is not registered, WP silently
+	 * drops the dep and `window.FFC.request()` becomes undefined at
+	 * runtime. AdminAssetsManager already enqueues ffc-core on FFC
+	 * pages (which also registers it); this hook covers the gap on
+	 * regular post/page edit screens where the URL Shortener metabox
+	 * is enabled for the post type but is_ffc_page() returns false.
+	 *
+	 * Hook priority 1 so the registration runs before any module's
+	 * enqueue callback (default priority 10).
+	 *
+	 * @since 6.6.9
+	 */
+	public function register_admin_core_assets(): void {
+		if ( wp_script_is( 'ffc-core', 'registered' ) ) {
+			return;
+		}
+
+		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
+		wp_register_script(
+			'ffc-core',
+			FFC_PLUGIN_URL . "assets/js/ffc-core{$s}.js",
+			array( 'jquery' ),
+			FFC_VERSION,
+			true
+		);
+		wp_localize_script(
+			'ffc-core',
+			'ffcCoreConfig',
+			array(
+				'version' => FFC_VERSION,
 			)
 		);
 	}

--- a/includes/frontend/class-ffc-frontend.php
+++ b/includes/frontend/class-ffc-frontend.php
@@ -497,17 +497,46 @@ class Frontend {
 		}
 
 		// Find all form IDs in post content.
-		preg_match_all( '/\[ffc_form\s+id=[\'"](\d+)[\'"]\]/', $post->post_content, $matches );
+		//
+		// Pre-6.6.8 used a hand-rolled regex that ONLY matched
+		// `[ffc_form id="42"]` (double-quoted) and `[ffc_form id='42']`
+		// (single-quoted). It silently missed two WP-valid formats that
+		// are common in the wild:
+		// `[ffc_form id=42]` (quotes are optional in shortcode atts) and
+		// `[ffc_form id="42" class="extra"]` (additional attributes).
+		// When the regex missed, `wp_localize_script` was never called
+		// for that form, so the JS geofence layer never received its
+		// config, never validated the datetime window, and the form
+		// rendered as if no geofence existed. Users would set
+		// "hide before start" in admin and still see the form on the
+		// public page.
+		//
+		// Fix: use `get_shortcode_regex(['ffc_form'])`, the canonical
+		// WP helper, then parse atts via `shortcode_parse_atts()` which
+		// handles all the quoting variants WP's own parser accepts.
+		$form_ids = array();
+		$pattern  = get_shortcode_regex( array( 'ffc_form' ) );
+		if ( preg_match_all( '/' . $pattern . '/', $post->post_content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				// $match[3] holds the raw attribute string in WP's
+				// get_shortcode_regex layout (group 3).
+				$atts_raw = isset( $match[3] ) ? (string) $match[3] : '';
+				$atts     = shortcode_parse_atts( $atts_raw );
+				$id       = isset( $atts['id'] ) ? (int) $atts['id'] : 0;
+				if ( $id > 0 ) {
+					$form_ids[] = $id;
+				}
+			}
+		}
 
-		if ( empty( $matches[1] ) ) {
+		if ( empty( $form_ids ) ) {
 			return;
 		}
 
 		$geofence_configs = array();
 
-		foreach ( $matches[1] as $form_id ) {
-			$form_id_int = (int) $form_id;
-			$config      = \FreeFormCertificate\Security\Geofence::get_frontend_config( $form_id_int );
+		foreach ( array_unique( $form_ids ) as $form_id_int ) {
+			$config = \FreeFormCertificate\Security\Geofence::get_frontend_config( $form_id_int );
 
 			if ( null !== $config ) {
 				$geofence_configs[ $form_id_int ] = $config;

--- a/includes/url-shortener/class-ffc-url-shortener-admin-page.php
+++ b/includes/url-shortener/class-ffc-url-shortener-admin-page.php
@@ -86,7 +86,14 @@ class UrlShortenerAdminPage {
 		wp_enqueue_script(
 			'ffc-url-shortener-admin',
 			FFC_PLUGIN_URL . 'assets/js/ffc-url-shortener-admin.js',
-			array( 'jquery' ),
+			// `ffc-core` carries `window.FFC.request()` which the QR-download
+			// click handler calls. Declaring it as a dep makes the load
+			// order survive JS-combining cache plugins (LiteSpeed Combine,
+			// WP Rocket Combine, etc.) that flatten the bundle and would
+			// otherwise drop `ffc-core` for not being in the chain. Same
+			// fix shape as 6.6.7 (#367) applied to the 4 public-facing
+			// sites; admin sites missed that pass.
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/includes/url-shortener/class-ffc-url-shortener-meta-box.php
+++ b/includes/url-shortener/class-ffc-url-shortener-meta-box.php
@@ -230,7 +230,14 @@ class UrlShortenerMetaBox {
 		wp_enqueue_script(
 			'ffc-url-shortener-admin',
 			FFC_PLUGIN_URL . 'assets/js/ffc-url-shortener-admin.js',
-			array( 'jquery' ),
+			// `ffc-core` carries `window.FFC.request()` which the QR-download
+			// click handler calls. Declaring it as a dep makes the load
+			// order survive JS-combining cache plugins (LiteSpeed Combine,
+			// WP Rocket Combine, etc.) that flatten the bundle and would
+			// otherwise drop `ffc-core` for not being in the chain. Same
+			// fix shape as 6.6.7 (#367) applied to the 4 public-facing
+			// sites; admin sites missed that pass.
+			array( 'jquery', 'ffc-core' ),
 			FFC_VERSION,
 			true
 		);

--- a/tests/Unit/CptTest.php
+++ b/tests/Unit/CptTest.php
@@ -241,6 +241,122 @@ class CptTest extends TestCase {
         $cpt->handle_form_duplication();
     }
 
+    public function test_handle_form_duplication_copies_all_per_form_metas(): void {
+        // 6.6.10 regression lock — the duplicator's copy list must include
+        // EVERY per-form meta key that FormEditorSaveHandler persists,
+        // minus the explicitly-excluded counters / hashes / audit logs
+        // documented in the source comment.
+        //
+        // Pre-6.6.10 the four CSV-download sub-feature toggles below were
+        // missing, so a duplicate forgot whether the admin had turned
+        // off the download / preview / start-early features or turned ON
+        // the extend-end feature.
+        $_GET['post'] = '10';
+
+        Functions\when( 'absint' )->alias( function ( $v ) {
+            return abs( (int) $v );
+        } );
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        // Real production flow calls `exit;` after wp_safe_redirect. Throw
+        // a sentinel exception from the stub to abort the call and let us
+        // assert on the side effects captured in $written_meta below.
+        Functions\when( 'wp_safe_redirect' )->alias( function ( $url ) {
+            throw new \RuntimeException( 'redirect:' . $url );
+        } );
+        Functions\when( 'admin_url' )->alias( function ( $path = '' ) {
+            return 'https://example.com/wp-admin/' . ltrim( $path, '/' );
+        } );
+
+        $source_post = (object) array(
+            'ID'         => 10,
+            'post_type'  => 'ffc_form',
+            'post_title' => 'Original',
+        );
+        Functions\when( 'get_post' )->justReturn( $source_post );
+
+        // Source has every per-form meta set to a recognisable value.
+        // The duplicator iterates a hard-coded $config_metas list; empty
+        // values are skipped per the source code's
+        //   if ( '' === $value || array() === $value || null === $value ) continue;
+        // guard, so we give every key a non-empty value below.
+        $source_meta = array(
+            '_ffc_form_fields'                     => array( 'field-a' ),
+            '_ffc_form_config'                     => array( 'k' => 'v' ),
+            '_ffc_form_bg'                         => 'https://example.com/bg.png',
+            '_ffc_geofence_config'                 => array( 'enabled' => '1' ),
+            '_ffc_csv_public_enabled'              => '1',
+            '_ffc_csv_public_download_enabled'     => '0',
+            '_ffc_csv_public_preview_enabled'      => '0',
+            '_ffc_csv_public_start_early_enabled'  => '0',
+            '_ffc_csv_public_extend_end_enabled'   => '1',
+            '_ffc_csv_public_limit'                => 99,
+            '_ffc_csv_public_cpf_mode'             => 'audit',
+            '_ffc_csv_public_cpf_whitelist'        => "12345678901\n98765432100",
+            '_ffc_device_limit_enabled'            => '1',
+            '_ffc_device_limit_max'                => '3',
+            '_ffc_device_match_threshold'          => '0.7',
+            '_ffc_device_limit_message'            => 'Bloqueado',
+            // Excluded by design — must NOT appear on the duplicate.
+            '_ffc_csv_public_hash'                 => 'OLD-HASH',
+            '_ffc_csv_public_count'                => 42,
+        );
+
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key, $single = false ) use ( $source_meta ) {
+            return $source_meta[ $key ] ?? '';
+        } );
+
+        Functions\when( 'wp_insert_post' )->justReturn( 999 );
+
+        $written_meta = array();
+        Functions\when( 'update_post_meta' )->alias( function ( $post_id, $key, $value ) use ( &$written_meta ) {
+            $written_meta[ $key ] = $value;
+            return true;
+        } );
+
+        $cpt = new CPT();
+
+        try {
+            $cpt->handle_form_duplication();
+        } catch ( \Throwable $e ) {
+            // The real flow calls exit; in tests admin_url + wp_safe_redirect
+            // are stubbed to no-op so control returns normally. Re-raise
+            // anything we did not anticipate.
+            if ( false === strpos( $e->getMessage(), 'redirect' ) ) {
+                throw $e;
+            }
+        }
+
+        // All expected metas copied verbatim.
+        $expected_copied = array(
+            '_ffc_form_fields',
+            '_ffc_form_config',
+            '_ffc_form_bg',
+            '_ffc_geofence_config',
+            '_ffc_csv_public_enabled',
+            '_ffc_csv_public_download_enabled',
+            '_ffc_csv_public_preview_enabled',
+            '_ffc_csv_public_start_early_enabled',
+            '_ffc_csv_public_extend_end_enabled',
+            '_ffc_csv_public_limit',
+            '_ffc_csv_public_cpf_mode',
+            '_ffc_csv_public_cpf_whitelist',
+            '_ffc_device_limit_enabled',
+            '_ffc_device_limit_max',
+            '_ffc_device_match_threshold',
+            '_ffc_device_limit_message',
+        );
+        foreach ( $expected_copied as $key ) {
+            $this->assertArrayHasKey( $key, $written_meta, "Duplicator should copy {$key}" );
+            $this->assertSame( $source_meta[ $key ], $written_meta[ $key ], "Duplicate should carry original {$key} value" );
+        }
+
+        // Explicit security exclusions — hash and counter NEVER leak.
+        $this->assertArrayNotHasKey( '_ffc_csv_public_hash', $written_meta, 'Hash must NOT be copied (security)' );
+        $this->assertArrayNotHasKey( '_ffc_csv_public_count', $written_meta, 'Counter must NOT be copied (fresh start)' );
+    }
+
     public function test_handle_form_duplication_dies_for_wrong_post_type(): void {
         $_GET['post'] = '10';
 

--- a/tests/Unit/FrontendTest.php
+++ b/tests/Unit/FrontendTest.php
@@ -43,6 +43,25 @@ class FrontendTest extends TestCase {
             }
             return $defaults;
         } );
+        // Stubs for the WP shortcode helpers used by
+        // localize_geofence_config() since the 6.6.8 fix. Default
+        // regex pattern matches `[ffc_form ...]` and captures the
+        // attribute string in group 3 (WP's actual layout).
+        Functions\when( 'get_shortcode_regex' )->justReturn(
+            '\[(\[?)(ffc_form)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)'
+        );
+        Functions\when( 'shortcode_parse_atts' )->alias( function ( $text ) {
+            $atts    = array();
+            $pattern = '/(\w+)\s*=\s*"([^"]*)"|(\w+)\s*=\s*\'([^\']*)\'|(\w+)\s*=\s*([^\s\]]+)/';
+            if ( preg_match_all( $pattern, (string) $text, $m, PREG_SET_ORDER ) ) {
+                foreach ( $m as $row ) {
+                    $key            = $row[1] !== '' ? $row[1] : ( $row[3] !== '' ? $row[3] : $row[5] );
+                    $val            = $row[1] !== '' ? $row[2] : ( $row[3] !== '' ? $row[4] : $row[6] );
+                    $atts[ $key ] = $val;
+                }
+            }
+            return $atts;
+        } );
 
         // PublicCsvDownload::register_hooks() instantiates PublicCsvExporter,
         // whose SubmissionRepository constructor reads $wpdb->prefix.
@@ -229,5 +248,81 @@ class FrontendTest extends TestCase {
         // Geofence config should be localized
         $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
         $this->assertArrayHasKey( '_global', $localized['ffcGeofenceConfig'] );
+    }
+
+    /**
+     * Stub `get_shortcode_regex` + `shortcode_parse_atts` with simplified
+     * WP-shape implementations so the production regex switch (#XXX 6.6.8)
+     * can be driven through both quoted and unquoted attribute formats.
+     * Returns the captured `wp_localize_script` payload bag.
+     *
+     * @param string $post_content Raw `$post->post_content` to drive.
+     * @return array<string, mixed>
+     */
+    private function capture_geofence_for_content( string $post_content ): array {
+        global $post;
+        $post = Mockery::mock( 'WP_Post' );
+        $post->post_content = $post_content;
+
+        Functions\when( 'has_shortcode' )->justReturn( true );
+
+        // Alias Geofence so we don't have to wire up get_post_meta /
+        // settings / option reads — we're testing the regex+atts path,
+        // not the config builder.
+        $geofence_mock = Mockery::mock( 'alias:\FreeFormCertificate\Security\Geofence' );
+        $geofence_mock->shouldReceive( 'get_frontend_config' )
+            ->andReturnUsing( static fn( $id ) => array( 'formId' => (int) $id, 'datetime' => array( 'enabled' => true ) ) );
+
+        $localized = array();
+        Functions\when( 'wp_localize_script' )->alias( function ( $handle, $name, $data ) use ( &$localized ) {
+            $localized[ $name ] = $data;
+        } );
+
+        $handler  = $this->makeSubmissionHandlerMock();
+        $frontend = new Frontend( $handler );
+        $frontend->frontend_assets();
+
+        return $localized;
+    }
+
+    public function test_localize_geofence_accepts_quoted_id(): void {
+        $localized = $this->capture_geofence_for_content( '[ffc_form id="42"]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        // Form id was extracted — `_global` PLUS the per-form key share the array.
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ) );
+    }
+
+    public function test_localize_geofence_accepts_unquoted_id(): void {
+        // The bug fixed in 6.6.8: pre-fix regex required quotes around
+        // the id attribute, so `[ffc_form id=42]` (WP-valid unquoted
+        // shorthand) silently failed to localize and the JS geofence
+        // never received its config. The form rendered as if no
+        // datetime restriction existed.
+        $localized = $this->capture_geofence_for_content( '[ffc_form id=42]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ), 'unquoted id MUST localize too' );
+    }
+
+    public function test_localize_geofence_accepts_extra_attributes(): void {
+        // Same root cause, second failing shape: pre-fix regex required
+        // `id=...` to be the LAST attribute before the closing bracket.
+        $localized = $this->capture_geofence_for_content( '[ffc_form id="42" class="ffc-custom"]' );
+
+        $this->assertArrayHasKey( 'ffcGeofenceConfig', $localized );
+        $form_keys = array_filter(
+            array_keys( $localized['ffcGeofenceConfig'] ),
+            static fn( $k ) => is_int( $k ) || ( is_string( $k ) && ctype_digit( $k ) )
+        );
+        $this->assertContains( 42, array_map( 'intval', $form_keys ), 'extra attributes MUST NOT block localize' );
     }
 }

--- a/tests/Unit/LoaderTest.php
+++ b/tests/Unit/LoaderTest.php
@@ -227,4 +227,61 @@ class LoaderTest extends TestCase {
         $this->assertArrayHasKey( 'ajaxUrl', $match['l10n'] );
         $this->assertStringContainsString( 'admin-ajax.php', $match['l10n']['ajaxUrl'] );
     }
+
+    // ==================================================================
+    // register_admin_core_assets() — 6.6.9
+    // ==================================================================
+
+    public function test_constructor_registers_admin_enqueue_scripts_hook(): void {
+        $actions_added = [];
+        Functions\when( 'add_action' )->alias( function ( $hook, $callback, $priority = 10 ) use ( &$actions_added ) {
+            $actions_added[] = [ 'hook' => $hook, 'callback' => $callback, 'priority' => $priority ];
+        } );
+        Functions\when( 'register_activation_hook' )->justReturn( true );
+        Functions\when( 'register_deactivation_hook' )->justReturn( true );
+
+        new Loader();
+
+        $admin_hooks = array_filter( $actions_added, function ( $entry ) {
+            return $entry['hook'] === 'admin_enqueue_scripts'
+                && is_array( $entry['callback'] )
+                && $entry['callback'][1] === 'register_admin_core_assets';
+        } );
+
+        $this->assertNotEmpty( $admin_hooks, '6.6.9 fix: ffc-core must register on every admin request.' );
+        $match = reset( $admin_hooks );
+        $this->assertSame( 1, $match['priority'], 'Priority 1 so dep is resolvable before module enqueues run at default priority 10.' );
+    }
+
+    public function test_register_admin_core_assets_registers_ffc_core(): void {
+        $spies = $this->build_loader_and_asset_spies();
+        // First call: handle not yet registered.
+        Functions\when( 'wp_script_is' )->justReturn( false );
+
+        $spies['loader']->register_admin_core_assets();
+
+        $core = array_filter( $spies['registered_scripts'], function ( $entry ) {
+            return $entry['handle'] === 'ffc-core';
+        } );
+
+        $this->assertNotEmpty( $core, 'Should register ffc-core on admin pages.' );
+        $match = reset( $core );
+        $this->assertStringContainsString( 'ffc-core.min.js', $match['src'] );
+        $this->assertContains( 'jquery', $match['deps'] );
+        $this->assertTrue( $match['in_footer'] );
+    }
+
+    public function test_register_admin_core_assets_is_noop_when_already_registered(): void {
+        $spies = $this->build_loader_and_asset_spies();
+        // AdminAssetsManager already enqueued ffc-core earlier in the request.
+        Functions\when( 'wp_script_is' )->justReturn( true );
+
+        $spies['loader']->register_admin_core_assets();
+
+        $core = array_filter( $spies['registered_scripts'], function ( $entry ) {
+            return $entry['handle'] === 'ffc-core';
+        } );
+
+        $this->assertEmpty( $core, 'Must not re-register when AdminAssetsManager already did it.' );
+    }
 }


### PR DESCRIPTION
Forward-port das fixes 6.6.8 (#370) + 6.6.9 (#372) + 6.6.10 (#373) de `release/6.6.x` para `main`.

Sem bump de versão — `main` continua em 6.7.0. Os três fixes ficam embarcados na release 6.7.0.

## Conteúdo

**6.6.8 — fix A**: `Frontend::localize_geofence_config()` — regex hand-rolled trocado por `get_shortcode_regex()` + `shortcode_parse_atts()`.

**6.6.8 — fix B**: URL Shortener admin enqueues — adicionar `'ffc-core'` à dep array.

**6.6.9 — follow-up**: `Loader::register_admin_core_assets()` — registra `ffc-core` em todo `admin_enqueue_scripts` (priority 1), idempotente.

**6.6.10**: `CPT::handle_form_duplication()` — 4 sub-toggles do CSV Download público adicionados ao `$config_metas`.

## Tests

- 3 PHPUnit em `FrontendTest` (regex shapes — quoted / unquoted / extra-atts).
- 3 PHPUnit em `LoaderTest` (hook wiring + register + idempotência).
- 1 PHPUnit em `CptTest` (regression lock pros 16 metas per-form do duplicador, hash/counter excluídos).

## CHANGELOG

- Seção 6.7.0: bloco "Fixed (forward-ported from 6.6.8 / 6.6.9 / 6.6.10)" com 4 bullets.
- Seções 6.6.10, 6.6.9 e 6.6.8 inseridas cronologicamente, todas referenciando o detalhe técnico sob 6.7.0.

## Test plan

- [x] PHPUnit / PHPStan / WPCS locais.
- [ ] Smoke equivalente aos dos PRs #370, #372, #373 (já validado nos release branches).