### PR TITLE
fix(geofence): never send an empty block message + enforce min length

### DIFF
--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -25,6 +25,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FormEditorSaveHandler {
 
 	/**
+	 * Minimum length (characters) required for each geofence block /
+	 * error message when its parent restriction is enabled.
+	 *
+	 * Empty or too-short messages produced silent frontend failures: a
+	 * legitimate date/time or geolocation block returned an empty
+	 * `message`, which ffc-core.js (`err.fromServer = !!serverMsg`)
+	 * treated as "no server message" and surfaced as a generic
+	 * "Connection error" — the user saw nothing actionable. The runtime
+	 * fallback in {@see \FreeFormCertificate\Security\Geofence::message_or_default()}
+	 * guarantees a non-empty string at render time; this save-side gate
+	 * pushes the requirement upstream so operators author a meaningful
+	 * message instead of relying on the generic fallback. Tune here.
+	 */
+	public const GEOFENCE_MESSAGE_MIN_LENGTH = 25;
+
+	/**
 	 * Saves all form data and configurations
 	 *
 	 * @param int $post_id The post ID.
@@ -219,15 +235,21 @@ class FormEditorSaveHandler {
 
 				// Multi-day toggle (UX scope: hides the End Date / Time
 				// Behavior / Display-during-slot controls when off). When
-				// the operator unchecks it, normalise the dependent fields
-				// so the runtime treats the form as a single-day event:
-				// date_end mirrors date_start and time_mode becomes 'span'
-				// (single calendar day → span and daily are equivalent, but
-				// span keeps Display-during-slot inert per its own rule).
+				// the operator unchecks it, mirror date_end onto date_start
+				// so the runtime bounds the form to a single calendar day
+				// (the hidden End Date input can't be edited, so a stale
+				// range from a prior multi-day config must not linger).
+				//
+				// time_mode is left untouched: a single-day event with a
+				// time window is exactly "daily mode, one day", which
+				// validate_datetime handles directly. Forcing 'span' here
+				// (an earlier approach) was both unnecessary — the
+				// `date_start !== date_end` guard in validate_datetime
+				// neutralises span the moment the dates are equal — and
+				// surprising, so it's been dropped.
 				$clean_geofence['multi_day'] = isset( $geofence['multi_day'] ) ? '1' : '0';
 				if ( '0' === $clean_geofence['multi_day'] ) {
-					$clean_geofence['date_end']  = $clean_geofence['date_start'];
-					$clean_geofence['time_mode'] = 'span';
+					$clean_geofence['date_end'] = $clean_geofence['date_start'];
 				}
 			}
 
@@ -607,7 +629,67 @@ class FormEditorSaveHandler {
 			$errors    = array_merge( $errors, $ip_errors );
 		}
 
+		// Block / error message minimum length (Time + Geolocation). Only
+		// enforced when the owning restriction is enabled — a form that
+		// doesn't gate by date/time or location isn't forced to author
+		// messages it will never show.
+		$message_errors = $this->geofence_message_errors( $config );
+		$errors         = array_merge( $errors, $message_errors['time'], $message_errors['geolocation'] );
+
 		return $errors;
+	}
+
+	/**
+	 * Validate the geofence block / error messages, split by owning tab.
+	 *
+	 * Returns a two-bucket map so {@see geofence_error_tab_keys()} can route
+	 * each failure to the tab that owns the field without re-matching on
+	 * message text. Each message is only checked when its parent toggle is
+	 * on:
+	 *  - `time`        → `msg_datetime` (when `datetime_enabled`)
+	 *  - `geolocation` → `msg_geo_blocked` + `msg_geo_error` (when `geo_enabled`)
+	 *
+	 * Length is measured with `mb_strlen` so accented Portuguese copy isn't
+	 * penalised byte-for-byte.
+	 *
+	 * @param array<string, mixed> $config Merged geofence config.
+	 * @return array{time: list<string>, geolocation: list<string>}
+	 */
+	private function geofence_message_errors( array $config ): array {
+		$min = self::GEOFENCE_MESSAGE_MIN_LENGTH;
+		$out = array(
+			'time'        => array(),
+			'geolocation' => array(),
+		);
+
+		if ( '1' === ( $config['datetime_enabled'] ?? '0' ) ) {
+			if ( mb_strlen( trim( (string) ( $config['msg_datetime'] ?? '' ) ) ) < $min ) {
+				$out['time'][] = sprintf(
+					/* translators: %d: minimum character count */
+					__( 'The date/time "Blocked Message" must be at least %d characters so visitors understand why the form is unavailable.', 'ffcertificate' ),
+					$min
+				);
+			}
+		}
+
+		if ( '1' === ( $config['geo_enabled'] ?? '0' ) ) {
+			if ( mb_strlen( trim( (string) ( $config['msg_geo_blocked'] ?? '' ) ) ) < $min ) {
+				$out['geolocation'][] = sprintf(
+					/* translators: %d: minimum character count */
+					__( 'The geolocation "Blocked Message" must be at least %d characters.', 'ffcertificate' ),
+					$min
+				);
+			}
+			if ( mb_strlen( trim( (string) ( $config['msg_geo_error'] ?? '' ) ) ) < $min ) {
+				$out['geolocation'][] = sprintf(
+					/* translators: %d: minimum character count */
+					__( 'The geolocation "Error Message" must be at least %d characters.', 'ffcertificate' ),
+					$min
+				);
+			}
+		}
+
+		return $out;
 	}
 
 	/**
@@ -632,11 +714,21 @@ class FormEditorSaveHandler {
 				)
 			)
 		);
-		if ( ! empty( $datetime_errors ) ) {
+		$message_errors  = $this->geofence_message_errors( $config );
+
+		// Time tab owns the datetime-order messages plus the date/time
+		// "Blocked Message" length error.
+		$time_errors = array_merge( $datetime_errors, $message_errors['time'] );
+		if ( ! empty( $time_errors ) ) {
 			$keys[] = 'time';
 		}
-		// Any error that isn't a datetime-order message is an area/format one.
-		if ( ! empty( array_diff( $all_errors, $datetime_errors ) ) ) {
+
+		// Geolocation tab owns everything else: GPS/IP area + format errors
+		// (whatever remains in $all_errors after removing the time-tab
+		// messages and the geo message-length errors) plus those geo
+		// message-length errors themselves.
+		$area_errors = array_diff( $all_errors, $time_errors, $message_errors['geolocation'] );
+		if ( ! empty( $area_errors ) || ! empty( $message_errors['geolocation'] ) ) {
 			$keys[] = 'geolocation';
 		}
 		return $keys;

--- a/includes/security/class-ffc-geofence.php
+++ b/includes/security/class-ffc-geofence.php
@@ -203,6 +203,30 @@ class Geofence {
 	}
 
 	/**
+	 * Return the operator-configured block message, or a phase-specific
+	 * default when it's missing OR empty.
+	 *
+	 * The `??` null-coalescing operator only substitutes for `null`, not
+	 * for an empty string — so `$config['msg_datetime'] ?? $default`
+	 * returned `''` whenever the operator cleared the "Blocked Message"
+	 * field (a saved empty string, not an absent key). An empty message
+	 * propagated to the AJAX response, where the frontend's
+	 * `err.fromServer = !!serverMsg` check (ffc-core.js) treated the
+	 * blank as "no server message" and fell back to a generic
+	 * "Connection error" — making a legitimate date/time block look like
+	 * a silent failure to the visitor. `empty()` catches both the null
+	 * and the '' cases so the phase-specific default always wins.
+	 *
+	 * @param array<string, mixed> $config  Geofence config.
+	 * @param string               $key     Message key (msg_datetime / msg_geo_*).
+	 * @param string               $default Phase-specific fallback copy.
+	 * @return string Non-empty message.
+	 */
+	private static function message_or_default( array $config, string $key, string $default ): string {
+		return empty( $config[ $key ] ) ? $default : (string) $config[ $key ];
+	}
+
+	/**
 	 * Validate date/time restrictions
 	 *
 	 * @param array<string, mixed> $config Form geofence configuration.
@@ -228,7 +252,7 @@ class Geofence {
 			if ( $now < $start_datetime ) {
 				return array(
 					'valid'   => false,
-					'message' => $config['msg_datetime'] ?? __( 'This form is not yet available.', 'ffcertificate' ),
+					'message' => self::message_or_default( $config, 'msg_datetime', __( 'This form is not yet available.', 'ffcertificate' ) ),
 					'details' => array(
 						'reason' => 'before_start_datetime',
 						'mode'   => 'span',
@@ -241,7 +265,7 @@ class Geofence {
 			if ( $now > $end_datetime ) {
 				return array(
 					'valid'   => false,
-					'message' => $config['msg_datetime'] ?? __( 'This form is no longer available.', 'ffcertificate' ),
+					'message' => self::message_or_default( $config, 'msg_datetime', __( 'This form is no longer available.', 'ffcertificate' ) ),
 					'details' => array(
 						'reason' => 'after_end_datetime',
 						'mode'   => 'span',
@@ -264,7 +288,7 @@ class Geofence {
 		if ( ! empty( $config['date_start'] ) && $current_date < $config['date_start'] ) {
 			return array(
 				'valid'   => false,
-				'message' => $config['msg_datetime'] ?? __( 'This form is not yet available.', 'ffcertificate' ),
+				'message' => self::message_or_default( $config, 'msg_datetime', __( 'This form is not yet available.', 'ffcertificate' ) ),
 				'details' => array(
 					'reason'       => 'before_start_date',
 					'current_date' => $current_date,
@@ -276,7 +300,7 @@ class Geofence {
 		if ( ! empty( $config['date_end'] ) && $current_date > $config['date_end'] ) {
 			return array(
 				'valid'   => false,
-				'message' => $config['msg_datetime'] ?? __( 'This form is no longer available.', 'ffcertificate' ),
+				'message' => self::message_or_default( $config, 'msg_datetime', __( 'This form is no longer available.', 'ffcertificate' ) ),
 				'details' => array(
 					'reason'       => 'after_end_date',
 					'current_date' => $current_date,
@@ -294,7 +318,7 @@ class Geofence {
 			if ( $current_time < $time_start || $current_time > $time_end ) {
 				return array(
 					'valid'   => false,
-					'message' => $config['msg_datetime'] ?? __( 'This form is only available during specific hours.', 'ffcertificate' ),
+					'message' => self::message_or_default( $config, 'msg_datetime', __( 'This form is only available during specific hours.', 'ffcertificate' ) ),
 					'details' => array(
 						'reason'       => 'outside_time_range',
 						'mode'         => 'daily',
@@ -345,7 +369,7 @@ class Geofence {
 		if ( empty( $user_location ) || empty( $user_location['latitude'] ) || empty( $user_location['longitude'] ) ) {
 			return array(
 				'valid'   => false,
-				'message' => $config['msg_geo_error'] ?? __( 'Unable to determine your location.', 'ffcertificate' ),
+				'message' => self::message_or_default( $config, 'msg_geo_error', __( 'Unable to determine your location.', 'ffcertificate' ) ),
 				'details' => array( 'reason' => 'location_unavailable' ),
 			);
 		}
@@ -367,7 +391,7 @@ class Geofence {
 		if ( ! $within ) {
 			return array(
 				'valid'   => false,
-				'message' => $config['msg_geo_blocked'] ?? __( 'This form is not available in your location.', 'ffcertificate' ),
+				'message' => self::message_or_default( $config, 'msg_geo_blocked', __( 'This form is not available in your location.', 'ffcertificate' ) ),
 				'details' => array(
 					'reason'        => 'outside_allowed_areas',
 					'user_location' => $user_location,
@@ -419,7 +443,7 @@ class Geofence {
 			case 'block':
 				return array(
 					'valid'   => false,
-					'message' => $config['msg_geo_error'] ?? __( 'Location verification failed.', 'ffcertificate' ),
+					'message' => self::message_or_default( $config, 'msg_geo_error', __( 'Location verification failed.', 'ffcertificate' ) ),
 					'details' => array(
 						'reason' => 'ip_fallback_block',
 						'error'  => $error->get_error_message(),

--- a/tests/Unit/FormEditorSaveHandlerTest.php
+++ b/tests/Unit/FormEditorSaveHandlerTest.php
@@ -276,6 +276,99 @@ class FormEditorSaveHandlerTest extends TestCase {
     }
 
     // ==================================================================
+    // Geofence block-message minimum length (Time + Geolocation)
+    // ==================================================================
+
+    private const VALID_MSG = 'This form is closed outside its scheduled window.'; // 49 chars.
+
+    public function test_empty_datetime_message_blocks_save_when_enabled(): void {
+        $config = array(
+            'datetime_enabled' => '1',
+            'date_start'       => '2026-01-01',
+            'date_end'         => '2026-01-01',
+            'msg_datetime'     => '', // cleared by operator → too short.
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $this->assertNotEmpty( $errors );
+        $joined = implode( ' | ', $errors );
+        $this->assertStringContainsString( 'Blocked Message', $joined );
+    }
+
+    public function test_short_datetime_message_blocks_save(): void {
+        $config = array(
+            'datetime_enabled' => '1',
+            'date_start'       => '2026-01-01',
+            'date_end'         => '2026-01-01',
+            'msg_datetime'     => 'Closed.', // 7 chars < 25.
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $this->assertNotEmpty( $errors );
+    }
+
+    public function test_valid_datetime_message_passes(): void {
+        $config = array(
+            'datetime_enabled' => '1',
+            'date_start'       => '2026-01-01',
+            'date_end'         => '2026-01-01',
+            'msg_datetime'     => self::VALID_MSG,
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $this->assertSame( array(), $errors );
+    }
+
+    public function test_datetime_message_not_checked_when_restriction_disabled(): void {
+        // datetime_enabled off → the message is never shown, so an empty
+        // one must NOT block the save.
+        $config = array(
+            'datetime_enabled' => '0',
+            'msg_datetime'     => '',
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $this->assertSame( array(), $errors );
+    }
+
+    public function test_short_datetime_message_routes_to_time_tab_not_geolocation(): void {
+        // Dates are in valid order (no datetime-order error); the ONLY
+        // failure is the short message. It must route to 'time', proving
+        // the new length error isn't mis-bucketed as a geolocation error.
+        $config = array(
+            'datetime_enabled' => '1',
+            'date_start'       => '2026-01-01',
+            'date_end'         => '2026-01-02',
+            'time_start'       => '08:00',
+            'time_end'         => '17:00',
+            'time_mode'        => 'span',
+            'msg_datetime'     => 'too short',
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $keys   = $this->invoke( 'geofence_error_tab_keys', array( $config, $errors ) );
+        $this->assertSame( array( 'time' ), $keys );
+    }
+
+    public function test_short_geo_messages_block_save_and_route_to_geolocation(): void {
+        $config = array(
+            'geo_enabled'     => '1',
+            'msg_geo_blocked' => 'no',  // too short.
+            'msg_geo_error'   => 'err', // too short.
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        // Two geo message errors (blocked + error).
+        $this->assertCount( 2, $errors );
+        $keys = $this->invoke( 'geofence_error_tab_keys', array( $config, $errors ) );
+        $this->assertSame( array( 'geolocation' ), $keys );
+    }
+
+    public function test_geo_messages_not_checked_when_geo_disabled(): void {
+        $config = array(
+            'geo_enabled'     => '0',
+            'msg_geo_blocked' => '',
+            'msg_geo_error'   => '',
+        );
+        $errors = $this->invoke( 'validate_geofence_config', array( $config ) );
+        $this->assertSame( array(), $errors );
+    }
+
+    // ==================================================================
     // validate_areas_format()
     // ==================================================================
 
@@ -624,12 +717,13 @@ class FormEditorSaveHandlerTest extends TestCase {
 
     /**
      * Multi-day toggle OFF + datetime_enabled ON → date_end mirrors
-     * date_start and time_mode is normalised to 'span'. The UI gates the
-     * end-date and time-behavior controls behind the multi_day toggle;
-     * the save handler must back that up server-side so a tampered POST
-     * can't sneak through a divergent end date or 'daily' time mode.
+     * date_start so the runtime bounds the form to a single calendar day.
+     * time_mode is left exactly as posted (no longer forced to 'span') —
+     * a single-day event with a time window is "daily mode, one day", and
+     * validate_datetime's `date_start !== date_end` guard neutralises span
+     * for equal dates anyway, so forcing it was unnecessary.
      */
-    public function test_multi_day_off_normalises_end_date_and_time_mode(): void {
+    public function test_multi_day_off_mirrors_end_date_and_preserves_time_mode(): void {
         $bag = $this->stub_for_save();
         $written = &$bag[0];
 
@@ -644,7 +738,9 @@ class FormEditorSaveHandlerTest extends TestCase {
                 'date_end'         => '2026-05-25', // would-be multi-day end
                 'time_start'       => '08:00',
                 'time_end'         => '17:00',
-                'time_mode'        => 'daily',      // would-be per-day mode
+                'time_mode'        => 'daily',
+                // ≥25 chars so the block-message length gate passes.
+                'msg_datetime'     => 'This form is closed outside its scheduled window.',
             ),
         );
 
@@ -653,7 +749,7 @@ class FormEditorSaveHandlerTest extends TestCase {
         $merged = $written['_ffc_geofence_config'];
         $this->assertSame( '0', $merged['multi_day'], 'multi_day persisted as off' );
         $this->assertSame( '2026-05-20', $merged['date_end'], 'date_end forced to mirror date_start' );
-        $this->assertSame( 'span', $merged['time_mode'], 'time_mode forced to span (single-day equivalence)' );
+        $this->assertSame( 'daily', $merged['time_mode'], 'time_mode preserved as-posted (not forced to span)' );
         $this->assertSame( '08:00', $merged['time_start'], 'time_start preserved verbatim' );
         $this->assertSame( '17:00', $merged['time_end'], 'time_end preserved verbatim' );
     }
@@ -679,6 +775,8 @@ class FormEditorSaveHandlerTest extends TestCase {
                 'time_start'       => '08:00',
                 'time_end'         => '17:00',
                 'time_mode'        => 'daily',
+                // ≥25 chars so the block-message length gate passes.
+                'msg_datetime'     => 'This form is closed outside its scheduled window.',
             ),
         );
 
@@ -791,9 +889,12 @@ class FormEditorSaveHandlerTest extends TestCase {
         $_POST = array(
             'ffc_form_nonce' => 'ok',
             'ffc_geofence'   => array(
-                'geo_enabled'   => '1',                 // outer master on
+                'geo_enabled'     => '1',                 // outer master on
                 // geo_ip_areas_permissive absent → '0'
-                'geo_ip_areas'  => 'should-not-overwrite',
+                'geo_ip_areas'    => 'should-not-overwrite',
+                // ≥25 chars each so the geo message-length gate passes.
+                'msg_geo_blocked' => 'This form is not available in your region.',
+                'msg_geo_error'   => 'We could not verify your location. Try again.',
             ),
         );
 


### PR DESCRIPTION
## Summary

Diagnosing a "submitting the certificate form does nothing — no download, no DB write, no error message" report on form 240. Browser geofence logs confirmed the form passes **client-side** GPS validation (user 41m from a 200m area) and the submit XHR fires and completes — but the submission is silently rejected server-side.

### Root cause (this PR)

`validate_datetime` / `validate_geolocation` resolved their copy with `$config['msg_*'] ?? $default`. The `??` operator only substitutes for **null**, not for an **empty string** — so an operator who cleared the "Blocked Message" field (a saved `''`) propagated that empty string to the AJAX response. ffc-core.js then maps `err.fromServer = !!serverMsg` → `false` for the empty message and surfaces a generic "Connection error", which auto-dismisses in 8s and reads as "nothing happened".

### Two layers of fix

1. **Runtime fallback** (`Geofence::message_or_default`): every block message falls back to a phase-specific default when the configured value is null OR empty. Covers legacy data, imports, direct DB edits. Aligns the PHP side with the frontend, which already used `||` (catches `''`).
2. **Save-side enforcement** (`FormEditorSaveHandler`): when a restriction is enabled, its message must be ≥ `GEOFENCE_MESSAGE_MIN_LENGTH` (25) chars (`mb_strlen`). Applies to `msg_datetime` + `msg_geo_blocked` + `msg_geo_error`, each gated on its parent toggle; errors route to the owning tab. Render defaults already exceed 25 chars, so forms keeping the defaults save cleanly.

Also drops the unnecessary `time_mode = 'span'` forcing from the multi-day-off normalization (keeps the `date_end` mirror) — span is neutralised by the `date_start !== date_end` guard in `validate_datetime` the moment the dates are equal, so forcing it was inert and surprising.

### What this PR does NOT fix (follow-up, pending confirmation)

The **functional** reason the submission is rejected: server-side `validate_geolocation` ignores `geo_gps_ip_logic` and hard-blocks on a coarse IP lookup even under `'or'` logic, where a frontend-validated GPS pass should be sufficient. That's a separate, security-relevant change I'm confirming with the maintainer before touching. This PR makes that block **visible** instead of silent; the follow-up will make it **correct**.

## Test plan

- [x] Full PHP suite — 4830 green
- [x] PHPStan (level 8) + WPCS clean on changed files
- [x] +7 message-length test cases; updated multi_day + ip-permissive save tests
- [ ] On a form with an empty `msg_datetime`/`msg_geo_*`, trigger a block → the visitor now sees the phase-specific default instead of a silent failure
- [ ] Clearing a message and saving with the restriction enabled → save is blocked, error routed to the correct tab

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_