### PR TITLE
fix(settings): load tabs on admin_init so autosave script enqueues in time (5 tabs affected)

### DIFF
--- a/includes/admin/class-ffc-settings.php
+++ b/includes/admin/class-ffc-settings.php
@@ -62,6 +62,14 @@ class Settings {
 
 		// Hooks.
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ), 20 );
+		// Tabs MUST be instantiated before `admin_enqueue_scripts` fires so
+		// each tab's own enqueue hook (registered in its constructor via
+		// SettingsTab::init()) actually catches the event. The previous
+		// lazy-load inside display_settings_page ran during the render
+		// callback — long after admin_enqueue_scripts — and silently
+		// dropped every tab's script enqueue. admin_init fires after init
+		// (so __() in tab metadata is safe) and before admin_enqueue_scripts.
+		add_action( 'admin_init', array( $this, 'load_tabs' ), 5 );
 		add_action( 'admin_init', array( $this, 'handle_settings_submission' ) );
 		add_action( 'admin_init', array( $this, 'handle_clear_qr_cache' ) );
 		add_action( 'admin_init', array( $this, 'handle_migration_execution' ) );
@@ -78,7 +86,14 @@ class Settings {
 	 *
 	 * @since 4.0.0 Uses autoloader and namespaces (Hotfix 9)
 	 */
-	private function load_tabs(): void {
+	public function load_tabs(): void {
+		// Idempotent — admin_init may call this and display_settings_page
+		// keeps a defensive fallback below for any code path that bypasses
+		// the hook chain.
+		if ( ! empty( $this->tabs ) ) {
+			return;
+		}
+
 		// Autoloader handles class loading - no require_once needed.
 
 		// Tab classes with proper namespaces.

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -118,6 +118,18 @@ class SettingsTest extends TestCase {
             ->once()
             ->with( 'admin_menu', Mockery::type( 'array' ), 20 );
 
+        // Tabs MUST be loaded on admin_init (before admin_enqueue_scripts)
+        // so each tab's enqueue hook is registered in time. The lazy
+        // display_settings_page fallback runs too late and silently
+        // dropped every tab's enqueue (the autosave bug we just fixed).
+        // priority 5 keeps it ahead of the other admin_init handlers
+        // registered below.
+        Functions\expect( 'add_action' )
+            ->once()
+            ->with( 'admin_init', Mockery::on( function ( $cb ) {
+                return is_array( $cb ) && $cb[1] === 'load_tabs';
+            } ), 5 );
+
         Functions\expect( 'add_action' )
             ->once()
             ->with( 'admin_init', Mockery::on( function ( $cb ) {


### PR DESCRIPTION
## Summary

User-reported bug: the **`delete_data_on_uninstall`** toggle (added in #438) didn't autosave on Settings → Advanced. Browser diagnostics surfaced the real shape — the **`enable_activity_log`** toggle right above it also wasn't autosaving:

```json
{
  "autosave_script_loaded": false,
  "autosave_localized": false,
  "enable_activity_log":      { "existe": 1, "bound": false },
  "delete_data_on_uninstall": { "existe": 1, "bound": false }
}
```

`ffc-admin-autosave.js` was never enqueued on the page. **Pre-existing regression** that hid for a long time because the affected toggles (debug flags, activity-log filters) are rarely changed once configured.

## Root cause

`FFC_Settings::load_tabs()` was called lazily from inside `display_settings_page()` — the page render callback. Render runs **long after** `admin_enqueue_scripts` has fired.

Each `SettingsTab::init()` constructor registers `add_action('admin_enqueue_scripts', …)` for its own scripts. Because the tabs were instantiated AFTER `admin_enqueue_scripts` had already fired, the callbacks registered too late and never ran.

**Five tabs were affected** (General, Cache, SMTP, Rate Limit, Advanced) — every tab that calls `enqueue_autosave_infra()`.

## Fix

Load tabs on `admin_init` (priority 5, ahead of the other admin_init handlers registered alongside).

- `admin_init` fires **after `init`** (so tab metadata's `__()` calls stay safe — the original reason for the lazy load).
- `admin_init` fires **before `admin_enqueue_scripts`** (so per-tab enqueue hooks register in time).

Plus:
- `load_tabs()` becomes idempotent — first call instantiates, subsequent no-ops — so the defensive lazy fallback inside `display_settings_page` keeps protecting any future caller that bypasses the hook chain.
- Method visibility flips to public so the action callback can reach it.

## Test plan
- [x] PHPUnit full suite — OK (4817 tests)
- [x] PHPStan level 8 — clean
- [x] WPCS — clean
- [x] `SettingsTest::test_constructor_registers_hooks` gains explicit `add_action('admin_init', load_tabs, 5)` expectation — future refactor that drops it back to lazy fails loudly here.
- [ ] **Manual testes check (after hard refresh):** every toggle on Settings → Advanced now autosaves (Enable Activity Log, debug_*, activity_log_cat_*, Delete all plugin data on uninstall). Reload page → state persists. Also worth spot-checking General / Cache / Rate Limit / SMTP tab toggles, which were affected by the same regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_