### PR TITLE
feat(form-editor): filter layout-template dropdown to certificate-shaped HTML

### DIFF
--- a/includes/admin/class-ffc-form-editor-layout-metabox.php
+++ b/includes/admin/class-ffc-form-editor-layout-metabox.php
@@ -35,8 +35,21 @@ class FormEditorLayoutMetabox {
 		$layout   = isset( $config['pdf_layout'] ) ? $config['pdf_layout'] : '';
 		$bg_image = isset( $config['bg_image'] ) ? $config['bg_image'] : '';
 
+		// Surface only certificate-shaped templates in the layout-editor
+		// dropdown — the same `html/` folder holds receipts (appointment),
+		// ficha PDFs, and one-off atestados that aren't valid layouts for
+		// this metabox. Case-insensitive substring match keeps a third-party
+		// `My_Certificate_Template.html` discoverable.
 		$templates_dir = FFC_PLUGIN_DIR . 'html/';
-		$templates     = glob( $templates_dir . '*.html' );
+		$all_html      = glob( $templates_dir . '*.html' );
+		$templates     = $all_html
+			? array_values(
+				array_filter(
+					$all_html,
+					static fn( string $path ): bool => false !== stripos( basename( $path ), 'certificate' )
+				)
+			)
+			: array();
 
 		wp_nonce_field( 'ffc_save_form_data', 'ffc_form_nonce' );
 		?>


### PR DESCRIPTION
## Summary

In the form-editor Layout metabox (`post_type=ffc_form#ffc-tab-layout`),
the "Select Server Template" dropdown was loading every `html/*.html`
file in the plugin — including non-certificate templates like
`default_appointment_receipt_1.html`, `default_ficha_template.html` and
the one-off `atestado_estagios.html`. None of those are valid layouts
for the Certificate HTML Editor, so they're noise.

Filter the `glob()` result to filenames whose basename contains
"certificate" (case-insensitive, anywhere in the name). The three
shipped `default_certificate_{1,2,3}.html` keep showing up, and a
third-party `My_Certificate_Template.html` stays discoverable.

## Test plan

- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/phpcs` — clean
- [ ] Open `post_type=ffc_form#ffc-tab-layout` on testes — dropdown lists the three `default_certificate_*.html` and hides `default_appointment_receipt_1.html`, `default_ficha_template.html`, `atestado_estagios.html`
- [ ] Click "Load" with one selected — the certificate HTML loads into the editor as before

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_