### PR TITLE
Audience bookings: render wall-clock dates/times without TZ shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Audience bookings: wall-clock `booking_date`/`start_time`/`end_time` no longer shift by the site UTC offset on display — the admin bookings list, the user-dashboard bookings REST response (and its `is_past` flag, now a site-local date comparison), and the booking created/cancelled e-mails all render the literal value via `format_wallclock_date()`/`format_wallclock_time()`. (Same class as the self-scheduling/holiday fix; the audience JS already handled times correctly.)
 - Self-scheduling: wall-clock `appointment_date`/`start_time`/`end_time` no longer shift by the site UTC offset on display — new `DateFormatter::format_wallclock_date()`/`format_wallclock_time()` render the literal value across every self-scheduling display (instant API unchanged).
 - Scheduling Settings → Holidays: global and per-calendar holiday dates no longer display one day early on sub-UTC sites — both lists render the wall-clock DATE via `format_wallclock_date()`.
 - Certificate preview (form editor + operator page) no longer crops borders — renders at the real PDF page size (A4, landscape default) and scales the whole frame to fit the modal, preserving aspect (recomputes on resize).

--- a/includes/api/class-ffc-user-audience-rest-controller.php
+++ b/includes/api/class-ffc-user-audience-rest-controller.php
@@ -139,20 +139,24 @@ class UserAudienceRestController {
 			foreach ( $bookings as $booking ) {
 				$date_formatted = '';
 				if ( ! empty( $booking['booking_date'] ) ) {
-					$timestamp      = strtotime( $booking['booking_date'] );
-					$date_formatted = ( false !== $timestamp ) ? \FreeFormCertificate\Core\DateFormatter::format_date( $timestamp ) : $booking['booking_date'];
+					// booking_date is a wall-clock DATE (Category B) — render literally, no TZ shift.
+					$date_formatted = \FreeFormCertificate\Core\DateFormatter::format_wallclock_date( (string) $booking['booking_date'] );
+					if ( '' === $date_formatted ) {
+						$date_formatted = (string) $booking['booking_date'];
+					}
 				}
 
 				$time_formatted = '';
 				if ( ! empty( $booking['start_time'] ) ) {
-					$time_timestamp = strtotime( $booking['start_time'] );
-					$time_formatted = ( false !== $time_timestamp ) ? \FreeFormCertificate\Core\DateFormatter::format_time( $time_timestamp ) : $booking['start_time'];
+					$time_formatted = \FreeFormCertificate\Core\DateFormatter::format_wallclock_time( (string) $booking['start_time'] );
+					if ( '' === $time_formatted ) {
+						$time_formatted = (string) $booking['start_time'];
+					}
 				}
 
 				$end_time_formatted = '';
 				if ( ! empty( $booking['end_time'] ) ) {
-					$end_timestamp      = strtotime( $booking['end_time'] );
-					$end_time_formatted = ( false !== $end_timestamp ) ? \FreeFormCertificate\Core\DateFormatter::format_time( $end_timestamp ) : '';
+					$end_time_formatted = \FreeFormCertificate\Core\DateFormatter::format_wallclock_time( (string) $booking['end_time'] );
 				}
 
 				$status_labels = array(
@@ -161,7 +165,7 @@ class UserAudienceRestController {
 				);
 
 				$status  = $booking['status'] ?? 'active';
-				$is_past = strtotime( $booking['booking_date'] ) < strtotime( 'today' );
+				$is_past = (string) $booking['booking_date'] < current_time( 'Y-m-d' );
 
 				$bookings_formatted[] = array(
 					'id'               => (int) $booking['id'],

--- a/includes/audience/class-ffc-audience-admin-bookings.php
+++ b/includes/audience/class-ffc-audience-admin-bookings.php
@@ -192,8 +192,8 @@ class AudienceAdminBookings {
 							?>
 							<tr>
 								<td><?php echo esc_html( $booking->id ); ?></td>
-								<td><?php echo esc_html( \FreeFormCertificate\Core\DateFormatter::format_date( $booking->booking_date ) ); ?></td>
-								<td><?php echo esc_html( \FreeFormCertificate\Core\DateFormatter::format_time( $booking->start_time ) . ' - ' . \FreeFormCertificate\Core\DateFormatter::format_time( $booking->end_time ) ); ?></td>
+								<td><?php echo esc_html( \FreeFormCertificate\Core\DateFormatter::format_wallclock_date( $booking->booking_date ) ); ?></td>
+								<td><?php echo esc_html( \FreeFormCertificate\Core\DateFormatter::format_wallclock_time( $booking->start_time ) . ' - ' . \FreeFormCertificate\Core\DateFormatter::format_wallclock_time( $booking->end_time ) ); ?></td>
 								<td><?php echo esc_html( $booking->environment_name ); ?></td>
 								<td><?php echo esc_html( wp_trim_words( $booking->description, 10 ) ); ?></td>
 								<td>

--- a/includes/audience/class-ffc-audience-notification-handler.php
+++ b/includes/audience/class-ffc-audience-notification-handler.php
@@ -398,22 +398,25 @@ class AudienceNotificationHandler {
 	}
 
 	/**
-	 * Format date for display.
-	 * Delegates to EmailTemplateService::format_date().
+	 * Format a wall-clock booking date for display.
 	 *
-	 * @param string $date Date.
+	 * `booking_date` is a Category B wall-clock DATE — render the literal value
+	 * with no timezone conversion (passing it through the instant API would
+	 * parse it as UTC midnight and re-apply wp_timezone(), rolling the date
+	 * back a day on sub-UTC sites).
+	 *
+	 * @param string $date Wall-clock date string (Y-m-d).
 	 */
 	private static function format_date( string $date ): string {
-		return \FreeFormCertificate\Scheduling\EmailTemplateService::format_date( $date );
+		return \FreeFormCertificate\Core\DateFormatter::format_wallclock_date( $date );
 	}
 
 	/**
-	 * Format time for display.
-	 * Delegates to EmailTemplateService::format_time().
+	 * Format a wall-clock booking time for display (Category B, no TZ shift).
 	 *
-	 * @param string $time Time.
+	 * @param string $time Wall-clock time string (H:i:s).
 	 */
 	private static function format_time( string $time ): string {
-		return \FreeFormCertificate\Scheduling\EmailTemplateService::format_time( $time );
+		return \FreeFormCertificate\Core\DateFormatter::format_wallclock_time( $time );
 	}
 }

--- a/tests/Unit/UserAudienceRestControllerTest.php
+++ b/tests/Unit/UserAudienceRestControllerTest.php
@@ -178,6 +178,60 @@ class UserAudienceRestControllerTest extends TestCase {
         $this->assertEmpty( $result['bookings'] );
     }
 
+    public function test_get_user_audience_bookings_renders_wall_clock_without_tz_shift(): void {
+        // Regression: booking_date/start_time/end_time are wall-clock (Category B)
+        // values. On a UTC-3 site they must render literally — a 05/06 09:00–17:00
+        // booking must NOT shift to 04/06 06:00–14:00. Drives a real booking row
+        // through the controller with a timezone-honouring wp_date stub.
+        $prev_tz = date_default_timezone_get(); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_get
+        date_default_timezone_set( 'UTC' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set
+
+        Functions\when( 'get_current_user_id' )->justReturn( 5 );
+        Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'current_time' )->justReturn( '2026-06-06' );
+        Functions\when( 'get_option' )->alias( function ( $key, $default = false ) {
+            return 'ffc_settings' === $key ? array() : ( false !== $default ? $default : '' );
+        } );
+        Functions\when( 'wp_timezone' )->alias( static function () {
+            return new \DateTimeZone( '-03:00' );
+        } );
+        Functions\when( 'wp_date' )->alias( static function ( $format, $ts = null, $tz = null ) {
+            $ts = null === $ts ? time() : (int) $ts;
+            $dt = ( new \DateTimeImmutable( '@' . $ts ) )->setTimezone(
+                $tz instanceof \DateTimeZone ? $tz : new \DateTimeZone( 'UTC' )
+            );
+            return $dt->format( $format );
+        } );
+
+        $booking_row = array(
+            'id'               => 1,
+            'booking_date'     => '2026-06-05',
+            'start_time'       => '09:00:00',
+            'end_time'         => '17:00:00',
+            'status'           => 'active',
+            'environment_id'   => 2,
+            'environment_name' => 'Env',
+            'schedule_name'    => 'Sched',
+            'description'      => '',
+        );
+        // 1st get_results = the booking; 2nd = audience batch-load (empty).
+        $this->wpdb->shouldReceive( 'get_results' )->andReturn( array( $booking_row ), array() );
+
+        $ctrl    = new UserAudienceRestController( 'ffc/v1' );
+        $result  = $ctrl->get_user_audience_bookings( $this->make_request() );
+
+        date_default_timezone_set( $prev_tz ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set
+
+        $this->assertIsArray( $result );
+        $this->assertNotEmpty( $result['bookings'] );
+        $row = $result['bookings'][0];
+        $this->assertSame( '05/06/2026', $row['booking_date'], 'date must not shift back a day' );
+        $this->assertSame( '09:00', $row['start_time'], 'start time must not shift' );
+        $this->assertSame( '17:00', $row['end_time'], 'end time must not shift' );
+        $this->assertSame( '2026-06-05', $row['booking_date_raw'] );
+        $this->assertTrue( $row['is_past'], '2026-06-05 is before site-local today 2026-06-06' );
+    }
+
     // ------------------------------------------------------------------
     // get_joinable_groups()
     // ------------------------------------------------------------------


### PR DESCRIPTION
Audit you requested — the **`ffc_audience` booking subsystem** for the same wall-clock-vs-instant timezone bug class fixed earlier in self-scheduling/holidays.

## Confirmed bugs (fixed)
`booking_date` (DATE), `start_time`/`end_time` (TIME) are Category B wall-clock columns, but were rendered through the instant API (`strtotime` + `DateFormatter::format_date/format_time`), so on a **UTC-3 site** a 05/06 09:00–17:00 booking displayed as **04/06 06:00–14:00**:

| Surface | File |
|---|---|
| Admin bookings list | `class-ffc-audience-admin-bookings.php` |
| User-dashboard bookings REST | `class-ffc-user-audience-rest-controller.php` |
| Booking created/cancelled e-mails | `class-ffc-audience-notification-handler.php` (private `format_date`/`format_time` wrappers) |

All now use `format_wallclock_date()` / `format_wallclock_time()`. Also fixed the REST **`is_past`** flag: was `strtotime($booking_date) < strtotime('today')` (skews near midnight on offset sites) → now a site-local `'Y-m-d'` string comparison via `current_time()`.

## Already correct (no change)
- **Holiday lists** (global + per-calendar) — fixed in #516.
- **REST raw response** (`class-ffc-audience-rest-controller.php`) returns raw wall-clock strings; the **audience JS** (`ffc-audience.js`/`ffc-audience-calendar.js`) `formatTime()` is a `substring(0,5)` and `parseDate()` builds a local `Date` from Y/M/D integers — neither shifts.
- **ICS generation** uses the `*_raw` values.
- Housekeeping `created_at`/`updated_at`/`cancelled_at` (DATETIME instants) — correct as-is.

## Verification
New `UserAudienceRestControllerTest` regression test drives a booking through under a UTC-3 site (timezone-honouring `wp_date` stub) and asserts `05/06/2026` / `09:00` / `17:00` with no shift + `is_past` correct. Full audience + REST suites green; PHPStan L8 + WPCS clean. PHP-only (no bundle change).

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_