### PR TITLE
Email tab: seed a default message body when the user-email is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Form editor → Email tab: enabling "Send Email to User" now seeds the message editor with a default body (a friendly `{{name}}` intro) instead of a blank field, so operators start from a ready template they can keep or edit. A form that already has a custom message keeps it untouched.
+
 ### Fixed
 
 - Activation no longer logs a malformed `ALTER TABLE … ADD COLUMN -- …` DB error: a `-- ` SQL comment that contained backtick identifiers (e.g. `` `submitted_at` ``) inside a `dbDelta()` CREATE TABLE made dbDelta's column-diff parser misread the comment as a real column. Removed the offending backtick comments from the four affected schema files (reregistration submissions, custom fields, self-scheduling, recruitment); guarded by a test that scans every dbDelta source.

--- a/includes/admin/class-ffc-form-editor-email-metabox.php
+++ b/includes/admin/class-ffc-form-editor-email-metabox.php
@@ -36,10 +36,12 @@ class FormEditorEmailMetabox {
 		$subject    = isset( $config['email_subject'] ) ? $config['email_subject'] : __( 'Your Certificate', 'ffcertificate' );
 		$body       = isset( $config['email_body'] ) ? (string) $config['email_body'] : '';
 		// When the email is enabled but no custom message was written yet, seed
-		// the editor with a sensible default so the operator starts from a
-		// ready template instead of a blank field. `wp_strip_all_tags` treats a
-		// cleared TinyMCE body (`<p></p>`) as empty too.
-		if ( '' === trim( wp_strip_all_tags( $body ) ) ) {
+		// the editor with a sensible default so the operator starts from a ready
+		// template instead of a blank field. Strip tags / &nbsp; / whitespace
+		// with a native preg_replace (no WP function dependency, so every test
+		// that renders this metabox doesn't need to stub one) so a cleared
+		// TinyMCE body (`<p></p>`) also counts as empty.
+		if ( '' === (string) preg_replace( '/<[^>]*>|&nbsp;|\s+/', '', $body ) ) {
 			$body = self::default_email_body();
 		}
 		$collapsed = ( '1' !== (string) $send_email );

--- a/includes/admin/class-ffc-form-editor-email-metabox.php
+++ b/includes/admin/class-ffc-form-editor-email-metabox.php
@@ -34,8 +34,15 @@ class FormEditorEmailMetabox {
 		$config     = get_post_meta( $post->ID, '_ffc_form_config', true );
 		$send_email = isset( $config['send_user_email'] ) ? $config['send_user_email'] : '0';
 		$subject    = isset( $config['email_subject'] ) ? $config['email_subject'] : __( 'Your Certificate', 'ffcertificate' );
-		$body       = isset( $config['email_body'] ) ? $config['email_body'] : '';
-		$collapsed  = ( '1' !== (string) $send_email );
+		$body       = isset( $config['email_body'] ) ? (string) $config['email_body'] : '';
+		// When the email is enabled but no custom message was written yet, seed
+		// the editor with a sensible default so the operator starts from a
+		// ready template instead of a blank field. `wp_strip_all_tags` treats a
+		// cleared TinyMCE body (`<p></p>`) as empty too.
+		if ( '' === trim( wp_strip_all_tags( $body ) ) ) {
+			$body = self::default_email_body();
+		}
+		$collapsed = ( '1' !== (string) $send_email );
 		?>
 		<table class="form-table">
 			<tr>
@@ -115,5 +122,19 @@ class FormEditorEmailMetabox {
 		</table>
 		</div><!-- /.ffc-collapsed-target -->
 		<?php
+	}
+
+	/**
+	 * Default user-email body (custom message) seeded into the editor when a
+	 * form enables the email without a message of its own. Complements the
+	 * fixed email chrome (heading, authentication-code card, view/download
+	 * button) that {@see \FreeFormCertificate\Integrations\EmailHandler}
+	 * already builds — so this is just a friendly intro, not the whole email.
+	 *
+	 * @return string Default email body HTML (with `{{name}}` placeholder).
+	 */
+	public static function default_email_body(): string {
+		return '<p>' . __( 'Hello {{name}},', 'ffcertificate' ) . '</p>'
+			. '<p>' . __( 'Your certificate has been issued. Use the button below to view and download it, and keep your authentication code for future verification.', 'ffcertificate' ) . '</p>';
 	}
 }

--- a/tests/Unit/FormEditorEmailMetaboxTest.php
+++ b/tests/Unit/FormEditorEmailMetaboxTest.php
@@ -32,9 +32,6 @@ class FormEditorEmailMetaboxTest extends TestCase {
         Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
         Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
         Functions\when( 'wp_kses_post' )->returnArg();
-        Functions\when( 'wp_strip_all_tags' )->alias( function ( $s ) {
-            return trim( strip_tags( (string) $s ) );
-        } );
         Functions\when( 'wp_editor' )->alias( function ( $content, $id ) {
             echo '<textarea id="' . $id . '">' . $content . '</textarea>';
         } );

--- a/tests/Unit/FormEditorEmailMetaboxTest.php
+++ b/tests/Unit/FormEditorEmailMetaboxTest.php
@@ -32,6 +32,9 @@ class FormEditorEmailMetaboxTest extends TestCase {
         Functions\when( 'admin_url' )->alias( function ( $p = '' ) { return '/wp-admin/' . $p; } );
         Functions\when( 'esc_html_e' )->alias( function ( $text ) { echo $text; } );
         Functions\when( 'wp_kses_post' )->returnArg();
+        Functions\when( 'wp_strip_all_tags' )->alias( function ( $s ) {
+            return trim( strip_tags( (string) $s ) );
+        } );
         Functions\when( 'wp_editor' )->alias( function ( $content, $id ) {
             echo '<textarea id="' . $id . '">' . $content . '</textarea>';
         } );
@@ -88,5 +91,27 @@ class FormEditorEmailMetaboxTest extends TestCase {
         $html = $this->render();
 
         $this->assertStringContainsString( 'Your Certificate', $html );
+    }
+
+    public function test_render_seeds_default_body_when_email_body_empty(): void {
+        // Email enabled, no custom body yet → editor is pre-filled with the
+        // default intro instead of a blank field.
+        $html = $this->render( array( 'send_user_email' => '1' ) );
+
+        $this->assertStringContainsString( FormEditorEmailMetabox::default_email_body(), $html );
+        $this->assertStringContainsString( 'Hello {{name}},', $html );
+    }
+
+    public function test_render_keeps_custom_body_over_default(): void {
+        // A real custom body is preserved (not overwritten by the default).
+        $html = $this->render(
+            array(
+                'send_user_email' => '1',
+                'email_body'      => '<p>My own message</p>',
+            )
+        );
+
+        $this->assertStringContainsString( '<p>My own message</p>', $html );
+        $this->assertStringNotContainsString( 'Use the button below to view and download it', $html );
     }
 }


### PR DESCRIPTION
## O que

Na aba **Email** do editor (`&action=edit#ffc-tab-email`), ao ativar "Send Email to User" sem corpo definido, o editor ficava **em branco**. Agora ele é **pré-preenchido com um texto padrão** (uma intro amigável usando `{{name}}`) quando o corpo armazenado está vazio (um TinyMCE limpo, `<p></p>`, também conta como vazio).

## Detalhes

- Novo `FormEditorEmailMetabox::default_email_body()` — o padrão complementa o "chrome" fixo do email (título, card do código de autenticação, botão de ver/baixar) que o `EmailHandler` já monta; é só uma intro, não o email inteiro.
- Forms com **mensagem custom** ficam intactos (o padrão só entra quando vazio).
- O `subject` já tinha default (`"Your Certificate"`); agora o body também.

## Testes
- Default semeado quando o body está vazio; body custom preservado. 6 testes verdes; PHPStan/WPCS limpos.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_