### PR TITLE
chore: gitignore Claude Code local state (.claude/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ html/*.png
 html/atestado_jair.html
 # JS coverage output
 /coverage-js/
+
+# Claude Code local state (settings.local.json, agent worktrees, etc.)
+/.claude/


### PR DESCRIPTION
## O que muda

Adiciona `/.claude/` ao `.gitignore`. O diretório guarda estado local de sessão do Claude Code — `settings.local.json` e as **worktrees transitórias dos agentes** criadas em execuções paralelas — nada que pertença ao versionamento. Sem isso, rodar agentes em worktree faz o `git status` da árvore principal acusar centenas de arquivos "untracked".

Apenas tooling/hygiene — nenhum source/CI/teste tocado.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_