### PR TITLE
chore(ci): point Dependabot at develop, not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -16,6 +17,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -30,6 +32,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot had no `target-branch`, so it opened dependency bumps against the repository default branch (`main`) — e.g. the currently-open #397/#398/#399/#401. Under the develop workflow (CLAUDE.md), only the release PR (`develop → main`) and hotfix PRs touch `main`; dependency bumps are ordinary changes that belong on `develop`.

Set `target-branch: "develop"` for the `composer`, `npm`, and `github-actions` ecosystems so future Dependabot PRs target `develop` and flow through the normal CI gates there.

This does not retarget the four already-open PRs — those are being handled separately.

## Test plan

- [x] YAML is a config-only change; no code paths affected.

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_