### PR TITLE
fix(preview): resolve {{schedule}} sample from the form's actual time config

### DIFF
--- a/includes/admin/class-ffc-admin-assets-manager.php
+++ b/includes/admin/class-ffc-admin-assets-manager.php
@@ -724,6 +724,14 @@ class AdminAssetsManager {
 	 * @return array<string, mixed> Localization data
 	 */
 	private function get_localization_data(): array {
+		// Capture the post the editor is currently on so the schedule sample
+		// reflects this form's actual Class/Time configuration instead of
+		// the docs-row fallback. `global $post` is reliable during
+		// admin_enqueue_scripts on the post-edit screen; defaults to 0
+		// (and therefore the fallback) for new-post and list screens.
+		global $post;
+		$form_id = ( $post && isset( $post->ID ) ) ? (int) $post->ID : 0;
+
 		return array(
 			'ajax_url'       => admin_url( 'admin-ajax.php' ),
 			'nonce'          => wp_create_nonce( 'ffc_admin_pdf_nonce' ),
@@ -731,7 +739,7 @@ class AdminAssetsManager {
 			// Canonical placeholder → sample-value map for the in-editor
 			// certificate preview. Single source of truth lives in PHP so
 			// the JS can't drift from the generators' real placeholders.
-			'previewSamples' => \FreeFormCertificate\Core\CertificatePreviewSamples::get_map(),
+			'previewSamples' => \FreeFormCertificate\Core\CertificatePreviewSamples::get_map( $form_id ),
 			'templates'      => self::discover_layout_templates(),
 			'strings'        => array(
 				// General.

--- a/includes/core/class-ffc-certificate-preview-samples.php
+++ b/includes/core/class-ffc-certificate-preview-samples.php
@@ -42,12 +42,23 @@ class CertificatePreviewSamples {
 	 * them specially: `{{qr_code…}}` (rendered as a placeholder SVG) and
 	 * `{{validation_url…}}` (rendered as a sample link).
 	 *
+	 * When `$form_id` is provided the `schedule` / `schedule_total` slots
+	 * are resolved from that form's geofence config (Class Schedule first,
+	 * then Time Range) instead of the hardcoded fallback — mirrors
+	 * {@see PdfGenerator::resolve_effective_schedule()} so the preview
+	 * reflects what the real PDF would render for a submission on this
+	 * form. Forms without either time range fall back to the sample
+	 * `08:00 – 17:30` shown in the variables docs.
+	 *
+	 * @param int|null $form_id Optional form post ID for per-form schedule lookup.
 	 * @return array<string, string> Placeholder name (no braces) → sample value.
 	 */
-	public static function get_map(): array {
+	public static function get_map( ?int $form_id = null ): array {
 		$now      = time();
 		$today    = DateFormatter::format_date( $now, 'pdf' );
 		$now_full = DateFormatter::format_datetime( $now, 'pdf' );
+
+		list( $schedule, $schedule_total ) = self::resolve_schedule_sample( $form_id );
 
 		return array(
 			// Identity.
@@ -121,10 +132,58 @@ class CertificatePreviewSamples {
 
 			// Effective wall-clock schedule (resolved by PdfGenerator via
 			// per-submission "Schedule Exception" → form-level Class
-			// Schedule → form Time Range — see #366 Sprint 7). Sample
-			// matches the value shown in the §2 docs row.
-			'schedule'                 => '08:00 – 17:30',
-			'schedule_total'           => '9h 30min',
+			// Schedule → form Time Range — see #366 Sprint 7). When a
+			// form ID is passed to get_map(), self::resolve_schedule_sample()
+			// reads the same Class/Time configuration the generator does,
+			// so the preview reflects the operator's actual setting instead
+			// of a static value (#bug-schedule). Sample fallback matches
+			// the §2 docs row.
+			'schedule'                 => $schedule,
+			'schedule_total'           => $schedule_total,
+		);
+	}
+
+	/**
+	 * Look up `{{schedule}}` / `{{schedule_total}}` sample values from the
+	 * given form's geofence config — the same chain
+	 * {@see PdfGenerator::resolve_effective_schedule()} uses on real PDF
+	 * renders. Falls back to the docs-row sample when no form ID is
+	 * passed or the form has no time range configured at all.
+	 *
+	 * @param int|null $form_id Form post ID, or null to skip the lookup.
+	 * @return array{0: string, 1: string} [schedule, schedule_total].
+	 */
+	private static function resolve_schedule_sample( ?int $form_id ): array {
+		if ( null === $form_id || $form_id <= 0 ) {
+			return array( '08:00 – 17:30', '9h 30min' );
+		}
+
+		$geofence = get_post_meta( $form_id, '_ffc_geofence_config', true );
+		if ( ! is_array( $geofence ) ) {
+			return array( '08:00 – 17:30', '9h 30min' );
+		}
+
+		$start = '';
+		if ( ! empty( $geofence['class_time_start'] ) ) {
+			$start = (string) $geofence['class_time_start'];
+		} elseif ( ! empty( $geofence['time_start'] ) ) {
+			$start = (string) $geofence['time_start'];
+		}
+
+		$end = '';
+		if ( ! empty( $geofence['class_time_end'] ) ) {
+			$end = (string) $geofence['class_time_end'];
+		} elseif ( ! empty( $geofence['time_end'] ) ) {
+			$end = (string) $geofence['time_end'];
+		}
+
+		if ( '' === $start || '' === $end ) {
+			return array( '08:00 – 17:30', '9h 30min' );
+		}
+
+		return array(
+			DateFormatter::format_schedule( $start, $end ),
+			DateFormatter::format_schedule_total( $start, $end ),
 		);
 	}
 }

--- a/includes/frontend/class-ffc-public-csv-download.php
+++ b/includes/frontend/class-ffc-public-csv-download.php
@@ -504,8 +504,10 @@ class PublicCsvDownload {
 				'fields'         => $field_names,
 				// Canonical placeholder → sample-value map (single source of
 				// truth) so the preview fills system placeholders, not just
-				// the form's own fields.
-				'previewSamples' => \FreeFormCertificate\Core\CertificatePreviewSamples::get_map(),
+				// the form's own fields. Pass $form_id so the {{schedule}}
+				// sample matches what the operator configured on the form's
+				// Time tab — same lookup the real PDF generator uses.
+				'previewSamples' => \FreeFormCertificate\Core\CertificatePreviewSamples::get_map( $form_id ),
 			)
 		);
 	}


### PR DESCRIPTION
## Summary

`{{schedule}}` and `{{schedule_total}}` placeholders never picked up the
operator's configured Class Schedule / Time Range on either preview
surface — both the admin layout editor (`post=X&action=edit#ffc-tab-layout`)
and the public CSV-download preview substituted the hardcoded sample
`08:00 – 17:30` regardless of the form's own configuration.

### Root cause

`CertificatePreviewSamples::get_map()` returned the same docs-row
sample for every caller, with no awareness of which form was being
previewed.

### Fix

- `get_map()` now accepts an optional `?int $form_id`. When provided,
  the schedule slots are resolved via a new private
  `resolve_schedule_sample()` helper that walks the same Class
  Schedule → Time Range chain as `PdfGenerator::resolve_effective_schedule()`.
- Forms without either time range configured still get the docs-row
  fallback so the published Variables documentation stays accurate.

### Callers updated

- `AdminAssetsManager::get_localization_data()` captures the current
  post via `global $post` on the post-edit screen and forwards its ID
  (defaults to 0 / fallback on list / new screens).
- `PublicCsvDownload::ajax_cert_preview()` forwards the already-validated
  `$form_id` from the payload.

## Test plan

- [x] PHPStan / PHPCS clean
- [x] `vendor/bin/phpunit --filter "CertificatePreviewSamples"` — 6/6
- [ ] Open `post=240&action=edit` with a Class Schedule of `09:00`–`12:00` set on the Time tab → click **Visualizar** on the Layout tab → preview shows `09:00 – 12:00` and `3h` (not the docs sample)
- [ ] Same form, open the public CSV-download preview before collection starts → same effective values

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_