### PR TITLE
fix(deploy): support custom SSH port via TESTES_SSH_PORT secret

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -39,19 +39,27 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.TESTES_SSH_KEY }}
           SSH_HOST: ${{ secrets.TESTES_SSH_HOST }}
+          SSH_PORT: ${{ secrets.TESTES_SSH_PORT }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          # Adiciona o host conhecido para evitar prompt interativo.
-          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          # `TESTES_SSH_PORT` é opcional — VPS padrão usa 22; hospedagem
+          # gerenciada (Hostinger, KingHost) costuma usar porta alta.
+          PORT="${SSH_PORT:-22}"
+          # Best-effort: keyscan pode falhar (firewall, host atrás de
+          # CDN, etc.) sem derrubar o deploy. O step de rsync abaixo usa
+          # `StrictHostKeyChecking=accept-new` como fallback TOFU.
+          ssh-keyscan -p "$PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Rsync to testes
         env:
           SSH_HOST: ${{ secrets.TESTES_SSH_HOST }}
           SSH_USER: ${{ secrets.TESTES_SSH_USER }}
+          SSH_PORT: ${{ secrets.TESTES_SSH_PORT }}
           REMOTE_PATH: ${{ secrets.TESTES_REMOTE_PATH }}
         run: |
+          PORT="${SSH_PORT:-22}"
           # `--delete` remove arquivos no destino que não existem na
           # origem (idempotência total). Exclusões abaixo cobrem:
           # - VCS / CI metadata que não pertence ao runtime do plugin.
@@ -62,6 +70,10 @@ jobs:
           # `composer.json` e `package.json` são intencionalmente
           # *enviados* — admins de hospedagem gerenciada às vezes os
           # inspecionam pra entender o que está rodando.
+          # `StrictHostKeyChecking=accept-new`: TOFU — aceita a chave do
+          # host na primeira conexão e exige match em conexões futuras.
+          # Mais seguro que `no` (vulnerável a MITM); funciona quando o
+          # `ssh-keyscan` acima falhou silenciosamente.
           rsync -avz --delete \
             --exclude='.git/' \
             --exclude='.github/' \
@@ -86,7 +98,7 @@ jobs:
             --exclude='vitest.config.*' \
             --exclude='CLAUDE.md' \
             --exclude='html/' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes" \
+            -e "ssh -i ~/.ssh/deploy_key -p $PORT -o StrictHostKeyChecking=accept-new" \
             ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_PATH}/"
 
       - name: Cleanup SSH key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,10 @@ Reasoning: develop is single-maintainer integration territory, not a shared prod
 
 | Secret | Example | Notes |
 | --- | --- | --- |
-| `TESTES_SSH_HOST` | `ssh.testes.example.com` | DNS or IP of the testes host |
+| `TESTES_SSH_HOST` | `ssh.testes.example.com` or `185.239.210.8` | DNS or IP of the testes host. **Hostname only, no port, no protocol prefix.** |
 | `TESTES_SSH_USER` | `wp-deploy` | Account with write access to the plugin dir |
 | `TESTES_SSH_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----…` | Private half of a dedicated keypair; public half goes in `~/.ssh/authorized_keys` on the testes host |
+| `TESTES_SSH_PORT` | `65002` | **Optional.** Defaults to `22`. Managed hosting (Hostinger, KingHost, Locaweb) usually exposes SSH on a high port — set this when so. |
 | `TESTES_REMOTE_PATH` | `/var/www/testes/wp-content/plugins/ffcertificate` | Absolute path; no trailing slash |
 
 The rsync uses `--delete`, so anything in the remote path that isn't in the develop working tree is removed on each deploy. The workflow excludes `.git/`, `.github/`, `vendor/`, `node_modules/`, `tests/`, and dev tooling (PHPStan, PHPUnit, PHPCS configs) — those don't belong in a runtime plugin dir.


### PR DESCRIPTION
## Summary

Primeira tentativa de deploy end-to-end na Hostinger BR falhou silenciosamente porque o workflow `deploy-develop.yml` hardcodava porta 22, enquanto a hospedagem expõe SSH em porta alta (65002). Dois ajustes pequenos resolvem e tornam o workflow robusto pra outros provedores no futuro.

## Changes

- **`.github/workflows/deploy-develop.yml`**:
  - Adiciona suporte ao secret opcional `TESTES_SSH_PORT` (default `22` — VPS DigitalOcean/Linode/AWS continuam funcionando sem mudança). Tanto `ssh-keyscan` quanto o `ssh` dentro do `rsync -e` agora passam `-p $PORT`.
  - Troca `StrictHostKeyChecking=yes` por `accept-new` no rsync (TOFU — aceita a chave do host na primeira conexão, exige match nas subsequentes). Mais seguro que `no` (que seria vulnerável a MITM); recupera de cenários em que o `ssh-keyscan` falha silenciosamente por causa de firewall/CDN.
  - Marca o `ssh-keyscan` como best-effort (`|| true`) — antes, falha dele com `set -e` derrubava o deploy inteiro sem log útil.

- **`CLAUDE.md`** (seção "Deploy to testes"): adiciona linha pra `TESTES_SSH_PORT` na tabela de secrets, com nota explicando que hospedagem gerenciada (Hostinger, KingHost, Locaweb) costuma usar portas não-padrão.

## Required manual actions (paralelas a este PR)

Pra que o próximo deploy funcione, o secret novo precisa estar cadastrado **antes** do merge deste PR ou o deploy disparado por ele vai falhar de novo:

1. Em https://github.com/rpgmem/ffcertificate/settings/secrets/actions adicionar `TESTES_SSH_PORT` = `65002`.
2. Garantir que `TESTES_SSH_KEY` tem a chave privada nova (gerada com `ssh-keygen` no servidor, sem passphrase).
3. Garantir que a pública correspondente foi appendada em `~/.ssh/authorized_keys` no servidor.
4. Confirmar `TESTES_REMOTE_PATH` (path absoluto até `wp-content/plugins/ffcertificate` no Hostinger, tipicamente sob `/home/u690874273/domains/<dominio>/public_html/...`).

## Test plan

- [ ] CI: PHPStan, WPCS, PHPUnit, coverage, Vitest, ESLint, Stylelint, CodeQL, asset build verify.
- [ ] Após merge, o push em develop dispara `deploy-develop.yml` automaticamente.
- [ ] Validar no run: step "Configure SSH" deve completar sem erro; step "Rsync to testes" deve listar os arquivos enviados e terminar com `total size is …  speedup is …`.
- [ ] No servidor: `ls -lah $TESTES_REMOTE_PATH | head` deve mostrar `ffcertificate.php`, `includes/`, `assets/`, `templates/` com mtime de agora.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_