### PR TITLE
6.6.9 — register ffc-core on every admin request (QR download follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [6.6.9] (2026-05-22)
+
+Follow-up to the URL Shortener half of 6.6.8 (#370). The 6.6.8 fix declared `'ffc-core'` as a dependency on the URL Shortener admin enqueues, expecting AdminAssetsManager to have already registered the handle. That holds on FFC-owned pages (`post_type === 'ffc_form'` or `page=ffc-*`), but the URL Shortener metabox also renders on **regular post / page edit screens** when the post type is enabled — and on those screens `AdminAssetsManager::is_ffc_page()` returns false, so `ffc-core` was never registered for the request. WordPress's enqueue path silently dropped the unknown dep, `window.FFC` stayed undefined, and the QR PNG / SVG / Regenerate / Copy buttons still failed silently. Reported on the production site (Gutenberg post edit screen, standard `post` post type, URL Shortener metabox visible in the sidebar).
+
+### Fixed
+
+- **URL Shortener admin: QR PNG / SVG / Regenerate / Copy buttons still inert on non-FFC admin screens (regression-aware follow-up to 6.6.8).** Register `ffc-core` early on every `admin_enqueue_scripts` request via a new `Loader::register_admin_core_assets()` hook (priority 1, before any module enqueues run). The new method is idempotent — guarded by `wp_script_is('ffc-core', 'registered')` so it's a no-op on FFC pages where `AdminAssetsManager` already registered the handle. Mirrors the frontend `register_frontend_assets()` pattern. After this fix, the `'ffc-core'` dep declared by `UrlShortenerMetaBox::enqueue_assets()` (and any future admin module that depends on `window.FFC.request()`) resolves correctly regardless of the post type being edited.
+
+### Tests
+
+- 3 new PHPUnit cases in `LoaderTest` covering: (1) the constructor wires `admin_enqueue_scripts` to the new method at priority 1; (2) the method registers `ffc-core` when not yet registered; (3) the method is a no-op when AdminAssetsManager already registered it.
+
+### Notes
+
+- Same release line as 6.6.8 (release/6.6.x). Will be forward-ported to main alongside the 6.6.8 forward-port (PR #371).
+- No JS/CSS asset rebuild needed — fix is PHP-only (script registration). The `?ver=6.6.9` rotation flowing from the FFC_VERSION bump invalidates cached `ffc-url-shortener-admin.js` on visitors who hit pre-6.6.9 cached HTML.
+
+---
+
 ## [6.6.8] (2026-05-22)
 
 Hotfix on the 6.6.x maintenance branch. Two production-reported bugs surfaced by an admin who configured "Hide form completely" on a form's date/time restrictions and saw the form still rendering, and by the QR Code download buttons silently doing nothing on a site that combines JS through a cache plugin.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.6.8
+ * Version:            6.6.9
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.6.8' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.6.9' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -159,6 +159,18 @@ class Loader {
 	public function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'init_plugin' ), 10 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_assets' ) );
+		// Mirror the frontend register_frontend_assets pattern in admin.
+		// `ffc-core` carries `window.FFC.request()` and is used by several
+		// admin enqueues (URL Shortener metabox, etc.). Pre-6.6.9 it was
+		// only registered when AdminAssetsManager decided the current page
+		// was an FFC page (post_type === 'ffc_form' OR page === 'ffc-*').
+		// On regular post/page admin screens where the URL Shortener
+		// metabox is rendered, that gate failed and the dep silently
+		// dropped, leaving `window.FFC` undefined and the QR download /
+		// regenerate / copy buttons inert. Registering early on every
+		// admin request makes `ffc-core` resolvable as a dep regardless
+		// of post type. Enqueue happens elsewhere; this is register-only.
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_core_assets' ), 1 );
 		$this->define_activation_hooks();
 	}
 
@@ -504,6 +516,45 @@ class Loader {
 			'ffcDynamic',
 			array(
 				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			)
+		);
+	}
+
+	/**
+	 * Register `ffc-core` on every admin request.
+	 *
+	 * Sibling of register_frontend_assets() for the admin side. Other
+	 * admin enqueues (URL Shortener metabox, etc.) declare `ffc-core` as
+	 * a dependency — when this script is not registered, WP silently
+	 * drops the dep and `window.FFC.request()` becomes undefined at
+	 * runtime. AdminAssetsManager already enqueues ffc-core on FFC
+	 * pages (which also registers it); this hook covers the gap on
+	 * regular post/page edit screens where the URL Shortener metabox
+	 * is enabled for the post type but is_ffc_page() returns false.
+	 *
+	 * Hook priority 1 so the registration runs before any module's
+	 * enqueue callback (default priority 10).
+	 *
+	 * @since 6.6.9
+	 */
+	public function register_admin_core_assets(): void {
+		if ( wp_script_is( 'ffc-core', 'registered' ) ) {
+			return;
+		}
+
+		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
+		wp_register_script(
+			'ffc-core',
+			FFC_PLUGIN_URL . "assets/js/ffc-core{$s}.js",
+			array( 'jquery' ),
+			FFC_VERSION,
+			true
+		);
+		wp_localize_script(
+			'ffc-core',
+			'ffcCoreConfig',
+			array(
+				'version' => FFC_VERSION,
 			)
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.6.8
+Stable tag: 6.6.9
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Unit/LoaderTest.php
+++ b/tests/Unit/LoaderTest.php
@@ -227,4 +227,61 @@ class LoaderTest extends TestCase {
         $this->assertArrayHasKey( 'ajaxUrl', $match['l10n'] );
         $this->assertStringContainsString( 'admin-ajax.php', $match['l10n']['ajaxUrl'] );
     }
+
+    // ==================================================================
+    // register_admin_core_assets() — 6.6.9
+    // ==================================================================
+
+    public function test_constructor_registers_admin_enqueue_scripts_hook(): void {
+        $actions_added = [];
+        Functions\when( 'add_action' )->alias( function ( $hook, $callback, $priority = 10 ) use ( &$actions_added ) {
+            $actions_added[] = [ 'hook' => $hook, 'callback' => $callback, 'priority' => $priority ];
+        } );
+        Functions\when( 'register_activation_hook' )->justReturn( true );
+        Functions\when( 'register_deactivation_hook' )->justReturn( true );
+
+        new Loader();
+
+        $admin_hooks = array_filter( $actions_added, function ( $entry ) {
+            return $entry['hook'] === 'admin_enqueue_scripts'
+                && is_array( $entry['callback'] )
+                && $entry['callback'][1] === 'register_admin_core_assets';
+        } );
+
+        $this->assertNotEmpty( $admin_hooks, '6.6.9 fix: ffc-core must register on every admin request.' );
+        $match = reset( $admin_hooks );
+        $this->assertSame( 1, $match['priority'], 'Priority 1 so dep is resolvable before module enqueues run at default priority 10.' );
+    }
+
+    public function test_register_admin_core_assets_registers_ffc_core(): void {
+        $spies = $this->build_loader_and_asset_spies();
+        // First call: handle not yet registered.
+        Functions\when( 'wp_script_is' )->justReturn( false );
+
+        $spies['loader']->register_admin_core_assets();
+
+        $core = array_filter( $spies['registered_scripts'], function ( $entry ) {
+            return $entry['handle'] === 'ffc-core';
+        } );
+
+        $this->assertNotEmpty( $core, 'Should register ffc-core on admin pages.' );
+        $match = reset( $core );
+        $this->assertStringContainsString( 'ffc-core.min.js', $match['src'] );
+        $this->assertContains( 'jquery', $match['deps'] );
+        $this->assertTrue( $match['in_footer'] );
+    }
+
+    public function test_register_admin_core_assets_is_noop_when_already_registered(): void {
+        $spies = $this->build_loader_and_asset_spies();
+        // AdminAssetsManager already enqueued ffc-core earlier in the request.
+        Functions\when( 'wp_script_is' )->justReturn( true );
+
+        $spies['loader']->register_admin_core_assets();
+
+        $core = array_filter( $spies['registered_scripts'], function ( $entry ) {
+            return $entry['handle'] === 'ffc-core';
+        } );
+
+        $this->assertEmpty( $core, 'Must not re-register when AdminAssetsManager already did it.' );
+    }
 }


### PR DESCRIPTION
Follow-up hotfix sobre o PR #370 (6.6.8). Mesmo sintoma reportado pelo usuário (botão PNG do QR Code não funciona), mas root cause diferente do que cobri em 6.6.8.

## Diagnóstico em camadas

**6.6.8 cobriu**: declarar `'ffc-core'` como dep nas enqueues do URL Shortener admin (metabox + admin list page). Mesma shape do fix #367.

**O que 6.6.8 NÃO cobriu**: `ffc-core` precisa estar **registrado** no request para a dep ser resolvida. Registration paths atuais:

| Hook | Quando registra ffc-core |
|------|--------------------------|
| `wp_enqueue_scripts` (`Loader::register_frontend_assets`) | Sempre que página pública usa o plugin |
| `admin_enqueue_scripts` (`AdminAssetsManager::enqueue_core_module`) | **Só quando `is_ffc_page()` retorna true** — `post_type === 'ffc_form'` ou `page === 'ffc-*'` |

O contexto do usuário (screenshot): tela de edição Gutenberg de um post comum (`post_type='post'`, categorias Blog/Educadores/Comunidade/etc.). Sem o gate `is_ffc_page()` passar, ffc-core nunca foi registrado nesse request, e WP silenciosamente removeu a dep desconhecida.

Resultado: `window.FFC` undefined → `FFC.request('ffc_download_qr_png', ...)` lança TypeError → handler do click morre depois de fazer `$btn.prop('disabled', true)`. Botão fica permanentemente disabled.

## Fix

Novo hook `admin_enqueue_scripts` (priority 1) que registra `ffc-core` em TODO request admin. Idempotente: guard de `wp_script_is('ffc-core', 'registered')` para não duplicar quando AdminAssetsManager já registrou.

Espelha o pattern de `register_frontend_assets()` que existe pra frontend desde 4.12.0.

## Tests

3 PHPUnit novas em `LoaderTest`:
1. Constructor faz `add_action('admin_enqueue_scripts', ..., 1)` apontando pro novo método.
2. Método registra ffc-core com args corretos quando não estava registrado.
3. Método é no-op quando AdminAssetsManager já registrou.

Suite local 4604/4604 verde. PHPStan level 8 ✅, WPCS ✅.

## Test plan

- [ ] Após merge + deploy em produção, abrir edit de um `post` regular com URL Shortener habilitado.
- [ ] Hard refresh (Ctrl+Shift+R) — o `?ver=6.6.9` flush invalida o JS antigo.
- [ ] Verificar no DevTools Network que `ffc-core.js?ver=6.6.9` aparece carregado.
- [ ] Clicar botão PNG → arquivo deve baixar.
- [ ] Clicar SVG → arquivo deve baixar.
- [ ] Clicar Re-gerado → URL muda e página recarrega.

## Forward-port

Vai junto com o forward-port de 6.6.8 (PR #371) — fará update naquela PR para incluir 6.6.9 também antes do merge em main.

Closes #370 (follow-up).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7grqE9h5TssSekVW74DFF)_