### PR TITLE
Release 6.10.0 — version bump + CHANGELOG cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [6.10.0] (2026-06-05)
+
 ### Added
 
 - `ffc_administrator` aggregator role — every FFC capability (admin + end-user), but not `manage_options`, so the whole plugin can be delegated without WP super-admin (GAP F).

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.9.0
+ * Version:            6.10.0
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.9.0' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.10.0' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.9.0
+Stable tag: 6.10.0
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Prep da release **6.10.0**. Bump de `FFC_VERSION` 6.9.0 → 6.10.0 nas 3 fontes + rename `[Unreleased]` → `[6.10.0] (2026-06-05)` com novo `[Unreleased]` vazio.

Este PR só leva o bump pra `develop`; em seguida abro a **release `develop → main`** consolidando o lote.

Assets minificados verificados (sem drift). Sem mudança de código.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_