### PR TITLE
feat(recruitment-admin): subscription column (PCD/GERAL) on notice classification tables

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-notice-edit-page-renderer.php
+++ b/includes/recruitment/class-ffc-recruitment-notice-edit-page-renderer.php
@@ -920,7 +920,19 @@ final class RecruitmentNoticeEditPageRenderer {
 		$candidate_ids = array_map( static fn( $r ) => (int) $r->candidate_id, $rows );
 		$adjutancy_ids = array_map( static fn( $r ) => (int) $r->adjutancy_id, $rows );
 
-		$candidates  = self::lookup_map( array_unique( $candidate_ids ), array( RecruitmentCandidateRepository::class, 'get_by_id' ), 'name' );
+		// Bulk-load the full candidate rows once (we need `pcd_hash` for
+		// the Subscription column; the `name` map below is fed from the
+		// same payload to keep this a single SQL round-trip).
+		$candidate_rows = RecruitmentCandidateRepository::get_by_ids( array_unique( $candidate_ids ) );
+		$candidates     = array();
+		$pcd_map        = array();
+		foreach ( $candidate_rows as $cand ) {
+			$cid                = (int) $cand->id;
+			$candidates[ $cid ] = (string) ( $cand->name ?? '' );
+			// `verify` returns null on hash decode failure — fall back to
+			// GERAL, mirroring the public shortcode's defensive default.
+			$pcd_map[ $cid ] = true === RecruitmentPcdHasher::verify( (string) ( $cand->pcd_hash ?? '' ), $cid );
+		}
 		$adjutancies = self::lookup_map( array_unique( $adjutancy_ids ), array( RecruitmentAdjutancyRepository::class, 'get_by_id' ), 'slug' );
 
 		// Bulk-call toolbar (Definitive tab only): selected `empty` rows
@@ -945,6 +957,7 @@ final class RecruitmentNoticeEditPageRenderer {
 		echo '<th>' . esc_html__( 'Rank', 'ffcertificate' ) . '</th>';
 		echo '<th>' . esc_html__( 'Candidate', 'ffcertificate' ) . '</th>';
 		echo '<th>' . esc_html__( 'Adjutancy', 'ffcertificate' ) . '</th>';
+		echo '<th>' . esc_html__( 'Subscription', 'ffcertificate' ) . '</th>';
 		echo '<th>' . esc_html__( 'Score', 'ffcertificate' ) . '</th>';
 		if ( $is_preview_tab ) {
 			echo '<th>' . esc_html__( 'Preliminary status', 'ffcertificate' ) . '</th>';
@@ -983,6 +996,9 @@ final class RecruitmentNoticeEditPageRenderer {
 			echo '<td>' . esc_html( $candidate_name ) . '</td>';
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- helper returns escaped HTML.
 			echo '<td>' . RecruitmentAdminPage::adjutancy_badge( RecruitmentAdjutancyRepository::get_by_id( (int) $row->adjutancy_id ) ) . '</td>';
+			$is_pcd = $pcd_map[ (int) $row->candidate_id ] ?? false;
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- helper returns escaped HTML.
+			echo '<td>' . RecruitmentPublicShortcodeRenderer::render_subscription_badge( $is_pcd ) . '</td>';
 			echo '<td>' . esc_html( (string) $row->score ) . '</td>';
 			if ( $is_preview_tab ) {
 				$current_preview = isset( $row->preview_status ) ? (string) $row->preview_status : 'empty';

--- a/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
@@ -561,7 +561,7 @@ final class RecruitmentPublicShortcodeRenderer {
 	 * @param bool $is_pcd Whether the candidate is PCD.
 	 * @return string Already-escaped HTML.
 	 */
-	private static function render_subscription_badge( bool $is_pcd ): string {
+	public static function render_subscription_badge( bool $is_pcd ): string {
 		$settings = RecruitmentSettings::all();
 		$bg       = $is_pcd
 			? (string) $settings['subscription_color_pcd']


### PR DESCRIPTION
## Summary

- Notice edit page now shows a **Subscription** column on both Preliminary and Definitive classification tables. Each row gets a PCD or GERAL chip identical to the one the public list emits — same colors via `RecruitmentSettings`, same shape via the inline-styled `BadgeHtml` (no admin-CSS dependency).
- Promotes `RecruitmentPublicShortcodeRenderer::render_subscription_badge` from private to public so the admin can reuse the canonical badge instead of duplicating the markup.
- Bulk-loads the full candidate rows via `RecruitmentCandidateRepository::get_by_ids()` in one SQL round-trip, reuses the same fetch for the existing `name` lookup map → no N+1 introduced by the new column.

## Test plan

- [x] `vendor/bin/phpunit --filter Recruitment tests/Unit` — 446 tests, 0 failures
- [x] `vendor/bin/phpstan analyse` on changed files — 0 errors
- [x] `vendor/bin/phpcs` on changed files — 0 errors after `phpcbf` realignment
- [ ] On testes: open a notice with mixed PCD/GERAL candidates, confirm the column renders, verify the PCD chips match the public list color

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_