### PR TITLE
fix(uninstall): close orphan tables + add opt-in "delete data" toggle (default OFF)

### DIFF
--- a/includes/admin/class-ffc-settings-ajax-endpoint.php
+++ b/includes/admin/class-ffc-settings-ajax-endpoint.php
@@ -96,6 +96,11 @@ class SettingsAjaxEndpoint {
 			'activity_log_cat_recruitment',
 			'activity_log_cat_migrations',
 			'activity_log_cat_system',
+			// Danger Zone opt-in: when on, uninstall.php removes ALL plugin
+			// data (tables, options, CPT posts, roles, caps). Default OFF
+			// matches the WooCommerce / EDD / Yoast convention so plugin
+			// deletion never wipes data unintentionally.
+			'delete_data_on_uninstall',
 		);
 
 		$allowlist = array(

--- a/includes/settings/class-ffc-settings-reader.php
+++ b/includes/settings/class-ffc-settings-reader.php
@@ -170,6 +170,20 @@ final class SettingsReader {
 		return self::get_bool( 'allow_admin_bar' );
 	}
 
+	/**
+	 * Whether deleting the plugin (uninstall.php) should drop tables /
+	 * options / CPT posts / roles / caps / user meta.
+	 *
+	 * Defaults to FALSE to match the WooCommerce / EDD / Yoast convention
+	 * — a plain "Delete plugin" click preserves data unless the admin
+	 * opted in via Settings → Advanced → Danger Zone. uninstall.php reads
+	 * the raw option directly (no autoloader available there); this
+	 * accessor exists for code paths that run inside a normal request.
+	 */
+	public static function delete_data_on_uninstall(): bool {
+		return self::get_bool( 'delete_data_on_uninstall' );
+	}
+
 	/** Whether the FFC user role is blocked from wp-admin. */
 	public static function wp_admin_blocked(): bool {
 		return self::get_bool( 'block_wp_admin' );

--- a/includes/settings/views/ffc-tab-advanced.php
+++ b/includes/settings/views/ffc-tab-advanced.php
@@ -584,6 +584,33 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 	<h2 class="ffc-icon-warning"><?php esc_html_e( 'Danger Zone', 'ffcertificate' ); ?></h2>
 	<p class="description"><?php esc_html_e( 'Warning: These actions cannot be undone.', 'ffcertificate' ); ?></p>
 
+	<table class="form-table" role="presentation">
+		<tbody>
+			<tr>
+				<th scope="row">
+					<label for="ffc_delete_data_on_uninstall"><?php esc_html_e( 'Delete all plugin data on uninstall', 'ffcertificate' ); ?></label>
+				</th>
+				<td>
+					<?php
+					$ffcertificate_delete_on_uninstall = '1' === (string) ( $ffcertificate_get_option( 'delete_data_on_uninstall', '0' ) );
+					\FreeFormCertificate\Admin\AdminUI::render_toggle(
+						array(
+							'name'    => 'ffc_settings[delete_data_on_uninstall]',
+							'id'      => 'ffc_delete_data_on_uninstall',
+							'checked' => $ffcertificate_delete_on_uninstall,
+							'label'   => __( 'Drop all tables, options, custom posts, roles, capabilities and transients when the plugin is deleted via the WordPress admin', 'ffcertificate' ),
+							'data'    => array( 'ffc-autosave-key' => 'delete_data_on_uninstall' ),
+						)
+					);
+					?>
+					<p class="description">
+						<?php esc_html_e( 'OFF by default (same as WooCommerce, EDD, Yoast). With the toggle OFF, deleting the plugin from the Plugins page preserves every form, calendar, submission, audit log and configuration — so re-installing keeps the site exactly as it was. Turn ON only when you really want a clean removal.', 'ffcertificate' ); ?>
+					</p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
 	<form method="post" id="ffc-danger-zone-form">
 		<?php wp_nonce_field( 'ffc_delete_all_data', 'ffc_critical_nonce' ); ?>
 		<input type="hidden" name="ffc_delete_all_data" value="1">

--- a/tests/Unit/SettingsReaderTest.php
+++ b/tests/Unit/SettingsReaderTest.php
@@ -213,6 +213,7 @@ class SettingsReaderTest extends TestCase {
 			'emails_disabled'                 => array( 'emails_disabled', 'disable_all_emails' ),
 			'activity_log_enabled'            => array( 'activity_log_enabled', 'enable_activity_log' ),
 			'admin_bar_allowed'               => array( 'admin_bar_allowed', 'allow_admin_bar' ),
+			'delete_data_on_uninstall'        => array( 'delete_data_on_uninstall', 'delete_data_on_uninstall' ),
 			'wp_admin_blocked'                => array( 'wp_admin_blocked', 'block_wp_admin' ),
 			'admins_bypassed'                 => array( 'admins_bypassed', 'bypass_for_admins' ),
 			'qr_cache_enabled'                => array( 'qr_cache_enabled', 'qr_cache_enabled' ),

--- a/uninstall.php
+++ b/uninstall.php
@@ -31,6 +31,7 @@ $ffcertificate_tables = array(
 	$wpdb->prefix . 'ffc_recruitment_reason',
 	// Reregistration (children first).
 	$wpdb->prefix . 'ffc_reregistration_submissions',
+	$wpdb->prefix . 'ffc_reregistration_audiences',
 	$wpdb->prefix . 'ffc_reregistrations',
 	// Custom fields (depends on audiences).
 	$wpdb->prefix . 'ffc_custom_fields',
@@ -48,9 +49,12 @@ $ffcertificate_tables = array(
 	$wpdb->prefix . 'ffc_self_scheduling_blocked_dates',
 	$wpdb->prefix . 'ffc_self_scheduling_appointments',
 	$wpdb->prefix . 'ffc_self_scheduling_calendars',
-	// Rate limiting.
+	// Rate limiting + device fingerprinting.
 	$wpdb->prefix . 'ffc_rate_limit_logs',
 	$wpdb->prefix . 'ffc_rate_limits',
+	$wpdb->prefix . 'ffc_device_signals',
+	// URL Shortener.
+	$wpdb->prefix . 'ffc_short_urls',
 	// User profiles.
 	$wpdb->prefix . 'ffc_user_profiles',
 	// Core.
@@ -89,6 +93,25 @@ $ffcertificate_options = array(
 	'ffc_columns_dropped_date',
 	'ffc_migration_user_profiles_errors',
 	'ffc_migration_user_profiles_last_run',
+	// Schema-version markers (audited gap — were never on the list).
+	'ffc_activity_log_db_version',
+	'ffc_perf_indexes_db_version',
+	'ffc_submissions_db_version',
+	// Per-feature migration completion markers (audited gap).
+	'ffc_sibling_instants_unix_migrated',
+	'ffc_submission_date_unix_migrated',
+	'ffc_submitted_at_unix_migrated',
+	// Audience module options (audited gap — were never on the list).
+	'ffc_aud_multiple_audiences_color',
+	'ffc_aud_private_display_mode',
+	'ffc_aud_scheduling_message',
+	'ffc_aud_visibility_message',
+	// Self-scheduling module options (audited gap).
+	'ffc_ss_business_hours_booking_message',
+	'ffc_ss_business_hours_viewing_message',
+	'ffc_ss_private_display_mode',
+	'ffc_ss_scheduling_message',
+	'ffc_ss_visibility_message',
 	// Recruitment module (v6.0.0).
 	'ffc_recruitment_settings',
 	'ffc_recruitment_schema_version',
@@ -102,9 +125,16 @@ foreach ( $ffcertificate_options as $ffcertificate_option ) {
 // ──────────────────────────────────────
 // 3. Delete transients
 // ──────────────────────────────────────
+// The activity-log stats triple is explicitly named to keep the obvious
+// case in code; the wildcard sweep below catches every other ffc_* /
+// _ffc_* transient (per-user error transients, per-form caches, etc.)
+// without having to enumerate them.
 delete_transient( 'ffc_activity_stats_7' );
 delete_transient( 'ffc_activity_stats_30' );
 delete_transient( 'ffc_activity_stats_90' );
+
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Uninstall-time wildcard delete; bounded by table scope, no user input.
+$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_ffc\\_%' OR option_name LIKE '\\_transient\\_timeout\\_ffc\\_%' OR option_name LIKE '\\_transient\\_\\_ffc\\_%' OR option_name LIKE '\\_transient\\_timeout\\_\\_ffc\\_%'" );
 
 // ──────────────────────────────────────
 // 4. Clear scheduled cron hooks
@@ -120,20 +150,25 @@ wp_clear_scheduled_hook( 'ffc_process_submission_hook' );
 wp_clear_scheduled_hook( 'ffc_warm_cache_hook' );
 
 // ──────────────────────────────────────
-// 5. Delete all ffc_form custom posts
+// 5. Delete all FFC custom posts (CPTs)
 // ──────────────────────────────────────
-$ffcertificate_forms = get_posts(
-	array(
-		'post_type'      => 'ffc_form',
-		'posts_per_page' => -1,
-		'post_status'    => 'any',
-		'fields'         => 'ids',
-	)
-);
+// Both CPTs registered by the plugin — `ffc_form` (certificate forms)
+// and `ffc_self_scheduling` (self-scheduling calendars). wp_delete_post
+// with force=true also clears each post's post_meta + revisions.
+foreach ( array( 'ffc_form', 'ffc_self_scheduling' ) as $ffcertificate_cpt ) {
+	$ffcertificate_post_ids = get_posts(
+		array(
+			'post_type'      => $ffcertificate_cpt,
+			'posts_per_page' => -1,
+			'post_status'    => 'any',
+			'fields'         => 'ids',
+		)
+	);
 
-if ( ! empty( $ffcertificate_forms ) ) {
-	foreach ( $ffcertificate_forms as $ffcertificate_form_id ) {
-		wp_delete_post( $ffcertificate_form_id, true );
+	if ( ! empty( $ffcertificate_post_ids ) ) {
+		foreach ( $ffcertificate_post_ids as $ffcertificate_post_id ) {
+			wp_delete_post( $ffcertificate_post_id, true );
+		}
 	}
 }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,6 +17,39 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 global $wpdb;
 
 // ──────────────────────────────────────
+// 0. Danger Zone opt-in gate
+// ──────────────────────────────────────
+// The heavy cleanup below (tables, options, CPT posts, roles, caps,
+// user meta) only runs when the admin opted in via Settings →
+// Advanced → Danger Zone → "Delete all plugin data on uninstall".
+// Default OFF, matching the WooCommerce / EDD / Yoast convention so
+// deleting the plugin never wipes data unintentionally.
+//
+// Cron hooks are cleared regardless — their callbacks reference plugin
+// code that's about to be gone, so leaving them registered would
+// produce "no callback" warnings until WP self-heals on the next visit.
+//
+// SettingsReader isn't available here — uninstall.php runs in a
+// stripped-down context that doesn't load the plugin's autoloader —
+// so read the option directly from ffc_settings.
+$ffcertificate_settings = get_option( 'ffc_settings', array() );
+$ffcertificate_purge    = is_array( $ffcertificate_settings )
+	&& '1' === (string) ( $ffcertificate_settings['delete_data_on_uninstall'] ?? '0' );
+
+if ( ! $ffcertificate_purge ) {
+	// Cron-only cleanup: leave data + structure untouched but clear
+	// scheduled events that point at code about to be removed.
+	wp_clear_scheduled_hook( 'ffcertificate_daily_cleanup_hook' );
+	wp_clear_scheduled_hook( 'ffcertificate_process_submission_hook' );
+	wp_clear_scheduled_hook( 'ffcertificate_warm_cache_hook' );
+	wp_clear_scheduled_hook( 'ffcertificate_reregistration_expire_hook' );
+	wp_clear_scheduled_hook( 'ffc_daily_cleanup_hook' );
+	wp_clear_scheduled_hook( 'ffc_process_submission_hook' );
+	wp_clear_scheduled_hook( 'ffc_warm_cache_hook' );
+	return;
+}
+
+// ──────────────────────────────────────
 // 1. Drop all plugin database tables
 // (order: child tables first to avoid FK issues)
 // ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the data-leak you reported on re-install. 1 PR, 2 commits matching the agreed sprints.

### `30762bb` — Sprint 1: complete the uninstall.php cleanup

A re-install audit confirmed three categories of gap. The fix lists each by name with a one-line "why was it missing" so future audits start with this list.

**Missing tables** (3):
- `ffc_short_urls` — URL Shortener (the whole module's storage).
- `ffc_device_signals` — Device Fingerprint sub-table created alongside `ffc_rate_limits` in #195 but never reached uninstall.
- `ffc_reregistration_audiences` — junction table created in `class-ffc-activator.php`; the parent `ffc_reregistrations` was on the list but the child wasn't.

**Missing CPT posts** (1):
- `ffc_self_scheduling` (calendars). The loop only iterated `ffc_form`. Refactored into a small `foreach` over both CPTs so each `wp_delete_post(..., true)` also wipes post_meta + revisions.

**Missing options** (14):
- Schema-version markers: `ffc_activity_log_db_version`, `ffc_perf_indexes_db_version`, `ffc_submissions_db_version`.
- Per-feature migration completion markers: `ffc_sibling_instants_unix_migrated`, `ffc_submission_date_unix_migrated`, `ffc_submitted_at_unix_migrated`.
- Audience block (4): `ffc_aud_multiple_audiences_color`, `ffc_aud_private_display_mode`, `ffc_aud_scheduling_message`, `ffc_aud_visibility_message`.
- Self-scheduling block (5): `ffc_ss_business_hours_booking_message`, `ffc_ss_business_hours_viewing_message`, `ffc_ss_private_display_mode`, `ffc_ss_scheduling_message`, `ffc_ss_visibility_message`.

**Transients**:
- Added a wildcard sweep on `_transient_(timeout_)?(_?)ffc_%` so dynamic per-user / per-form transients (which can't be enumerated by name) are cleared too. The three named activity-stats transients stay in code as the obvious case.

### `53d8c95` — Sprint 2: opt-in toggle (default OFF)

Adds the conventional "Delete all plugin data on uninstall" toggle (the WooCommerce / EDD / Yoast pattern). With the toggle **OFF — the default** — deleting the plugin from the Plugins page preserves every form, calendar, submission, audit log and configuration, so a re-install lands on the existing data.

- New `ffc_settings['delete_data_on_uninstall']` boolean, default false. Persists via the autosave AJAX endpoint allowlist.
- UI row at the top of Settings → Advanced → Danger Zone, rendered with the standard `AdminUI::render_toggle`. Lives outside the existing "Delete Data Permanently" form so the autosave channel doesn't collide with the form-scoped submit.
- `SettingsReader::delete_data_on_uninstall()` typed accessor for any code path inside a normal request; uninstall.php reads the raw option directly (no autoloader available there).
- `uninstall.php` opens with the gate: when off, only orphan cron hooks are cleared and the script returns. When on, the full cleanup runs.

The cron-only path on default OFF is important — even when the admin preserves data, the scheduled hooks reference plugin code that's about to be gone and would otherwise emit "no callback" warnings on the next WP-Cron tick.

## Test plan
- [x] PHPUnit full suite — OK (4817 tests)
- [x] PHPStan level 8 — clean on all changed files
- [x] WPCS — clean on uninstall.php + the 3 PHP files
- [x] `SettingsReaderTest` — new row in the bool-accessor data provider pins the accessor's default and the ON-state mapping
- [ ] **Manual testes check (CRITICAL — destructive):**
  1. Default state: deactivate + delete plugin from Plugins page → data tables / CPT posts / options still in DB. Re-installing lands on the existing data.
  2. Toggle ON state: Settings → Advanced → Danger Zone → flip "Delete all plugin data on uninstall" → deactivate + delete plugin → DB clean (all `wp_ffc_*` tables dropped, `ffc_form` + `ffc_self_scheduling` posts gone, `ffc_*` options gone, `_transient_ffc_*` rows gone).
  3. Either path: scheduled WP-Cron hooks (`ffcertificate_*` + legacy `ffc_*`) are cleared.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_