### PR TITLE
fix(recruitment-public): show translated label + configured color for `withdrew` status

### DIFF
--- a/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
+++ b/includes/recruitment/class-ffc-recruitment-public-shortcode-renderer.php
@@ -519,6 +519,7 @@ final class RecruitmentPublicShortcodeRenderer {
 			'accepted'  => __( 'Called', 'ffcertificate' ),
 			'not_shown' => __( 'Did not show up', 'ffcertificate' ),
 			'hired'     => __( 'Hired', 'ffcertificate' ),
+			'withdrew'  => __( 'Withdrew', 'ffcertificate' ),
 		);
 		return $map[ $status ] ?? $status;
 	}
@@ -652,6 +653,7 @@ final class RecruitmentPublicShortcodeRenderer {
 			'accepted'  => (string) $settings['status_color_called'],
 			'hired'     => (string) $settings['status_color_hired'],
 			'not_shown' => (string) $settings['status_color_not_shown'],
+			'withdrew'  => (string) $settings['status_color_withdrew'],
 		);
 		return BadgeHtml::render(
 			'ffc-recruitment-status-badge',


### PR DESCRIPTION
## Summary

Two parallel maps in `RecruitmentPublicShortcodeRenderer` were missing the `withdrew` enum value that V8 added to the schema:

- `status_label()` fell through `?? $status` and emitted the raw `"withdrew"` string instead of the existing pt_BR translation `Desistiu`.
- `render_status_badge()` fell back to the literal `#e9ecef` neutral instead of `status_color_withdrew` from `RecruitmentSettings`.

One row added to each map. The pt_BR.po already carries `Withdrew → Desistiu` (used by the admin list table since v6.x), so no .pot/.po regeneration needed.

## Test plan

- [x] `vendor/bin/phpunit --filter PublicShortcode tests/Unit` — 19 tests, 0 failures
- [x] `vendor/bin/phpcs` on changed file — 0 errors
- [x] `vendor/bin/phpstan analyse` on changed file — 0 errors
- [ ] On testes: a candidate in `withdrew` status on the public list shows "Desistiu" with the operator-configured pink/red color

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUEoUQmxb5d7akkVmaSVY)_