### PR TITLE
deploy(develop): retry rsync to testes on transient SSH timeout

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -76,7 +76,17 @@ jobs:
           # host na primeira conexão e exige match em conexões futuras.
           # Mais seguro que `no` (vulnerável a MITM); funciona quando o
           # `ssh-keyscan` acima falhou silenciosamente.
-          rsync -avz --delete \
+          #
+          # `ConnectTimeout` + retry: a hospedagem de testes ocasionalmente
+          # recusa/derruba a conexão (servidor reiniciando, blip de rede).
+          # Sem timeout explícito o connect espera ~2min no SYN e o deploy
+          # falha num único blip — deixando o testes numa versão antiga. Aqui
+          # cada tentativa falha rápido (30s) e o rsync (idempotente) é
+          # repetido até 3× com backoff antes de dar o build como falho.
+          SSH_CMD="ssh -i ~/.ssh/deploy_key -p $PORT -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
+          attempt=1
+          max_attempts=3
+          until rsync -avz --delete \
             --exclude='.git/' \
             --exclude='.github/' \
             --exclude='.githooks/' \
@@ -111,8 +121,18 @@ jobs:
             --exclude='CONTRIBUTING.md' \
             --exclude='SECURITY.md' \
             --exclude='html/' \
-            -e "ssh -i ~/.ssh/deploy_key -p $PORT -o StrictHostKeyChecking=accept-new" \
-            ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_PATH}/"
+            -e "$SSH_CMD" \
+            ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_PATH}/"; do
+            status=$?
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::rsync to testes failed after ${max_attempts} attempts (last exit ${status})."
+              exit "$status"
+            fi
+            backoff=$((attempt * 20))
+            echo "::warning::rsync attempt ${attempt} failed (exit ${status}); retrying in ${backoff}s…"
+            sleep "$backoff"
+            attempt=$((attempt + 1))
+          done
 
       - name: Cleanup SSH key
         if: always()


### PR DESCRIPTION
## Why

The "visual doesn't match the redesign" report traced back to a **failed deploy**, not to the code: PR #482 (the capability-panel redesign) is on `develop`, but its `Deploy develop → testes` run (#99) **failed** at the rsync step:

```
ssh: connect to host *** port ***: Connection timed out
rsync error: unexplained error (code 255) at io.c(232) [sender=3.2.7]
```

The SSH connect to the testes host timed out (a server reboot / network blip — earlier deploys with the same secrets succeeded). With no explicit `ConnectTimeout`, the single attempt waited ~2 min on the SYN and then failed the whole job, leaving the **testes domain stuck on the previous develop HEAD** (which still has the old, pre-#482 permissions UI — exactly what was on screen).

## What

Make the deploy resilient to transient connection failures:
- Add `-o ConnectTimeout=30` (+ `ServerAliveInterval`/`ServerAliveCountMax` keepalives) so a dead host **fails fast** instead of hanging ~2 min.
- Wrap the (idempotent) rsync in a **retry loop — up to 3 attempts with 20s/40s backoff** before failing the job.

No change to the excludes, the `--delete` semantics, or the TOFU host-key handling.

## Effect

Merging this triggers a fresh `develop → testes` deploy with the new retry logic, which re-syncs current `develop` HEAD (including #482's redesigned panel + editable audiences) to the testes domain. If the testes host is reachable, it lands; if it's genuinely down, the job now reports that clearly after 3 fast attempts instead of one slow hang.

> Note: a single SSH timeout is environmental — if re-runs keep timing out, the testes server itself is unreachable (host down / IP or port changed in the `TESTES_SSH_*` secrets) and needs attention on the hosting side.

Workflow-only change; targets `develop`.

https://claude.ai/code/session_011ErkuJ7jnF9zkqCkGs3qKN

---
_Generated by [Claude Code](https://claude.ai/code/session_011ErkuJ7jnF9zkqCkGs3qKN)_