### PR TITLE
docs: record the ≤5pp acceptable coverage-floor buffer policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ The same gates run on PRs to `develop` and on the release PR `develop → main`.
 
 The coverage floors are ratcheted upward in the PR that delivers the gain — never lowered. The comment block above each `*_FLOOR_LINES` keeps the audit trail.
 
+**Acceptable floor buffer:** when bumping, the floor may sit up to **5 percentage points** below the freshly measured coverage. A buffer of ≤5pp is acceptable for both JS (`JS_COVERAGE_FLOOR_LINES`) and PHP (`COVERAGE_FLOOR_LINES`) — it absorbs v8/clover run-to-run jitter so the gate doesn't flake on fractional swings, without forcing the floor to chase every decimal. So: still ratchet up when a PR delivers a real gain, but leave no more than ~5pp on the table, and never set the floor *above* the lowest run you've actually observed.
+
 ## Test infrastructure
 
 - PHP: PHPUnit 9; tests under `tests/Unit` and `tests/Integration`.


### PR DESCRIPTION
## O que muda

Registra no `CLAUDE.md` (arquivo de regras duráveis que toda sessão herda) a política de **buffer aceitável do coverage floor**:

> Ao subir o floor, ele pode ficar **até 5 pontos percentuais** abaixo da cobertura recém-medida. Um buffer de ≤5pp é aceitável para **JS** (`JS_COVERAGE_FLOOR_LINES`) e **PHP** (`COVERAGE_FLOOR_LINES`) — absorve o jitter run-a-run do v8/clover sem o gate "piscar" em variações fracionárias, sem obrigar o floor a perseguir cada decimal. Continua-se subindo o floor quando um PR entrega ganho real, mas sem deixar mais que ~5pp na mesa, e nunca acima do run mais baixo já observado.

Apenas documentação — nenhum source/CI tocado.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_