### PR TITLE
chore(deploy): exclude dev tooling and repo docs from testes deploy

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -77,11 +77,13 @@ jobs:
           # - VCS / CI metadata que não pertence ao runtime do plugin.
           # - Dependências de dev (composer require-dev only, node_modules).
           # - Testes e ferramentas de análise estática.
-          # - Configurações locais (wp-config-local.php).
+          # - Manifests de build/lint (composer.json, package.json e locks
+          #   não servem runtime do WordPress; analisadores externos não
+          #   precisam deles na pasta do plugin em produção).
+          # - Docs de repositório (CONTRIBUTING.md, SECURITY.md) que vivem
+          #   no GitHub e não no runtime. `CHANGELOG.md` é mantido por
+          #   preferência — consulta histórica via SSH.
           # - Saídas de coverage / build intermediário.
-          # `composer.json` e `package.json` são intencionalmente
-          # *enviados* — admins de hospedagem gerenciada às vezes os
-          # inspecionam pra entender o que está rodando.
           # `StrictHostKeyChecking=accept-new`: TOFU — aceita a chave do
           # host na primeira conexão e exige match em conexões futuras.
           # Mais seguro que `no` (vulnerável a MITM); funciona quando o
@@ -89,8 +91,10 @@ jobs:
           rsync -avz --delete \
             --exclude='.git/' \
             --exclude='.github/' \
+            --exclude='.githooks/' \
             --exclude='.gitignore' \
             --exclude='.gitattributes' \
+            --exclude='.distignore' \
             --exclude='vendor/' \
             --exclude='node_modules/' \
             --exclude='tests/' \
@@ -103,12 +107,21 @@ jobs:
             --exclude='phpunit.xml.dist' \
             --exclude='phpstan.neon' \
             --exclude='phpstan.neon.dist' \
+            --exclude='phpstan-stubs.php' \
             --exclude='phpcs.xml' \
             --exclude='phpcs.xml.dist' \
+            --exclude='patchwork.json' \
             --exclude='.eslintrc*' \
+            --exclude='eslint.config.*' \
             --exclude='.stylelintrc*' \
             --exclude='vitest.config.*' \
+            --exclude='composer.json' \
+            --exclude='composer.lock' \
+            --exclude='package.json' \
+            --exclude='package-lock.json' \
             --exclude='CLAUDE.md' \
+            --exclude='CONTRIBUTING.md' \
+            --exclude='SECURITY.md' \
             --exclude='html/' \
             -e "ssh -i ~/.ssh/deploy_key -p $PORT -o StrictHostKeyChecking=accept-new" \
             ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_PATH}/"


### PR DESCRIPTION
## Summary

Você notou que o servidor de testes ficou com arquivos de tooling de dev que não pertencem ao runtime do plugin. Este PR amplia a lista de `--exclude` do rsync pra cobrir tudo isso de uma vez.

## Categorias adicionadas

| Categoria | Arquivos |
|---|---|
| Metadata de repo | `.githooks/`, `.distignore` |
| Manifests de build/deps | `composer.json`, `composer.lock`, `package.json`, `package-lock.json` |
| Static analysis / testing | `phpstan-stubs.php`, `patchwork.json` |
| Lint config (flat config) | `eslint.config.*` ← o `.eslintrc*` antigo não pegava o nome novo do ESLint v9 |
| Docs de repo | `CONTRIBUTING.md`, `SECURITY.md` |

## Mantido por preferência

- `CHANGELOG.md` — útil pra consulta histórica via SSH no testes; usuário final WordPress não vê ele (WP.org puxa do `readme.txt`).

## Mudança de política

Removo o comentário antigo que dizia que `composer.json` e `package.json` eram "intencionalmente enviados" porque admins de hospedagem gerenciada poderiam inspecioná-los. Você não concorda com essa justificativa na prática, então o comentário foi reescrito refletindo a nova política (exclui tudo de build/lint).

## Bug bônus corrigido

O `--exclude='.eslintrc*'` não cobria `eslint.config.mjs` porque ESLint v9+ mudou pro "flat config" com naming `eslint.config.{js,mjs,cjs}`. Por isso o arquivo estava passando pro servidor. Adicionado `eslint.config.*` explicitamente.

## Test plan

- [ ] CI verde.
- [ ] Após merge + push em develop → deploy automático.
- [ ] Rsync vai listar `deleting .githooks/`, `deleting composer.json`, etc. nos arquivos transferidos (`--delete` apaga o que não está no envio).
- [ ] No servidor, após o deploy: `ls -la` na pasta do plugin não deve mais conter nenhum dos arquivos listados acima.

## Note

Empilhado na ordem cronológica com #391 (cleanup do DEBUG) — ambos tocam `deploy-develop.yml` mas em seções diferentes (Configure SSH vs Rsync). Sem conflito esperado; se #391 mergear antes, este PR rebaseia naturalmente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_