### PR TITLE
fix(ficha): render Divisão/Setor from split dependent_select placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ficha PDF: Divisão and Setor cells printed the literal placeholder instead of the values.** `default_ficha_template.html` referenced `{{divisao}}` / `{{setor}}`, but `FichaGenerator` only ever emits the combined `divisao_setor` value (`"<parent> - <child>"`), so neither placeholder was substituted. The generator now also exposes each `dependent_select` field's two halves as `{{<key>_parent}}` / `{{<key>_child}}` (the combined `{{<key>}}` form stays for back-compat), and the template's Divisão/Setor cells point at `{{divisao_setor_parent}}` / `{{divisao_setor_child}}`. The standard-field variable building moved into the unit-tested `FichaGenerator::build_standard_field_variables()`.
+
 ---
 
 ## [6.7.7] (2026-05-23)

--- a/html/default_ficha_template.html
+++ b/html/default_ficha_template.html
@@ -59,9 +59,9 @@
                     <td style="padding: 2px 0;font-weight: bold;color: #666">Un. Exercício:</td>
                     <td style="padding: 2px 0;color: #222">{{unidade_exercicio}}</td>
                     <td style="padding: 2px 0;font-weight: bold;color: #666">Divisão:</td>
-                    <td style="padding: 2px 0;color: #222">{{divisao}}</td>
+                    <td style="padding: 2px 0;color: #222">{{divisao_setor_parent}}</td>
                     <td style="padding: 2px 0;font-weight: bold;color: #666">Setor:</td>
-                    <td style="padding: 2px 0;color: #222">{{setor}}</td>
+                    <td style="padding: 2px 0;color: #222">{{divisao_setor_child}}</td>
                 </tr>
                 <tr>
                     <td style="padding: 2px 0;font-weight: bold;color: #666">Endereço:</td>

--- a/includes/reregistration/class-ffc-ficha-generator.php
+++ b/includes/reregistration/class-ffc-ficha-generator.php
@@ -107,18 +107,10 @@ class FichaGenerator {
 			'generation_date'      => \FreeFormCertificate\Core\DateFormatter::format_datetime( time(), 'pdf' ),
 		);
 
-		foreach ( $standard_fields as $field ) {
-			$key   = (string) $field->field_key;
-			$value = $decrypted_values[ $key ] ?? '';
-
-			// Hide accumulation-related fields unless the user declared they hold another job.
-			if ( ! $has_acumulo && in_array( $key, array( 'jornada_acumulo', 'cargo_funcao_acumulo', 'horario_trabalho_acumulo' ), true ) ) {
-				$variables[ $key ] = '';
-				continue;
-			}
-
-			$variables[ $key ] = self::format_field_value( $field, $value );
-		}
+		$variables = array_merge(
+			$variables,
+			self::build_standard_field_variables( $standard_fields, $decrypted_values, $has_acumulo )
+		);
 
 		// Sensible defaults for framework-level keys.
 		if ( empty( $variables['display_name'] ) ) {
@@ -332,6 +324,47 @@ class FichaGenerator {
 		}
 
 		return $decrypted;
+	}
+
+	/**
+	 * Build template variables for the standard reregistration fields.
+	 *
+	 * Each field exposes its formatted value under its `field_key`. A
+	 * dependent_select additionally exposes `<key>_parent` / `<key>_child`
+	 * so a template can place the two halves in separate cells (the default
+	 * ficha prints Divisão and Setor side by side from `divisao_setor`).
+	 * Accumulation-only fields collapse to empty unless the participant
+	 * declared a second post.
+	 *
+	 * @param array<int, object>   $standard_fields  Standard field definitions.
+	 * @param array<string, mixed> $decrypted_values field_key => plaintext value.
+	 * @param bool                 $has_acumulo      Whether the user holds a second post.
+	 * @phpstan-param list<CustomFieldRow> $standard_fields
+	 * @return array<string, string>
+	 */
+	public static function build_standard_field_variables( array $standard_fields, array $decrypted_values, bool $has_acumulo ): array {
+		$vars = array();
+
+		foreach ( $standard_fields as $field ) {
+			$key   = (string) $field->field_key;
+			$value = $decrypted_values[ $key ] ?? '';
+
+			// Hide accumulation-related fields unless the user declared they hold another job.
+			if ( ! $has_acumulo && in_array( $key, array( 'jornada_acumulo', 'cargo_funcao_acumulo', 'horario_trabalho_acumulo' ), true ) ) {
+				$vars[ $key ] = '';
+				continue;
+			}
+
+			$vars[ $key ] = self::format_field_value( $field, $value );
+
+			if ( 'dependent_select' === (string) $field->field_type ) {
+				$dep                      = is_string( $value ) ? json_decode( $value, true ) : $value;
+				$vars[ $key . '_parent' ] = is_array( $dep ) ? (string) ( $dep['parent'] ?? '' ) : '';
+				$vars[ $key . '_child' ]  = is_array( $dep ) ? (string) ( $dep['child'] ?? '' ) : '';
+			}
+		}
+
+		return $vars;
 	}
 
 	/**

--- a/tests/Unit/FichaGeneratorTest.php
+++ b/tests/Unit/FichaGeneratorTest.php
@@ -265,6 +265,85 @@ class FichaGeneratorTest extends TestCase {
     }
 
     // ==================================================================
+    // build_standard_field_variables()
+    // ==================================================================
+
+    public function test_build_standard_field_variables_splits_dependent_select_into_parent_child(): void {
+        $field = (object) [
+            'id'         => 1,
+            'field_key'  => 'divisao_setor',
+            'field_type' => 'dependent_select',
+        ];
+
+        $values = ['divisao_setor' => json_encode(['parent' => 'DRE - DIAF', 'child' => 'Contabilidade'])];
+
+        $vars = $this->invokePrivateStatic('build_standard_field_variables', [[$field], $values, false]);
+
+        // Combined value stays available for back-compat templates.
+        $this->assertSame('DRE - DIAF - Contabilidade', $vars['divisao_setor']);
+        // Split halves drive the two separate cells in the default ficha.
+        $this->assertSame('DRE - DIAF', $vars['divisao_setor_parent']);
+        $this->assertSame('Contabilidade', $vars['divisao_setor_child']);
+    }
+
+    public function test_build_standard_field_variables_dependent_select_empty_when_value_missing(): void {
+        $field = (object) [
+            'id'         => 1,
+            'field_key'  => 'divisao_setor',
+            'field_type' => 'dependent_select',
+        ];
+
+        $vars = $this->invokePrivateStatic('build_standard_field_variables', [[$field], [], false]);
+
+        $this->assertSame('', $vars['divisao_setor']);
+        $this->assertSame('', $vars['divisao_setor_parent']);
+        $this->assertSame('', $vars['divisao_setor_child']);
+    }
+
+    public function test_build_standard_field_variables_hides_accumulation_fields_without_acumulo(): void {
+        $field = (object) [
+            'id'         => 2,
+            'field_key'  => 'jornada_acumulo',
+            'field_type' => 'text',
+        ];
+
+        $values = ['jornada_acumulo' => '40h'];
+
+        $vars = $this->invokePrivateStatic('build_standard_field_variables', [[$field], $values, false]);
+
+        $this->assertSame('', $vars['jornada_acumulo']);
+    }
+
+    public function test_build_standard_field_variables_keeps_accumulation_fields_with_acumulo(): void {
+        $field = (object) [
+            'id'         => 2,
+            'field_key'  => 'jornada_acumulo',
+            'field_type' => 'text',
+        ];
+
+        $values = ['jornada_acumulo' => '40h'];
+
+        $vars = $this->invokePrivateStatic('build_standard_field_variables', [[$field], $values, true]);
+
+        $this->assertSame('40h', $vars['jornada_acumulo']);
+    }
+
+    public function test_build_standard_field_variables_passes_through_plain_field(): void {
+        $field = (object) [
+            'id'         => 3,
+            'field_key'  => 'sindicato',
+            'field_type' => 'text',
+        ];
+
+        $values = ['sindicato' => 'SINPEEM'];
+
+        $vars = $this->invokePrivateStatic('build_standard_field_variables', [[$field], $values, false]);
+
+        $this->assertSame('SINPEEM', $vars['sindicato']);
+        $this->assertArrayNotHasKey('sindicato_parent', $vars);
+    }
+
+    // ==================================================================
     // load_template()
     // ==================================================================
 
@@ -298,5 +377,12 @@ class FichaGeneratorTest extends TestCase {
         $this->assertStringContainsString('{{display_name}}', $result);
         $this->assertStringContainsString('{{custom_fields_section}}', $result);
         $this->assertNotEmpty($result);
+
+        // Divisão/Setor must use the split dependent_select placeholders,
+        // never the stale {{divisao}} / {{setor}} names the generator never emits.
+        $this->assertStringContainsString('{{divisao_setor_parent}}', $result);
+        $this->assertStringContainsString('{{divisao_setor_child}}', $result);
+        $this->assertStringNotContainsString('{{divisao}}', $result);
+        $this->assertStringNotContainsString('{{setor}}', $result);
     }
 }


### PR DESCRIPTION
## Problem

No **ficha PDF** (gerada ao finalizar o recadastramento), as células **Divisão** e **Setor** imprimiam o texto literal do placeholder, não os valores.

**Causa:** `html/default_ficha_template.html` referenciava `{{divisao}}` e `{{setor}}`, mas o `FichaGenerator` só emite o valor **combinado** do campo `divisao_setor` (`dependent_select`) como `"<parent> - <child>"` — nunca as chaves separadas. Resultado: os dois placeholders nunca eram substituídos.

## Fix

- **`FichaGenerator`** agora expõe, para qualquer campo `dependent_select`, suas duas metades como `{{<key>_parent}}` / `{{<key>_child}}` — além da forma combinada `{{<key>}}` (mantida para back-compat / templates customizados).
- **Template**: as células Divisão/Setor passam a usar `{{divisao_setor_parent}}` (Divisão) e `{{divisao_setor_child}}` (Setor).
- O loop de variáveis dos campos standard foi extraído para `FichaGenerator::build_standard_field_variables()` — agora coberto por testes unitários (antes a lógica vivia inline em `generate_ficha_data`, fora do alcance dos testes).

`parent`/`child` já são armazenados como **labels legíveis** (validados contra `field_options['groups']` por audience em `ReregistrationDataProcessor`), então vão direto pro PDF sem lookup adicional.

## Tests

- Novos testes de `build_standard_field_variables`: split parent/child de `dependent_select`, valor ausente → vazio, hide/show dos campos de acúmulo, e passthrough de campo plano.
- Asserção no `load_template`: o template real usa `{{divisao_setor_parent}}`/`{{divisao_setor_child}}` e **não** contém mais `{{divisao}}`/`{{setor}}`.

## Checks locais

- PHPStan L8 ✅ · WPCS ✅ · PHPUnit `FichaGeneratorTest` 21/21 ✅

## Notes

- Sem bump de `FFC_VERSION` (PR pra `develop`).
- Escopo restrito ao bug do placeholder. Tornar o **termo de ciência** configurável (per-audience + replicar, alimentando formulário + PDF) vem num PR separado, já decidido.

## Test plan

- [ ] CI verde (6 gates).
- [ ] Finalizar um recadastramento com `divisao_setor` preenchido → no PDF, célula Divisão mostra a divisão e Setor mostra o setor (sem texto `{{…}}`).
- [ ] Submissão sem `divisao_setor` → células ficam vazias, não com placeholder literal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_