### PR TITLE
fix(settings): geolocation autosave 403 — wire ffcAdminAutosave nonce

### DIFF
--- a/includes/settings/tabs/class-ffc-tab-geolocation.php
+++ b/includes/settings/tabs/class-ffc-tab-geolocation.php
@@ -60,21 +60,12 @@ class TabGeolocation extends SettingsTab {
 		}
 
 		$s = \FreeFormCertificate\Core\Utils::asset_suffix();
-		// Core is needed for FFC.request; autosave depends on FFC.Admin.
-		wp_enqueue_script(
-			'ffc-core',
-			FFC_PLUGIN_URL . "assets/js/ffc-core{$s}.js",
-			array( 'jquery' ),
-			FFC_VERSION,
-			true
-		);
-		wp_enqueue_script(
-			'ffc-admin-autosave',
-			FFC_PLUGIN_URL . "assets/js/ffc-admin-autosave{$s}.js",
-			array( 'jquery', 'ffc-core', 'ffc-admin-js' ),
-			FFC_VERSION,
-			true
-		);
+		// Shared helper enqueues ffc-core + ffc-admin-autosave AND localizes
+		// `ffcAdminAutosave.nonce` for the `ffc_update_setting` endpoint.
+		// Inlining the enqueues here (the pre-#440 shape) skipped the nonce
+		// localization, so autosave fell back to the global ffc_ajax.nonce
+		// (created for ffc_admin_pdf_nonce) and every toggle save 403'd.
+		$this->enqueue_autosave_infra();
 		wp_enqueue_script(
 			'ffc-geolocation-settings',
 			FFC_PLUGIN_URL . "assets/js/ffc-geolocation-settings{$s}.js",


### PR DESCRIPTION
## Summary

The Geolocation tab inlined the `ffc-core` + `ffc-admin-autosave` enqueues but skipped the `ffcAdminAutosave.nonce` localization the autosave script reads. Toggles tagged `data-ffc-autosave-key` (`admin_bypass_datetime`, `admin_bypass_geo`) therefore fell back to `FFC.config.nonce` — created for the unrelated `ffc_admin_pdf_nonce` action — and every change returned 403 / "connection error".

Switching to the shared `SettingsTab::enqueue_autosave_infra()` helper attaches the correct nonce. Tab-specific scripts (`ffc-geolocation-settings`, `ffc-locations-crud`) keep their own enqueues.

## Test plan

- [ ] Manual: toggle `admin_bypass_datetime` and `admin_bypass_geo` on `page=ffc-settings&tab=geolocation`; expect the "Saved" badge and no 403 in DevTools Network.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_