### PR TITLE
fix(rate-limit): honor the IP 'enabled' toggle + never send an empty message

### DIFF
--- a/includes/security/class-ffc-rate-limit-checker.php
+++ b/includes/security/class-ffc-rate-limit-checker.php
@@ -198,7 +198,19 @@ final class RateLimitChecker {
 	 * @return array{allowed: bool, message?: string, reason?: string, wait_seconds?: int}
 	 */
 	public static function check_ip_limit( string $ip, ?int $form_id = null ): array {
-		$s  = self::get_settings()['ip'];
+		$s = self::get_settings()['ip'];
+
+		// Respect the operator's master toggle. The form-submission DoS
+		// gate (FormProcessor::handle_submission_ajax) calls this method
+		// DIRECTLY at the top of the handler — before, and independently
+		// of, check_all()'s own `$s['ip']['enabled']` gating. Without this
+		// guard a form would keep blocking off a stale hour/day counter
+		// even after the operator turned IP rate limiting OFF in the panel
+		// (the reported "submit does nothing" with every limit disabled).
+		if ( empty( $s['enabled'] ) ) {
+			return array( 'allowed' => true );
+		}
+
 		$hk = 'ffc_rate_ip_' . md5( $ip . $form_id ) . '_hour';
 		// v3.2.0: Use Object Cache API (auto Redis/Memcached if available).
 		$hc = wp_cache_get( $hk, RateLimiter::CACHE_GROUP );
@@ -925,10 +937,22 @@ final class RateLimitChecker {
 	/**
 	 * Format message.
 	 *
+	 * Falls back to a sensible default when the configured template is empty
+	 * or whitespace-only. An operator can clear the rate-limit "Message"
+	 * field in settings (or an autosave can land an empty value), which used
+	 * to propagate an empty string all the way to the AJAX response —
+	 * surfacing as a silent block on the frontend (`rate_limit:true` with
+	 * `message:''`, which the client's RateLimit display renders as nothing).
+	 * Guaranteeing a non-empty string here keeps every rate-limit gate
+	 * (IP / email / CPF / device) visible regardless of the stored copy.
+	 *
 	 * @param string               $template Template.
 	 * @param array<string, mixed> $data Data.
 	 */
 	private static function format_message( string $template, array $data ): string {
+		if ( '' === trim( $template ) ) {
+			$template = __( 'Submission limit reached. Please wait {time} and try again.', 'ffcertificate' );
+		}
 		return str_replace( array( '{time}', '{count}', '{max}', '{remaining}' ), array( (string) ( $data['time'] ?? '' ), (string) ( $data['count'] ?? 0 ), (string) ( $data['max'] ?? 0 ), (string) ( ( $data['max'] ?? 0 ) - ( $data['count'] ?? 0 ) ) ), $template );
 	}
 

--- a/tests/Unit/RateLimiterTest.php
+++ b/tests/Unit/RateLimiterTest.php
@@ -100,6 +100,51 @@ class RateLimiterTest extends TestCase {
         $this->assertSame( 3600, $result['wait_seconds'] );
     }
 
+    public function test_ip_limit_allows_when_disabled_even_if_counter_exceeded(): void {
+        // Operator turned IP rate limiting OFF in the panel. The form
+        // processor's early DoS gate calls check_ip_limit() directly, so
+        // the method itself must honour the toggle — otherwise a stale
+        // counter keeps blocking submissions after the operator disabled
+        // the feature (the reported "submit does nothing").
+        $this->stub_default_settings( array( 'ip' => array( 'enabled' => false ) ) );
+
+        // Counter is WAY over the hour limit, but it must not matter.
+        Functions\when( 'wp_cache_get' )->justReturn( 9999 );
+
+        $result = RateLimiter::check_ip_limit( '192.168.1.1' );
+
+        $this->assertTrue( $result['allowed'], 'disabled IP rate limit must never block' );
+    }
+
+    public function test_ip_limit_block_message_falls_back_when_template_empty(): void {
+        // Operator cleared the IP rate-limit "Message" field (or an autosave
+        // landed an empty value). The block must still carry a non-empty,
+        // visible message instead of propagating '' to the frontend (which
+        // rendered as a silent failure).
+        $this->stub_default_settings( array( 'ip' => array( 'message' => '' ) ) );
+
+        Functions\when( 'wp_cache_get' )->justReturn( 5 ); // hour exceeded.
+
+        $result = RateLimiter::check_ip_limit( '192.168.1.1' );
+
+        $this->assertFalse( $result['allowed'] );
+        $this->assertNotSame( '', trim( $result['message'] ), 'block message must not be empty' );
+        // The {time} token is still interpolated against the default copy.
+        $this->assertStringContainsString( '1 hour', $result['message'] );
+    }
+
+    public function test_ip_limit_keeps_configured_message_when_present(): void {
+        // Sanity: a non-empty configured template is used verbatim (token-
+        // expanded), the fallback only kicks in for empty templates.
+        $this->stub_default_settings();
+
+        Functions\when( 'wp_cache_get' )->justReturn( 5 );
+
+        $result = RateLimiter::check_ip_limit( '192.168.1.1' );
+
+        $this->assertStringContainsString( 'Limit reached', $result['message'] );
+    }
+
     public function test_ip_limit_blocks_on_cooldown(): void {
         $this->stub_default_settings();
 


### PR DESCRIPTION
## Summary

Root cause of the "submitting the certificate form does nothing — no download, no DB write, no message" report on form 240. A console XHR sniffer captured the actual server response:

```json
{"success":false,"data":{"message":"","rate_limit":true,"wait_seconds":3600}}
```

The submission was being **rate-limited** — even though the operator had **disabled every rate limit** (IP / Email / CPF / Global) in the panel. Two defects:

### 1. Early DoS gate ignored the `ip.enabled` toggle (the actual blocker)

`FormProcessor::handle_submission_ajax` calls `RateLimiter::check_ip_limit()` **directly at the top of the handler** (before the nonce check, as a brute-force guard) — independently of `check_all()`, which is the only path that gates on `$s['ip']['enabled']`. So with IP rate limiting turned **off**, the early gate still fired off a stale hour counter sitting in the object cache (the user had hammered the form while testing), blocking every submission with a 1-hour wait.

**Fix:** `check_ip_limit()` returns `allowed` immediately when `ip.enabled` is false, so the operator's toggle is honored on every call path.

### 2. Empty limit message → silent failure (why no message showed)

`format_message()` returned the configured template verbatim. An empty "Message" field propagated `''` to the response, which the frontend's RateLimit display renders as nothing — indistinguishable from "the button does nothing". It now falls back to a non-empty default when the template is blank, covering every gate (IP / email / CPF / device).

## How it was diagnosed

GPS geofence passed client-side (`Form validation passed, showing form`); the submit XHR completed 200 but with the silent rate-limit envelope above. IP geolocation was confirmed off, ruling out the geofence path — the sniffer pointed straight at the rate limiter.

## Test plan

- [x] Full PHP suite — 4826 green
- [x] PHPStan (level 8) + WPCS clean
- [x] +3 tests: disabled-toggle bypass, empty-message fallback, configured-message passthrough
- [ ] On a form with all rate limits disabled, a previously-throttled IP can submit immediately (no 3600s block)
- [ ] With IP rate limiting enabled but its Message field cleared, a throttled submit shows a real message instead of nothing

## Related

Companion to #451 (geofence block messages never empty). Same "never silent block" theme, different subsystem — this is the one that fixes the reported form-240 failure.

https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_