### PR TITLE
fix(recruitment): rename validate_job's `lines` alias (MariaDB reserved word)

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-csv-importer.php
+++ b/includes/recruitment/class-ffc-recruitment-csv-importer.php
@@ -1176,12 +1176,12 @@ final class RecruitmentCsvImporter {
 		foreach ( array( 'cpf_normalized', 'rf_normalized', 'email' ) as $id_col ) {
 			$dup_groups = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 				$wpdb->prepare(
-					"SELECT GROUP_CONCAT(line_no ORDER BY row_no) AS lines FROM {$staging_table} WHERE job_id = %s AND {$id_col} <> '' GROUP BY {$id_col}, adjutancy_id HAVING COUNT(*) > 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- id_col is hard-coded above; not user input.
+					"SELECT GROUP_CONCAT(line_no ORDER BY row_no) AS csv_lines FROM {$staging_table} WHERE job_id = %s AND {$id_col} <> '' GROUP BY {$id_col}, adjutancy_id HAVING COUNT(*) > 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- id_col is hard-coded above; not user input.
 					$job_id
 				)
 			);
 			foreach ( $dup_groups as $group ) {
-				$lines = array_map( 'intval', explode( ',', (string) $group->lines ) );
+				$lines = array_map( 'intval', explode( ',', (string) $group->csv_lines ) );
 				$first = (int) array_shift( $lines );
 				foreach ( $lines as $line ) {
 					$errors[] = self::line_error(
@@ -1198,7 +1198,7 @@ final class RecruitmentCsvImporter {
 		// sniff suppression.
 		$diverge_groups = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				'SELECT GROUP_CONCAT(line_no ORDER BY row_no) AS lines,
+				'SELECT GROUP_CONCAT(line_no ORDER BY row_no) AS csv_lines,
 					COUNT(DISTINCT name)          AS d_name,
 					COUNT(DISTINCT email)         AS d_email,
 					COUNT(DISTINCT rf_normalized) AS d_rf,
@@ -1213,7 +1213,7 @@ final class RecruitmentCsvImporter {
 			)
 		);
 		foreach ( $diverge_groups as $group ) {
-			$lines = array_map( 'intval', explode( ',', (string) $group->lines ) );
+			$lines = array_map( 'intval', explode( ',', (string) $group->csv_lines ) );
 			$first = (int) array_shift( $lines );
 			$which = array();
 			if ( $group->d_name > 1 ) {


### PR DESCRIPTION
## Summary

- `LINES` is a MariaDB reserved word (`LOAD DATA INFILE … LINES TERMINATED BY …`). The `validate_job` queries using `AS lines` parse fine on a generic MySQL but fail on the testes host with: `You have an error in your SQL syntax … near 'lines FROM wp_ffc_recruitment_import_staging …'`.
- Latent since V10 — but V10 never reached `/validate` (the synchronous `/start` was timing out at the gateway), so the bug only became reachable once the plaintext refactor in #470 let the four phases actually run end-to-end.
- Rename `AS lines` → `AS csv_lines` in both Rule 4 (per-identifier duplicate detection, 3 queries) and Rule 5 (`cpf_normalized` field divergence, single query). PHP that reads `$group->lines` updated to `$group->csv_lines` in both foreach blocks.

## Test plan

- [x] `vendor/bin/phpunit --filter Recruitment tests/Unit` — 446 tests, 1179 assertions, 0 failures
- [ ] On testes: re-run the 4-candidate CSV import and confirm `/import-job/validate` completes without the SQL syntax errors in debug.log

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_