### PR TITLE
chore: adopt develop branch workflow (testes auto-deploy + per-PR base switch)

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -2,7 +2,7 @@ name: Asset Build Verification
 
 on:
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
 # Path filters were removed because branch protection requires this
 # check on every PR. Skipped runs (path-filtered) never report status
 # and leave PRs in mergeable_state: blocked. With npm cache + npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
     # maintenance branch) get the same PHPStan + PHPUnit + WPCS +
     # coverage-floor gates as PRs targeting `main`. Without this,
     # hotfix PRs were merging with zero CI signal.
-    branches: [main, "release/**"]
+    # `develop` so the batched-release integration branch enforces the
+    # same gates per PR — develop must stay deployable to the testes site.
+    branches: [main, develop, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
   push:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
   schedule:
     # Weekly catch-all run so newly-disclosed query packs surface on
     # unchanged code too. Monday 03:00 UTC keeps it off business hours.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,94 @@
+name: Deploy develop → testes
+
+# Sync da branch `develop` pro servidor de testes via SSH + rsync.
+# Dispara em cada push em `develop` (após merge de PR ou push direto).
+# Pré-requisitos operacionais documentados em CLAUDE.md (seção
+# "Develop branch workflow"): SSH habilitado na hospedagem, par de
+# chaves gerado, 4 secrets cadastrados no GitHub.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+    # Manual re-deploy útil quando o servidor de testes foi resetado
+    # ou o último push falhou e o estado da develop não mudou.
+
+concurrency:
+  # Cancelar pushes consecutivos: só o último vence. Evita corrida
+  # de dois rsync paralelos sobre o mesmo destino.
+  group: deploy-develop-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: rsync to testes
+    runs-on: ubuntu-latest
+    # Sem environment gating — develop é território livre por design.
+    # Se um dia esse workflow virar `deploy-prod`, aí sim entra
+    # `environment: production` com required reviewers.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Shallow clone OK — rsync envia working tree, não histórico.
+          fetch-depth: 1
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.TESTES_SSH_KEY }}
+          SSH_HOST: ${{ secrets.TESTES_SSH_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          # Adiciona o host conhecido para evitar prompt interativo.
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Rsync to testes
+        env:
+          SSH_HOST: ${{ secrets.TESTES_SSH_HOST }}
+          SSH_USER: ${{ secrets.TESTES_SSH_USER }}
+          REMOTE_PATH: ${{ secrets.TESTES_REMOTE_PATH }}
+        run: |
+          # `--delete` remove arquivos no destino que não existem na
+          # origem (idempotência total). Exclusões abaixo cobrem:
+          # - VCS / CI metadata que não pertence ao runtime do plugin.
+          # - Dependências de dev (composer require-dev only, node_modules).
+          # - Testes e ferramentas de análise estática.
+          # - Configurações locais (wp-config-local.php).
+          # - Saídas de coverage / build intermediário.
+          # `composer.json` e `package.json` são intencionalmente
+          # *enviados* — admins de hospedagem gerenciada às vezes os
+          # inspecionam pra entender o que está rodando.
+          rsync -avz --delete \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='.gitignore' \
+            --exclude='.gitattributes' \
+            --exclude='vendor/' \
+            --exclude='node_modules/' \
+            --exclude='tests/' \
+            --exclude='coverage-js/' \
+            --exclude='coverage/' \
+            --exclude='build/' \
+            --exclude='dist/' \
+            --exclude='.phpunit.result.cache' \
+            --exclude='phpunit.xml' \
+            --exclude='phpunit.xml.dist' \
+            --exclude='phpstan.neon' \
+            --exclude='phpstan.neon.dist' \
+            --exclude='phpcs.xml' \
+            --exclude='phpcs.xml.dist' \
+            --exclude='.eslintrc*' \
+            --exclude='.stylelintrc*' \
+            --exclude='vitest.config.*' \
+            --exclude='CLAUDE.md' \
+            --exclude='html/' \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes" \
+            ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_PATH}/"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,7 +2,7 @@ name: PHPCS
 
 on:
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, develop, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ Project conventions for Claude (Anthropic CLI / agent sessions) working on this 
 The repository has **"Allow auto-merge"** enabled in Settings → General.
 Use it on every PR — no manual squash + merge unless auto-merge fails.
 
+**PR base branch:** by default, target `develop`, not `main`. The only PRs that target `main` are (1) the periodic release PR `develop → main` that consolidates the accumulated batch with a single version bump, and (2) hotfix PRs from `hotfix/*` branches when a critical bug needs to ship without waiting for develop's queue to consolidate. See "Develop branch workflow" below for the full mapping.
+
 After `mcp__github__create_pull_request`:
 
 1. `mcp__github__update_pull_request` with `draft: false` (auto-merge only fires on non-draft PRs).
@@ -15,11 +17,13 @@ After `mcp__github__create_pull_request`:
 
 Don't poll CI manually after step 2 unless the user asks. The webhook subscription delivers **failures + comments + the final merge event**; green completion is silent by design.
 
-## CI gates (all gating, enforced on `main`)
+## CI gates (all gating, enforced on `main` and `develop`)
 
 - PHP: PHPStan (level 8) · WPCS · PHPUnit (8.3/8.4) · Coverage ≥ floor (clover, env `COVERAGE_FLOOR_LINES` in `.github/workflows/ci.yml`).
 - JS / CSS: ESLint (zero-error) · Stylelint (zero-error) · Vitest + coverage ≥ floor (env `JS_COVERAGE_FLOOR_LINES` in `.github/workflows/lint.yml`).
 - Misc: CodeQL (javascript) · Composer audit · Review dependency changes · Verify minified assets are up to date.
+
+The same gates run on PRs to `develop` and on the release PR `develop → main`. Develop must stay deployable to the testes site, so we don't relax gates there — a green develop is the precondition for opening the next release PR.
 
 The coverage floors are ratcheted upward in the PR that delivers the gain — never lowered. The comment block above each `*_FLOOR_LINES` keeps the audit trail.
 
@@ -114,7 +118,93 @@ Classes that already encapsulate `get_option('ffc_settings')` in their own priva
 
 ## Branch naming
 
-Use `claude/<short-kebab-description>`. Examples in main history: `claude/js-coverage-sprint-B-audience-smoke`, `claude/csv-import-normalize-cpf-rf`. The remote refuses pushes to `main` directly; always go through a PR.
+Use `claude/<short-kebab-description>` for feature branches that target `develop`. Examples in main history: `claude/js-coverage-sprint-B-audience-smoke`, `claude/csv-import-normalize-cpf-rf`. Use `hotfix/<short-kebab-description>` when cutting an urgent fix from `main` (see "Develop branch workflow" → Hotfixes). The remote refuses pushes to `main` and `develop` directly; always go through a PR.
+
+## Develop branch workflow
+
+Adopted v6.7.7 to decouple iteration cadence from production. Source domain (prod) only sees one version bump per batch; the testes domain runs `develop` HEAD and absorbs the per-PR churn.
+
+### Branch topology
+
+```
+main      ─o──────────────────────o────────────  ← PROD (source domain)
+                                  ↑
+                                  release PR
+                                  with consolidated bump
+develop   ─o─o─o─o─o─o─o─o─o─o─o─/             ← TESTES (testes domain)
+           PR1 PR2 PR3 …                         each merge auto-deploys
+```
+
+- **`main`** — the production branch. Updated only by (1) the release PR `develop → main` (squash merge with the final bump + consolidated CHANGELOG entry) and (2) hotfix PRs `hotfix/* → main` when a critical bug bypasses the queue.
+- **`develop`** — the integration branch. Default base for every feature PR. Each merge into `develop` triggers `.github/workflows/deploy-develop.yml`, which rsyncs the working tree to the testes server.
+- **`hotfix/*`** — short-lived. Cut from `main`, merge back to `main`, then rebase `develop` on top of the new `main` (see Hotfixes).
+
+### Per-PR flow (the common case)
+
+1. Feature branch `claude/<desc>` cut from `develop`.
+2. PR targets `develop`. CI gates run identically to PRs against main.
+3. **No `FFC_VERSION` bump in the feature PR.** Develop accumulates work under the existing `FFC_VERSION` until release time.
+4. CHANGELOG entries go under the `[Unreleased]` section at the top of `CHANGELOG.md` — they stay there across multiple PRs.
+5. Auto-merge enabled (SQUASH). Once merged, `deploy-develop.yml` pushes the new HEAD to the testes server within ~1 minute.
+
+### Release PR (`develop → main`)
+
+When the batch on develop is validated against the testes site and ready to ship to prod:
+
+1. Open a single PR `develop → main`.
+2. In that PR (committed onto `develop` immediately before opening):
+   - Bump `FFC_VERSION` in the three sync sites (`ffcertificate.php` header, `FFC_VERSION` constant, `readme.txt` `Stable tag`). See "Versioning".
+   - Rename the `[Unreleased]` heading in `CHANGELOG.md` to `[X.Y.Z] (YYYY-MM-DD)` and add a fresh empty `[Unreleased]` heading above it.
+   - Run `npm run build:js` if any JS/CSS in `assets/` changed across the batch and the bundles weren't already rebuilt mid-flight (the "Verify minified assets are up to date" gate would catch this anyway).
+3. Auto-merge SQUASH into `main`. The squash commit subject should follow main's convention: `X.Y.Z — <short summary of the batch>`.
+4. After merge, rebase `develop` on `main` (see Sync below) so the next batch starts from the bumped baseline.
+
+### Hotfix flow (urgent fix that can't wait for the next release)
+
+When a critical bug needs to ship to prod while develop has un-released commits:
+
+1. `git fetch origin && git checkout -b hotfix/<desc> origin/main`.
+2. Apply the fix. Bump `FFC_VERSION` as a real patch (e.g. `6.7.7 → 6.7.8`) — hotfixes consume patch numbers, not the `.x.y.z.N` cache-bust convention.
+3. PR `hotfix/<desc> → main`. Auto-merge SQUASH.
+4. **Then sync develop with the new main** (see below) so develop carries the hotfix and the next release PR doesn't try to "undo" it.
+
+### Sync `develop` with `main` (post-hotfix or post-release)
+
+```bash
+git fetch origin
+git checkout develop
+git rebase origin/main
+git push --force-with-lease origin develop
+```
+
+This rewrites develop's SHAs on top of the new `main` tip. Force-push is permitted on `develop` by design (the branch protection deliberately omits "Require linear history" and the push restriction) — see "Branch protection" below. If a feature PR was open against develop at the moment of the rebase, the PR author rebases their branch on the new develop tip; this is the cost of keeping develop linear.
+
+### Branch protection (`develop`)
+
+Configured in Settings → Branches with intentionally lighter rules than `main`:
+
+- ✅ Require a pull request before merging (no required reviewers — solo maintainer).
+- ✅ Require status checks to pass before merging — all 6 gating jobs listed under "CI gates".
+- ❌ Require linear history — left off so the rebase workflow above doesn't need admin bypass.
+- ❌ Restrict who can push to matching branches — leaving force-push permitted is what makes the rebase sync above mechanical.
+- ❌ Require deployments to succeed — `deploy-develop.yml` runs *after* merge, not as a merge gate.
+
+Reasoning: develop is single-maintainer integration territory, not a shared production branch. Stronger protection here would force admin bypass for routine syncs and provide negligible safety benefit.
+
+### Deploy to testes
+
+`.github/workflows/deploy-develop.yml` runs on every `push` to `develop` and rsyncs the working tree to the testes server. Required GitHub secrets (Settings → Secrets and variables → Actions):
+
+| Secret | Example | Notes |
+| --- | --- | --- |
+| `TESTES_SSH_HOST` | `ssh.testes.example.com` | DNS or IP of the testes host |
+| `TESTES_SSH_USER` | `wp-deploy` | Account with write access to the plugin dir |
+| `TESTES_SSH_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----…` | Private half of a dedicated keypair; public half goes in `~/.ssh/authorized_keys` on the testes host |
+| `TESTES_REMOTE_PATH` | `/var/www/testes/wp-content/plugins/ffcertificate` | Absolute path; no trailing slash |
+
+The rsync uses `--delete`, so anything in the remote path that isn't in the develop working tree is removed on each deploy. The workflow excludes `.git/`, `.github/`, `vendor/`, `node_modules/`, `tests/`, and dev tooling (PHPStan, PHPUnit, PHPCS configs) — those don't belong in a runtime plugin dir.
+
+The testes server should have `SCRIPT_DEBUG=true` in `wp-config.php` so non-minified assets load and `?ver=…` cache aggressiveness stays low while iterating.
 
 ## Versioning
 
@@ -134,11 +224,18 @@ When changing the version, update all three in the same commit.
 
 ### When to bump
 
-Any PR that touches a bundled asset file (`assets/**/*.min.js`, `assets/**/*.min.css`, `templates/**.php`, or `languages/*.l10n.php` / `.mo`) MUST bump `FFC_VERSION` in the same PR — otherwise iOS Safari, LiteSpeed / Varnish / WP Rocket, and CDN edges keep serving the pre-PR bundle from cache. The "Verify minified assets are up to date" CI job catches build freshness but does NOT enforce the version bump.
+The trigger has not changed — bundled-asset changes still rotate the cache key. What changed with the develop branch workflow is **where the bump lands**:
+
+- **PRs targeting `main`** (release PR `develop → main`, hotfix PR `hotfix/* → main`): bump `FFC_VERSION` in the same PR. The release PR consolidates every `assets/**/*.min.js`, `assets/**/*.min.css`, `templates/**.php`, and `languages/*.l10n.php` / `.mo` change from the develop batch under one version. Hotfix PRs bump their own patch number.
+- **PRs targeting `develop`**: do **not** bump. Develop sits at the last released version (the cache key on the testes domain stays stable across the batch), and the testes site sidesteps cache aggressiveness via `SCRIPT_DEBUG=true`. Bumping per-PR on develop would consume version numbers that have no production analog.
+
+The "Verify minified assets are up to date" CI job catches build freshness on both bases but does NOT enforce the version bump — that's still a human discipline on the release PR.
 
 ## What not to do
 
-- Do not amend or rewrite published commits (force-push reserved for branches you own and are still mid-rebase).
+- Do not amend or rewrite published commits on `main`. On `develop`, force-push is permitted only for the documented sync-with-main rebase ("Develop branch workflow" → Sync) — never to rewrite arbitrary history.
 - Do not skip hooks (`--no-verify`) or signing.
 - Do not bypass the coverage floor — bump it forward or restore the lost coverage. Never lower it.
 - Do not add new untested code paths in a coverage-aware PR; either cover them in the same PR or document the deferral.
+- Do not target `main` directly from a feature PR. The only PRs that base on `main` are the release PR (`develop → main`) and hotfix PRs (`hotfix/* → main`).
+- Do not bump `FFC_VERSION` in a PR that targets `develop` — the bump belongs to the release PR.


### PR DESCRIPTION
## Summary

Adopts a `develop` integration branch to decouple iteration cadence from production. Feature PRs target `develop` by default, each merge auto-deploys to the testes domain via SSH+rsync, and a single consolidated release PR `develop → main` bumps `FFC_VERSION` + renames `[Unreleased]` → `[X.Y.Z]` once the batch is validated against testes.

**Motivation:** today every PR ships straight to prod with its own version bump and cache-key rotation, which means (a) the source domain sees N "update available" notifications per batch and (b) bugs that only manifest in real prod (recent example: post-submit card width) reach end users before being caught. With a separate testes environment, we can stage N commits on `develop`, validate against testes, then promote the whole batch with one bump.

## Changes

### Workflows

- **`.github/workflows/deploy-develop.yml`** (new): SSH+rsync deploy on push to `develop`. Excludes `.git/`, `.github/`, `vendor/`, `node_modules/`, `tests/`, dev tooling (PHPStan/PHPUnit/PHPCS configs, eslint/stylelint/vitest configs), and `CLAUDE.md`. Uses `--delete` for idempotent state. Requires 4 GitHub secrets (`TESTES_SSH_HOST`, `TESTES_SSH_USER`, `TESTES_SSH_KEY`, `TESTES_REMOTE_PATH`).
- **All 6 CI workflows** (`ci.yml`, `lint.yml`, `phpcs.yml`, `assets.yml`, `dependency-review.yml`, `codeql.yml`): add `develop` to the `branches:` filter so PRs against develop run the same PHPStan/WPCS/PHPUnit/coverage/Vitest/ESLint/Stylelint/CodeQL/dependency-review/asset-build gates as PRs against main. CodeQL additionally runs on `push` to develop so the security database tracks the integration branch.

### CLAUDE.md

- New **"Develop branch workflow"** section documenting: branch topology diagram, per-PR flow (no version bump on develop PRs, CHANGELOG `[Unreleased]` accumulates), release PR consolidation (`develop → main` with bump + CHANGELOG rename), hotfix flow (`hotfix/* → main` then rebase develop on main), branch protection config rationale, and deploy-to-testes prerequisites including the 4 required secrets.
- **Pull-request workflow**: clarifies default base branch is now `develop`.
- **CI gates**: title updated to "enforced on `main` and `develop`".
- **Branch naming**: adds `hotfix/<desc>` convention alongside `claude/<desc>`.
- **Versioning → When to bump**: clarifies bumps live in release PRs and hotfix PRs only, never in feature PRs against develop.
- **What not to do**: adds prohibitions against bumping on develop PRs and against targeting `main` directly from feature work.

## Required manual actions before this workflow goes live

This PR is the **code/documentation half** of the migration. The operational half needs you:

1. **Habilitar SSH na hospedagem de testes** + gerar par de chaves dedicado (não reusar chave pessoal).
2. **Cadastrar 4 secrets em Settings → Secrets and variables → Actions:**
   - `TESTES_SSH_HOST` — DNS ou IP do servidor de testes.
   - `TESTES_SSH_USER` — usuário SSH com permissão de escrita na pasta do plugin.
   - `TESTES_SSH_KEY` — chave privada (par cuja pública está em `~/.ssh/authorized_keys` no servidor).
   - `TESTES_REMOTE_PATH` — caminho absoluto até a pasta do plugin (ex: `/var/www/testes/wp-content/plugins/ffcertificate`), sem barra no final.
3. **Criar a branch `develop`** após este PR mergear:
   ```
   git checkout main && git pull && git checkout -b develop && git push -u origin develop
   ```
4. **Configurar branch protection em `develop`** (Settings → Branches → Add rule):
   - ✅ Require a pull request before merging (sem required reviewers).
   - ✅ Require status checks to pass before merging — selecionar todos os 6 jobs.
   - ❌ Require linear history (deixar desmarcado).
   - ❌ Restrict who can push to matching branches (deixar desmarcado).
   - ❌ Do not allow bypassing the above settings (deixar desmarcado).
5. **Configurar `SCRIPT_DEBUG=true`** no `wp-config.php` do servidor de testes (reduz agressividade de cache em iteração).

O primeiro push em `develop` dispara o workflow `deploy-develop.yml` end-to-end — esse run serve como validação de que os 4 secrets e a permissão de escrita estão corretos.

## Test plan

- [ ] CI passa: PHPStan, WPCS, PHPUnit (8.3 + 8.4), coverage floor, ESLint, Stylelint, Vitest, CodeQL, dependency review, asset build verify.
- [ ] Após merge, criar branch `develop` e fazer um push trivial (commit vazio) pra verificar que `deploy-develop.yml` dispara e completa o rsync com sucesso.
- [ ] Validar no servidor de testes que `.git/`, `tests/`, `vendor/`, `node_modules/` NÃO foram copiados.
- [ ] Configurar branch protection conforme acima e tentar abrir um PR de teste contra `develop` pra confirmar que os 6 jobs aparecem como required checks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_