### PR TITLE
fix(schema): silence "Duplicate column" + skip already-migrated recruitment v7

### DIFF
--- a/includes/core/class-ffc-database-helper-trait.php
+++ b/includes/core/class-ffc-database-helper-trait.php
@@ -41,7 +41,10 @@ trait DatabaseHelperTrait {
 	/**
 	 * Check if a column exists in a table.
 	 *
-	 * Uses SHOW COLUMNS consistently (avoids INFORMATION_SCHEMA inconsistencies).
+	 * Uses `SHOW COLUMNS … LIKE` with `esc_like()` applied to the column
+	 * name so `_` and `%` are treated as literal characters — without the
+	 * escape, `environment_label` would match `environmentXlabel` too,
+	 * producing false positives on tables with similarly-named columns.
 	 *
 	 * @param string $table_name  Full table name.
 	 * @param string $column_name Column name.
@@ -49,13 +52,49 @@ trait DatabaseHelperTrait {
 	 */
 	protected static function column_exists( string $table_name, string $column_name ): bool {
 		global $wpdb;
+		$like = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( $column_name ) : $column_name;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $column_name ) );
+		$result = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $like ) );
 		return ! empty( $result );
 	}
 
 	/**
+	 * Return the raw SQL type of a column (e.g. `bigint(20) unsigned`,
+	 * `datetime`, `varchar(100)`), or null when the column is missing.
+	 *
+	 * Used by migrations that need to detect an already-migrated state —
+	 * matching by name alone can't distinguish `called_at DATETIME` from
+	 * `called_at BIGINT UNSIGNED`, but the type string can.
+	 *
+	 * @param string $table_name  Full table name.
+	 * @param string $column_name Column name.
+	 * @return string|null
+	 */
+	protected static function column_type( string $table_name, string $column_name ): ?string {
+		global $wpdb;
+		$like = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( $column_name ) : $column_name;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $like ) );
+		if ( empty( $rows ) ) {
+			return null;
+		}
+		foreach ( $rows as $row ) {
+			if ( isset( $row->Field ) && (string) $row->Field === $column_name ) {
+				return isset( $row->Type ) ? (string) $row->Type : null;
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Add a column to a table if it doesn't already exist.
+	 *
+	 * Defense in depth: even with the `column_exists()` pre-check, the
+	 * ALTER is wrapped in `suppress_errors()` and a `Duplicate column
+	 * name` response is treated as a benign no-op. This keeps debug.log
+	 * clean in the rare cases where the existence check disagrees with
+	 * the actual schema (concurrent activations, stale wpdb connection,
+	 * sites running WP < 6.2 where `%i` isn't substituted, etc.).
 	 *
 	 * @param string      $table_name  Full table name.
 	 * @param string      $column_name Column name.
@@ -76,9 +115,25 @@ trait DatabaseHelperTrait {
 		}
 
 		global $wpdb;
-		$after_sql = $after ? $wpdb->prepare( 'AFTER %i', $after ) : '';
+		$after_sql     = $after ? $wpdb->prepare( 'AFTER %i', $after ) : '';
+		$prev_suppress = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : false;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $type is a SQL type definition from trusted internal config.
-		$wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN %i {$type} {$after_sql}", $table_name, $column_name ) );
+		$result = $wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN %i {$type} {$after_sql}", $table_name, $column_name ) );
+		$error  = isset( $wpdb->last_error ) ? (string) $wpdb->last_error : '';
+		if ( method_exists( $wpdb, 'suppress_errors' ) ) {
+			$wpdb->suppress_errors( $prev_suppress );
+		}
+
+		if ( false === $result && '' !== $error ) {
+			if ( false !== stripos( $error, 'Duplicate column' ) ) {
+				return false;
+			}
+			// Real, unexpected failure — re-surface so it reaches debug.log.
+			if ( method_exists( $wpdb, 'print_error' ) ) {
+				$wpdb->print_error( $error );
+			}
+			return false;
+		}
 
 		if ( $index_name ) {
 			self::add_index_if_missing( $table_name, $index_name, "({$column_name})" );

--- a/includes/core/class-ffc-database-helper-trait.php
+++ b/includes/core/class-ffc-database-helper-trait.php
@@ -52,7 +52,7 @@ trait DatabaseHelperTrait {
 	 */
 	protected static function column_exists( string $table_name, string $column_name ): bool {
 		global $wpdb;
-		$like = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( $column_name ) : $column_name;
+		$like = $wpdb->esc_like( $column_name );
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $like ) );
 		return ! empty( $result );
@@ -72,7 +72,7 @@ trait DatabaseHelperTrait {
 	 */
 	protected static function column_type( string $table_name, string $column_name ): ?string {
 		global $wpdb;
-		$like = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( $column_name ) : $column_name;
+		$like = $wpdb->esc_like( $column_name );
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $like ) );
 		if ( empty( $rows ) ) {
@@ -116,22 +116,18 @@ trait DatabaseHelperTrait {
 
 		global $wpdb;
 		$after_sql     = $after ? $wpdb->prepare( 'AFTER %i', $after ) : '';
-		$prev_suppress = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : false;
+		$prev_suppress = $wpdb->suppress_errors( true );
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $type is a SQL type definition from trusted internal config.
 		$result = $wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN %i {$type} {$after_sql}", $table_name, $column_name ) );
 		$error  = isset( $wpdb->last_error ) ? (string) $wpdb->last_error : '';
-		if ( method_exists( $wpdb, 'suppress_errors' ) ) {
-			$wpdb->suppress_errors( $prev_suppress );
-		}
+		$wpdb->suppress_errors( $prev_suppress );
 
 		if ( false === $result && '' !== $error ) {
 			if ( false !== stripos( $error, 'Duplicate column' ) ) {
 				return false;
 			}
 			// Real, unexpected failure — re-surface so it reaches debug.log.
-			if ( method_exists( $wpdb, 'print_error' ) ) {
-				$wpdb->print_error( $error );
-			}
+			$wpdb->print_error( $error );
 			return false;
 		}
 

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -161,6 +161,18 @@ class RecruitmentActivator {
 		$has_old = self::column_exists( $table, 'called_at' );
 		$has_new = self::column_exists( $table, 'called_at_ts' );
 
+		// Already at the target shape: `called_at` is the BIGINT (no
+		// staging column hanging around). This happens on fresh 6.6.0+
+		// installs and on uninstall+reinstall cycles where the schema
+		// version option was cleared but the table itself was already
+		// migrated by a prior activation.
+		if ( $has_old && ! $has_new ) {
+			$type = self::column_type( $table, 'called_at' );
+			if ( null !== $type && false !== stripos( $type, 'int' ) ) {
+				return;
+			}
+		}
+
 		if ( ! $has_new ) {
 			if ( ! $has_old ) {
 				return; // Fresh table at 6.6.0+ already has the int column.
@@ -203,10 +215,18 @@ class RecruitmentActivator {
 				}
 			} while ( $row_count === $batch_size );
 
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN %i', $table, 'called_at' ) );
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE %i %i BIGINT UNSIGNED NOT NULL', $table, 'called_at_ts', 'called_at' ) );
+			// Re-check both columns before the destructive ALTERs so a
+			// partially-completed prior run (or a stale `column_exists`
+			// reading) can't trigger "Can't DROP / Unknown column" noise
+			// in debug.log.
+			if ( self::column_exists( $table, 'called_at' ) ) {
+                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN %i', $table, 'called_at' ) );
+			}
+			if ( self::column_exists( $table, 'called_at_ts' ) && ! self::column_exists( $table, 'called_at' ) ) {
+                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE %i %i BIGINT UNSIGNED NOT NULL', $table, 'called_at_ts', 'called_at' ) );
+			}
 		}
 	}
 

--- a/tests/Unit/AbstractRepositoryTest.php
+++ b/tests/Unit/AbstractRepositoryTest.php
@@ -69,7 +69,7 @@ class AbstractRepositoryTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->insert_id = 0;

--- a/tests/Unit/ActivatorTest.php
+++ b/tests/Unit/ActivatorTest.php
@@ -33,7 +33,7 @@ class ActivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->users = 'wp_users';
@@ -359,12 +359,16 @@ class ActivatorTest extends TestCase {
 
         // Make column_exists() return true for the two override columns so
         // add_column_if_missing() short-circuits without issuing ALTER TABLE.
+        // column_exists() runs the column name through esc_like(), which
+        // renders the underscores as `\_` in the prepared query — strip
+        // the backslashes before matching so the stub stays readable.
         $this->wpdb->shouldReceive( 'get_results' )
             ->andReturnUsing( function ( $query ) {
-                if ( stripos( $query, 'SHOW COLUMNS' ) !== false
+                $normalized = str_replace( '\\', '', $query );
+                if ( stripos( $normalized, 'SHOW COLUMNS' ) !== false
                     && (
-                        stripos( $query, 'schedule_start_override' ) !== false
-                        || stripos( $query, 'schedule_end_override' ) !== false
+                        stripos( $normalized, 'schedule_start_override' ) !== false
+                        || stripos( $normalized, 'schedule_end_override' ) !== false
                     )
                 ) {
                     return [ (object) [ 'Field' => 'present' ] ];

--- a/tests/Unit/ActivityLogClearPlaintextMigrationStrategyTest.php
+++ b/tests/Unit/ActivityLogClearPlaintextMigrationStrategyTest.php
@@ -32,7 +32,7 @@ class ActivityLogClearPlaintextMigrationStrategyTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb              = Mockery::mock( 'wpdb' );
+        $wpdb              = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix      = 'wp_';
         $wpdb->last_error  = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();

--- a/tests/Unit/ActivityLogQueryTest.php
+++ b/tests/Unit/ActivityLogQueryTest.php
@@ -45,7 +45,7 @@ class ActivityLogQueryTest extends TestCase {
         } );
 
         global $wpdb;
-        $this->wpdb = Mockery::mock( 'wpdb' );
+        $this->wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $this->wpdb->prefix = 'wp_';
         $wpdb = $this->wpdb;
     }

--- a/tests/Unit/ActivityLogSubscriberTest.php
+++ b/tests/Unit/ActivityLogSubscriberTest.php
@@ -170,7 +170,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -182,7 +182,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -194,7 +194,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -206,7 +206,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -218,7 +218,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -230,7 +230,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -251,7 +251,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -265,7 +265,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -279,7 +279,7 @@ class ActivityLogSubscriberTest extends TestCase {
         Functions\when( 'add_action' )->justReturn( true );
 
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'insert' );
 
@@ -290,7 +290,7 @@ class ActivityLogSubscriberTest extends TestCase {
 
     public function test_on_daily_cleanup_runs_without_error(): void {
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->atLeast()->once()->andReturn( '' );
         $wpdb->shouldReceive( 'query' )->atLeast()->once()->andReturn( 0 );
@@ -303,7 +303,7 @@ class ActivityLogSubscriberTest extends TestCase {
 
     public function test_cleanup_fallback_skips_when_transient_exists(): void {
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldNotReceive( 'query' );
 
@@ -321,7 +321,7 @@ class ActivityLogSubscriberTest extends TestCase {
 
     public function test_cleanup_fallback_runs_when_transient_missing(): void {
         global $wpdb;
-        $wpdb = \Mockery::mock( 'wpdb' );
+        $wpdb = \Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->atLeast()->once()->andReturn( '' );
         $wpdb->shouldReceive( 'query' )->atLeast()->once()->andReturn( 5 );

--- a/tests/Unit/AdminAjaxTest.php
+++ b/tests/Unit/AdminAjaxTest.php
@@ -91,7 +91,7 @@ class AdminAjaxTest extends TestCase {
 
         // Global wpdb for search_user_by_cpf
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;

--- a/tests/Unit/AdminUserColumnsTest.php
+++ b/tests/Unit/AdminUserColumnsTest.php
@@ -51,7 +51,7 @@ class AdminUserColumnsTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $this->wpdb   = $wpdb;
 

--- a/tests/Unit/AppointmentAjaxHandlerTest.php
+++ b/tests/Unit/AppointmentAjaxHandlerTest.php
@@ -82,7 +82,7 @@ class AppointmentAjaxHandlerTest extends TestCase {
 
         // Mock $wpdb for repo constructors
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         // Create a mock AppointmentHandler

--- a/tests/Unit/AppointmentCsvExporterTest.php
+++ b/tests/Unit/AppointmentCsvExporterTest.php
@@ -45,7 +45,7 @@ class AppointmentCsvExporterTest extends TestCase {
 
         // global $wpdb for repo constructors
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $this->exporter = new AppointmentCsvExporter();

--- a/tests/Unit/AppointmentHandlerTest.php
+++ b/tests/Unit/AppointmentHandlerTest.php
@@ -33,7 +33,7 @@ class AppointmentHandlerTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/AppointmentRepositoryCentralizationTest.php
+++ b/tests/Unit/AppointmentRepositoryCentralizationTest.php
@@ -29,7 +29,7 @@ class AppointmentRepositoryCentralizationTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/AudienceActivatorTest.php
+++ b/tests/Unit/AudienceActivatorTest.php
@@ -28,7 +28,7 @@ class AudienceActivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;
@@ -62,9 +62,6 @@ class AudienceActivatorTest extends TestCase {
             ->byDefault();
         $this->wpdb->shouldReceive( 'query' )
             ->andReturn( 1 )
-            ->byDefault();
-        $this->wpdb->shouldReceive( 'esc_like' )
-            ->andReturnUsing( function ( $text ) { return addcslashes( (string) $text, '_%\\' ); } )
             ->byDefault();
 
         // Default WP function stubs

--- a/tests/Unit/AudienceActivatorTest.php
+++ b/tests/Unit/AudienceActivatorTest.php
@@ -63,6 +63,9 @@ class AudienceActivatorTest extends TestCase {
         $this->wpdb->shouldReceive( 'query' )
             ->andReturn( 1 )
             ->byDefault();
+        $this->wpdb->shouldReceive( 'esc_like' )
+            ->andReturnUsing( function ( $text ) { return addcslashes( (string) $text, '_%\\' ); } )
+            ->byDefault();
 
         // Default WP function stubs
         Functions\when( 'dbDelta' )->justReturn( [] );

--- a/tests/Unit/AudienceAdminAudienceTest.php
+++ b/tests/Unit/AudienceAdminAudienceTest.php
@@ -49,7 +49,7 @@ class AudienceAdminAudienceTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceAdminBookingsTest.php
+++ b/tests/Unit/AudienceAdminBookingsTest.php
@@ -51,7 +51,7 @@ class AudienceAdminBookingsTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceAdminCalendarTest.php
+++ b/tests/Unit/AudienceAdminCalendarTest.php
@@ -54,7 +54,7 @@ class AudienceAdminCalendarTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceAdminDashboardTest.php
+++ b/tests/Unit/AudienceAdminDashboardTest.php
@@ -46,7 +46,7 @@ class AudienceAdminDashboardTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->posts = 'wp_posts';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();

--- a/tests/Unit/AudienceAdminEnvironmentTest.php
+++ b/tests/Unit/AudienceAdminEnvironmentTest.php
@@ -54,7 +54,7 @@ class AudienceAdminEnvironmentTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceAdminImportTest.php
+++ b/tests/Unit/AudienceAdminImportTest.php
@@ -52,7 +52,7 @@ class AudienceAdminImportTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceAdminSettingsTest.php
+++ b/tests/Unit/AudienceAdminSettingsTest.php
@@ -63,7 +63,7 @@ class AudienceAdminSettingsTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/AudienceCsvImporterTest.php
+++ b/tests/Unit/AudienceCsvImporterTest.php
@@ -414,7 +414,7 @@ class AudienceCsvImporterTest extends TestCase {
 
     private function mock_wpdb(): \Mockery\MockInterface {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () {
             return func_get_args()[0]; // Return the query string

--- a/tests/Unit/AudienceQueryServiceTest.php
+++ b/tests/Unit/AudienceQueryServiceTest.php
@@ -28,7 +28,7 @@ class AudienceQueryServiceTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/AuthCodeServiceTest.php
+++ b/tests/Unit/AuthCodeServiceTest.php
@@ -166,7 +166,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_returns_clean_code_on_first_attempt(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         // All three tables return null (no collision)
@@ -188,7 +188,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_retries_on_first_table_collision(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
@@ -216,7 +216,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_retries_on_second_table_collision(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
@@ -245,7 +245,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_retries_on_third_table_collision(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
@@ -275,7 +275,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_falls_back_after_max_attempts(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
@@ -298,7 +298,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_checks_all_three_tables(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $prepared_queries = [];
@@ -327,7 +327,7 @@ class AuthCodeServiceTest extends TestCase {
 
     public function test_globally_unique_auth_code_returns_code_without_dashes(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );

--- a/tests/Unit/BlockedDateRepositoryTest.php
+++ b/tests/Unit/BlockedDateRepositoryTest.php
@@ -32,7 +32,7 @@ class BlockedDateRepositoryTest extends TestCase {
 
         // Provide a mock $wpdb global for AbstractRepository
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $this->repository = new BlockedDateRepository();

--- a/tests/Unit/CalendarRepositoryTest.php
+++ b/tests/Unit/CalendarRepositoryTest.php
@@ -35,7 +35,7 @@ class CalendarRepositoryTest extends TestCase {
 
         // Mock global $wpdb BEFORE constructing the repository
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->insert_id = 0;
@@ -162,7 +162,7 @@ class CalendarRepositoryTest extends TestCase {
         Functions\when( 'get_the_title' )->justReturn( 'Test Calendar' );
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->insert_id = 0;
@@ -742,7 +742,7 @@ class CalendarRepositoryTest extends TestCase {
         } );
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->insert_id = 12;

--- a/tests/Unit/CpfRfSplitMigrationStrategyTest.php
+++ b/tests/Unit/CpfRfSplitMigrationStrategyTest.php
@@ -39,7 +39,7 @@ class CpfRfSplitMigrationStrategyTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/DashboardAssetManagerTest.php
+++ b/tests/Unit/DashboardAssetManagerTest.php
@@ -47,7 +47,7 @@ class DashboardAssetManagerTest extends TestCase {
 
         // Mock $wpdb (needed by ReregistrationSubmissionRepository)
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/DashboardShortcodeTest.php
+++ b/tests/Unit/DashboardShortcodeTest.php
@@ -41,7 +41,7 @@ class DashboardShortcodeTest extends TestCase {
 
         // Mock $wpdb for ReregistrationSubmissionRepository
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/DeactivatorTest.php
+++ b/tests/Unit/DeactivatorTest.php
@@ -32,7 +32,7 @@ class DeactivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;

--- a/tests/Unit/DecryptFailureLoggingTest.php
+++ b/tests/Unit/DecryptFailureLoggingTest.php
@@ -42,7 +42,7 @@ class DecryptFailureLoggingTest extends TestCase {
         $this->resetActivityLogState();
 
         global $wpdb;
-        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb             = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb       = $wpdb;

--- a/tests/Unit/EmailHashRehashMigrationStrategyTest.php
+++ b/tests/Unit/EmailHashRehashMigrationStrategyTest.php
@@ -35,7 +35,7 @@ class EmailHashRehashMigrationStrategyTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb             = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();

--- a/tests/Unit/FrontendTest.php
+++ b/tests/Unit/FrontendTest.php
@@ -67,7 +67,7 @@ class FrontendTest extends TestCase {
         // whose SubmissionRepository constructor reads $wpdb->prefix.
         global $wpdb;
         if ( ! $wpdb ) {
-            $wpdb         = Mockery::mock( 'wpdb' );
+            $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
             $wpdb->prefix = 'wp_';
         }
 

--- a/tests/Unit/IpGeolocationTest.php
+++ b/tests/Unit/IpGeolocationTest.php
@@ -269,7 +269,7 @@ class IpGeolocationTest extends TestCase {
 
     public function test_clear_cache_specific_ip(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->options = 'wp_options';
 
@@ -281,7 +281,7 @@ class IpGeolocationTest extends TestCase {
 
     public function test_clear_cache_all(): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->options = 'wp_options';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'DELETE QUERY' );

--- a/tests/Unit/MigrationCustomFieldsTablesTest.php
+++ b/tests/Unit/MigrationCustomFieldsTablesTest.php
@@ -29,7 +29,7 @@ class MigrationCustomFieldsTablesTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/MigrationDynamicReregFieldsTest.php
+++ b/tests/Unit/MigrationDynamicReregFieldsTest.php
@@ -27,7 +27,7 @@ class MigrationDynamicReregFieldsTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error  = '';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_args()[0]; } )->byDefault();

--- a/tests/Unit/MigrationForeignKeysTest.php
+++ b/tests/Unit/MigrationForeignKeysTest.php
@@ -36,7 +36,7 @@ class MigrationForeignKeysTest extends TestCase {
         Functions\when( 'FreeFormCertificate\Core\absint' )->alias( function ( $v ) { return abs( (int) $v ); } );
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->users = 'wp_users';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();

--- a/tests/Unit/MigrationManagerTest.php
+++ b/tests/Unit/MigrationManagerTest.php
@@ -34,7 +34,7 @@ class MigrationManagerTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/MigrationSelfSchedulingTablesTest.php
+++ b/tests/Unit/MigrationSelfSchedulingTablesTest.php
@@ -29,7 +29,7 @@ class MigrationSelfSchedulingTablesTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/PublicCsvDownloadTest.php
+++ b/tests/Unit/PublicCsvDownloadTest.php
@@ -115,7 +115,7 @@ class PublicCsvDownloadTest extends TestCase {
 
         // Stub $wpdb for RateLimiter's get_count_from_db().
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();
         $wpdb->shouldReceive( 'get_var' )->andReturn( '0' )->byDefault();

--- a/tests/Unit/QRCodeGeneratorTest.php
+++ b/tests/Unit/QRCodeGeneratorTest.php
@@ -29,7 +29,7 @@ class QRCodeGeneratorTest extends TestCase {
 
         // Mock $wpdb for DatabaseHelperTrait
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'QUERY' )->byDefault();

--- a/tests/Unit/RateLimitActivatorTest.php
+++ b/tests/Unit/RateLimitActivatorTest.php
@@ -27,7 +27,7 @@ class RateLimitActivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
 

--- a/tests/Unit/RateLimitLoggerTest.php
+++ b/tests/Unit/RateLimitLoggerTest.php
@@ -28,7 +28,7 @@ class RateLimitLoggerTest extends TestCase {
         $cache->setValue( null );
 
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();
         $wpdb->shouldReceive( 'get_var' )->andReturn( '0' )->byDefault();

--- a/tests/Unit/RateLimitStatsTest.php
+++ b/tests/Unit/RateLimitStatsTest.php
@@ -21,7 +21,7 @@ class RateLimitStatsTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
     }
 

--- a/tests/Unit/RateLimiterTest.php
+++ b/tests/Unit/RateLimiterTest.php
@@ -32,7 +32,7 @@ class RateLimiterTest extends TestCase {
 
         // Provide global $wpdb mock for DB-hitting methods.
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' )->byDefault();
         $wpdb->shouldReceive( 'get_var' )->andReturn( '0' )->byDefault();

--- a/tests/Unit/ReadRateLimitTest.php
+++ b/tests/Unit/ReadRateLimitTest.php
@@ -82,7 +82,7 @@ class ReadRateLimitTest extends TestCase {
 		// Minimal wpdb stub — record_read_attempt → record_attempt
 		// → increment_counter writes one row per (type, identifier, day).
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$wpdb->shouldReceive( 'prepare' )->andReturnUsing( fn ( $sql ) => $sql )->byDefault();
 		$wpdb->shouldReceive( 'get_row' )->andReturn( null )->byDefault();

--- a/tests/Unit/RecruitmentActivatorTest.php
+++ b/tests/Unit/RecruitmentActivatorTest.php
@@ -53,6 +53,10 @@ class RecruitmentActivatorTest extends TestCase {
 			)
 			->byDefault();
 
+		$this->wpdb->shouldReceive( 'esc_like' )
+			->andReturnUsing( function ( $text ) { return addcslashes( (string) $text, '_%\\' ); } )
+			->byDefault();
+
 		Functions\when( 'dbDelta' )->justReturn( array() );
 	}
 
@@ -208,6 +212,88 @@ class RecruitmentActivatorTest extends TestCase {
 
 		$this->assertStringContainsString( 'PRIMARY KEY (notice_id, adjutancy_id)', $junction_sql );
 		$this->assertStringContainsString( 'KEY idx_adjutancy_id (adjutancy_id)', $junction_sql );
+	}
+
+	/**
+	 * Regression for #444 — uninstall+reinstall with `delete_data_on_uninstall`
+	 * ON wipes `ffc_recruitment_schema_version` and recreates the table
+	 * with the 6.6.0+ schema (`called_at` already BIGINT). The legacy v7
+	 * code path treated "old column present" as "needs migration",
+	 * dropped the BIGINT column and renamed an empty staging column over
+	 * it — silently corrupting fresh installs. The hardened path detects
+	 * the integer type via `column_type()` and short-circuits before any
+	 * ALTER runs.
+	 */
+	public function test_migrate_called_at_to_unix_skips_when_column_is_already_bigint(): void {
+		// Table exists.
+		$this->wpdb->shouldReceive( 'get_var' )
+			->andReturnUsing(
+				function ( $query ) {
+					if ( false !== stripos( $query, 'SHOW TABLES LIKE' ) ) {
+						return 'wp_ffc_recruitment_call';
+					}
+					return null;
+				}
+			);
+
+		// SHOW COLUMNS responses: called_at present as BIGINT,
+		// called_at_ts absent. The production code wraps the column
+		// name with esc_like(), so the rendered query carries
+		// `called\_at` / `called\_at\_ts` — normalize before matching.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->andReturnUsing(
+				function ( $query ) {
+					$normalized = str_replace( '\\', '', $query );
+					if ( false !== stripos( $normalized, "LIKE 'called_at_ts'" ) ) {
+						return array();
+					}
+					if ( false !== stripos( $normalized, "LIKE 'called_at'" ) ) {
+						return array(
+							(object) array(
+								'Field' => 'called_at',
+								'Type'  => 'bigint(20) unsigned',
+							),
+						);
+					}
+					return array();
+				}
+			);
+
+		$queries = array();
+		$this->wpdb->shouldReceive( 'query' )
+			->andReturnUsing(
+				function ( $query ) use ( &$queries ) {
+					$queries[] = $query;
+					return 1;
+				}
+			);
+
+		// Drive the v7 step by forcing the schema-version gate at 6
+		// (one below v7).
+		Functions\when( 'get_option' )->justReturn( 6 );
+		$version_writes = array();
+		Functions\when( 'update_option' )->alias(
+			function ( $key, $value ) use ( &$version_writes ) {
+				if ( 'ffc_recruitment_schema_version' === $key ) {
+					$version_writes[] = $value;
+				}
+				return true;
+			}
+		);
+		Functions\when( 'wp_timezone' )->justReturn( new \DateTimeZone( 'UTC' ) );
+
+		\FreeFormCertificate\Recruitment\RecruitmentActivator::maybe_migrate();
+
+		$called_at_alters = array_filter(
+			$queries,
+			function ( $q ) {
+				return false !== stripos( $q, 'ALTER TABLE' )
+					&& false !== stripos( $q, 'called_at' );
+			}
+		);
+
+		$this->assertSame( array(), $called_at_alters, 'No ALTER TABLE statements should touch called_at when it is already BIGINT.' );
+		$this->assertContains( 7, $version_writes, 'Schema-version marker should still advance past v7.' );
 	}
 
 	/**

--- a/tests/Unit/RecruitmentActivatorTest.php
+++ b/tests/Unit/RecruitmentActivatorTest.php
@@ -30,7 +30,7 @@ class RecruitmentActivatorTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->last_error = '';
 		$this->wpdb       = $wpdb;
@@ -51,10 +51,6 @@ class RecruitmentActivatorTest extends TestCase {
 					return $sql;
 				}
 			)
-			->byDefault();
-
-		$this->wpdb->shouldReceive( 'esc_like' )
-			->andReturnUsing( function ( $text ) { return addcslashes( (string) $text, '_%\\' ); } )
 			->byDefault();
 
 		Functions\when( 'dbDelta' )->justReturn( array() );

--- a/tests/Unit/RecruitmentActivityLoggerTest.php
+++ b/tests/Unit/RecruitmentActivityLoggerTest.php
@@ -32,7 +32,7 @@ class RecruitmentActivityLoggerTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
+++ b/tests/Unit/RecruitmentAdjutancyRepositoryTest.php
@@ -28,7 +28,7 @@ class RecruitmentRecruitmentAdjutancyRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->insert_id  = 0;
 		$wpdb->last_error = '';

--- a/tests/Unit/RecruitmentCallRepositoryTest.php
+++ b/tests/Unit/RecruitmentCallRepositoryTest.php
@@ -29,7 +29,7 @@ class RecruitmentCallRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->insert_id  = 0;
 		$wpdb->last_error = '';

--- a/tests/Unit/RecruitmentCallServiceTest.php
+++ b/tests/Unit/RecruitmentCallServiceTest.php
@@ -30,7 +30,7 @@ class RecruitmentCallServiceTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb            = Mockery::mock( 'wpdb' );
+		$wpdb            = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix    = 'wp_';
 		$wpdb->insert_id = 0;
 		$this->wpdb      = $wpdb;

--- a/tests/Unit/RecruitmentCandidateRepositoryTest.php
+++ b/tests/Unit/RecruitmentCandidateRepositoryTest.php
@@ -29,7 +29,7 @@ class RecruitmentCandidateRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->insert_id  = 0;
 		$wpdb->last_error = '';

--- a/tests/Unit/RecruitmentClassificationRepositoryTest.php
+++ b/tests/Unit/RecruitmentClassificationRepositoryTest.php
@@ -30,7 +30,7 @@ class RecruitmentClassificationRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->insert_id  = 0;
 		$wpdb->last_error = '';

--- a/tests/Unit/RecruitmentClassificationStateMachineTest.php
+++ b/tests/Unit/RecruitmentClassificationStateMachineTest.php
@@ -30,7 +30,7 @@ class RecruitmentClassificationStateMachineTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -39,7 +39,7 @@ class RecruitmentCsvImporterTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentDashboardSectionTest.php
+++ b/tests/Unit/RecruitmentDashboardSectionTest.php
@@ -30,7 +30,7 @@ class RecruitmentDashboardSectionTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentDeleteServiceTest.php
+++ b/tests/Unit/RecruitmentDeleteServiceTest.php
@@ -29,7 +29,7 @@ class RecruitmentDeleteServiceTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentEmailDispatcherTest.php
+++ b/tests/Unit/RecruitmentEmailDispatcherTest.php
@@ -32,7 +32,7 @@ class RecruitmentEmailDispatcherTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentNoticeAdjutancyRepositoryTest.php
+++ b/tests/Unit/RecruitmentNoticeAdjutancyRepositoryTest.php
@@ -27,7 +27,7 @@ class RecruitmentNoticeAdjutancyRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentNoticeRepositoryTest.php
+++ b/tests/Unit/RecruitmentNoticeRepositoryTest.php
@@ -33,7 +33,7 @@ class RecruitmentNoticeRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb             = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix     = 'wp_';
 		$wpdb->insert_id  = 0;
 		$wpdb->last_error = '';

--- a/tests/Unit/RecruitmentNoticeStateMachineTest.php
+++ b/tests/Unit/RecruitmentNoticeStateMachineTest.php
@@ -29,7 +29,7 @@ class RecruitmentNoticeStateMachineTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentPromotionServiceTest.php
+++ b/tests/Unit/RecruitmentPromotionServiceTest.php
@@ -29,7 +29,7 @@ class RecruitmentPromotionServiceTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$wpdb->insert_id = 0;
 		$this->wpdb   = $wpdb;

--- a/tests/Unit/RecruitmentPublicShortcodeTest.php
+++ b/tests/Unit/RecruitmentPublicShortcodeTest.php
@@ -32,7 +32,7 @@ class RecruitmentPublicShortcodeTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/RecruitmentReasonRepositoryTest.php
+++ b/tests/Unit/RecruitmentReasonRepositoryTest.php
@@ -28,7 +28,7 @@ class RecruitmentReasonRepositoryTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb             = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->insert_id  = 0;
         $wpdb->last_error = '';

--- a/tests/Unit/ReregistrationDataProcessorTest.php
+++ b/tests/Unit/ReregistrationDataProcessorTest.php
@@ -76,7 +76,7 @@ class ReregistrationDataProcessorTest extends TestCase {
      */
     private function setup_wpdb_with_fields( array $fields ): void {
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
 
         $audience = (object) array(

--- a/tests/Unit/ReregistrationFormRendererTest.php
+++ b/tests/Unit/ReregistrationFormRendererTest.php
@@ -55,7 +55,7 @@ class ReregistrationFormRendererTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_row' )->andReturn( null )->byDefault();

--- a/tests/Unit/ReregistrationStandardFieldsSeederTest.php
+++ b/tests/Unit/ReregistrationStandardFieldsSeederTest.php
@@ -27,7 +27,7 @@ class ReregistrationStandardFieldsSeederTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error  = '';
         $wpdb->insert_id   = 0;

--- a/tests/Unit/RestControllerTest.php
+++ b/tests/Unit/RestControllerTest.php
@@ -37,7 +37,7 @@ class RestControllerTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->posts = 'wp_posts';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/SelfSchedulingActivatorTest.php
+++ b/tests/Unit/SelfSchedulingActivatorTest.php
@@ -28,7 +28,7 @@ class SelfSchedulingActivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;

--- a/tests/Unit/SelfSchedulingCleanupHandlerTest.php
+++ b/tests/Unit/SelfSchedulingCleanupHandlerTest.php
@@ -105,7 +105,7 @@ class SelfSchedulingCleanupHandlerTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'Q' )->byDefault();

--- a/tests/Unit/SelfSchedulingShortcodeTest.php
+++ b/tests/Unit/SelfSchedulingShortcodeTest.php
@@ -72,7 +72,7 @@ class SelfSchedulingShortcodeTest extends TestCase {
         }
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/SensitiveFieldPolicyTest.php
+++ b/tests/Unit/SensitiveFieldPolicyTest.php
@@ -50,7 +50,7 @@ class SensitiveFieldPolicyTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->insert_id = 0;

--- a/tests/Unit/SensitiveFieldRegistryTest.php
+++ b/tests/Unit/SensitiveFieldRegistryTest.php
@@ -40,7 +40,7 @@ class SensitiveFieldRegistryTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -46,7 +46,7 @@ class SettingsTest extends TestCase {
 
         // Mock $wpdb
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $this->wpdb   = $wpdb;
 

--- a/tests/Unit/SubmissionHandlerTest.php
+++ b/tests/Unit/SubmissionHandlerTest.php
@@ -34,7 +34,7 @@ class SubmissionHandlerTest extends TestCase {
 
         // Mock global $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         // Allow auth-code uniqueness check & orphan-linking calls

--- a/tests/Unit/SubmissionRepositoryCentralizationTest.php
+++ b/tests/Unit/SubmissionRepositoryCentralizationTest.php
@@ -30,7 +30,7 @@ class SubmissionRepositoryCentralizationTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/SubmissionRepositoryTest.php
+++ b/tests/Unit/SubmissionRepositoryTest.php
@@ -27,7 +27,7 @@ class SubmissionRepositoryTest extends TestCase {
 
         // Mock global $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
 

--- a/tests/Unit/SubmissionsListTest.php
+++ b/tests/Unit/SubmissionsListTest.php
@@ -48,7 +48,7 @@ class SubmissionsListTest extends TestCase {
 
         // SubmissionsList extends WP_List_Table which needs $wpdb
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->shouldReceive( 'prepare' )->andReturnUsing( function () { return func_get_arg(0); } )->byDefault();
         $wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/UrlShortenerActivatorTest.php
+++ b/tests/Unit/UrlShortenerActivatorTest.php
@@ -28,7 +28,7 @@ class UrlShortenerActivatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
 

--- a/tests/Unit/UrlShortenerLoaderTest.php
+++ b/tests/Unit/UrlShortenerLoaderTest.php
@@ -35,7 +35,7 @@ class UrlShortenerLoaderTest extends TestCase {
 
         // Mock global $wpdb (needed by UrlShortenerRepository created inside Service)
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
 

--- a/tests/Unit/UrlShortenerRepositoryTest.php
+++ b/tests/Unit/UrlShortenerRepositoryTest.php
@@ -30,7 +30,7 @@ class UrlShortenerRepositoryTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
 

--- a/tests/Unit/UserAudienceRestControllerTest.php
+++ b/tests/Unit/UserAudienceRestControllerTest.php
@@ -58,7 +58,7 @@ class UserAudienceRestControllerTest extends TestCase {
         $user_manager_mock->shouldReceive( 'grant_audience_capabilities' )->byDefault();
 
         // Global $wpdb mock
-        $this->wpdb = Mockery::mock( 'wpdb' );
+        $this->wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $this->wpdb->prefix = 'wp_';
         $this->wpdb->shouldReceive( 'prepare' )->andReturn( '' )->byDefault();
         $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/UserCertificatesRestControllerTest.php
+++ b/tests/Unit/UserCertificatesRestControllerTest.php
@@ -75,7 +75,7 @@ class UserCertificatesRestControllerTest extends TestCase {
         $magic_link_mock->shouldReceive( 'generate_magic_link' )->andReturn( 'https://example.com/magic/abc123' )->byDefault();
 
         // Global $wpdb mock
-        $this->wpdb = Mockery::mock( 'wpdb' );
+        $this->wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $this->wpdb->prefix = 'wp_';
         $this->wpdb->posts = 'wp_posts';
         $this->wpdb->shouldReceive( 'prepare' )->andReturn( '' )->byDefault();

--- a/tests/Unit/UserCreatorTest.php
+++ b/tests/Unit/UserCreatorTest.php
@@ -22,7 +22,7 @@ class UserCreatorTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->posts  = 'wp_posts';
         $wpdb->last_error = '';

--- a/tests/Unit/UserIdentifiersQueryServiceTest.php
+++ b/tests/Unit/UserIdentifiersQueryServiceTest.php
@@ -34,7 +34,7 @@ class UserIdentifiersQueryServiceTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';
 		$this->wpdb   = $wpdb;
 

--- a/tests/Unit/UserManagerTest.php
+++ b/tests/Unit/UserManagerTest.php
@@ -30,7 +30,7 @@ class UserManagerTest extends TestCase {
         Monkey\setUp();
 
         global $wpdb;
-        $wpdb         = Mockery::mock( 'wpdb' );
+        $wpdb         = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb   = $wpdb;

--- a/tests/Unit/UserProfileRepositoryTest.php
+++ b/tests/Unit/UserProfileRepositoryTest.php
@@ -29,7 +29,7 @@ class UserProfileRepositoryTest extends TestCase {
 		Monkey\setUp();
 
 		global $wpdb;
-		$wpdb            = Mockery::mock( 'wpdb' );
+		$wpdb            = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix    = 'wp_';
 		$wpdb->insert_id = 0;
 		$this->wpdb      = $wpdb;

--- a/tests/Unit/UserProfileRestControllerTest.php
+++ b/tests/Unit/UserProfileRestControllerTest.php
@@ -93,7 +93,7 @@ class UserProfileRestControllerTest extends TestCase {
         $rate_limiter_mock->shouldReceive( 'check_user_limit' )->andReturn( array( 'allowed' => true ) )->byDefault();
 
         // Global $wpdb mock
-        $this->wpdb = Mockery::mock( 'wpdb' );
+        $this->wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $this->wpdb->prefix = 'wp_';
         $this->wpdb->shouldReceive( 'prepare' )->andReturn( '' )->byDefault();
         $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/UserProfileServiceTest.php
+++ b/tests/Unit/UserProfileServiceTest.php
@@ -48,7 +48,7 @@ class UserProfileServiceTest extends TestCase {
         $this->usermeta_store = array();
 
         global $wpdb;
-        $wpdb             = Mockery::mock( 'wpdb' );
+        $wpdb             = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix     = 'wp_';
         $wpdb->last_error = '';
         $this->wpdb       = $wpdb;

--- a/tests/Unit/UserSummaryRestControllerTest.php
+++ b/tests/Unit/UserSummaryRestControllerTest.php
@@ -65,7 +65,7 @@ class UserSummaryRestControllerTest extends TestCase {
         $rereg_mock->shouldReceive( 'get_user_reregistrations' )->andReturn( array() )->byDefault();
 
         // Global $wpdb mock
-        $this->wpdb = Mockery::mock( 'wpdb' );
+        $this->wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $this->wpdb->prefix = 'wp_';
         $this->wpdb->shouldReceive( 'prepare' )->andReturn( '' )->byDefault();
         $this->wpdb->shouldReceive( 'get_results' )->andReturn( array() )->byDefault();

--- a/tests/Unit/VerificationHandlerTest.php
+++ b/tests/Unit/VerificationHandlerTest.php
@@ -41,7 +41,7 @@ class VerificationHandlerTest extends TestCase {
 
         // Mock global $wpdb (used by repositories created internally)
         global $wpdb;
-        $wpdb = Mockery::mock( 'wpdb' );
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
         $wpdb->last_error = '';
         $wpdb->shouldReceive( 'prepare' )->andReturn( 'PREPARED_QUERY' )->byDefault();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,6 +71,43 @@ if ( ! defined( 'DAY_IN_SECONDS' ) ) {
     define( 'DAY_IN_SECONDS', 86400 );
 }
 
+// Stub wpdb class for unit tests. Mockery::mock('wpdb') subclasses this
+// stub, so methods we never explicitly mock (esc_like / suppress_errors /
+// print_error) fall through to safe no-ops instead of throwing
+// BadMethodCallException. Tests that exercise these methods set up
+// `shouldReceive` expectations themselves; tests that don't care now
+// rely on the partial behaviour configured below.
+if ( ! defined( 'OBJECT' ) ) {
+    define( 'OBJECT', 'OBJECT' );
+}
+if ( ! class_exists( 'wpdb' ) ) {
+    class wpdb {
+        public $prefix = '';
+        public $last_error = '';
+        public $suppress_errors = false;
+        public function prepare( $query, ...$args ) { return $query; }
+        public function query( $query ) { return 0; }
+        public function get_var( $query = null, $x = 0, $y = 0 ) { return null; }
+        public function get_row( $query = null, $output = OBJECT, $y = 0 ) { return null; }
+        public function get_col( $query = null, $x = 0 ) { return array(); }
+        public function get_results( $query = null, $output = OBJECT ) { return array(); }
+        public function insert( $table, $data, $format = null ) { return 0; }
+        public function update( $table, $data, $where, $format = null, $where_format = null ) { return 0; }
+        public function delete( $table, $where, $where_format = null ) { return 0; }
+        public function replace( $table, $data, $format = null ) { return 0; }
+        public function esc_like( $text ) { return addcslashes( (string) $text, '_%\\' ); }
+        public function suppress_errors( $suppress = true ) {
+            $previous              = $this->suppress_errors;
+            $this->suppress_errors = (bool) $suppress;
+            return $previous;
+        }
+        public function hide_errors() { return $this->suppress_errors( true ); }
+        public function show_errors( $show = true ) { return $this->suppress_errors( ! $show ); }
+        public function print_error( $str = '' ) { /* no-op in tests */ }
+        public function get_charset_collate() { return ''; }
+    }
+}
+
 // Stub WP_Query for the obsolete shortcode cleaner (and any other test
 // instantiating a WP_Query directly). Consumers seed a FIFO queue in
 // `$GLOBALS['ffc_test_wp_query_queue']` — each constructor invocation pops


### PR DESCRIPTION
## Summary

Two debug.log noise patterns reported in production after the uninstall/reinstall flow that landed in #438:

1. **`AudienceActivator::maybe_migrate()` "Duplicate column name"** — runs on every `plugins_loaded` without a version gate. When `column_exists()` ever disagrees with the live schema (concurrent activation, stale wpdb connection, WP < 6.2 missing `%i` substitution), the follow-up `ALTER TABLE ADD COLUMN` logs the warning forever. `DatabaseHelperTrait::add_column_if_missing()` now wraps the ALTER in `$wpdb->suppress_errors()` and treats the duplicate-column response as a benign no-op; non-duplicate errors still surface via `print_error()`.

2. **`RecruitmentActivator` v7 "Can't DROP COLUMN called_at" / "Unknown column called_at_ts"** — happens on uninstall+reinstall when `ffc_recruitment_schema_version` was wiped but the table stayed at the post-v7 shape (`called_at` BIGINT, no `called_at_ts`). The legacy path treated "old column present" as "needs migration" and would drop the BIGINT column then rename an empty staging column over it — silent data corruption on installs that ran the cycle with `delete_data_on_uninstall` ON. Hardened path detects the already-migrated state via a new `DatabaseHelperTrait::column_type()` helper and short-circuits before any ALTER.

Also escapes the LIKE pattern in `column_exists()` / `column_type()` with `esc_like()` — without it, `environment_label` matches `environmentXlabel` as a false positive on tables that ever grow a similarly-named column.

## Test plan

- [x] PHPUnit full suite green (4818 tests, 12384 assertions)
- [x] Regression test added: `test_migrate_called_at_to_unix_skips_when_column_is_already_bigint`
- [ ] Manual: re-test uninstall+reinstall on testes with `delete_data_on_uninstall=ON`, confirm no "Duplicate column" / "Can't DROP" lines in debug.log


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_