### PR TITLE
test(js): deep-cover audience-calendar cluster (last sub-50% files) + floor 82→85

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,9 +59,15 @@ jobs:
       # 0%→100% and ffc-csv-extend-end 7.7%→98.5% (the two remaining
       # near-0% shipped files). Overall 84.0%→85.05% — real per-file
       # gains banked, but still a hair under the 85.53% high-water, so the
-      # floor stays 82 here; the audience-cluster follow-up (booking-form,
-      # bookings, audience) is expected to clear the high-water and bump.
-      JS_COVERAGE_FLOOR_LINES: '82'
+      # floor stayed 82 there; the audience-cluster follow-up clears it.
+      #
+      # Audience-cluster follow-up: ffc-audience 36%→71%, ffc-audience-
+      # bookings 28%→99%, ffc-audience-booking-form 13%→91%. Overall
+      # statement coverage → ~88% (clover 87.8–88.9% across runs; v8 async
+      # jitter ~1pp), clearing the 85.53% high-water. Bumping 82 → 85 with
+      # a ~2.8pp buffer over the lowest run (≤5pp floor-buffer policy —
+      # see CLAUDE.md).
+      JS_COVERAGE_FLOOR_LINES: '85'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/tests/js/audience-booking-form.test.js
+++ b/tests/js/audience-booking-form.test.js
@@ -1,0 +1,323 @@
+// Deep coverage for assets/js/ffc-audience-booking-form.js — the booking
+// modal: open/reset + environment-select population, user search, the
+// selected-users chips, form validation, form-data extraction, the
+// conflict check (hard / soft-audience / soft-user / none / error) and
+// the create-booking flow. Drives the methods registered on
+// window.FFCAudience by the module.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+let api;
+
+beforeAll(() => {
+	window.ffcAudience = {
+		ajaxUrl: '/wp-admin/admin-ajax.php',
+		restUrl: '/wp-json/ffc/v1/audience/',
+		nonce: 'n',
+		searchUsersNonce: 'su-nonce',
+		locale: 'pt_BR',
+		strings: {
+			createBooking: 'Create booking',
+			loading: 'Loading…',
+			error: 'Error',
+			invalidTime: 'End must be after start.',
+			fillTimeFields: 'Please fill in the time fields.',
+			descriptionRequired: 'Description must be 15–300 chars.',
+			selectAudience: 'Select an audience.',
+			selectUser: 'Select a user.',
+			hardConflict: 'Already booked for this environment.',
+			audienceSameDayWarning: 'This audience already has a booking today:',
+			membersOverlapping: 'member(s) overlap.',
+			bookingCreated: 'Booking created.',
+			timeout: 'Timed out.',
+		},
+	};
+	window.ffc_ajax = { ajax_url: '/wp-admin/admin-ajax.php', nonce: 'n', strings: {} };
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-audience.js');
+	loadScript('assets/js/ffc-audience-booking-form.js');
+	api = window.FFCAudience;
+});
+
+function modalFixture() {
+	document.body.innerHTML = `
+		<form id="ffc-booking-form">
+			<div id="ffc-booking-modal" style="display:none">
+				<button class="ffc-modal-close">x</button>
+				<input type="checkbox" id="booking-all-day" />
+				<div id="booking-time-row"></div>
+				<input id="booking-start-time" value="09:00" />
+				<input id="booking-end-time" value="10:00" />
+				<input id="booking-date" />
+				<span class="ffc-booking-date-display"></span>
+				<select id="booking-environment-id"></select>
+				<label for="booking-environment-id">Env *</label>
+				<select id="booking-type">
+					<option value="audience">Audience</option>
+					<option value="users">Users</option>
+				</select>
+				<select id="booking-audiences" multiple><option value="11">Sub</option></select>
+				<input id="booking-user-search" />
+				<div id="booking-user-results"></div>
+				<div id="booking-selected-users"></div>
+				<input id="booking-user-ids" />
+				<textarea id="booking-description">A valid description here</textarea>
+				<span id="desc-char-count"></span>
+				<div id="ffc-conflict-warning" style="display:none"><div id="ffc-conflict-details"></div></div>
+				<div id="ffc-conflict-error" style="display:none"><div id="ffc-conflict-error-details"></div></div>
+				<input type="checkbox" id="ffc-conflict-acknowledge" />
+				<button id="ffc-check-conflicts-btn">Check</button>
+				<button id="ffc-create-booking-btn" style="display:none">Create</button>
+			</div>
+		</form>
+	`;
+}
+
+// Fill a valid audience-type booking so validate passes.
+function setValidAudienceForm() {
+	window.$('#booking-all-day').prop('checked', false);
+	window.$('#booking-start-time').val('09:00');
+	window.$('#booking-end-time').val('10:00');
+	window.$('#booking-description').val('A valid description here');
+	window.$('#booking-type').val('audience');
+	window.$('#booking-audiences').val(['11']);
+	window.$('#booking-environment-id').html('<option value="10">A</option>').val('10');
+	window.$('#booking-date').val('2026-06-10');
+}
+
+beforeEach(() => {
+	window.$.fx.off = true;
+	modalFixture();
+	api.state.config = {
+		selectedSchedule: 0,
+		audiences: [{ id: 1, name: 'Group', children: [{ id: 11, name: 'Sub' }] }],
+		schedules: [
+			{ id: 1, name: 'Sched A', environmentLabel: 'Room', environments: [
+				{ id: 10, name: 'Env A' }, { id: 20, name: 'Env B' },
+			] },
+		],
+	};
+	api.state.selectedSchedule = 0;
+	api.state.selectedEnvironment = 0;
+	api.state.selectedUsers = {};
+	api.closeModals = vi.fn();
+	api.renderCalendar = vi.fn();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('ffc-audience-booking-form — openBookingModal', () => {
+	it('populates the environment select, sets the date display and shows the modal', () => {
+		api.openBookingModal('2026-06-10');
+		const $opts = window.$('#booking-environment-id option');
+		expect($opts.length).toBe(2); // two environments
+		expect(window.$('.ffc-booking-date-display').text().length).toBeGreaterThan(0);
+		expect(window.$('#ffc-booking-modal').css('display')).not.toBe('none');
+		expect(window.$('#booking-date').val()).toBe('2026-06-10');
+		// Single schedule with environmentLabel relabels the env field.
+		expect(window.$('label[for="booking-environment-id"]').html()).toContain('Room');
+	});
+
+	it('pre-selects the passed environment id', () => {
+		api.openBookingModal('2026-06-10', '20');
+		expect(window.$('#booking-environment-id').val()).toBe('20');
+	});
+});
+
+describe('ffc-audience-booking-form — updateSelectedUsers', () => {
+	it('renders a chip per selected user and fills the hidden ids field', () => {
+		api.state.selectedUsers = { 5: 'Alice', 7: 'Bob' };
+		api.updateSelectedUsers();
+		expect(window.$('#booking-selected-users .ffc-selected-user').length).toBe(2);
+		expect(window.$('#booking-user-ids').val()).toBe('5,7');
+	});
+});
+
+describe('ffc-audience-booking-form — searchUsers', () => {
+	it('renders matching users, skipping already-selected ones', async () => {
+		api.state.selectedUsers = { 7: 'Bob' };
+		vi.spyOn(window.FFC, 'request').mockResolvedValue([
+			{ id: 5, name: 'Alice', email: 'a@x.test' },
+			{ id: 7, name: 'Bob', email: 'b@x.test' }, // already selected → skipped
+		]);
+		api.searchUsers('al');
+		await Promise.resolve().then(() => Promise.resolve());
+		const $results = window.$('#booking-user-results .ffc-user-result');
+		expect($results.length).toBe(1);
+		expect($results.attr('data-id')).toBe('5');
+		expect(window.$('#booking-user-results').hasClass('active')).toBe(true);
+	});
+
+	it('clears the results when the search returns nothing', async () => {
+		vi.spyOn(window.FFC, 'request').mockResolvedValue([]);
+		window.$('#booking-user-results').addClass('active').html('<div>old</div>');
+		api.searchUsers('zzz');
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#booking-user-results').hasClass('active')).toBe(false);
+		expect(window.$('#booking-user-results').html()).toBe('');
+	});
+
+	it('clears the results on a request rejection', async () => {
+		vi.spyOn(window.FFC, 'request').mockRejectedValue(new Error('net'));
+		window.$('#booking-user-results').addClass('active').html('<div>old</div>');
+		api.searchUsers('x');
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#booking-user-results').hasClass('active')).toBe(false);
+	});
+});
+
+describe('ffc-audience-booking-form — validation guards (via checkConflicts)', () => {
+	it('blocks when time fields are empty', () => {
+		setValidAudienceForm();
+		window.$('#booking-start-time').val('');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		const restSpy = vi.spyOn(window.FFC, 'rest');
+		api.checkConflicts();
+		expect(alertSpy).toHaveBeenCalledWith('Please fill in the time fields.');
+		expect(restSpy).not.toHaveBeenCalled();
+	});
+
+	it('blocks when start >= end', () => {
+		setValidAudienceForm();
+		window.$('#booking-end-time').val('09:00');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		api.checkConflicts();
+		expect(alertSpy).toHaveBeenCalledWith('End must be after start.');
+	});
+
+	it('blocks when the description is too short', () => {
+		setValidAudienceForm();
+		window.$('#booking-description').val('too short');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		api.checkConflicts();
+		expect(alertSpy).toHaveBeenCalledWith('Description must be 15–300 chars.');
+	});
+
+	it('blocks an audience booking with no audience selected', () => {
+		setValidAudienceForm();
+		window.$('#booking-audiences').val([]);
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		api.checkConflicts();
+		expect(alertSpy).toHaveBeenCalledWith('Select an audience.');
+	});
+
+	it('blocks a user booking with no users selected', () => {
+		setValidAudienceForm();
+		window.$('#booking-type').val('users');
+		window.$('#booking-user-ids').val('');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		api.checkConflicts();
+		expect(alertSpy).toHaveBeenCalledWith('Select a user.');
+	});
+
+	it('skips time validation for an all-day booking', () => {
+		setValidAudienceForm();
+		window.$('#booking-all-day').prop('checked', true);
+		window.$('#booking-start-time').val(''); // ignored when all-day
+		const restSpy = vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: true, conflicts: {} });
+		api.checkConflicts();
+		expect(restSpy).toHaveBeenCalled();
+		// getBookingFormData substitutes the all-day window.
+		expect(restSpy.mock.calls[0][1].data.start_time).toBe('00:00');
+		expect(restSpy.mock.calls[0][1].data.end_time).toBe('23:59');
+	});
+});
+
+describe('ffc-audience-booking-form — checkConflicts outcomes', () => {
+	beforeEach(setValidAudienceForm);
+
+	it('shows the hard-conflict error and hides the create button', async () => {
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({
+			success: true,
+			conflicts: { type: 'environment', bookings: [{ start_time: '09:00', end_time: '10:00' }] },
+		});
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#ffc-conflict-error').css('display')).not.toBe('none');
+		expect(window.$('#ffc-conflict-error-details').html()).toContain('09:00');
+		expect(window.$('#ffc-create-booking-btn').css('display')).toBe('none');
+	});
+
+	it('shows a soft audience-same-day warning and a disabled create button', async () => {
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({
+			success: true,
+			conflicts: { audience_same_day: [{ audience_name: 'Sub', start_time: '11:00', end_time: '12:00' }] },
+		});
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#ffc-conflict-warning').css('display')).not.toBe('none');
+		expect(window.$('#ffc-conflict-details').html()).toContain('Sub');
+		expect(window.$('#ffc-create-booking-btn').prop('disabled')).toBe(true);
+	});
+
+	it('shows a soft user-overlap warning', async () => {
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({
+			success: true,
+			conflicts: { type: 'user', bookings: [{}], affected_users: [1, 2] },
+		});
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#ffc-conflict-warning').css('display')).not.toBe('none');
+		expect(window.$('#ffc-conflict-details').html()).toContain('2 member(s) overlap.');
+	});
+
+	it('enables create directly when there is no conflict', async () => {
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: true, conflicts: {} });
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(window.$('#ffc-create-booking-btn').css('display')).not.toBe('none');
+		expect(window.$('#ffc-create-booking-btn').prop('disabled')).toBe(false);
+	});
+
+	it('alerts when the server reports failure', async () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: false, message: 'Bad' });
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(alertSpy).toHaveBeenCalledWith('Bad');
+	});
+
+	it('alerts on a rejected conflict request', async () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(window.FFC, 'rest').mockRejectedValue({ message: 'boom', xhr: null });
+		api.checkConflicts();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(alertSpy).toHaveBeenCalledWith('Error');
+	});
+});
+
+describe('ffc-audience-booking-form — createBooking', () => {
+	beforeEach(setValidAudienceForm);
+
+	it('POSTs the booking and closes the modal on success', async () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		const restSpy = vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: true });
+		api.createBooking();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(restSpy.mock.calls[0][0]).toContain('/bookings');
+		expect(restSpy.mock.calls[0][1].method).toBe('POST');
+		expect(alertSpy).toHaveBeenCalledWith('Booking created.');
+		expect(api.closeModals).toHaveBeenCalled();
+		expect(api.renderCalendar).toHaveBeenCalled();
+	});
+
+	it('re-enables the button and alerts on a server failure', async () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: false, message: 'Nope' });
+		api.createBooking();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(alertSpy).toHaveBeenCalledWith('Nope');
+		expect(window.$('#ffc-create-booking-btn').prop('disabled')).toBe(false);
+	});
+
+	it('alerts on a rejected create request', async () => {
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(window.FFC, 'rest').mockRejectedValue(new Error('net'));
+		api.createBooking();
+		await Promise.resolve().then(() => Promise.resolve());
+		expect(alertSpy).toHaveBeenCalledWith('Error');
+	});
+});

--- a/tests/js/audience-bookings.test.js
+++ b/tests/js/audience-bookings.test.js
@@ -1,0 +1,178 @@
+// Deep coverage for assets/js/ffc-audience-bookings.js — the day modal,
+// day-bookings list rendering (active/cancelled/all-day/timed, audience
+// tags, cancel action gating) and the cancel-booking flow. Drives the
+// methods registered back on window.FFCAudience by the module.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadScript } from './helpers.js';
+
+let api;
+
+beforeAll(() => {
+	window.ffcAudience = {
+		ajaxUrl: '/wp-admin/admin-ajax.php',
+		restUrl: '/wp-json/ffc/v1/audience/',
+		nonce: 'n',
+		locale: 'pt_BR',
+		strings: {
+			booking: 'booking', bookings: 'bookings',
+			noBookings: 'No bookings for this day.',
+			noActiveBookings: 'No active bookings for this day.',
+			allDay: 'All Day',
+			cancelled: 'Cancelled',
+			cancel: 'Cancel',
+			cancelReason: 'Reason?',
+			bookingCancelled: 'Booking cancelled.',
+			error: 'Error',
+			environmentLabel: 'Environment',
+		},
+	};
+	window.ffc_ajax = { ajax_url: '/wp-admin/admin-ajax.php', nonce: 'n', strings: {} };
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-audience.js');
+	loadScript('assets/js/ffc-audience-bookings.js');
+	api = window.FFCAudience;
+});
+
+function dayModalFixture() {
+	document.body.innerHTML = `
+		<div id="ffc-day-modal" style="display:none">
+			<div class="ffc-day-modal-title"></div>
+			<button class="ffc-modal-close">x</button>
+			<input type="checkbox" id="ffc-show-cancelled" />
+			<div id="ffc-day-bookings"></div>
+		</div>
+	`;
+}
+
+const DATE = '2026-06-10';
+
+function seedBookings() {
+	api.state.config = {
+		canBook: true,
+		audiences: [{ id: 1, name: 'Group', children: [{ id: 11, name: 'Sub' }] }],
+		schedules: [{ environmentLabel: 'Room', environments: [{ id: 10, name: 'Env A', color: '#abc' }] }],
+	};
+	api.state.bookings = {
+		[DATE]: [
+			{ id: 1, status: 'active', is_all_day: 0, start_time: '09:00:00', end_time: '10:00:00',
+			  description: 'Timed <b>one</b>', environment_id: 10, environment_name: 'Env A',
+			  audiences: [{ id: 11, name: 'Sub', color: '#f00' }] },
+			{ id: 2, status: 'active', is_all_day: 1, start_time: '00:00:00', end_time: '23:59:00',
+			  description: 'All day', environment_id: 10, environment_name: 'Env A', audiences: [] },
+			{ id: 3, status: 'cancelled', is_all_day: 0, start_time: '14:00:00', end_time: '15:00:00',
+			  description: 'Gone', environment_id: 10, environment_name: 'Env A', audiences: [] },
+		],
+	};
+}
+
+beforeEach(() => {
+	window.$.fx.off = true;
+	dayModalFixture();
+	seedBookings();
+	api.renderCalendar = vi.fn(); // defined in the calendar module (not loaded here)
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('ffc-audience-bookings — loadDayBookings render', () => {
+	it('renders only active bookings by default (cancelled hidden)', () => {
+		api.loadDayBookings(DATE);
+		const $items = window.$('#ffc-day-bookings .ffc-booking-item');
+		expect($items.length).toBe(2); // two active, cancelled filtered out
+		// Timed booking shows HH:MM - HH:MM; all-day shows the All Day label.
+		const html = window.$('#ffc-day-bookings').html();
+		expect(html).toContain('09:00 - 10:00');
+		expect(html).toContain('All Day');
+		// Description is HTML-escaped.
+		expect(html).toContain('Timed &lt;b&gt;one&lt;/b&gt;');
+		// Audience tag rendered with the collapsed/sub name.
+		expect(html).toContain('ffc-audience-tag');
+		expect(html).toContain('Sub');
+		// canBook → cancel action present for active bookings.
+		expect(window.$('#ffc-day-bookings .ffc-cancel-booking').length).toBe(2);
+	});
+
+	it('includes cancelled bookings and marks them when show-cancelled is on', () => {
+		window.$('#ffc-show-cancelled').prop('checked', true);
+		api.loadDayBookings(DATE);
+		expect(window.$('#ffc-day-bookings .ffc-booking-item').length).toBe(3);
+		expect(window.$('#ffc-day-bookings .ffc-booking-cancelled').length).toBe(1);
+		expect(window.$('#ffc-day-bookings').html()).toContain('Cancelled');
+	});
+
+	it('omits the cancel button when canBook is false', () => {
+		api.state.config.canBook = false;
+		api.loadDayBookings(DATE);
+		expect(window.$('#ffc-day-bookings .ffc-cancel-booking').length).toBe(0);
+	});
+
+	it('shows the no-bookings message when the day is empty', () => {
+		api.state.bookings = { [DATE]: [] };
+		api.loadDayBookings(DATE);
+		expect(window.$('#ffc-day-bookings .ffc-no-bookings').text()).toBe('No bookings for this day.');
+	});
+
+	it('shows the no-active message when all bookings are cancelled and hidden', () => {
+		api.state.bookings = { [DATE]: [
+			{ id: 9, status: 'cancelled', is_all_day: 0, start_time: '08:00:00', end_time: '09:00:00',
+			  description: 'x', environment_id: 10, environment_name: 'Env A', audiences: [] },
+		] };
+		api.loadDayBookings(DATE);
+		expect(window.$('#ffc-day-bookings .ffc-no-bookings').text()).toBe('No active bookings for this day.');
+	});
+});
+
+describe('ffc-audience-bookings — openDayModal', () => {
+	it('sets the title, shows the modal, stores the date and loads bookings', () => {
+		api.openDayModal(DATE);
+		expect(window.$('#ffc-day-modal .ffc-day-modal-title').text().length).toBeGreaterThan(0);
+		expect(window.$('#ffc-day-modal').css('display')).not.toBe('none');
+		expect(window.$('#ffc-day-modal').data('date')).toBe(DATE);
+		expect(window.$('#ffc-day-bookings .ffc-booking-item').length).toBe(2);
+	});
+});
+
+describe('ffc-audience-bookings — cancelBooking', () => {
+	it('bails without a REST call when the reason prompt is empty', () => {
+		const restSpy = vi.spyOn(window.FFC, 'rest');
+		vi.spyOn(window, 'prompt').mockReturnValue('   '); // whitespace → treated as empty
+		api.loadDayBookings(DATE);
+		window.$('#ffc-day-bookings .ffc-cancel-booking').first().trigger('click');
+		expect(restSpy).not.toHaveBeenCalled();
+	});
+
+	it('DELETEs the booking and refreshes on a successful cancel', async () => {
+		vi.spyOn(window, 'prompt').mockReturnValue('Double booked');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		const restSpy = vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: true });
+
+		api.loadDayBookings(DATE);
+		// Bookings render sorted by start_time, so target the 09:00 one by id
+		// rather than relying on DOM order.
+		window.$('#ffc-day-bookings .ffc-cancel-booking[data-id="1"]').trigger('click');
+		await Promise.resolve().then(() => Promise.resolve());
+
+		expect(restSpy).toHaveBeenCalled();
+		const [url, opts] = restSpy.mock.calls[0];
+		expect(url).toContain('/bookings/1');
+		expect(opts.method).toBe('DELETE');
+		expect(opts.data.reason).toBe('Double booked');
+		expect(alertSpy).toHaveBeenCalledWith('Booking cancelled.');
+		expect(api.renderCalendar).toHaveBeenCalled();
+	});
+
+	it('alerts the error message when the cancel fails', async () => {
+		vi.spyOn(window, 'prompt').mockReturnValue('reason');
+		const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+		vi.spyOn(window.FFC, 'rest').mockResolvedValue({ success: false, message: 'Nope' });
+
+		api.loadDayBookings(DATE);
+		window.$('#ffc-day-bookings .ffc-cancel-booking').first().trigger('click');
+		await Promise.resolve().then(() => Promise.resolve());
+
+		expect(alertSpy).toHaveBeenCalledWith('Nope');
+	});
+});

--- a/tests/js/audience-core-helpers.test.js
+++ b/tests/js/audience-core-helpers.test.js
@@ -1,0 +1,176 @@
+// Deep coverage for the pure helpers on window.FFCAudience
+// (assets/js/ffc-audience.js): date/time formatting, HTML escaping,
+// booking-label resolution, the audience-tree utilities (parent-name
+// map, name formatting, parent collapse), environment colour/label
+// lookup, and modal focus/close. These are exercised directly against
+// the singleton with a synthetic state.config, complementing the
+// init()/bindEvents() smoke in audience-smoke.test.js.
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+let api;
+
+beforeAll(() => {
+	window.ffcAudience = {
+		ajaxUrl: '/wp-admin/admin-ajax.php',
+		restUrl: '/wp-json/ffc/v1/audience/',
+		nonce: 'n',
+		locale: 'pt_BR',
+		strings: { booking: 'booking', bookings: 'bookings', environmentLabel: 'Environment' },
+	};
+	window.ffc_ajax = { ajax_url: '/wp-admin/admin-ajax.php', nonce: 'n', strings: {} };
+	loadScript('assets/js/ffc-core.js');
+	loadScript('assets/js/ffc-audience.js');
+	api = window.FFCAudience;
+});
+
+beforeEach(() => {
+	window.$.fx.off = true;
+	api.state.config = {};
+	api.state._triggerElement = null;
+	document.body.innerHTML = '';
+});
+
+describe('FFCAudience helpers — date / time / pad', () => {
+	it('pad adds a leading zero below 10 only', () => {
+		expect(api.pad(5)).toBe('05');
+		expect(api.pad(12)).toBe('12');
+	});
+
+	it('formatDate renders YYYY-MM-DD with padding', () => {
+		expect(api.formatDate(new Date(2026, 5, 9))).toBe('2026-06-09');
+		expect(api.formatDate(new Date(2026, 11, 25))).toBe('2026-12-25');
+	});
+
+	it('parseDate builds a local-timezone date (no UTC shift)', () => {
+		const d = api.parseDate('2026-06-09');
+		expect(d.getFullYear()).toBe(2026);
+		expect(d.getMonth()).toBe(5);
+		expect(d.getDate()).toBe(9);
+	});
+
+	it('formatTime trims to HH:MM and tolerates empty', () => {
+		expect(api.formatTime('09:30:00')).toBe('09:30');
+		expect(api.formatTime('')).toBe('');
+	});
+});
+
+describe('FFCAudience helpers — escapeHtml', () => {
+	it('escapes the five entities', () => {
+		expect(api.escapeHtml('<a href="x">&\'')).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;');
+	});
+
+	it('returns empty string for falsy input', () => {
+		expect(api.escapeHtml('')).toBe('');
+		expect(api.escapeHtml(null)).toBe('');
+	});
+});
+
+describe('FFCAudience helpers — booking label', () => {
+	it('prefers the schedule-level custom label', () => {
+		api.state.config = { schedules: [{ bookingLabelSingular: 'Aula', bookingLabelPlural: 'Aulas' }] };
+		expect(api.getBookingLabel('singular')).toBe('Aula');
+		expect(api.getBookingLabel('plural')).toBe('Aulas');
+	});
+
+	it('falls back to the global strings when no schedule label', () => {
+		api.state.config = { schedules: [{}] };
+		expect(api.getBookingLabel('singular')).toBe('booking');
+		expect(api.getBookingLabel('plural')).toBe('bookings');
+	});
+});
+
+describe('FFCAudience helpers — audience tree', () => {
+	const tree = [
+		{ id: 1, name: 'Parent', children: [
+			{ id: 11, name: 'Child A', children: [{ id: 111, name: 'Grand' }] },
+			{ id: 12, name: 'Child B' },
+		] },
+	];
+
+	it('buildParentNameMap maps every child to its parent name', () => {
+		api.state.config = { audiences: tree };
+		const map = api.buildParentNameMap();
+		expect(map[11]).toBe('Parent');
+		expect(map[12]).toBe('Parent');
+		expect(map[111]).toBe('Child A');
+	});
+
+	it('formatAudienceName prefixes the parent only in parent_name mode', () => {
+		api.state.config = { audiences: tree, audienceBadgeFormat: 'parent_name' };
+		const map = api.buildParentNameMap();
+		expect(api.formatAudienceName({ id: 11, name: 'Child A' }, map)).toBe('Parent: Child A');
+		// Root node has no parent → plain name.
+		expect(api.formatAudienceName({ id: 1, name: 'Parent' }, map)).toBe('Parent');
+		// Non-parent_name mode → always plain.
+		api.state.config.audienceBadgeFormat = 'plain';
+		expect(api.formatAudienceName({ id: 11, name: 'Child A' }, map)).toBe('Child A');
+	});
+
+	it('collapseParentAudiences hides children when the parent + all descendants are present', () => {
+		api.state.config = { audiences: tree };
+		const input = [{ id: 1 }, { id: 11 }, { id: 111 }, { id: 12 }];
+		expect(api.collapseParentAudiences(input).map((a) => a.id)).toEqual([1]);
+	});
+
+	it('collapseParentAudiences keeps children when not every descendant is present', () => {
+		api.state.config = { audiences: tree };
+		const input = [{ id: 1 }, { id: 11 }]; // 12 + 111 missing
+		expect(api.collapseParentAudiences(input).map((a) => a.id)).toEqual([1, 11]);
+	});
+
+	it('collapseParentAudiences returns the input unchanged when empty', () => {
+		expect(api.collapseParentAudiences([])).toEqual([]);
+	});
+});
+
+describe('FFCAudience helpers — environment colour / label', () => {
+	beforeEach(() => {
+		api.state.config = { schedules: [
+			{ environmentLabel: 'Sala', environments: [
+				{ id: 10, name: 'A', color: '#abcdef' },
+				{ id: 11, name: 'B' },
+			] },
+		] };
+	});
+
+	it('getEnvironmentColor returns the env colour, else the default', () => {
+		expect(api.getEnvironmentColor(10)).toBe('#abcdef');
+		expect(api.getEnvironmentColor(11)).toBe('#3788d8'); // env present, no colour
+		expect(api.getEnvironmentColor(999)).toBe('#3788d8'); // unknown env
+	});
+
+	it('getEnvironmentLabelForBooking resolves the owning schedule label', () => {
+		expect(api.getEnvironmentLabelForBooking({ environment_id: 10 })).toBe('Sala');
+		expect(api.getEnvironmentLabelForBooking({ environment_id: 999 })).toBe('Environment');
+	});
+});
+
+describe('FFCAudience helpers — closeModals + trapFocus', () => {
+	it('closeModals hides both modals and restores focus to the trigger', () => {
+		document.body.innerHTML = `
+			<button id="trigger">open</button>
+			<div id="ffc-booking-modal" style="display:block"></div>
+			<div id="ffc-day-modal" style="display:block"></div>
+		`;
+		api.state._triggerElement = document.getElementById('trigger');
+		api.closeModals();
+		expect(window.$('#ffc-booking-modal').css('display')).toBe('none');
+		expect(window.$('#ffc-day-modal').css('display')).toBe('none');
+		expect(api.state._triggerElement).toBeNull();
+	});
+
+	it('trapFocus binds a Tab handler that runs without throwing', () => {
+		document.body.innerHTML = '<div id="m"><button id="b1">1</button><button id="b2">2</button></div>';
+		const $m = window.$('#m');
+		api.trapFocus($m);
+		// Non-Tab key returns early; Tab key runs the focus-collection path.
+		// (jsdom has no layout so :visible filters all out — the wrap
+		// branches stay dormant, but the handler body still executes.)
+		expect(() => {
+			$m.trigger(window.$.Event('keydown', { key: 'a' }));
+			$m.trigger(window.$.Event('keydown', { key: 'Tab', shiftKey: false }));
+			$m.trigger(window.$.Event('keydown', { key: 'Tab', shiftKey: true }));
+		}).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Contexto

Fecha a campanha "≥50% de cobertura por arquivo" no JS: os **últimos arquivos abaixo de 50%** eram o subsistema do calendário de audiência (admin), que só tinha cobertura *smoke*.

| Arquivo | Antes | Depois |
|---|---|---|
| `ffc-audience.js` | 36% | **71%** |
| `ffc-audience-bookings.js` | 28% | **99%** |
| `ffc-audience-booking-form.js` | 13% | **91%** |

## Testes adicionados

- **audience-core-helpers**: helpers puros do singleton `FFCAudience` — datas/hora, `escapeHtml`, `getBookingLabel`, mapa de pais, `formatAudienceName`, a lógica de árvore `collapseParentAudiences`, cor/label de ambiente, `closeModals`/`trapFocus`.
- **audience-bookings**: render do modal de dia (ativo/cancelado/all-day/timed, tags de audiência, gating da ação cancelar, estados vazios), `openDayModal` e o fluxo de cancelamento (guard do prompt, REST DELETE sucesso/falha).
- **audience-booking-form**: `openBookingModal` (popular/relabel do select de ambiente), busca de usuários (resultados/vazio/reject), chips de selecionados, guards de validação, extração de dados, a matriz completa de conflitos (hard / soft-audiência / soft-usuário / nenhum / erro) e `createBooking` (sucesso/falha/reject).

## Cobertura / floor (catraca)

- **100 arquivos / 1192 testes** verdes; ESLint limpo.
- Statement coverage **~82% → ~88%** (clover mede 87.8–88.9% entre runs; paths async do v8 oscilam ~1pp), **cruzando o high-water histórico de 85.53%**.
- **Ratchet `JS_COVERAGE_FLOOR_LINES` 82 → 85** (~2.8pp de buffer sobre o run mais baixo). Nota de auditoria adicionada ao bloco.
- Nenhum source tocado.

Com isto, **todo arquivo JS shipado está ≥50%**. Restam as lacunas **PHP 0%** (`RateLimitRepository`, `CsvDownloadValidator`, `ReregistrationAjaxHandler`, `AppointmentsListTable`) — próximo PR; a % PHP só é mensurável na CI (sem pcov/xdebug local).

> ⚠️ Edita a mesma região de comentário do `lint.yml` que o #526; o segundo a mergear precisará de um rebase trivial.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_