### PR TITLE
feat(settings): autosave every settings-page toggle + fix rate-limit "read" 403

### DIFF
--- a/includes/admin/class-ffc-settings-ajax-endpoint.php
+++ b/includes/admin/class-ffc-settings-ajax-endpoint.php
@@ -70,6 +70,13 @@ class SettingsAjaxEndpoint {
 			'qr_cache_enabled',
 			// SMTP tab.
 			'disable_all_emails',
+			'send_wp_user_email_submission',
+			'send_wp_user_email_appointment',
+			'send_wp_user_email_csv_import',
+			'send_wp_user_email_migration',
+			// URL Shortener tab.
+			'url_shortener_enabled',
+			'url_shortener_auto_create',
 			// Advanced tab — activity log master switch + per-module debug.
 			'enable_activity_log',
 			'debug_pdf_generator',
@@ -104,13 +111,49 @@ class SettingsAjaxEndpoint {
 		);
 
 		$allowlist = array(
-			'admin_bypass_datetime' => array(
+			'admin_bypass_datetime'         => array(
 				'option' => 'ffc_geolocation_settings',
 				'type'   => 'bool',
 				'cap'    => 'manage_options',
 			),
-			'admin_bypass_geo'      => array(
+			'admin_bypass_geo'              => array(
 				'option' => 'ffc_geolocation_settings',
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			'ip_api_enabled'                => array(
+				'option' => 'ffc_geolocation_settings',
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			'ip_api_cascade'                => array(
+				'option' => 'ffc_geolocation_settings',
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			'ip_cache_enabled'              => array(
+				'option' => 'ffc_geolocation_settings',
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			// User Access tab — stored in its own option (ffc_user_access_settings)
+			// with flat keys. The JS-side key is prefixed `user_access_*` so it
+			// doesn't collide with same-named keys in ffc_settings.
+			'user_access_block_wp_admin'    => array(
+				'option' => 'ffc_user_access_settings',
+				'path'   => array( 'block_wp_admin' ),
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			'user_access_bypass_for_admins' => array(
+				'option' => 'ffc_user_access_settings',
+				'path'   => array( 'bypass_for_admins' ),
+				'type'   => 'bool',
+				'cap'    => 'manage_options',
+			),
+			'user_access_allow_admin_bar'   => array(
+				'option' => 'ffc_user_access_settings',
+				'path'   => array( 'allow_admin_bar' ),
 				'type'   => 'bool',
 				'cap'    => 'manage_options',
 			),
@@ -137,7 +180,24 @@ class SettingsAjaxEndpoint {
 			'device_enabled'                   => array( 'device', 'enabled' ),
 			'device_bypass_logged_in_managers' => array( 'device', 'bypass_logged_in_managers' ),
 			'device_log_blocks'                => array( 'device', 'log_blocks' ),
+			// Read-endpoint group (#259).
+			'read_respect_whitelist'           => array( 'read', 'respect_whitelist' ),
+			'read_bypass_logged_in'            => array( 'read', 'bypass_logged_in' ),
+			// Logging group.
+			'logging_enabled'                  => array( 'logging', 'enabled' ),
+			'logging_log_allowed'              => array( 'logging', 'log_allowed' ),
+			'logging_log_blocked'              => array( 'logging', 'log_blocked' ),
+			// UI / display group.
+			'ui_show_remaining'                => array( 'ui', 'show_remaining' ),
+			'ui_show_wait_time'                => array( 'ui', 'show_wait_time' ),
+			'ui_countdown_timer'               => array( 'ui', 'countdown_timer' ),
 		);
+
+		// Per-endpoint enable toggles under `read.endpoints.<ep>.enabled`.
+		// Keep the endpoint list aligned with TabRateLimit::$defaults['read']['endpoints'].
+		foreach ( array( 'calendar_slots', 'calendar_list', 'calendar_detail' ) as $ffc_ep ) {
+			$rate_limit_paths[ 'read_endpoint_' . $ffc_ep . '_enabled' ] = array( 'read', 'endpoints', $ffc_ep, 'enabled' );
+		}
 
 		foreach ( $rate_limit_paths as $key => $path ) {
 			$allowlist[ $key ] = array(
@@ -313,7 +373,22 @@ class SettingsAjaxEndpoint {
 			'device_message'         => array( array( 'device', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
 			'logging_retention_days' => array( array( 'logging', 'retention_days' ), 'int', array( 'min' => 1 ) ),
 			'logging_max_logs'       => array( array( 'logging', 'max_logs' ), 'int', array( 'min' => 100 ) ),
+			'read_message'           => array( array( 'read', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
 		);
+
+		// Per-endpoint numeric thresholds under read.endpoints.<ep>.{max_per_minute,max_per_hour}.
+		foreach ( array( 'calendar_slots', 'calendar_list', 'calendar_detail' ) as $ffc_ep ) {
+			$rate_limit_typed[ 'read_endpoint_' . $ffc_ep . '_max_per_minute' ] = array(
+				array( 'read', 'endpoints', $ffc_ep, 'max_per_minute' ),
+				'int',
+				array( 'min' => 0 ),
+			);
+			$rate_limit_typed[ 'read_endpoint_' . $ffc_ep . '_max_per_hour' ]   = array(
+				array( 'read', 'endpoints', $ffc_ep, 'max_per_hour' ),
+				'int',
+				array( 'min' => 0 ),
+			);
+		}
 
 		foreach ( $rate_limit_typed as $key => list( $path, $type, $extra ) ) {
 			$allowlist[ $key ] = array_merge(

--- a/includes/settings/tabs/class-ffc-tab-url-shortener.php
+++ b/includes/settings/tabs/class-ffc-tab-url-shortener.php
@@ -29,6 +29,25 @@ class TabUrlShortener extends SettingsTab {
 		$this->tab_title = __( 'URL Shortener', 'ffcertificate' );
 		$this->tab_icon  = 'ffc-icon-link';
 		$this->tab_order = 35;
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueue autosave infra so the two `.ffc-toggle` switches on this tab
+	 * (url_shortener_enabled / url_shortener_auto_create) bind to the
+	 * incremental settings AJAX endpoint.
+	 *
+	 * @param string $hook Hook name.
+	 */
+	public function enqueue_scripts( string $hook ): void {
+		if ( 'ffc_form_page_ffc-settings' !== $hook ) {
+			return;
+		}
+		$active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tab parameter for conditional script loading.
+		if ( 'url_shortener' === $active_tab ) {
+			$this->enqueue_autosave_infra();
+		}
 	}
 
 	/**

--- a/includes/settings/tabs/class-ffc-tab-user-access.php
+++ b/includes/settings/tabs/class-ffc-tab-user-access.php
@@ -32,22 +32,24 @@ class TabUserAccess extends SettingsTab {
 		$this->tab_icon  = 'ffc-icon-users';
 		$this->tab_order = 60;
 
-		// Enqueue styles for this tab.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 	}
 
 	/**
-	 * Enqueue styles for User Access settings page
+	 * Enqueue autosave infra so the three `.ffc-toggle` switches on this tab
+	 * (block_wp_admin / bypass_for_admins / allow_admin_bar) bind to the
+	 * incremental settings AJAX endpoint via their `user_access_*` allowlist keys.
 	 *
 	 * @param string $hook Hook name.
 	 */
 	public function enqueue_styles( string $hook ): void {
-		// Only load on settings page with this tab active.
 		if ( 'ffc_form_page_ffc-settings' !== $hook ) {
 			return;
 		}
-
 		$active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tab parameter for conditional script loading.
+		if ( 'user_access' === $active_tab ) {
+			$this->enqueue_autosave_infra();
+		}
 	}
 
 	/**

--- a/includes/settings/views/ffc-tab-geolocation.php
+++ b/includes/settings/views/ffc-tab-geolocation.php
@@ -209,6 +209,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								'name'    => 'ip_api_enabled',
 								'checked' => (bool) $settings['ip_api_enabled'],
 								'label'   => __( 'Enable IP geolocation API for backend validation', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'ip_api_enabled' ),
 							)
 						);
 						?>
@@ -250,6 +251,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								'name'    => 'ip_api_cascade',
 								'checked' => (bool) $settings['ip_api_cascade'],
 								'label'   => __( 'Enable cascade: if primary fails, try the other service', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'ip_api_cascade' ),
 							)
 						);
 						?>
@@ -290,6 +292,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								'name'    => 'ip_cache_enabled',
 								'checked' => (bool) $settings['ip_cache_enabled'],
 								'label'   => __( 'Cache IP geolocation results to reduce API calls', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'ip_cache_enabled' ),
 							)
 						);
 						?>

--- a/includes/settings/views/ffc-tab-rate-limit.php
+++ b/includes/settings/views/ffc-tab-rate-limit.php
@@ -402,6 +402,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'logging_enabled',
 				'checked' => (bool) $ffcertificate_s['logging']['enabled'],
 				'label'   => __( 'Enable logs', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'logging_enabled' ),
 			)
 		);
 		?>
@@ -413,6 +414,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'logging_log_allowed',
 				'checked' => (bool) $ffcertificate_s['logging']['log_allowed'],
 				'label'   => __( 'Log allowed requests', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'logging_log_allowed' ),
 			)
 		);
 		?>
@@ -424,6 +426,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'logging_log_blocked',
 				'checked' => (bool) $ffcertificate_s['logging']['log_blocked'],
 				'label'   => __( 'Log blocked requests', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'logging_log_blocked' ),
 			)
 		);
 		?>
@@ -443,6 +446,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'ui_show_remaining',
 				'checked' => (bool) $ffcertificate_s['ui']['show_remaining'],
 				'label'   => __( 'Show remaining attempts', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'ui_show_remaining' ),
 			)
 		);
 		?>
@@ -454,6 +458,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'ui_show_wait_time',
 				'checked' => (bool) $ffcertificate_s['ui']['show_wait_time'],
 				'label'   => __( 'Show wait time', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'ui_show_wait_time' ),
 			)
 		);
 		?>
@@ -465,6 +470,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 				'name'    => 'ui_countdown_timer',
 				'checked' => (bool) $ffcertificate_s['ui']['countdown_timer'],
 				'label'   => __( 'Countdown timer', 'ffcertificate' ),
+				'data'    => array( 'ffc-autosave-key' => 'ui_countdown_timer' ),
 			)
 		);
 		?>

--- a/includes/settings/views/ffc-tab-smtp.php
+++ b/includes/settings/views/ffc-tab-smtp.php
@@ -94,6 +94,7 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 									'id'      => $ffcertificate_key,
 									'checked' => '1' === $ffcertificate_current,
 									'label'   => __( 'Enabled', 'ffcertificate' ),
+									'data'    => array( 'ffc-autosave-key' => $ffcertificate_key ),
 								)
 							);
 							?>

--- a/includes/settings/views/ffc-tab-url-shortener.php
+++ b/includes/settings/views/ffc-tab-url-shortener.php
@@ -51,6 +51,7 @@ $all_post_types = get_post_types( array( 'public' => true ), 'objects' );
 					'id'      => 'url_shortener_enabled',
 					'checked' => 1 === (int) $enabled,
 					'label'   => __( 'Enable the URL Shortener module', 'ffcertificate' ),
+					'data'    => array( 'ffc-autosave-key' => 'url_shortener_enabled' ),
 				)
 			);
 			?>
@@ -115,6 +116,7 @@ $all_post_types = get_post_types( array( 'public' => true ), 'objects' );
 					'id'      => 'url_shortener_auto_create',
 					'checked' => 1 === (int) $auto_create,
 					'label'   => __( 'Automatically generate a short URL when a post/page is published', 'ffcertificate' ),
+					'data'    => array( 'ffc-autosave-key' => 'url_shortener_auto_create' ),
 				)
 			);
 			?>

--- a/includes/settings/views/ffc-tab-user-access.php
+++ b/includes/settings/views/ffc-tab-user-access.php
@@ -58,6 +58,7 @@ $ffcertificate_dashboard_url     = $ffcertificate_dashboard_page_id ? get_permal
 								'id'      => 'block_wp_admin',
 								'checked' => (bool) $ffcertificate_settings['block_wp_admin'],
 								'label'   => __( 'Prevent selected roles from accessing /wp-admin', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'user_access_block_wp_admin' ),
 							)
 						);
 						?>
@@ -108,6 +109,7 @@ $ffcertificate_dashboard_url     = $ffcertificate_dashboard_page_id ? get_permal
 								'id'      => 'bypass_for_admins',
 								'checked' => (bool) $ffcertificate_settings['bypass_for_admins'],
 								'label'   => __( 'Allow administrators to bypass the block (recommended)', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'user_access_bypass_for_admins' ),
 							)
 						);
 						?>
@@ -185,6 +187,7 @@ $ffcertificate_dashboard_url     = $ffcertificate_dashboard_page_id ? get_permal
 								'id'      => 'allow_admin_bar',
 								'checked' => (bool) $ffcertificate_settings['allow_admin_bar'],
 								'label'   => __( 'Show admin bar on frontend for blocked roles', 'ffcertificate' ),
+								'data'    => array( 'ffc-autosave-key' => 'user_access_allow_admin_bar' ),
 							)
 						);
 						?>

--- a/tests/Unit/TabUrlShortenerTest.php
+++ b/tests/Unit/TabUrlShortenerTest.php
@@ -26,6 +26,7 @@ class TabUrlShortenerTest extends TestCase {
         Functions\when( 'esc_html__' )->returnArg();
         Functions\when( 'esc_html' )->returnArg();
         Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'add_action' )->justReturn( true );
 
         $this->tab = new TabUrlShortener();
     }

--- a/tests/Unit/TabUserAccessTest.php
+++ b/tests/Unit/TabUserAccessTest.php
@@ -97,8 +97,12 @@ class TabUserAccessTest extends TestCase {
     public function test_enqueue_styles_runs_for_correct_hook(): void {
         $_GET['tab'] = 'user_access';
         Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'wp_enqueue_script' )->justReturn( null );
+        Functions\when( 'wp_localize_script' )->justReturn( null );
+        Functions\when( 'wp_create_nonce' )->justReturn( 'nonce' );
+        Functions\when( 'admin_url' )->justReturn( '' );
 
-        // Method runs without error; it currently reads the tab param but doesn't enqueue anything
+        // Method runs without error; enqueues the autosave infra (jQuery + ffc-core + ffc-admin-autosave).
         $this->tab->enqueue_styles( 'ffc_form_page_ffc-settings' );
         $this->assertTrue( true );
     }


### PR DESCRIPTION
## Summary

Resolves the "Erro de conexão" the user reported on `tab=rate_limit` plus
the broader "toggles X / Y / Z não autosalvam" inventory across the
settings page.

### 1. Bug fix — rate-limit `read.*` toggles returned 403

The view emitted `data-ffc-autosave-key="read_respect_whitelist"` etc.,
but `SettingsAjaxEndpoint::allowlist()` never had those keys, so every
click on:

- **Lista branca de IPs respeitáveis** (`read_respect_whitelist`)
- **Ignorar permissão para usuários conectados** (`read_bypass_logged_in`)
- **Calendário — Vagas / Lista / Detalhes** (`read_endpoint_calendar_*_enabled`)

returned `403 "This setting is not exposed for incremental updates."` —
surfaced as "Erro de conexão" in the UI. Added the missing entries
(bool toggles + the numeric `max_per_minute` / `max_per_hour` siblings +
`read_message`).

### 2. Migration — wired autosave on the remaining toggles

| Tab | Newly autosaved |
| --- | --- |
| **SMTP** | `send_wp_user_email_submission/appointment/csv_import/migration` |
| **URL Shortener** | `url_shortener_enabled`, `url_shortener_auto_create` (+ tab class now enqueues autosave infra) |
| **Geolocation** | `ip_api_enabled`, `ip_api_cascade`, `ip_cache_enabled` |
| **User Access** | `block_wp_admin`, `bypass_for_admins`, `allow_admin_bar` — stored in `ffc_user_access_settings` under `user_access_*` allowlist keys (avoids colliding with same-named slots in `ffc_settings`) |
| **Rate-limit** | `logging_enabled` / `logging_log_allowed` / `logging_log_blocked`, `ui_show_remaining`, `ui_show_wait_time`, `ui_countdown_timer` |

### 3. Deferred (out of this batch, see follow-up)

- `device_signals_enabled[]` (array-typed, needs new endpoint type).
- URL-cleanup criteria in the Migrations tab + Danger Zone `reset_counter`
  + CSV-import `create_users` — these are transient form parameters, not
  persistent settings.
- **Recruitment settings** (`ffc_recruitment_settings`, separate page,
  potentially separate cap) — needs allowlist extension + asset
  enqueue on a non-`ffc-settings` page.
- **SMTP semantic rework**: rename "Desativar todos os e-mails" to
  "Ativar envios de e-mails" + hide the SMTP options when off + default
  `smtp_mode='wp'` on fresh install. Pure behavior change, separate PR.
- **Visual cards on recruitment settings** — UI-only, also in the
  follow-up.

## Test plan

- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/phpcs` (project standard) — clean across the 8 modified files
- [x] `vendor/bin/phpunit --filter "SettingsAjaxEndpoint|AdminAjax"` — 41/41 green
- [ ] After deploy: open `tab=rate_limit`, toggle "Lista branca de IPs respeitáveis" — should save without "Erro de conexão"
- [ ] Open `tab=smtp` — toggle "E-mails de criação de usuário (Submissão)" — autosaves
- [ ] Open `tab=url_shortener` — toggle "Ativar encurtador de URL" — autosaves
- [ ] Open `tab=user_access` — toggle "Bloquear acesso do WP-Admin" — autosaves
- [ ] Open `tab=geolocation` — toggle "Geolocalização de IP" — autosaves

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_