### PR TITLE
docs: announce release/6.6.x channel closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Maintenance
+
+- **`release/6.6.x` channel closed.** All 6.6.x hotfixes (6.6.8 → 6.6.12) were forward-ported to `main` via #371 and #376. The branch was formally merged into `main` via #377 and then retired. The final tip is preserved at tag `v6.6.12-final` for any emergency 6.6.x backport need; from that tag a `hotfix/6.6.13` branch could be cut if required. Going forward, all maintenance happens on `main` and ships under the 6.7.x line — please upgrade to 6.7.x for continued support. Tracked in #378.
+
 ---
 
 ## [6.7.0] (2026-05-22)


### PR DESCRIPTION
Bookkeeping entry sob `[Unreleased]` anunciando que o canal `release/6.6.x` foi aposentado.

## Estado consolidado (já feito, este PR só documenta)

- ✅ Todos hotfixes 6.6.8 → 6.6.12 forward-portados pra `main` (#371, #376).
- ✅ `release/6.6.x` mergeada formalmente em `main` (#377).
- ✅ Tag `v6.6.12-final` criada apontando pra `da7e499` (tip final da 6.6.x).
- ✅ Branch `release/6.6.x` deletada do remoto.

## Conteúdo

Adiciona um único parágrafo no CHANGELOG sob `[Unreleased]` → `### Maintenance` explicando:
- Que o canal 6.6.x está fechado.
- Onde o histórico foi preservado (`v6.6.12-final` + merge commit em main).
- O caminho para emergency hotfix se algum dia precisar (`git checkout -b hotfix/6.6.13 v6.6.12-final`).
- Pedido pra produção subir pra 6.7.x.

## Sem mudança de código

Apenas docs — sem bump de versão, sem build artifacts. CI deve passar trivialmente.

## Fecha #378

Após este merge, fecho a issue de tracking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7grqE9h5TssSekVW74DFF)_