### PR TITLE
Fix two activation-time DB errors (dbDelta -- comments + audiences seed order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Activation no longer logs a malformed `ALTER TABLE … ADD COLUMN -- …` DB error: a `-- ` SQL comment that contained backtick identifiers (e.g. `` `submitted_at` ``) inside a `dbDelta()` CREATE TABLE made dbDelta's column-diff parser misread the comment as a real column. Removed the offending backtick comments from the four affected schema files (reregistration submissions, custom fields, self-scheduling, recruitment); guarded by a test that scans every dbDelta source.
+- Activation no longer logs a `Table 'ffc_audiences' doesn't exist` DB error on a fresh install: the reregistration standard-fields seeder ran before the audiences table was created, so it now skips cleanly (and re-seeds on a later load) when the table isn't present yet.
+
 ## [6.10.0] (2026-06-05)
 
 ### Added

--- a/includes/migrations/class-ffc-migration-custom-fields-tables.php
+++ b/includes/migrations/class-ffc-migration-custom-fields-tables.php
@@ -262,7 +262,6 @@ class MigrationCustomFieldsTables {
             data json DEFAULT NULL,
             status varchar(20) NOT NULL DEFAULT 'pending',
             submitted_at bigint(20) unsigned DEFAULT NULL,
-            -- `reviewed_at` is Category A (instant) since 6.6.0 — see CLAUDE.md.
             reviewed_at bigint(20) unsigned DEFAULT NULL,
             reviewed_by bigint(20) unsigned DEFAULT NULL,
             notes text DEFAULT NULL,

--- a/includes/migrations/class-ffc-migration-dynamic-rereg-fields.php
+++ b/includes/migrations/class-ffc-migration-dynamic-rereg-fields.php
@@ -161,13 +161,16 @@ class MigrationDynamicReregFields {
 		$table_name      = $wpdb->prefix . 'ffc_reregistration_submissions';
 		$charset_collate = $wpdb->get_charset_collate();
 
+		// `submitted_at` / `reviewed_at` are Category A instants since 6.6.0 (#249).
+		// Keep inline `-- ` SQL comments OUT of the dbDelta string: its column-diff
+		// parser misreads a backtick identifier inside a comment as a real column
+		// and emits a broken `ALTER TABLE … ADD COLUMN -- …` (logged DB error).
 		$sql = "CREATE TABLE {$table_name} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             reregistration_id bigint(20) unsigned NOT NULL,
             user_id bigint(20) unsigned NOT NULL,
             data json DEFAULT NULL,
             status varchar(20) NOT NULL DEFAULT 'pending',
-            -- `submitted_at`/`reviewed_at` are Category A instants since 6.6.0 (#249).
             submitted_at bigint(20) unsigned DEFAULT NULL,
             reviewed_at bigint(20) unsigned DEFAULT NULL,
             reviewed_by bigint(20) unsigned DEFAULT NULL,
@@ -222,6 +225,21 @@ class MigrationDynamicReregFields {
 			);
 		}
 
+		// Activation-order guard: on a fresh install the audiences table may not
+		// exist yet when this reregistration migration runs, and the seeder walks
+		// `ffc_audiences`. Skip cleanly (no audiences to seed yet) instead of
+		// emitting a "Table doesn't exist" DB error — the seeder re-runs on a
+		// later load once the table is present.
+		global $wpdb;
+		$audiences_table = $wpdb->prefix . 'ffc_audiences';
+		if ( ! self::table_exists( $audiences_table ) ) {
+			return array(
+				'success' => true,
+				'message' => __( 'Audiences table not ready yet (will seed on next run).', 'ffcertificate' ),
+				'seeded'  => 0,
+			);
+		}
+
 		$seeded = \FreeFormCertificate\Reregistration\ReregistrationStandardFieldsSeeder::seed_all_existing_audiences();
 
 		return array(
@@ -233,6 +251,25 @@ class MigrationDynamicReregFields {
 			),
 			'seeded'  => $seeded,
 		);
+	}
+
+	/**
+	 * Check if a table exists in the current database.
+	 *
+	 * @param string $table_name Fully-qualified table name.
+	 * @return bool
+	 */
+	private static function table_exists( string $table_name ): bool {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$found = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				DB_NAME,
+				$table_name
+			)
+		);
+		return ! empty( $found );
 	}
 
 	/**

--- a/includes/recruitment/class-ffc-recruitment-activator.php
+++ b/includes/recruitment/class-ffc-recruitment-activator.php
@@ -748,7 +748,6 @@ class RecruitmentActivator {
             out_of_order tinyint(1) NOT NULL DEFAULT 0,
             out_of_order_reason text DEFAULT NULL,
             cancellation_reason text DEFAULT NULL,
-            -- `cancelled_at` is Category A (instant) since 6.6.0 (#249 sub-escopo d).
             cancelled_at bigint(20) unsigned DEFAULT NULL,
             cancelled_by bigint(20) unsigned DEFAULT NULL,
             notes text DEFAULT NULL,

--- a/includes/self-scheduling/class-ffc-self-scheduling-activator.php
+++ b/includes/self-scheduling/class-ffc-self-scheduling-activator.php
@@ -174,7 +174,6 @@ class SelfSchedulingActivator {
             approved_at bigint(20) unsigned DEFAULT NULL,
             approved_by bigint(20) unsigned DEFAULT NULL,
 
-            -- Cancellation tracking. `cancelled_at` Category A instant since 6.6.0.
             cancelled_at bigint(20) unsigned DEFAULT NULL,
             cancelled_by bigint(20) unsigned DEFAULT NULL,
             cancellation_reason text DEFAULT NULL,
@@ -185,7 +184,6 @@ class SelfSchedulingActivator {
             -- Validation code (user-friendly code for verification, like certificates)
             validation_code varchar(20) DEFAULT NULL,
 
-            -- LGPD Consent. `consent_date` Category A instant since 6.6.0.
             consent_given tinyint(1) DEFAULT 0,
             consent_date bigint(20) unsigned DEFAULT NULL,
             consent_text text DEFAULT NULL,

--- a/tests/Unit/MigrationDynamicReregFieldsTest.php
+++ b/tests/Unit/MigrationDynamicReregFieldsTest.php
@@ -129,4 +129,49 @@ class MigrationDynamicReregFieldsTest extends TestCase {
 
         $this->assertFalse( $status['completed'] );
     }
+
+    // ==================================================================
+    // Activation-order guard: audiences table missing on a fresh install
+    // ==================================================================
+
+    public function test_seed_skips_cleanly_when_audiences_table_missing(): void {
+        // get_var() (the table-exists probe) returns null by default in setUp,
+        // so `ffc_audiences` reads as absent. The seeder must NOT be reached —
+        // otherwise it runs `SELECT id FROM wp_ffc_audiences` and logs a
+        // "Table doesn't exist" DB error on a fresh install.
+        $ref = new \ReflectionMethod( MigrationDynamicReregFields::class, 'seed_standard_fields_all_audiences' );
+        $ref->setAccessible( true );
+        $result = $ref->invoke( null );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 0, $result['seeded'] );
+    }
+
+    // ==================================================================
+    // dbDelta SQL hygiene — no backtick identifiers inside `-- ` comments
+    // ==================================================================
+
+    public function test_dbdelta_create_table_sql_has_no_backtick_inline_comments(): void {
+        // A standalone `-- ` SQL comment that contains a backtick identifier
+        // makes dbDelta's column-diff parser misread it as a real column and
+        // emit a broken `ALTER TABLE … ADD COLUMN -- …` (logged DB error on
+        // every activation). Guard every dbDelta source against re-introduction.
+        $files = array(
+            __DIR__ . '/../../includes/migrations/class-ffc-migration-dynamic-rereg-fields.php',
+            __DIR__ . '/../../includes/migrations/class-ffc-migration-custom-fields-tables.php',
+            __DIR__ . '/../../includes/self-scheduling/class-ffc-self-scheduling-activator.php',
+            __DIR__ . '/../../includes/recruitment/class-ffc-recruitment-activator.php',
+        );
+        foreach ( $files as $file ) {
+            $this->assertFileExists( $file );
+            $lines = file( $file );
+            foreach ( $lines as $i => $line ) {
+                $this->assertDoesNotMatchRegularExpression(
+                    '/^\s*--\s.*`/',
+                    $line,
+                    sprintf( '%s line %d: a backtick in a dbDelta `-- ` comment breaks dbDelta parsing', basename( $file ), $i + 1 )
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## O que

Corrige **dois erros de DB na ativação** (pré-existentes, vistos no log do testes) — nenhum dos dois é da release 6.10.0.

### 1. `ALTER TABLE … ADD COLUMN -- …` malformado
Vários `CREATE TABLE` que vão pro `dbDelta()` tinham um comentário SQL `-- ` **standalone** cujo corpo continha identificadores em crase (ex.: `` `submitted_at` ``/`` `reviewed_at` ``). O parser de diff de colunas do dbDelta lê a crase dentro do comentário como se fosse uma coluna real e emite um `ADD COLUMN` quebrado → erro logado em toda ativação. Removidos os 4 comentários `-- ` com crase (activators de **reregistration submissions, custom fields, self-scheduling, recruitment**). Mesma classe do fix da 6.0.1 (que removeu `COMMENT '…'` que o dbDelta também não parseia). Os comentários `-- ` **sem crase** foram mantidos (não quebram e documentam).

### 2. `Table 'ffc_audiences' doesn't exist`
Em install novo, o seeder de campos-padrão de reregistration (`seed_standard_fields_all_audiences`) varria a tabela de audiences **antes** dela ser criada. Adicionado um guard de ordem-de-ativação (`table_exists`): pula limpo (e re-semeia num load posterior) quando a tabela ainda não existe, em vez de consultar tabela inexistente.

## Testes
- Scan de higiene do dbDelta: proíbe comentário `-- \`…\`` em todos os 4 arquivos de schema (trava regressão).
- Guard do seed em install novo (skip limpo, `seeded: 0`).
- `MigrationDynamicReregFieldsTest` verde (8 testes); PHPStan/WPCS limpos.

## Contexto — os outros 2 erros do log são da hospedagem, não código
- **`CapabilityManager not found` na ativação:** estado transitório de deploy (a classe carrega 100% no `develop`; a 2ª ativação 2min depois passou desse ponto). Auto-cura num deploy completo.
- **`Invalid regular expression` (JS):** artefato do **LiteSpeed** (Load Delayed JS + Combine re-minificando). Todos os nossos `.min.js` passam no `node --check` (JS válido). Mitigação: excluir os scripts `ffc-*` do JS Combine/Delay do LiteSpeed no painel da hospedagem.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_