### PR TITLE
chore(deploy): remove temp DEBUG block + document no-passphrase rule

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -44,18 +44,6 @@ jobs:
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          # TEMP DEBUG (remover após resolver auth — issue de paste do secret).
-          # Tudo abaixo é seguro: fingerprint não vaza bytes da chave; head/tail
-          # do .pub derivado não vaza bytes da privada; `file` só reporta tipo.
-          echo "--- DEBUG: chave recebida do secret ---"
-          echo "Bytes:    $(wc -c < ~/.ssh/deploy_key)"
-          echo "Linhas:   $(wc -l < ~/.ssh/deploy_key)"
-          echo "Encoding: $(file ~/.ssh/deploy_key)"
-          echo "Header:   $(head -1 ~/.ssh/deploy_key)"
-          echo "Footer:   $(tail -1 ~/.ssh/deploy_key)"
-          echo "Fingerprint:"
-          ssh-keygen -lf ~/.ssh/deploy_key 2>&1 || echo "  (chave inválida — ssh-keygen rejeitou)"
-          echo "--- FIM DEBUG ---"
           # `TESTES_SSH_PORT` é opcional — VPS padrão usa 22; hospedagem
           # gerenciada (Hostinger, KingHost) costuma usar porta alta.
           PORT="${SSH_PORT:-22}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Reasoning: develop is single-maintainer integration territory, not a shared prod
 | --- | --- | --- |
 | `TESTES_SSH_HOST` | `ssh.testes.example.com` or `185.239.210.8` | DNS or IP of the testes host. **Hostname only, no port, no protocol prefix.** |
 | `TESTES_SSH_USER` | `wp-deploy` | Account with write access to the plugin dir |
-| `TESTES_SSH_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----…` | Private half of a dedicated keypair; public half goes in `~/.ssh/authorized_keys` on the testes host |
+| `TESTES_SSH_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----…` | Private half of a dedicated keypair; public half goes in `~/.ssh/authorized_keys` on the testes host. **Must have no passphrase** — generate with `ssh-keygen -t ed25519 -N "" -f <path>`. GitHub Actions cannot enter passphrases interactively; a passphrase-protected key surfaces as `Permission denied (publickey,password)` in the rsync step, indistinguishable from a wrong key. |
 | `TESTES_SSH_PORT` | `65002` | **Optional.** Defaults to `22`. Managed hosting (Hostinger, KingHost, Locaweb) usually exposes SSH on a high port — set this when so. |
 | `TESTES_REMOTE_PATH` | `/var/www/testes/wp-content/plugins/ffcertificate` | Absolute path; no trailing slash |
 


### PR DESCRIPTION
## Summary

Cleanup do diagnóstico que adicionei em #390. O bloco DEBUG cumpriu o papel — confirmou que o secret estava correto e isolou a verdadeira causa raiz: a chave privada gerada no servidor tinha **passphrase**, e GitHub Actions não tem como digitá-la interativamente.

Causa raiz, agora resolvida: usuário regenerou um par `ed25519 -N ""` (sem passphrase), atualizou `authorized_keys` + secret, e o deploy seguinte passou verde end-to-end.

## Changes

- **`.github/workflows/deploy-develop.yml`**: remove o bloco DEBUG do step "Configure SSH". Workflow volta à forma de produção (port-aware, accept-new TOFU, keyscan best-effort).

- **`CLAUDE.md`**: adiciona nota na linha do `TESTES_SSH_KEY` na tabela de secrets de deploy explicitando:
  - Chave NÃO pode ter passphrase.
  - Comando exato pra gerar certo: `ssh-keygen -t ed25519 -N "" -f <path>`.
  - Sintoma confuso: passphrase aparece como `Permission denied (publickey,password)`, idêntico a chave errada — sem essa nota, sessão futura repete o ciclo de debug inteiro.

## Test plan

- [ ] CI verde.
- [ ] Após merge, próximo push em develop dispara deploy automático. Step "Configure SSH" deve ficar silencioso (sem o `--- DEBUG ---` no log). Step "Rsync to testes" deve completar normalmente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_