### PR TITLE
Form-editor + settings UX batch (cards, multi-day toggle, geo/IP gates, collapses)

### DIFF
--- a/includes/admin/class-ffc-form-editor-geofence-metabox.php
+++ b/includes/admin/class-ffc-form-editor-geofence-metabox.php
@@ -349,6 +349,18 @@ class FormEditorGeofenceMetabox {
 	public function render_geolocation( WP_Post $post ): void {
 		$config = $this->get_config( $post );
 
+		// Global IP-geolocation kill-switch (Settings → Geolocation). When
+		// off, the form-level IP toggle below is rendered disabled — the
+		// runtime IP integration short-circuits anyway (see
+		// FFC_IP_Geolocation::lookup, which bails when this flag is
+		// falsy), so allowing the form-level toggle to be flipped on
+		// would silently produce an inert configuration. Read the
+		// `ffc_geolocation_settings` option directly because that's where
+		// the global flag lives — SettingsReader is scoped to
+		// `ffc_settings` and would always return false here.
+		$ffc_geo_settings      = get_option( 'ffc_geolocation_settings', array() );
+		$global_ip_api_enabled = is_array( $ffc_geo_settings ) && ! empty( $ffc_geo_settings['ip_api_enabled'] );
+
 		$geo_enabled              = ( $config['geo_enabled'] ?? '0' ) === '1' ? '1' : '0';
 		$geo_gps_enabled          = ( $config['geo_gps_enabled'] ?? '0' ) === '1' ? '1' : '0';
 		$geo_ip_enabled           = ( $config['geo_ip_enabled'] ?? '0' ) === '1' ? '1' : '0';
@@ -419,13 +431,26 @@ class FormEditorGeofenceMetabox {
 						<?php
 						\FreeFormCertificate\Admin\AdminUI::render_toggle(
 							array(
-								'name'    => 'ffc_geofence[geo_ip_enabled]',
-								'id'      => 'ffc_geofence_geo_ip_enabled',
-								'checked' => '1' === (string) $geo_ip_enabled,
-								'label'   => __( 'IP Address (backend validation)', 'ffcertificate' ),
+								'name'     => 'ffc_geofence[geo_ip_enabled]',
+								'id'       => 'ffc_geofence_geo_ip_enabled',
+								'checked'  => '1' === (string) $geo_ip_enabled,
+								'disabled' => ! $global_ip_api_enabled,
+								'label'    => __( 'IP Address (backend validation)', 'ffcertificate' ),
 							)
 						);
 						?>
+						<?php if ( ! $global_ip_api_enabled ) : ?>
+							<p class="description ffc-text-warning ffc-icon-warning">
+								<?php
+								$ffc_geo_settings_url = admin_url( 'admin.php?page=ffc-settings&tab=geolocation' );
+								printf(
+									/* translators: %s: link to the global geolocation settings page */
+									esc_html__( 'IP geolocation is disabled globally. Enable it in %s to allow IP-based validation here.', 'ffcertificate' ),
+									'<a href="' . esc_url( $ffc_geo_settings_url ) . '">' . esc_html__( 'Settings → Geolocation', 'ffcertificate' ) . '</a>'
+								);
+								?>
+							</p>
+						<?php endif; ?>
 						<p class="description"><?php esc_html_e( 'Choose one or both methods. GPS is more accurate but requires user permission.', 'ffcertificate' ); ?></p>
 					</td>
 				</tr>

--- a/includes/admin/class-ffc-form-editor-geofence-metabox.php
+++ b/includes/admin/class-ffc-form-editor-geofence-metabox.php
@@ -109,175 +109,179 @@ class FormEditorGeofenceMetabox {
 		<div class="ffc-geofence-container">
 			<!-- Sentinel: ensures ffc_geofence is always in POST even when all fields are disabled -->
 			<input type="hidden" name="ffc_geofence[_save]" value="1">
-			<table class="form-table">
-				<tbody class="ffc-event-schedule-section">
-				<tr>
-					<th colspan="2">
-						<h3 class="ffc-subsection-title"><?php esc_html_e( 'Event Schedule (Reference)', 'ffcertificate' ); ?></h3>
-						<p class="description ffc-subsection-description">
-							<?php esc_html_e( "When does this event take place? Renders as {{schedule}} on the certificate template (e.g. '9h às 12h'). When filled, the template must contain {{schedule}} — the form save will be blocked until the placeholder is present.", 'ffcertificate' ); ?>
-						</p>
-					</th>
-				</tr>
-				<tr>
-					<th><label><?php esc_html_e( 'From — To', 'ffcertificate' ); ?></label></th>
-					<td>
-						<label><?php esc_html_e( 'From:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[class_time_start]" value="<?php echo esc_attr( $class_time_start ); ?>"<?php echo $invalid_attr( 'class_time_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- closure returns pre-built class attribute. ?>></label>
-						&nbsp;&nbsp;
-						<label><?php esc_html_e( 'To:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[class_time_end]" value="<?php echo esc_attr( $class_time_end ); ?>"<?php echo $invalid_attr( 'class_time_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
-					</td>
-				</tr>
-				</tbody>
-				<tbody>
-				<tr>
-					<th><label><?php esc_html_e( 'Enable Date/Time Restrictions', 'ffcertificate' ); ?></label></th>
-					<td>
-						<?php
-						\FreeFormCertificate\Admin\AdminUI::render_toggle(
-							array(
-								'name'    => 'ffc_geofence[datetime_enabled]',
-								'id'      => 'ffc_geofence_datetime_enabled',
-								'checked' => '1' === (string) $datetime_enabled,
-								'label'   => __( 'Restrict form access by date and time', 'ffcertificate' ),
-								'data'    => array( 'ffc-autosave-form-key' => 'geofence_datetime_enabled' ),
-							)
-						);
-						?>
-						<p class="description"><?php esc_html_e( 'Control when users can access this form based on date range and daily hours.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				</tbody>
-				<tbody class="ffc-collapsed-target<?php echo '1' === $datetime_enabled ? '' : ' ffc-collapsed'; ?>"
-					data-ffc-master="ffc_geofence_datetime_enabled"
-					aria-hidden="<?php echo '1' === $datetime_enabled ? 'false' : 'true'; ?>">
-				<tr>
-					<th><label><?php esc_html_e( 'Date Range', 'ffcertificate' ); ?></label></th>
-					<td>
-						<label><?php esc_html_e( 'Start:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_start]" value="<?php echo esc_attr( $date_start ); ?>"<?php echo $invalid_attr( 'date_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- closure returns pre-built class attribute. ?>></label>
-						&nbsp;&nbsp;
-						<label><?php esc_html_e( 'End:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_end]" value="<?php echo esc_attr( $date_end ); ?>"<?php echo $invalid_attr( 'date_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
-						<p class="description"><?php esc_html_e( 'Leave empty for no date restriction. Format: YYYY-MM-DD', 'ffcertificate' ); ?></p>
-						<p class="description ffc-datetime-order-error"<?php echo $datetime_order_msg ? '' : ' style="display:none;"'; ?>>
-							<?php echo esc_html( $datetime_order_msg ); ?>
-						</p>
-					</td>
-				</tr>
-				<tr>
-					<th><label><?php esc_html_e( 'Time Range', 'ffcertificate' ); ?></label></th>
-					<td>
-						<label><?php esc_html_e( 'From:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[time_start]" value="<?php echo esc_attr( $time_start ); ?>"<?php echo $invalid_attr( 'time_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
-						&nbsp;&nbsp;
-						<label><?php esc_html_e( 'To:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[time_end]" value="<?php echo esc_attr( $time_end ); ?>"<?php echo $invalid_attr( 'time_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
-						<p class="description"><?php esc_html_e( 'Leave empty for 24/7 access. Default: 00:00 to 23:59', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				<tr id="ffc-time-mode-row">
-					<th><label><?php esc_html_e( 'Time Behavior', 'ffcertificate' ); ?></label></th>
-					<td>
-						<fieldset>
-							<label>
-								<input type="radio" name="ffc_geofence[time_mode]" value="span" <?php checked( $time_mode, 'span' ); ?>>
-								<strong><?php esc_html_e( 'Time spans across dates', 'ffcertificate' ); ?></strong>
-							</label>
-							<p class="description ffc-time-description">
-								<?php esc_html_e( 'Start time applies to start date, end time applies to end date. Form is open continuously between those timestamps.', 'ffcertificate' ); ?><br>
-								<?php esc_html_e( 'Example: Start 01/01 12:00 + End 10/01 23:00 = Open from 12:00 on Jan 1st until 23:00 on Jan 10th', 'ffcertificate' ); ?>
-							</p>
 
-							<label>
-								<input type="radio" name="ffc_geofence[time_mode]" value="daily" <?php checked( $time_mode, 'daily' ); ?>>
-								<strong><?php esc_html_e( 'Time applies to each day individually', 'ffcertificate' ); ?></strong>
-							</label>
-							<p class="description ffc-time-description">
-								<?php esc_html_e( 'Time range applies to every day in the date range. Form respects daily hours.', 'ffcertificate' ); ?><br>
-								<?php esc_html_e( 'Example: Start 01/01 + End 10/01 + Time 12:00-23:00 = Open 12:00-23:00 every day from Jan 1-10', 'ffcertificate' ); ?>
+			<div class="card ffc-event-schedule-section">
+				<h2 class="ffc-icon-calendar"><?php esc_html_e( 'Event Schedule (Reference)', 'ffcertificate' ); ?></h2>
+				<p class="description">
+					<?php esc_html_e( "When does this event take place? Renders as {{schedule}} on the certificate template (e.g. '9h às 12h'). When filled, the template must contain {{schedule}} — the form save will be blocked until the placeholder is present.", 'ffcertificate' ); ?>
+				</p>
+				<table class="form-table" role="presentation"><tbody>
+					<tr>
+						<th><label><?php esc_html_e( 'From — To', 'ffcertificate' ); ?></label></th>
+						<td>
+							<label><?php esc_html_e( 'From:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[class_time_start]" value="<?php echo esc_attr( $class_time_start ); ?>"<?php echo $invalid_attr( 'class_time_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- closure returns pre-built class attribute. ?>></label>
+							&nbsp;&nbsp;
+							<label><?php esc_html_e( 'To:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[class_time_end]" value="<?php echo esc_attr( $class_time_end ); ?>"<?php echo $invalid_attr( 'class_time_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+						</td>
+					</tr>
+				</tbody></table>
+			</div>
+
+			<div class="card">
+				<h2 class="ffc-icon-lock"><?php esc_html_e( 'Date/Time Restrictions', 'ffcertificate' ); ?></h2>
+				<table class="form-table" role="presentation">
+					<tbody>
+					<tr>
+						<th><label><?php esc_html_e( 'Enable Date/Time Restrictions', 'ffcertificate' ); ?></label></th>
+						<td>
+							<?php
+							\FreeFormCertificate\Admin\AdminUI::render_toggle(
+								array(
+									'name'    => 'ffc_geofence[datetime_enabled]',
+									'id'      => 'ffc_geofence_datetime_enabled',
+									'checked' => '1' === (string) $datetime_enabled,
+									'label'   => __( 'Restrict form access by date and time', 'ffcertificate' ),
+									'data'    => array( 'ffc-autosave-form-key' => 'geofence_datetime_enabled' ),
+								)
+							);
+							?>
+							<p class="description"><?php esc_html_e( 'Control when users can access this form based on date range and daily hours.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					</tbody>
+					<tbody class="ffc-collapsed-target<?php echo '1' === $datetime_enabled ? '' : ' ffc-collapsed'; ?>"
+						data-ffc-master="ffc_geofence_datetime_enabled"
+						aria-hidden="<?php echo '1' === $datetime_enabled ? 'false' : 'true'; ?>">
+					<tr>
+						<th><label><?php esc_html_e( 'Date Range', 'ffcertificate' ); ?></label></th>
+						<td>
+							<label><?php esc_html_e( 'Start:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_start]" value="<?php echo esc_attr( $date_start ); ?>"<?php echo $invalid_attr( 'date_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- closure returns pre-built class attribute. ?>></label>
+							&nbsp;&nbsp;
+							<label><?php esc_html_e( 'End:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_end]" value="<?php echo esc_attr( $date_end ); ?>"<?php echo $invalid_attr( 'date_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+							<p class="description"><?php esc_html_e( 'Leave empty for no date restriction. Format: YYYY-MM-DD', 'ffcertificate' ); ?></p>
+							<p class="description ffc-datetime-order-error"<?php echo $datetime_order_msg ? '' : ' style="display:none;"'; ?>>
+								<?php echo esc_html( $datetime_order_msg ); ?>
 							</p>
-						</fieldset>
-					</td>
-				</tr>
-				<tr>
-					<th><label for="ffc_datetime_hide_mode_before"><?php esc_html_e( 'Display before opening', 'ffcertificate' ); ?></label></th>
-					<td>
-						<select id="ffc_datetime_hide_mode_before" name="ffc_geofence[datetime_hide_mode_before]">
-							<option value="message" <?php selected( $datetime_hide_mode_before, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
-							<option value="title_message" <?php selected( $datetime_hide_mode_before, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
-							<option value="hide" <?php selected( $datetime_hide_mode_before, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
-						</select>
-						<p class="description"><?php esc_html_e( 'How to display the form before the start date / start time. "Hide form completely" makes the page render as if the form did not exist yet.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				<tr id="ffc-datetime-hide-mode-during-row" class="ffc-datetime-hide-during"<?php echo 'daily' === $time_mode ? '' : ' style="display:none;"'; ?>>
-					<th><label for="ffc_datetime_hide_mode_during"><?php esc_html_e( 'Display during, outside daily slot', 'ffcertificate' ); ?></label></th>
-					<td>
-						<select id="ffc_datetime_hide_mode_during" name="ffc_geofence[datetime_hide_mode_during]">
-							<option value="message" <?php selected( $datetime_hide_mode_during, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
-							<option value="title_message" <?php selected( $datetime_hide_mode_during, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
-							<option value="hide" <?php selected( $datetime_hide_mode_during, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
-						</select>
-						<p class="description"><?php esc_html_e( 'How to display the form when the campaign is in its date range but the current time is outside today\'s daily slot (only used in Time Behavior = "applies to each day individually").', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				<tr>
-					<th><label for="ffc_datetime_hide_mode_after"><?php esc_html_e( 'Display after closing', 'ffcertificate' ); ?></label></th>
-					<td>
-						<select id="ffc_datetime_hide_mode_after" name="ffc_geofence[datetime_hide_mode_after]">
-							<option value="message" <?php selected( $datetime_hide_mode_after, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
-							<option value="title_message" <?php selected( $datetime_hide_mode_after, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
-							<option value="hide" <?php selected( $datetime_hide_mode_after, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
-						</select>
-						<p class="description"><?php esc_html_e( 'How to display the form after the end date / end time.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				<tr>
-					<th><label><?php esc_html_e( 'Blocked Message', 'ffcertificate' ); ?></label></th>
-					<td>
-						<textarea name="ffc_geofence[msg_datetime]" rows="3" class="ffc-w100"><?php echo esc_textarea( $msg_datetime ); ?></textarea>
-						<p class="description"><?php esc_html_e( 'Message shown when form is accessed outside allowed date/time.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				</tbody>
-				<tbody class="ffc-schedule-exception-section">
-				<tr>
-					<th colspan="2">
-						<h3 class="ffc-subsection-title"><?php esc_html_e( 'Per-participant entry/exit exception', 'ffcertificate' ); ?></h3>
-						<p class="description ffc-subsection-description">
-							<?php esc_html_e( 'Optional. Lets an authenticated operator on the public CSV-download panel create a single submission with a different schedule (e.g. for a participant who left early), overriding the Event Schedule above for that one submission. Independent of the date/time restrictions toggle above.', 'ffcertificate' ); ?>
-						</p>
-					</th>
-				</tr>
-				<tr>
-					<th><label><?php esc_html_e( 'Enable Schedule Exception', 'ffcertificate' ); ?></label></th>
-					<td>
-						<?php
-						\FreeFormCertificate\Admin\AdminUI::render_toggle(
-							array(
-								'name'    => 'ffc_geofence[schedule_exception_enabled]',
-								'id'      => 'ffc_geofence_schedule_exception_enabled',
-								'checked' => '1' === (string) $schedule_exception_enabled,
-								'label'   => __( 'Allow operators to create per-submission schedule exceptions', 'ffcertificate' ),
-								'data'    => array( 'ffc-autosave-form-key' => 'geofence_schedule_exception_enabled' ),
-							)
-						);
-						?>
-						<p class="description"><?php esc_html_e( 'Off by default. When on, the public CSV-download panel shows an "Entry/exit exception" button to authenticated operators.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				</tbody>
-				<tbody class="ffc-collapsed-target<?php echo '1' === $schedule_exception_enabled ? '' : ' ffc-collapsed'; ?>"
-					data-ffc-master="ffc_geofence_schedule_exception_enabled"
-					aria-hidden="<?php echo '1' === $schedule_exception_enabled ? 'false' : 'true'; ?>">
-				<tr>
-					<th><label for="ffc_geofence_schedule_default_mode"><?php esc_html_e( 'Default Modal Mode', 'ffcertificate' ); ?></label></th>
-					<td>
-						<select id="ffc_geofence_schedule_default_mode" name="ffc_geofence[schedule_default_mode]">
-							<option value="now" <?php selected( $schedule_default_mode, 'now' ); ?>><?php esc_html_e( 'Now — pre-fill end time with the current moment', 'ffcertificate' ); ?></option>
-							<option value="manual" <?php selected( $schedule_default_mode, 'manual' ); ?>><?php esc_html_e( 'Manual — let the operator type both ends', 'ffcertificate' ); ?></option>
-						</select>
-						<p class="description"><?php esc_html_e( 'Which mode the operator exception modal opens in by default. Operators can flip the toggle on a per-exception basis.', 'ffcertificate' ); ?></p>
-					</td>
-				</tr>
-				</tbody>
-			</table>
+						</td>
+					</tr>
+					<tr>
+						<th><label><?php esc_html_e( 'Time Range', 'ffcertificate' ); ?></label></th>
+						<td>
+							<label><?php esc_html_e( 'From:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[time_start]" value="<?php echo esc_attr( $time_start ); ?>"<?php echo $invalid_attr( 'time_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+							&nbsp;&nbsp;
+							<label><?php esc_html_e( 'To:', 'ffcertificate' ); ?> <input type="time" name="ffc_geofence[time_end]" value="<?php echo esc_attr( $time_end ); ?>"<?php echo $invalid_attr( 'time_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+							<p class="description"><?php esc_html_e( 'Leave empty for 24/7 access. Default: 00:00 to 23:59', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					<tr id="ffc-time-mode-row">
+						<th><label><?php esc_html_e( 'Time Behavior', 'ffcertificate' ); ?></label></th>
+						<td>
+							<fieldset>
+								<label>
+									<input type="radio" name="ffc_geofence[time_mode]" value="span" <?php checked( $time_mode, 'span' ); ?>>
+									<strong><?php esc_html_e( 'Time spans across dates', 'ffcertificate' ); ?></strong>
+								</label>
+								<p class="description ffc-time-description">
+									<?php esc_html_e( 'Start time applies to start date, end time applies to end date. Form is open continuously between those timestamps.', 'ffcertificate' ); ?><br>
+									<?php esc_html_e( 'Example: Start 01/01 12:00 + End 10/01 23:00 = Open from 12:00 on Jan 1st until 23:00 on Jan 10th', 'ffcertificate' ); ?>
+								</p>
+
+								<label>
+									<input type="radio" name="ffc_geofence[time_mode]" value="daily" <?php checked( $time_mode, 'daily' ); ?>>
+									<strong><?php esc_html_e( 'Time applies to each day individually', 'ffcertificate' ); ?></strong>
+								</label>
+								<p class="description ffc-time-description">
+									<?php esc_html_e( 'Time range applies to every day in the date range. Form respects daily hours.', 'ffcertificate' ); ?><br>
+									<?php esc_html_e( 'Example: Start 01/01 + End 10/01 + Time 12:00-23:00 = Open 12:00-23:00 every day from Jan 1-10', 'ffcertificate' ); ?>
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+					<tr>
+						<th><label for="ffc_datetime_hide_mode_before"><?php esc_html_e( 'Display before opening', 'ffcertificate' ); ?></label></th>
+						<td>
+							<select id="ffc_datetime_hide_mode_before" name="ffc_geofence[datetime_hide_mode_before]">
+								<option value="message" <?php selected( $datetime_hide_mode_before, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
+								<option value="title_message" <?php selected( $datetime_hide_mode_before, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
+								<option value="hide" <?php selected( $datetime_hide_mode_before, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
+							</select>
+							<p class="description"><?php esc_html_e( 'How to display the form before the start date / start time. "Hide form completely" makes the page render as if the form did not exist yet.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					<tr id="ffc-datetime-hide-mode-during-row" class="ffc-datetime-hide-during"<?php echo 'daily' === $time_mode ? '' : ' style="display:none;"'; ?>>
+						<th><label for="ffc_datetime_hide_mode_during"><?php esc_html_e( 'Display during, outside daily slot', 'ffcertificate' ); ?></label></th>
+						<td>
+							<select id="ffc_datetime_hide_mode_during" name="ffc_geofence[datetime_hide_mode_during]">
+								<option value="message" <?php selected( $datetime_hide_mode_during, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
+								<option value="title_message" <?php selected( $datetime_hide_mode_during, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
+								<option value="hide" <?php selected( $datetime_hide_mode_during, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
+							</select>
+							<p class="description"><?php esc_html_e( 'How to display the form when the campaign is in its date range but the current time is outside today\'s daily slot (only used in Time Behavior = "applies to each day individually").', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th><label for="ffc_datetime_hide_mode_after"><?php esc_html_e( 'Display after closing', 'ffcertificate' ); ?></label></th>
+						<td>
+							<select id="ffc_datetime_hide_mode_after" name="ffc_geofence[datetime_hide_mode_after]">
+								<option value="message" <?php selected( $datetime_hide_mode_after, 'message' ); ?>><?php esc_html_e( 'Show blocked message (Recommended)', 'ffcertificate' ); ?></option>
+								<option value="title_message" <?php selected( $datetime_hide_mode_after, 'title_message' ); ?>><?php esc_html_e( 'Show title + description + message', 'ffcertificate' ); ?></option>
+								<option value="hide" <?php selected( $datetime_hide_mode_after, 'hide' ); ?>><?php esc_html_e( 'Hide form completely', 'ffcertificate' ); ?></option>
+							</select>
+							<p class="description"><?php esc_html_e( 'How to display the form after the end date / end time.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th><label><?php esc_html_e( 'Blocked Message', 'ffcertificate' ); ?></label></th>
+						<td>
+							<textarea name="ffc_geofence[msg_datetime]" rows="3" class="ffc-w100"><?php echo esc_textarea( $msg_datetime ); ?></textarea>
+							<p class="description"><?php esc_html_e( 'Message shown when form is accessed outside allowed date/time.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<div class="card ffc-schedule-exception-section">
+				<h2 class="ffc-icon-user"><?php esc_html_e( 'Per-participant entry/exit exception', 'ffcertificate' ); ?></h2>
+				<p class="description">
+					<?php esc_html_e( 'Lets an authenticated operator override the Event Schedule for a single submission via the public CSV-download panel.', 'ffcertificate' ); ?>
+				</p>
+				<table class="form-table" role="presentation">
+					<tbody>
+					<tr>
+						<th><label><?php esc_html_e( 'Enable Schedule Exception', 'ffcertificate' ); ?></label></th>
+						<td>
+							<?php
+							\FreeFormCertificate\Admin\AdminUI::render_toggle(
+								array(
+									'name'    => 'ffc_geofence[schedule_exception_enabled]',
+									'id'      => 'ffc_geofence_schedule_exception_enabled',
+									'checked' => '1' === (string) $schedule_exception_enabled,
+									'label'   => __( 'Allow operators to create per-submission schedule exceptions', 'ffcertificate' ),
+									'data'    => array( 'ffc-autosave-form-key' => 'geofence_schedule_exception_enabled' ),
+								)
+							);
+							?>
+							<p class="description"><?php esc_html_e( 'Off by default. When on, the public CSV-download panel shows an "Entry/exit exception" button to authenticated operators.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					</tbody>
+					<tbody class="ffc-collapsed-target<?php echo '1' === $schedule_exception_enabled ? '' : ' ffc-collapsed'; ?>"
+						data-ffc-master="ffc_geofence_schedule_exception_enabled"
+						aria-hidden="<?php echo '1' === $schedule_exception_enabled ? 'false' : 'true'; ?>">
+					<tr>
+						<th><label for="ffc_geofence_schedule_default_mode"><?php esc_html_e( 'Default Modal Mode', 'ffcertificate' ); ?></label></th>
+						<td>
+							<select id="ffc_geofence_schedule_default_mode" name="ffc_geofence[schedule_default_mode]">
+								<option value="now" <?php selected( $schedule_default_mode, 'now' ); ?>><?php esc_html_e( 'Now — pre-fill end time with the current moment', 'ffcertificate' ); ?></option>
+								<option value="manual" <?php selected( $schedule_default_mode, 'manual' ); ?>><?php esc_html_e( 'Manual — let the operator type both ends', 'ffcertificate' ); ?></option>
+							</select>
+							<p class="description"><?php esc_html_e( 'Which mode the operator exception modal opens in by default. Operators can flip the toggle on a per-exception basis.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					</tbody>
+				</table>
+			</div>
 		</div>
 		<?php
 	}

--- a/includes/admin/class-ffc-form-editor-geofence-metabox.php
+++ b/includes/admin/class-ffc-form-editor-geofence-metabox.php
@@ -78,6 +78,19 @@ class FormEditorGeofenceMetabox {
 		$time_start                = $config['time_start'] ?? '';
 		$time_end                  = $config['time_end'] ?? '';
 		$time_mode                 = $config['time_mode'] ?? 'daily'; // 'daily' or 'span'
+
+		// Multi-day toggle. Forms saved before this flag existed don't have
+		// the key — infer ON when both dates are populated and differ,
+		// otherwise OFF. Once the operator saves once, the explicit value
+		// is persisted and this branch stops mattering.
+		if ( array_key_exists( 'multi_day', $config ) ) {
+			$multi_day = '1' === (string) $config['multi_day'] ? '1' : '0';
+		} else {
+			$multi_day = ( '' !== $date_start && '' !== $date_end && $date_start !== $date_end ) ? '1' : '0';
+		}
+		$multi_day_collapsed_class = '1' === $multi_day ? '' : ' ffc-collapsed';
+		$multi_day_aria            = '1' === $multi_day ? 'false' : 'true';
+		$show_during_row           = ( '1' === $multi_day && 'daily' === $time_mode );
 		$datetime_hide_mode_before = Geofence::resolve_hide_mode( $config, 'before' );
 		$datetime_hide_mode_during = Geofence::resolve_hide_mode( $config, 'during' );
 		$datetime_hide_mode_after  = Geofence::resolve_hide_mode( $config, 'after' );
@@ -153,11 +166,31 @@ class FormEditorGeofenceMetabox {
 						data-ffc-master="ffc_geofence_datetime_enabled"
 						aria-hidden="<?php echo '1' === $datetime_enabled ? 'false' : 'true'; ?>">
 					<tr>
+						<th><label><?php esc_html_e( 'Multiple days', 'ffcertificate' ); ?></label></th>
+						<td>
+							<?php
+							\FreeFormCertificate\Admin\AdminUI::render_toggle(
+								array(
+									'name'    => 'ffc_geofence[multi_day]',
+									'id'      => 'ffc_geofence_multi_day',
+									'checked' => '1' === $multi_day,
+									'label'   => __( 'Event spans more than one day', 'ffcertificate' ),
+								)
+							);
+							?>
+							<p class="description"><?php esc_html_e( 'Off: form is open on the start date only, between the start and end times. On: enables the end date and the per-day "Time Behavior" controls below.', 'ffcertificate' ); ?></p>
+						</td>
+					</tr>
+					<tr>
 						<th><label><?php esc_html_e( 'Date Range', 'ffcertificate' ); ?></label></th>
 						<td>
 							<label><?php esc_html_e( 'Start:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_start]" value="<?php echo esc_attr( $date_start ); ?>"<?php echo $invalid_attr( 'date_start' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- closure returns pre-built class attribute. ?>></label>
-							&nbsp;&nbsp;
-							<label><?php esc_html_e( 'End:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_end]" value="<?php echo esc_attr( $date_end ); ?>"<?php echo $invalid_attr( 'date_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+							<span class="ffc-collapsed-target<?php echo esc_attr( $multi_day_collapsed_class ); ?>"
+								data-ffc-master="ffc_geofence_multi_day"
+								aria-hidden="<?php echo esc_attr( $multi_day_aria ); ?>">
+								&nbsp;&nbsp;
+								<label><?php esc_html_e( 'End:', 'ffcertificate' ); ?> <input type="date" name="ffc_geofence[date_end]" value="<?php echo esc_attr( $date_end ); ?>"<?php echo $invalid_attr( 'date_end' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>></label>
+							</span>
 							<p class="description"><?php esc_html_e( 'Leave empty for no date restriction. Format: YYYY-MM-DD', 'ffcertificate' ); ?></p>
 							<p class="description ffc-datetime-order-error"<?php echo $datetime_order_msg ? '' : ' style="display:none;"'; ?>>
 								<?php echo esc_html( $datetime_order_msg ); ?>
@@ -173,7 +206,9 @@ class FormEditorGeofenceMetabox {
 							<p class="description"><?php esc_html_e( 'Leave empty for 24/7 access. Default: 00:00 to 23:59', 'ffcertificate' ); ?></p>
 						</td>
 					</tr>
-					<tr id="ffc-time-mode-row">
+					<tr id="ffc-time-mode-row" class="ffc-collapsed-target<?php echo esc_attr( $multi_day_collapsed_class ); ?>"
+						data-ffc-master="ffc_geofence_multi_day"
+						aria-hidden="<?php echo esc_attr( $multi_day_aria ); ?>">
 						<th><label><?php esc_html_e( 'Time Behavior', 'ffcertificate' ); ?></label></th>
 						<td>
 							<fieldset>
@@ -208,7 +243,7 @@ class FormEditorGeofenceMetabox {
 							<p class="description"><?php esc_html_e( 'How to display the form before the start date / start time. "Hide form completely" makes the page render as if the form did not exist yet.', 'ffcertificate' ); ?></p>
 						</td>
 					</tr>
-					<tr id="ffc-datetime-hide-mode-during-row" class="ffc-datetime-hide-during"<?php echo 'daily' === $time_mode ? '' : ' style="display:none;"'; ?>>
+					<tr id="ffc-datetime-hide-mode-during-row" class="ffc-datetime-hide-during"<?php echo $show_during_row ? '' : ' style="display:none;"'; ?>>
 						<th><label for="ffc_datetime_hide_mode_during"><?php esc_html_e( 'Display during, outside daily slot', 'ffcertificate' ); ?></label></th>
 						<td>
 							<select id="ffc_datetime_hide_mode_during" name="ffc_geofence[datetime_hide_mode_during]">
@@ -283,6 +318,26 @@ class FormEditorGeofenceMetabox {
 				</table>
 			</div>
 		</div>
+		<script>
+		jQuery(function($) {
+			// "Display during, outside daily slot" row has a dual gate:
+			// it's only meaningful when the event spans multiple days AND
+			// the operator picked per-day time semantics. The outer
+			// .ffc-collapsed-target initializer handles the multi-day side
+			// for the End Date / Time Behavior rows; the during-row needs
+			// the AND of both, so we wire it manually here. Without this,
+			// flipping time_mode between span and daily wouldn't toggle the
+			// row at runtime (we currently only honour the initial SSR
+			// state).
+			function syncDuringRow() {
+				var multi   = $('#ffc_geofence_multi_day').is(':checked');
+				var isDaily = $('input[name="ffc_geofence[time_mode]"]:checked').val() === 'daily';
+				$('#ffc-datetime-hide-mode-during-row').toggle( multi && isDaily );
+			}
+			$('#ffc_geofence_multi_day, input[name="ffc_geofence[time_mode]"]').on('change', syncDuringRow);
+			syncDuringRow();
+		});
+		</script>
 		<?php
 	}
 

--- a/includes/admin/class-ffc-form-editor-geofence-metabox.php
+++ b/includes/admin/class-ffc-form-editor-geofence-metabox.php
@@ -72,12 +72,12 @@ class FormEditorGeofenceMetabox {
 	public function render_time( WP_Post $post ): void {
 		$config = $this->get_config( $post );
 
-		$datetime_enabled          = ( $config['datetime_enabled'] ?? '0' ) === '1' ? '1' : '0';
-		$date_start                = $config['date_start'] ?? '';
-		$date_end                  = $config['date_end'] ?? '';
-		$time_start                = $config['time_start'] ?? '';
-		$time_end                  = $config['time_end'] ?? '';
-		$time_mode                 = $config['time_mode'] ?? 'daily'; // 'daily' or 'span'
+		$datetime_enabled = ( $config['datetime_enabled'] ?? '0' ) === '1' ? '1' : '0';
+		$date_start       = $config['date_start'] ?? '';
+		$date_end         = $config['date_end'] ?? '';
+		$time_start       = $config['time_start'] ?? '';
+		$time_end         = $config['time_end'] ?? '';
+		$time_mode        = $config['time_mode'] ?? 'daily'; // 'daily' or 'span'
 
 		// Multi-day toggle. Forms saved before this flag existed don't have
 		// the key — infer ON when both dates are populated and differ,

--- a/includes/admin/class-ffc-form-editor-geofence-metabox.php
+++ b/includes/admin/class-ffc-form-editor-geofence-metabox.php
@@ -420,6 +420,7 @@ class FormEditorGeofenceMetabox {
 						\FreeFormCertificate\Admin\AdminUI::render_toggle(
 							array(
 								'name'    => 'ffc_geofence[geo_ip_enabled]',
+								'id'      => 'ffc_geofence_geo_ip_enabled',
 								'checked' => '1' === (string) $geo_ip_enabled,
 								'label'   => __( 'IP Address (backend validation)', 'ffcertificate' ),
 							)
@@ -460,7 +461,9 @@ class FormEditorGeofenceMetabox {
 						</div>
 					</td>
 				</tr>
-				<tr>
+				<tr class="ffc-collapsed-target<?php echo '1' === $geo_ip_enabled ? '' : ' ffc-collapsed'; ?>"
+					data-ffc-master="ffc_geofence_geo_ip_enabled"
+					aria-hidden="<?php echo '1' === $geo_ip_enabled ? 'false' : 'true'; ?>">
 					<th><label><?php esc_html_e( 'IP Geolocation Areas', 'ffcertificate' ); ?></label></th>
 					<td>
 						<?php
@@ -510,7 +513,9 @@ class FormEditorGeofenceMetabox {
 						</div>
 					</td>
 				</tr>
-				<tr>
+				<tr class="ffc-collapsed-target<?php echo '1' === $geo_ip_enabled ? '' : ' ffc-collapsed'; ?>"
+					data-ffc-master="ffc_geofence_geo_ip_enabled"
+					aria-hidden="<?php echo '1' === $geo_ip_enabled ? 'false' : 'true'; ?>">
 					<th><label><?php esc_html_e( 'GPS + IP Logic', 'ffcertificate' ); ?></label></th>
 					<td>
 						<select name="ffc_geofence[geo_gps_ip_logic]">

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -216,6 +216,19 @@ class FormEditorSaveHandler {
 				$clean_geofence['datetime_hide_mode_during'] = sanitize_key( $geofence['datetime_hide_mode_during'] ?? $legacy_hide_mode );
 				$clean_geofence['datetime_hide_mode_after']  = sanitize_key( $geofence['datetime_hide_mode_after'] ?? $legacy_hide_mode );
 				$clean_geofence['msg_datetime']              = sanitize_textarea_field( $geofence['msg_datetime'] ?? '' );
+
+				// Multi-day toggle (UX scope: hides the End Date / Time
+				// Behavior / Display-during-slot controls when off). When
+				// the operator unchecks it, normalise the dependent fields
+				// so the runtime treats the form as a single-day event:
+				// date_end mirrors date_start and time_mode becomes 'span'
+				// (single calendar day → span and daily are equivalent, but
+				// span keeps Display-during-slot inert per its own rule).
+				$clean_geofence['multi_day'] = isset( $geofence['multi_day'] ) ? '1' : '0';
+				if ( '0' === $clean_geofence['multi_day'] ) {
+					$clean_geofence['date_end']  = $clean_geofence['date_start'];
+					$clean_geofence['time_mode'] = 'span';
+				}
 			}
 
 			// Geolocation — 1 master toggle gating 8 sub-options +

--- a/includes/admin/class-ffc-settings-ajax-endpoint.php
+++ b/includes/admin/class-ffc-settings-ajax-endpoint.php
@@ -223,6 +223,11 @@ class SettingsAjaxEndpoint {
 			// Read-endpoint group (#259).
 			'read_respect_whitelist'           => array( 'read', 'respect_whitelist' ),
 			'read_bypass_logged_in'            => array( 'read', 'bypass_logged_in' ),
+			// Whitelist / Blacklist card UI-visibility toggles. The flag
+			// only collapses the card on the settings page — the lists
+			// continue to apply at runtime when populated.
+			'whitelist_enabled'                => array( 'whitelist', 'enabled' ),
+			'blacklist_enabled'                => array( 'blacklist', 'enabled' ),
 			// Logging group.
 			'logging_enabled'                  => array( 'logging', 'enabled' ),
 			'logging_log_allowed'              => array( 'logging', 'log_allowed' ),

--- a/includes/settings/tabs/class-ffc-tab-rate-limit.php
+++ b/includes/settings/tabs/class-ffc-tab-rate-limit.php
@@ -105,12 +105,19 @@ class TabRateLimit extends SettingsTab {
 				'log_blocks'                => true,
 			),
 			'whitelist' => array(
+				// UI visibility flag — when false the rate-limit settings
+				// page collapses the Whitelist card to declutter; the
+				// lists themselves still apply at runtime if populated.
+				// Defaults true so existing installs see no UI change.
+				'enabled'       => true,
 				'ips'           => array(),
 				'emails'        => array(),
 				'email_domains' => array(),
 				'cpfs'          => array(),
 			),
 			'blacklist' => array(
+				// UI visibility flag — see whitelist['enabled'] above.
+				'enabled'       => true,
 				'ips'           => array(),
 				'emails'        => array(),
 				'email_domains' => array(),
@@ -257,12 +264,14 @@ class TabRateLimit extends SettingsTab {
 				'log_blocks'                => isset( $_POST['device_log_blocks'] ),
 			),
 			'whitelist' => array(
+				'enabled'       => isset( $_POST['whitelist_enabled'] ),
 				'ips'           => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['whitelist_ips'] ?? '' ) ) ) ) ),
 				'emails'        => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['whitelist_emails'] ?? '' ) ) ) ) ),
 				'email_domains' => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['whitelist_email_domains'] ?? '' ) ) ) ) ),
 				'cpfs'          => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['whitelist_cpfs'] ?? '' ) ) ) ) ),
 			),
 			'blacklist' => array(
+				'enabled'       => isset( $_POST['blacklist_enabled'] ),
 				'ips'           => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['blacklist_ips'] ?? '' ) ) ) ) ),
 				'emails'        => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['blacklist_emails'] ?? '' ) ) ) ) ),
 				'email_domains' => array_filter( array_map( 'trim', explode( "\n", sanitize_textarea_field( wp_unslash( $_POST['blacklist_email_domains'] ?? '' ) ) ) ) ),

--- a/includes/settings/views/ffc-tab-advanced.php
+++ b/includes/settings/views/ffc-tab-advanced.php
@@ -33,6 +33,7 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 		<span class="ffc-text-info ffc-icon-info"><?php esc_html_e( 'When enabled, actions like submission creation, data access, and settings changes are logged.', 'ffcertificate' ); ?></span>
 	</p>
 
+		<?php $ffcertificate_log_on = (int) $ffcertificate_get_option( 'enable_activity_log' ) === 1; ?>
 		<table class="form-table" role="presentation">
 			<tbody>
 				<tr>
@@ -45,7 +46,7 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 							array(
 								'name'    => 'ffc_settings[enable_activity_log]',
 								'id'      => 'enable_activity_log',
-								'checked' => (int) $ffcertificate_get_option( 'enable_activity_log' ) === 1,
+								'checked' => $ffcertificate_log_on,
 								'label'   => __( 'Track activities for audit trail', 'ffcertificate' ),
 								'data'    => array( 'ffc-autosave-key' => 'enable_activity_log' ),
 							)
@@ -54,7 +55,7 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 						<p class="description">
 							<?php esc_html_e( 'Logs submission creation, data access, settings changes, and security events.', 'ffcertificate' ); ?><br>
 							<span class="ffc-text-success ffc-icon-success"><?php esc_html_e( 'Includes user ID, IP address, and timestamp for LGPD compliance.', 'ffcertificate' ); ?></span>
-							<?php if ( $ffcertificate_get_option( 'enable_activity_log' ) === 1 ) : ?>
+							<?php if ( $ffcertificate_log_on ) : ?>
 								<br>
 								<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=ffc_form&page=ffc-activity-log' ) ); ?>" class="button button-secondary ffc-mt-10">
 									<span class="ffc-icon-chart"></span><?php esc_html_e( 'View Activity Logs', 'ffcertificate' ); ?>
@@ -63,6 +64,10 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 						</p>
 					</td>
 				</tr>
+			</tbody>
+			<tbody class="ffc-collapsed-target<?php echo $ffcertificate_log_on ? '' : ' ffc-collapsed'; ?>"
+				data-ffc-master="enable_activity_log"
+				aria-hidden="<?php echo $ffcertificate_log_on ? 'false' : 'true'; ?>">
 				<tr>
 					<th scope="row">
 						<label for="activity_log_retention_days"><?php esc_html_e( 'Log Retention (days)', 'ffcertificate' ); ?></label>
@@ -140,6 +145,8 @@ $ffcertificate_get_option = \Closure::fromCallable( array( $settings, 'get_optio
 						<p class="description"><?php esc_html_e( 'Uncheck a category to stop logging its events. All on by default.', 'ffcertificate' ); ?></p>
 					</td>
 				</tr>
+			</tbody>
+			<tbody>
 				<tr>
 					<th scope="row">
 						<label for="public_csv_sync_max_rows"><?php esc_html_e( 'Public CSV Sync Export Limit', 'ffcertificate' ); ?></label>

--- a/includes/settings/views/ffc-tab-rate-limit.php
+++ b/includes/settings/views/ffc-tab-rate-limit.php
@@ -394,7 +394,23 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 
 <div class="card">
 	<h2 class="ffc-icon-checkmark"><?php esc_html_e( 'Whitelist', 'ffcertificate' ); ?></h2>
-	<table class="form-table" role="presentation"><tbody>
+	<p>
+		<?php
+		\FreeFormCertificate\Admin\AdminUI::render_toggle(
+			array(
+				'name'    => 'whitelist_enabled',
+				'id'      => 'whitelist_enabled',
+				'checked' => ! empty( $ffcertificate_s['whitelist']['enabled'] ),
+				'label'   => __( 'Show', 'ffcertificate' ),
+				'data'    => array(
+					'ffc-autosave-key'   => 'whitelist_enabled',
+					'ffc-section-master' => 'rl-whitelist',
+				),
+			)
+		);
+		?>
+	</p>
+	<table class="form-table" role="presentation" data-ffc-section="rl-whitelist"><tbody>
 		<tr><th><?php esc_html_e( 'IPs', 'ffcertificate' ); ?></th><td><textarea name="whitelist_ips" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['whitelist']['ips'] ) ); ?></textarea><p class="description"><?php esc_html_e( 'One per line', 'ffcertificate' ); ?></p></td></tr>
 		<tr><th><?php esc_html_e( 'Emails', 'ffcertificate' ); ?></th><td><textarea name="whitelist_emails" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['whitelist']['emails'] ) ); ?></textarea></td></tr>
 		<tr><th><?php esc_html_e( 'Domains', 'ffcertificate' ); ?></th><td><textarea name="whitelist_email_domains" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['whitelist']['email_domains'] ) ); ?></textarea><p class="description"><?php esc_html_e( 'Format: *@domain.com', 'ffcertificate' ); ?></p></td></tr>
@@ -404,7 +420,23 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 
 <div class="card">
 	<h2 class="ffc-icon-cross"><?php esc_html_e( 'Blacklist', 'ffcertificate' ); ?></h2>
-	<table class="form-table" role="presentation"><tbody>
+	<p>
+		<?php
+		\FreeFormCertificate\Admin\AdminUI::render_toggle(
+			array(
+				'name'    => 'blacklist_enabled',
+				'id'      => 'blacklist_enabled',
+				'checked' => ! empty( $ffcertificate_s['blacklist']['enabled'] ),
+				'label'   => __( 'Show', 'ffcertificate' ),
+				'data'    => array(
+					'ffc-autosave-key'   => 'blacklist_enabled',
+					'ffc-section-master' => 'rl-blacklist',
+				),
+			)
+		);
+		?>
+	</p>
+	<table class="form-table" role="presentation" data-ffc-section="rl-blacklist"><tbody>
 		<tr><th><?php esc_html_e( 'IPs', 'ffcertificate' ); ?></th><td><textarea name="blacklist_ips" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['blacklist']['ips'] ) ); ?></textarea></td></tr>
 		<tr><th><?php esc_html_e( 'Emails', 'ffcertificate' ); ?></th><td><textarea name="blacklist_emails" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['blacklist']['emails'] ) ); ?></textarea></td></tr>
 		<tr><th><?php esc_html_e( 'Domains', 'ffcertificate' ); ?></th><td><textarea name="blacklist_email_domains" rows="5" class="large-text"><?php echo esc_textarea( implode( "\n", $ffcertificate_s['blacklist']['email_domains'] ) ); ?></textarea><p class="description"><?php esc_html_e( 'Format: *@domain.com', 'ffcertificate' ); ?></p></td></tr>

--- a/tests/Unit/FormEditorGeofenceMetaboxTest.php
+++ b/tests/Unit/FormEditorGeofenceMetaboxTest.php
@@ -147,6 +147,60 @@ class FormEditorGeofenceMetaboxTest extends TestCase {
         );
     }
 
+    // ==================================================================
+    // Global IP-API kill-switch gate (Sprint 5 — form-editor UX batch)
+    // ==================================================================
+
+    public function test_render_geolocation_disables_ip_toggle_when_global_off(): void {
+        // get_option( 'ffc_geolocation_settings' ) → empty array
+        // ⇒ $global_ip_api_enabled === false ⇒ toggle must be disabled +
+        // a warning notice with a link to Settings → Geolocation appears.
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'get_post_meta' )->justReturn( array() );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 77;
+
+        ob_start();
+        $this->metabox->render_geolocation( $post );
+        $html = (string) ob_get_clean();
+
+        // The toggle's visible checkbox must carry the disabled attr.
+        $this->assertMatchesRegularExpression(
+            '/<input[^>]*name="ffc_geofence\[geo_ip_enabled\]"[^>]*disabled/s',
+            $html,
+            'IP toggle must be rendered disabled when the global ip_api_enabled is off'
+        );
+        // And the warning notice links to the global setting tab.
+        $this->assertStringContainsString( 'page=ffc-settings&tab=geolocation', $html );
+        $this->assertStringContainsString( 'IP geolocation is disabled globally', $html );
+    }
+
+    public function test_render_geolocation_enables_ip_toggle_when_global_on(): void {
+        // Stub the global option to return ip_api_enabled = true.
+        Functions\when( 'get_option' )->alias(
+            static function ( $key, $default = array() ) {
+                return 'ffc_geolocation_settings' === $key
+                    ? array( 'ip_api_enabled' => true )
+                    : $default;
+            }
+        );
+        Functions\when( 'get_post_meta' )->justReturn( array() );
+        $post     = Mockery::mock( 'WP_Post' );
+        $post->ID = 77;
+
+        ob_start();
+        $this->metabox->render_geolocation( $post );
+        $html = (string) ob_get_clean();
+
+        // The toggle should NOT carry the disabled attr, and the warning
+        // notice should NOT appear.
+        $this->assertDoesNotMatchRegularExpression(
+            '/<input[^>]*name="ffc_geofence\[geo_ip_enabled\]"[^>]*disabled/s',
+            $html
+        );
+        $this->assertStringNotContainsString( 'IP geolocation is disabled globally', $html );
+    }
+
     public function test_render_schedule_exception_expands_when_toggle_on(): void {
         $html = $this->render(
             array(

--- a/tests/Unit/FormEditorSaveHandlerTest.php
+++ b/tests/Unit/FormEditorSaveHandlerTest.php
@@ -623,6 +623,74 @@ class FormEditorSaveHandlerTest extends TestCase {
     }
 
     /**
+     * Multi-day toggle OFF + datetime_enabled ON → date_end mirrors
+     * date_start and time_mode is normalised to 'span'. The UI gates the
+     * end-date and time-behavior controls behind the multi_day toggle;
+     * the save handler must back that up server-side so a tampered POST
+     * can't sneak through a divergent end date or 'daily' time mode.
+     */
+    public function test_multi_day_off_normalises_end_date_and_time_mode(): void {
+        $bag = $this->stub_for_save();
+        $written = &$bag[0];
+
+        Functions\when( 'get_post_meta' )->alias( static fn( $id, $key ) => array() );
+
+        $_POST = array(
+            'ffc_form_nonce' => 'ok',
+            'ffc_geofence'   => array(
+                'datetime_enabled' => '1',
+                // multi_day absent → '0' (single-day event)
+                'date_start'       => '2026-05-20',
+                'date_end'         => '2026-05-25', // would-be multi-day end
+                'time_start'       => '08:00',
+                'time_end'         => '17:00',
+                'time_mode'        => 'daily',      // would-be per-day mode
+            ),
+        );
+
+        $this->handler->save_form_data( 10 );
+
+        $merged = $written['_ffc_geofence_config'];
+        $this->assertSame( '0', $merged['multi_day'], 'multi_day persisted as off' );
+        $this->assertSame( '2026-05-20', $merged['date_end'], 'date_end forced to mirror date_start' );
+        $this->assertSame( 'span', $merged['time_mode'], 'time_mode forced to span (single-day equivalence)' );
+        $this->assertSame( '08:00', $merged['time_start'], 'time_start preserved verbatim' );
+        $this->assertSame( '17:00', $merged['time_end'], 'time_end preserved verbatim' );
+    }
+
+    /**
+     * Multi-day toggle ON → end_date and time_mode are persisted as-posted
+     * (no normalisation), confirming the off-path override is gated on the
+     * toggle and doesn't accidentally fire when multi_day is on.
+     */
+    public function test_multi_day_on_preserves_end_date_and_time_mode(): void {
+        $bag = $this->stub_for_save();
+        $written = &$bag[0];
+
+        Functions\when( 'get_post_meta' )->alias( static fn( $id, $key ) => array() );
+
+        $_POST = array(
+            'ffc_form_nonce' => 'ok',
+            'ffc_geofence'   => array(
+                'datetime_enabled' => '1',
+                'multi_day'        => '1',
+                'date_start'       => '2026-05-20',
+                'date_end'         => '2026-05-25',
+                'time_start'       => '08:00',
+                'time_end'         => '17:00',
+                'time_mode'        => 'daily',
+            ),
+        );
+
+        $this->handler->save_form_data( 10 );
+
+        $merged = $written['_ffc_geofence_config'];
+        $this->assertSame( '1', $merged['multi_day'] );
+        $this->assertSame( '2026-05-25', $merged['date_end'] );
+        $this->assertSame( 'daily', $merged['time_mode'] );
+    }
+
+    /**
      * DateTime datetime_enabled OFF → 9 sub-options skipped; merge picks up
      * preserved values from the prior _ffc_geofence_config meta.
      */


### PR DESCRIPTION
## Summary

Seven self-contained UX commits on form-editor + settings, organised so reviewing any single sprint is independent of the others.

| Sprint | Item | Commit subject |
|---|---|---|
| 1 + 3 | #3, #4 | `ux(form-editor): split Time tab into cards + shorten exception copy` |
| 2 | #2 | `feat(form-editor): multi-day toggle gates end-date + time-behavior controls` |
| 4 | #5 | `ux(form-editor): hide IP geolocation rows when 'IP Address' validation off` |
| 5 | #6 | `feat(form-editor): gate 'IP Address' toggle on global IP-API setting` |
| 6 | #7 | `ux(rate-limit): add collapse toggles to Whitelist and Blacklist cards` |
| 7 | #8 | `ux(advanced): collapse Activity Log sub-options when the master is off` |

### Design decisions worth flagging

- **Sprint 2 (multi-day)** — persisted as `_ffc_geofence_config[multi_day]` (option **b** per pre-PR discussion). Forms saved before this flag existed infer ON when both dates differ, OFF otherwise; explicit value is persisted on first save. Save handler normalises `date_end = date_start` and `time_mode = 'span'` when multi-day is off so a tampered POST can't sneak a divergent end-date past the visual gate.
- **Sprint 4** — `geo_ip_enabled` toggle gains an `id` so the `.ffc-collapsed-target` initialiser can find it. Nested collapse with the parent `geo_enabled` tbody works because each `.ffc-collapsed-target` reads its own master independently.
- **Sprint 5 (legacy behaviour)** — option **b** per pre-PR discussion. Forms with `geo_ip_enabled='1'` already saved before the global flag was turned off stay as-is in DB; they become inert at runtime (FFC_IP_Geolocation::lookup already short-circuits) but the admin sees the warning. Auto-disabling the saved flag would be silent data loss; visible-but-inert keeps the audit trail intact. **Bonus finding:** `SettingsReader::ip_api_enabled()` was reading from the wrong option (`ffc_settings` instead of `ffc_geolocation_settings`) and would always return false — sidestepped by reading the option directly, matching what `Geofence::handle_ip_fallback` already does. Worth a follow-up to either fix or remove the broken accessor.
- **Sprint 6 (visual-only)** — UI-visibility toggles, no runtime gate per the user's "somente visuais" request. Hiding the textareas via `jQuery.toggle()` keeps them in the form (still POSTed), so toggling back on shows them populated; runtime keeps reading the lists regardless.

### Tests added

- `FormEditorSaveHandlerTest::test_multi_day_off_normalises_end_date_and_time_mode`
- `FormEditorSaveHandlerTest::test_multi_day_on_preserves_end_date_and_time_mode`
- `FormEditorGeofenceMetaboxTest::test_render_geolocation_disables_ip_toggle_when_global_off`
- `FormEditorGeofenceMetaboxTest::test_render_geolocation_enables_ip_toggle_when_global_on`

## Test plan

- [x] PHPStan / PHPCS / `vendor/bin/phpunit` (4823 tests pass)
- [x] `npm run lint:js` / `lint:css` / `test:js` (1024 tests pass)
- [ ] Open `post=240&action=edit#ffc-tab-time` → three distinct `<div class="card">` blocks with `ffc-icon-*` headers (Event Schedule, Date/Time Restrictions, Per-participant exception)
- [ ] On the same screen with `multi_day` off: End Date input + "Time Behavior" + "Display during" row are hidden; saving normalises `date_end=date_start` and `time_mode='span'`
- [ ] Toggle Time Behavior between "span" and "daily" while multi-day is on → "Display during" row toggles dynamically (previously only honoured SSR initial state)
- [ ] Open `#ffc-tab-geolocation` with global IP-API off → "IP Address" toggle disabled + warning notice links to Settings → Geolocation
- [ ] With IP toggle off → "IP Geolocation Areas" + "GPS + IP Logic" rows hidden
- [ ] `page=ffc-settings&tab=rate_limit` → Whitelist/Blacklist cards show "Show" toggle; off collapses the textareas; toggling back shows them populated
- [ ] `page=ffc-settings&tab=advanced` with Activity Log off → Log Retention / Min level / Log categories rows hidden; Public CSV Sync Export Limit stays visible

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_