### PR TITLE
test(php): raise audience admin/ajax coverage (logic paths)

### DIFF
--- a/tests/Unit/AudienceAdminAudienceTest.php
+++ b/tests/Unit/AudienceAdminAudienceTest.php
@@ -12,6 +12,8 @@ use FreeFormCertificate\Audience\AudienceAdminAudience;
 
 /**
  * @covers \FreeFormCertificate\Audience\AudienceAdminAudience
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class AudienceAdminAudienceTest extends TestCase {
 
@@ -114,5 +116,496 @@ class AudienceAdminAudienceTest extends TestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString( 'wrap', $output );
+    }
+
+    // ==================================================================
+    // render_list() — hierarchical rows (recursive)
+    // ==================================================================
+
+    public function test_render_list_renders_hierarchical_rows(): void {
+        Functions\when( 'settings_errors' )->justReturn( '' );
+        Functions\when( 'wp_nonce_url' )->justReturn( '/' );
+
+        $child  = (object) array(
+            'id'       => 2,
+            'name'     => 'Child Aud',
+            'color'    => '#00ff00',
+            'status'   => 'inactive',
+            'children' => array(),
+        );
+        $parent = (object) array(
+            'id'       => 1,
+            'name'     => 'Parent Aud',
+            'color'    => '#ff0000',
+            'status'   => 'active',
+            'children' => array( $child ),
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_hierarchical' )->andReturn( array( $parent ) );
+        $repo->shouldReceive( 'get_member_count' )->andReturnUsing(
+            static fn( $id, $recursive = false ) => $recursive ? 10 : 4
+        );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Parent Aud', $output );
+        $this->assertStringContainsString( 'Child Aud', $output );
+        // Parent has children: total (10) shown alongside direct (4).
+        $this->assertStringContainsString( '(10)', $output );
+        // Active parent shows Deactivate; inactive child shows Delete.
+        $this->assertStringContainsString( 'Deactivate', $output );
+        $this->assertStringContainsString( 'Delete', $output );
+    }
+
+    // ==================================================================
+    // render_form()
+    // ==================================================================
+
+    public function test_render_form_edit_renders_custom_fields_section(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '5';
+        Functions\when( 'settings_errors' )->justReturn( '' );
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+        Functions\when( 'current_user_can' )->justReturn( true ); // view + manage caps.
+
+        $audience = (object) array(
+            'id'              => 5,
+            'name'            => 'Grp',
+            'color'           => '#123456',
+            'status'          => 'active',
+            'parent_id'       => null,
+            'allow_self_join' => 0,
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( $audience );
+        $repo->shouldReceive( 'get_possible_parents' )->andReturn( array() );
+        $repo->shouldReceive( 'get_children' )->with( 5 )->andReturn( array() );
+
+        // Real CustomFieldRepository (for FIELD_TYPES const) returns no fields
+        // via the mocked $wpdb (get_results -> []).
+        $seeder = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationStandardFieldsSeeder' );
+        $seeder->shouldReceive( 'seed_for_audience' )->andReturn( 0 );
+        $seeder->shouldReceive( 'get_group_labels' )->andReturn( array() );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Reregistration Fields', $output );
+        $this->assertStringContainsString( 'ffc-add-custom-field', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_custom_fields_section_read_only_without_manage(): void {
+        // view cap present, manage cap absent -> read-only render path.
+        Functions\when( 'current_user_can' )->alias(
+            static fn( $cap ) => 'ffc_view_custom_fields' === $cap
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_children' )->with( 5 )->andReturn( array() );
+
+        $seeder = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationStandardFieldsSeeder' );
+        $seeder->shouldReceive( 'seed_for_audience' )->andReturn( 0 );
+        $seeder->shouldReceive( 'get_group_labels' )->andReturn( array() );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $ref  = new \ReflectionMethod( AudienceAdminAudience::class, 'render_custom_fields_section' );
+        $ref->setAccessible( true );
+        ob_start();
+        $ref->invoke( $page, 5 );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Read-only', $output );
+    }
+
+    public function test_render_custom_field_row_custom_select_field(): void {
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'wp_json_encode' )->alias( static fn( $v ) => json_encode( $v ) );
+
+        $field = (object) array(
+            'id'                => 12,
+            'field_label'       => 'My Select',
+            'field_type'        => 'select',
+            'field_key'         => 'my_select',
+            'field_group'       => 'extra',
+            'field_profile_key' => '',
+            'field_mask'        => '',
+            'field_source'      => 'custom',
+            'is_sensitive'      => 0,
+            'is_required'       => 1,
+            'is_active'         => 1,
+            'field_options'     => json_encode( array( 'choices' => array( 'A', 'B' ), 'help_text' => 'pick one' ) ),
+            'validation_rules'  => json_encode( array( 'format' => 'email' ) ),
+        );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $ref  = new \ReflectionMethod( AudienceAdminAudience::class, 'render_custom_field_row' );
+        $ref->setAccessible( true );
+        ob_start();
+        $ref->invoke( $page, $field, array( 'text', 'select', 'dependent_select' ), array() );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'My Select', $output );
+        $this->assertStringContainsString( 'A', $output );
+        // Custom field is deletable.
+        $this->assertStringContainsString( 'ffc-field-delete', $output );
+    }
+
+    public function test_render_custom_field_row_standard_locked_field(): void {
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'wp_json_encode' )->alias( static fn( $v ) => json_encode( $v ) );
+
+        $field = (object) array(
+            'id'                => 3,
+            'field_label'       => 'CPF',
+            'field_type'        => 'text',
+            'field_key'         => 'cpf',
+            'field_group'       => '',
+            'field_profile_key' => 'cpf',
+            'field_mask'        => 'cpf',
+            'field_source'      => 'standard',
+            'is_sensitive'      => 1,
+            'is_required'       => 1,
+            'is_active'         => 1,
+            'field_options'     => null,
+            'validation_rules'  => null,
+        );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $ref  = new \ReflectionMethod( AudienceAdminAudience::class, 'render_custom_field_row' );
+        $ref->setAccessible( true );
+        ob_start();
+        $ref->invoke( $page, $field, array( 'text' ), array() );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'CPF', $output );
+        $this->assertStringContainsString( 'disabled', $output );
+        // Standard field has no delete button.
+        $this->assertStringNotContainsString( 'ffc-field-delete', $output );
+    }
+
+    public function test_render_form_edit_with_breadcrumb_and_custom_fields(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '5';
+        Functions\when( 'settings_errors' )->justReturn( '' );
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+
+        $audience = (object) array(
+            'id'              => 5,
+            'name'            => 'Sub Group',
+            'color'           => '#123456',
+            'status'          => 'active',
+            'parent_id'       => 1,
+            'allow_self_join' => 1,
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( $audience );
+        $repo->shouldReceive( 'get_possible_parents' )->with( 5 )->andReturn(
+            array( (object) array( 'id' => 1, 'name' => 'Top', 'depth' => 0 ) )
+        );
+        $repo->shouldReceive( 'get_ancestors' )->with( 5 )->andReturn(
+            array( (object) array( 'id' => 1, 'name' => 'Top', 'color' => '#aaa' ) )
+        );
+        // render_custom_fields_section: no view/manage cap -> early return.
+        Functions\when( 'current_user_can' )->justReturn( false );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Sub Group', $output );
+        $this->assertStringContainsString( 'ffc-breadcrumb', $output );
+        $this->assertStringContainsString( 'Top', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_render_form_missing_audience_dies(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '99';
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 99 )->andReturn( null );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Audience not found' );
+        try {
+            $page->render_page();
+        } finally {
+            unset( $_GET['action'], $_GET['id'] );
+        }
+    }
+
+    // ==================================================================
+    // render_members()
+    // ==================================================================
+
+    public function test_render_members_lists_users(): void {
+        $_GET['action'] = 'members';
+        $_GET['id']     = '5';
+        Functions\when( 'settings_errors' )->justReturn( '' );
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'wp_nonce_url' )->justReturn( '/' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+        Functions\when( 'get_user_by' )->alias(
+            static fn( $field, $id ) => (object) array( 'ID' => $id, 'display_name' => 'User' . $id, 'user_email' => $id . '@e.com' )
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'id' => 5, 'name' => 'Grp' ) );
+        $repo->shouldReceive( 'get_members' )->with( 5 )->andReturn( array( 7, 8 ) );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'User7', $output );
+        $this->assertStringContainsString( '8@e.com', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_render_members_missing_audience_dies(): void {
+        $_GET['action'] = 'members';
+        $_GET['id']     = '99';
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 99 )->andReturn( null );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Audience not found' );
+        try {
+            $page->render_page();
+        } finally {
+            unset( $_GET['action'], $_GET['id'] );
+        }
+    }
+
+    // ==================================================================
+    // handle_actions() — save
+    // ==================================================================
+
+    public function test_handle_actions_creates_audience_and_redirects(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $_POST = array(
+            'ffc_action'         => 'save_audience',
+            'ffc_audience_nonce' => 'n',
+            'audience_id'        => '0',
+            'audience_name'      => 'Brand New',
+            'audience_color'     => '#abcabc',
+            'audience_parent'    => '',
+            'audience_status'    => 'active',
+            'audience_self_join' => '1',
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'create' )->once()->with(
+            Mockery::on(
+                static fn( $d ) => 'Brand New' === $d['name'] && null === $d['parent_id'] && 1 === $d['allow_self_join']
+            )
+        )->andReturn( 50 );
+        $repo->shouldReceive( 'cascade_self_join' )->once()->with( 50, 1 )->andReturn( true );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=created' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_updates_audience_and_cascades(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $_POST = array(
+            'ffc_action'         => 'save_audience',
+            'ffc_audience_nonce' => 'n',
+            'audience_id'        => '5',
+            'audience_name'      => 'Edited',
+            'audience_color'     => '#000000',
+            'audience_parent'    => '',
+            'audience_status'    => 'active',
+            'audience_self_join' => '0',
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'update' )->once()->with( 5, Mockery::type( 'array' ) )->andReturn( true );
+        $repo->shouldReceive( 'cascade_self_join' )->once()->with( 5, 0 )->andReturn( true );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_update_with_parent_skips_cascade(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $_POST = array(
+            'ffc_action'         => 'save_audience',
+            'ffc_audience_nonce' => 'n',
+            'audience_id'        => '5',
+            'audience_name'      => 'Child',
+            'audience_color'     => '#000000',
+            'audience_parent'    => '3',
+            'audience_status'    => 'active',
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'update' )->once()->with( 5, Mockery::on( static fn( $d ) => 3 === $d['parent_id'] ) )->andReturn( true );
+        $repo->shouldNotReceive( 'cascade_self_join' );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_save_aborts_on_bad_nonce(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        $_POST = array( 'ffc_action' => 'save_audience', 'ffc_audience_nonce' => 'bad' );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldNotReceive( 'create' );
+        $repo->shouldNotReceive( 'update' );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // handle_actions() — add members
+    // ==================================================================
+
+    public function test_handle_actions_adds_members(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $_POST = array(
+            'ffc_action'            => 'add_members',
+            'ffc_add_members_nonce' => 'n',
+            'audience_id'           => '5',
+            'user_ids'              => '7,8,9',
+        );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'bulk_add_members' )->once()->with( 5, array( 7, 8, 9 ) )->andReturn( 3 );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_add_members_bad_nonce_aborts(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        $_POST = array( 'ffc_action' => 'add_members', 'ffc_add_members_nonce' => 'bad' );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldNotReceive( 'bulk_add_members' );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // handle_actions() — remove member
+    // ==================================================================
+
+    public function test_handle_actions_removes_member_and_redirects(): void {
+        $_GET = array( 'remove_user' => '7', 'id' => '5', '_wpnonce' => 'n' );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'remove_member' )->once()->with( 5, 7 )->andReturn( true );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=member_removed' );
+        $page->handle_actions();
+    }
+
+    // ==================================================================
+    // handle_actions() — deactivate / delete
+    // ==================================================================
+
+    public function test_handle_actions_deactivates_audience(): void {
+        $_GET = array(
+            'action'   => 'deactivate',
+            'id'       => '5',
+            'page'     => 'ffc-scheduling-audiences',
+            '_wpnonce' => 'n',
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'update' )->once()->with( 5, array( 'status' => 'inactive' ) )->andReturn( true );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deactivated' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_deletes_inactive_audience(): void {
+        $_GET = array(
+            'action'   => 'delete',
+            'id'       => '5',
+            'page'     => 'ffc-scheduling-audiences',
+            '_wpnonce' => 'n',
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+        $repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'status' => 'inactive' ) );
+        $repo->shouldReceive( 'delete' )->once()->with( 5 )->andReturn( true );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deleted' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_delete_denied_without_cap(): void {
+        $_GET = array(
+            'action' => 'delete',
+            'id'     => '5',
+            'page'   => 'ffc-scheduling-audiences',
+        );
+        Functions\when( 'current_user_can' )->alias(
+            static fn( $cap ) => 'ffc_manage_audiences' === $cap
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+
+        $page = new AudienceAdminAudience( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'permission to delete' );
+        $page->handle_actions();
     }
 }

--- a/tests/Unit/AudienceAdminCalendarTest.php
+++ b/tests/Unit/AudienceAdminCalendarTest.php
@@ -12,6 +12,8 @@ use FreeFormCertificate\Audience\AudienceAdminCalendar;
 
 /**
  * @covers \FreeFormCertificate\Audience\AudienceAdminCalendar
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class AudienceAdminCalendarTest extends TestCase {
 
@@ -115,5 +117,333 @@ class AudienceAdminCalendarTest extends TestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString( 'wrap', $output );
+    }
+
+    // ==================================================================
+    // render_list() — with calendars
+    // ==================================================================
+
+    public function test_render_list_shows_calendars(): void {
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_all' )->andReturn(
+            array(
+                (object) array( 'id' => 1, 'name' => 'Public Cal', 'description' => 'A public one', 'visibility' => 'public', 'status' => 'active' ),
+                (object) array( 'id' => 2, 'name' => 'Private Cal', 'description' => '', 'visibility' => 'private', 'status' => 'inactive' ),
+            )
+        );
+        $schedRepo->shouldReceive( 'get_environment_label' )->andReturn( 'Environments' );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'count' )->andReturn( 2 );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Public Cal', $output );
+        $this->assertStringContainsString( 'Private Cal', $output );
+        $this->assertStringContainsString( 'Public', $output );
+        $this->assertStringContainsString( 'Deactivate', $output ); // active calendar.
+        $this->assertStringContainsString( 'Delete', $output );     // inactive calendar.
+    }
+
+    // ==================================================================
+    // render_form() — new + edit (full sections)
+    // ==================================================================
+
+    public function test_render_form_new_shows_create_button(): void {
+        $_GET['action'] = 'new';
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+        Functions\when( 'esc_attr__' )->returnArg();
+
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'schedule_name', $output );
+        $this->assertStringContainsString( 'Notifications', $output );
+    }
+
+    public function test_render_form_edit_with_permissions_and_holidays(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '5';
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'get_userdata' )->alias(
+            static fn( $id ) => (object) array( 'ID' => $id, 'display_name' => 'User' . $id, 'user_email' => $id . '@e.com' )
+        );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn(
+            (object) array(
+                'id'                     => 5,
+                'name'                   => 'Cal Five',
+                'description'            => 'desc',
+                'environment_label'      => 'Rooms',
+                'visibility'             => 'public',
+                'future_days_limit'      => 30,
+                'notify_on_booking'      => 1,
+                'notify_on_cancellation' => 0,
+                'include_ics'            => 1,
+                'show_event_list'        => 1,
+                'event_list_position'    => 'below',
+                'audience_badge_format'  => 'parent_name',
+                'booking_label_singular' => 'session',
+                'booking_label_plural'   => 'sessions',
+                'is_isolated'            => 1,
+                'status'                 => 'active',
+            )
+        );
+        $schedRepo->shouldReceive( 'get_all_permissions' )->with( 5 )->andReturn(
+            array( (object) array( 'user_id' => 7, 'can_book' => 1, 'can_cancel_others' => 0, 'can_override_conflicts' => 1 ) )
+        );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_holidays' )->with( 5 )->andReturn(
+            array( (object) array( 'id' => 3, 'holiday_date' => '2026-12-25', 'description' => 'Christmas' ) )
+        );
+
+        $df = Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' );
+        $df->shouldReceive( 'format_wallclock_date' )->andReturn( '25/12/2026' );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Cal Five', $output );
+        $this->assertStringContainsString( 'User7', $output );
+        $this->assertStringContainsString( 'Christmas', $output );
+        $this->assertStringContainsString( '25/12/2026', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_render_form_edit_no_permissions_no_holidays(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '5';
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( '' );
+        Functions\when( 'esc_attr__' )->returnArg();
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn(
+            (object) array( 'id' => 5, 'name' => 'Empty Cal', 'status' => 'active' )
+        );
+        $schedRepo->shouldReceive( 'get_all_permissions' )->with( 5 )->andReturn( array() );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_holidays' )->with( 5 )->andReturn( array() );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'No users have been granted access yet', $output );
+        $this->assertStringContainsString( 'No holidays defined yet', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_render_form_missing_calendar_dies(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '99';
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_by_id' )->with( 99 )->andReturn( null );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Calendar not found' );
+        try {
+            $page->render_page();
+        } finally {
+            unset( $_GET['action'], $_GET['id'] );
+        }
+    }
+
+    // ==================================================================
+    // handle_actions() — save
+    // ==================================================================
+
+    public function test_handle_actions_creates_calendar_and_redirects(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->returnArg();
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $_POST = array(
+            'ffc_action'                => 'save_schedule',
+            'ffc_schedule_nonce'        => 'n',
+            'schedule_id'               => '0',
+            'schedule_name'             => 'New Cal',
+            'schedule_visibility'       => 'public',
+            'schedule_event_list_position' => 'below',
+            'schedule_audience_badge_format' => 'parent_name',
+            'schedule_booking_label_singular' => 'evt',
+            'schedule_notify_booking'   => '1',
+            'schedule_is_isolated'      => '1',
+            'schedule_status'           => 'active',
+        );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'create' )->once()->with(
+            Mockery::on(
+                static function ( $d ) {
+                    return 'New Cal' === $d['name']
+                        && 'public' === $d['visibility']
+                        && 'below' === $d['event_list_position']
+                        && 'parent_name' === $d['audience_badge_format']
+                        && 1 === $d['notify_on_booking']
+                        && 0 === $d['notify_on_cancellation']
+                        && 1 === $d['is_isolated'];
+                }
+            )
+        )->andReturn( 60 );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=created' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_updates_calendar(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->returnArg();
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $_POST = array(
+            'ffc_action'         => 'save_schedule',
+            'ffc_schedule_nonce' => 'n',
+            'schedule_id'        => '5',
+            'schedule_name'      => 'Edited Cal',
+            // omit optional toggles -> defaults exercised.
+        );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'update' )->once()->with(
+            5,
+            Mockery::on(
+                static fn( $d ) => 'Edited Cal' === $d['name']
+                    && 'side' === $d['event_list_position']
+                    && 'name' === $d['audience_badge_format']
+                    && null === $d['booking_label_singular']
+            )
+        )->andReturn( true );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_save_aborts_on_bad_nonce(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        $_POST = array( 'ffc_action' => 'save_schedule', 'ffc_schedule_nonce' => 'bad' );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldNotReceive( 'create' );
+        $schedRepo->shouldNotReceive( 'update' );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // handle_actions() — deactivate / delete
+    // ==================================================================
+
+    public function test_handle_actions_deactivates_calendar(): void {
+        $_GET = array( 'action' => 'deactivate', 'id' => '5', '_wpnonce' => 'n' );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'update' )->once()->with( 5, array( 'status' => 'inactive' ) )->andReturn( true );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deactivated' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_deletes_inactive_calendar(): void {
+        $_GET = array( 'action' => 'delete', 'id' => '5', '_wpnonce' => 'n' );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'status' => 'inactive' ) );
+        $schedRepo->shouldReceive( 'delete' )->once()->with( 5 )->andReturn( true );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deleted' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_delete_denied_without_cap(): void {
+        $_GET = array( 'action' => 'delete', 'id' => '5' );
+        Functions\when( 'current_user_can' )->alias(
+            static fn( $cap ) => 'ffc_manage_audiences' === $cap
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'permission to delete' );
+        $page->handle_actions();
+    }
+
+    // ==================================================================
+    // handle_actions() — holidays
+    // ==================================================================
+
+    public function test_handle_actions_adds_holiday(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $_POST = array(
+            'ffc_action'          => 'add_holiday',
+            'ffc_holiday_nonce'   => 'n',
+            'schedule_id'         => '5',
+            'holiday_date'        => '2026-12-25',
+            'holiday_description' => 'Xmas',
+        );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'add_holiday' )->once()->with( 5, '2026-12-25', 'Xmas' )->andReturn( true );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_deletes_holiday_and_redirects(): void {
+        $_GET = array( 'delete_holiday' => '3', 'id' => '5', '_wpnonce' => 'n' );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $u ) { throw new \RuntimeException( 'redirect:' . $u ); } );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'remove_holiday' )->once()->with( 3 )->andReturn( true );
+
+        $page = new AudienceAdminCalendar( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=holiday_deleted' );
+        $page->handle_actions();
     }
 }

--- a/tests/Unit/AudienceAdminEnvironmentTest.php
+++ b/tests/Unit/AudienceAdminEnvironmentTest.php
@@ -12,6 +12,8 @@ use FreeFormCertificate\Audience\AudienceAdminEnvironment;
 
 /**
  * @covers \FreeFormCertificate\Audience\AudienceAdminEnvironment
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class AudienceAdminEnvironmentTest extends TestCase {
 
@@ -115,5 +117,315 @@ class AudienceAdminEnvironmentTest extends TestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString( 'wrap', $output );
+    }
+
+    // ==================================================================
+    // render_list() — with environments + calendars (data-prep / usort)
+    // ==================================================================
+
+    public function test_render_list_sorts_by_calendar_then_name(): void {
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_all' )->andReturn(
+            array(
+                (object) array( 'id' => 1, 'name' => 'Zeta', 'schedule_id' => 2, 'status' => 'active', 'color' => '#fff', 'description' => 'd' ),
+                (object) array( 'id' => 2, 'name' => 'Alpha', 'schedule_id' => 1, 'status' => 'inactive', 'color' => '#000', 'description' => '' ),
+            )
+        );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_all' )->andReturn(
+            array(
+                (object) array( 'id' => 1, 'name' => 'Cal One' ),
+                (object) array( 'id' => 2, 'name' => 'Cal Two' ),
+            )
+        );
+        $schedRepo->shouldReceive( 'get_environment_label' )->andReturn( 'Environments' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        // Alpha (Cal One) sorts before Zeta (Cal Two).
+        $this->assertLessThan( strpos( $output, 'Zeta' ), strpos( $output, 'Alpha' ) );
+        $this->assertStringContainsString( 'Cal One', $output );
+    }
+
+    public function test_render_list_filters_by_schedule(): void {
+        $_GET['schedule_id'] = '3';
+        Functions\when( 'esc_html__' )->returnArg();
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_all' )->with( array( 'schedule_id' => 3 ) )->once()->andReturn( array() );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_all' )->andReturn( array() );
+        $schedRepo->shouldReceive( 'get_environment_label' )->with( 3 )->andReturn( 'Rooms' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Rooms', $output );
+        unset( $_GET['schedule_id'] );
+    }
+
+    // ==================================================================
+    // render_form()
+    // ==================================================================
+
+    public function test_render_form_new_shows_create_title(): void {
+        $_GET['action'] = 'new';
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_environment_label' )->andReturn( 'Environment' );
+        $schedRepo->shouldReceive( 'get_all' )->andReturn(
+            array( (object) array( 'id' => 1, 'name' => 'Cal' ) )
+        );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'Cal', $output );
+        $this->assertStringContainsString( 'environment_name', $output );
+        unset( $_GET['action'] );
+    }
+
+    public function test_render_form_edit_loads_existing_with_working_hours(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '7';
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'wp_nonce_field' )->justReturn( '' );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_by_id' )->with( 7 )->andReturn(
+            (object) array(
+                'id'            => 7,
+                'schedule_id'   => 2,
+                'name'          => 'My Room',
+                'description'   => 'desc',
+                'color'         => '#abcdef',
+                'status'        => 'active',
+                'working_hours' => json_encode( array( 'mon' => array( 'closed' => true, 'start' => '09:00', 'end' => '17:00' ) ) ),
+            )
+        );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_environment_label' )->andReturn( 'Room' );
+        $schedRepo->shouldReceive( 'get_all' )->andReturn(
+            array( (object) array( 'id' => 2, 'name' => 'Cal' ) )
+        );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        ob_start();
+        $page->render_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'My Room', $output );
+        $this->assertStringContainsString( '#abcdef', $output );
+        unset( $_GET['action'], $_GET['id'] );
+    }
+
+    public function test_render_form_edit_missing_environment_dies(): void {
+        $_GET['action'] = 'edit';
+        $_GET['id']     = '99';
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_by_id' )->with( 99 )->andReturn( null );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Environment not found' );
+        try {
+            $page->render_page();
+        } finally {
+            unset( $_GET['action'], $_GET['id'] );
+        }
+    }
+
+    // ==================================================================
+    // handle_actions() — save (create + update)
+    // ==================================================================
+
+    public function test_handle_actions_creates_environment_and_redirects(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $url ) { throw new \RuntimeException( 'redirect:' . $url ); } );
+
+        $_POST = array(
+            'ffc_action'            => 'save_environment',
+            'ffc_environment_nonce' => 'n',
+            'environment_id'        => '0',
+            'environment_schedule'  => '3',
+            'environment_name'      => 'New Env',
+            'environment_color'     => '#112233',
+            'environment_status'    => 'active',
+            'working_hours'         => array(
+                'mon' => array( 'start' => '08:00', 'end' => '12:00' ),
+                'tue' => array( 'closed' => '1' ),
+            ),
+        );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'create' )->once()->with(
+            Mockery::on(
+                static function ( $data ) {
+                    return 3 === $data['schedule_id']
+                        && 'New Env' === $data['name']
+                        && true === $data['working_hours']['tue']['closed']
+                        && '08:00' === $data['working_hours']['mon']['start'];
+                }
+            )
+        )->andReturn( 42 );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=created' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_updates_environment(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+
+        $_POST = array(
+            'ffc_action'            => 'save_environment',
+            'ffc_environment_nonce' => 'n',
+            'environment_id'        => '5',
+            'environment_schedule'  => '2',
+            'environment_name'      => 'Edited',
+            'environment_color'     => '#222222',
+            'environment_status'    => 'inactive',
+        );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'update' )->once()->with( 5, Mockery::type( 'array' ) )->andReturn( true );
+
+        $schedRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+        $schedRepo->shouldReceive( 'get_environment_label' )->andReturn( 'Environment' );
+
+        Functions\when( 'add_settings_error' )->justReturn( true );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_save_aborts_on_bad_nonce(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        $_POST = array( 'ffc_action' => 'save_environment', 'ffc_environment_nonce' => 'bad' );
+
+        // No repo expectations — must return before any persistence.
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldNotReceive( 'create' );
+        $envRepo->shouldNotReceive( 'update' );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $page->handle_actions();
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // handle_actions() — deactivate
+    // ==================================================================
+
+    public function test_handle_actions_deactivates_environment(): void {
+        $_GET = array(
+            'action'   => 'deactivate',
+            'id'       => '8',
+            'page'     => 'ffc-scheduling-environments',
+            '_wpnonce' => 'n',
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $url ) { throw new \RuntimeException( 'redirect:' . $url ); } );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'update' )->once()->with( 8, array( 'status' => 'inactive' ) )->andReturn( true );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deactivated' );
+        $page->handle_actions();
+    }
+
+    // ==================================================================
+    // handle_actions() — delete
+    // ==================================================================
+
+    public function test_handle_actions_deletes_inactive_environment(): void {
+        $_GET = array(
+            'action'   => 'delete',
+            'id'       => '9',
+            'page'     => 'ffc-scheduling-environments',
+            '_wpnonce' => 'n',
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'admin_url' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( static function ( $url ) { throw new \RuntimeException( 'redirect:' . $url ); } );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'inactive' ) );
+        $envRepo->shouldReceive( 'delete' )->once()->with( 9 )->andReturn( true );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'message=deleted' );
+        $page->handle_actions();
+    }
+
+    public function test_handle_actions_delete_skips_active_environment(): void {
+        $_GET = array(
+            'action'   => 'delete',
+            'id'       => '9',
+            'page'     => 'ffc-scheduling-environments',
+            '_wpnonce' => 'n',
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+
+        $envRepo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        $envRepo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'active' ) );
+        $envRepo->shouldNotReceive( 'delete' );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $page->handle_actions(); // no redirect — active item can't be deleted.
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_actions_delete_denied_without_cap(): void {
+        $_GET = array(
+            'action' => 'delete',
+            'id'     => '9',
+            'page'   => 'ffc-scheduling-environments',
+        );
+        // Top gate admin_or('ffc_manage_audiences') passes via the granular cap;
+        // not a site admin and the delete cap is denied -> wp_die.
+        Functions\when( 'current_user_can' )->alias(
+            static fn( $cap ) => 'ffc_manage_audiences' === $cap
+        );
+        Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+        Functions\when( 'wp_die' )->alias( static function ( $m ) { throw new \RuntimeException( (string) $m ); } );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+        Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+
+        $page = new AudienceAdminEnvironment( 'ffc-scheduling' );
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'permission to delete' );
+        $page->handle_actions();
     }
 }

--- a/tests/Unit/AudienceAjaxControllerTest.php
+++ b/tests/Unit/AudienceAjaxControllerTest.php
@@ -35,6 +35,10 @@ class AudienceAjaxControllerTest extends TestCase {
 
 		Functions\when( '__' )->returnArg();
 		Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'absint' )->alias( static fn( $v ) => abs( (int) $v ) );
+		Functions\when( 'do_action' )->justReturn( null );
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
 
 		$this->responses = array();
 		Functions\when( 'wp_send_json_success' )->alias( function ( $data = null ) {
@@ -118,6 +122,808 @@ class AudienceAjaxControllerTest extends TestCase {
 
 		$this->assertFalse( $this->responses[0]['ok'] );
 		$this->assertStringContainsString( 'Missing required parameters', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_check_conflicts_returns_conflicts_from_service(): void {
+		$this->mockUtils();
+		$_POST = array(
+			'nonce'          => 'n',
+			'environment_id' => '5',
+			'booking_date'   => '2026-05-20',
+			'start_time'     => '09:00',
+			'end_time'       => '10:00',
+			'audience_ids'   => array( '2', '3' ),
+			'user_ids'       => array( '7' ),
+		);
+
+		$service = Mockery::mock( 'overload:FreeFormCertificate\Audience\AudienceConflictService' );
+		$service->shouldReceive( 'check_conflicts' )
+			->once()
+			->with( 5, '2026-05-20', '09:00', '10:00', array( 2, 3 ), array( 7 ) )
+			->andReturn( array( 'overlap' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_check_conflicts() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array( 'overlap' ), $this->responses[0]['data']['conflicts'] );
+	}
+
+	public function test_check_conflicts_handles_exception(): void {
+		$this->mockUtils();
+		Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )->shouldIgnoreMissing();
+		$_POST = array(
+			'nonce'          => 'n',
+			'environment_id' => '5',
+			'booking_date'   => '2026-05-20',
+			'start_time'     => '09:00',
+			'end_time'       => '10:00',
+		);
+
+		$service = Mockery::mock( 'overload:FreeFormCertificate\Audience\AudienceConflictService' );
+		$service->shouldReceive( 'check_conflicts' )->andThrow( new \RuntimeException( 'boom' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_check_conflicts() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertSame( 'ffc_internal_error', $this->responses[0]['data']['code'] );
+	}
+
+	// ── cancel_booking ─────────────────────────────────────────────────
+
+	public function test_cancel_booking_rejects_invalid_id(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_cancel_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid booking ID', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_cancel_booking_reports_not_found(): void {
+		$this->mockUtils();
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '9' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_cancel_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Booking not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_cancel_booking_rejects_already_cancelled(): void {
+		$this->mockUtils();
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '9' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'cancelled' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_cancel_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'already cancelled', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_cancel_booking_reports_failure(): void {
+		$this->mockUtils();
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '9', 'reason' => 'x' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'active' ) );
+		$repo->shouldReceive( 'cancel' )->with( 9, 'x' )->andReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_cancel_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Failed to cancel', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_cancel_booking_succeeds(): void {
+		$this->mockUtils();
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		Functions\when( 'do_action' )->justReturn( null );
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '9', 'reason' => 'x' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'active' ) );
+		$repo->shouldReceive( 'cancel' )->with( 9, 'x' )->andReturn( true );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_cancel_booking() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'cancelled successfully', $this->responses[0]['data']['message'] );
+	}
+
+	// ── get_booking ────────────────────────────────────────────────────
+
+	public function test_get_booking_rejects_invalid_id(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid booking ID', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_get_booking_reports_not_found(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '4' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_booking() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Booking not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_get_booking_maps_full_payload(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '4' );
+
+		$booking = (object) array(
+			'id'               => 4,
+			'created_by'       => 11,
+			'booking_date'     => '2026-05-20',
+			'start_time'       => '09:00',
+			'end_time'         => '10:00',
+			'is_all_day'       => 1,
+			'environment_name' => 'Room A',
+			'description'      => 'desc',
+			'booking_type'     => 'meeting',
+			'status'           => 'active',
+			'created_at'       => '2026-05-01',
+			'audiences'        => array(
+				(object) array( 'audience_id' => 2, 'name' => 'Aud2' ),
+			),
+			'users'            => array( 7 ),
+		);
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( $booking );
+
+		Functions\when( 'get_userdata' )->alias(
+			static function ( $id ) {
+				if ( 11 === $id ) {
+					return (object) array( 'ID' => 11, 'display_name' => 'Creator', 'user_email' => 'c@e.com' );
+				}
+				return (object) array( 'ID' => 7, 'display_name' => 'Member', 'user_email' => 'm@e.com' );
+			}
+		);
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_booking() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$data = $this->responses[0]['data'];
+		$this->assertSame( 4, $data['id'] );
+		$this->assertSame( 'Creator', $data['created_by'] );
+		$this->assertSame( 1, $data['is_all_day'] );
+		$this->assertSame( array( array( 'id' => 2, 'name' => 'Aud2' ) ), $data['audiences'] );
+		$this->assertSame( 7, $data['users'][0]['id'] );
+		$this->assertSame( 'm@e.com', $data['users'][0]['email'] );
+	}
+
+	public function test_get_booking_unknown_creator_and_empty_relations(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'booking_id' => '4' );
+
+		$booking = (object) array(
+			'id'               => 4,
+			'created_by'       => 0,
+			'booking_date'     => '2026-05-20',
+			'start_time'       => '09:00',
+			'end_time'         => '10:00',
+			'environment_name' => 'Room A',
+			'description'      => '',
+			'booking_type'     => 'meeting',
+			'status'           => 'active',
+			'created_at'       => '2026-05-01',
+			'audiences'        => array(),
+			'users'            => array(),
+		);
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceBookingRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( $booking );
+
+		Functions\when( 'get_userdata' )->justReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_booking() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$data = $this->responses[0]['data'];
+		$this->assertSame( 'Unknown', $data['created_by'] );
+		$this->assertSame( 0, $data['is_all_day'] );
+		$this->assertSame( array(), $data['audiences'] );
+		$this->assertSame( array(), $data['users'] );
+	}
+
+	// ── get_schedule_slots ─────────────────────────────────────────────
+
+	public function test_get_schedule_slots_reports_not_implemented(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_schedule_slots() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Not implemented', $this->responses[0]['data']['message'] );
+	}
+
+	// ── search_users ───────────────────────────────────────────────────
+
+	public function test_search_users_short_query_returns_empty(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'query' => 'a' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_search_users() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array(), $this->responses[0]['data'] );
+	}
+
+	public function test_search_users_maps_results(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'query' => 'john' );
+
+		Functions\when( 'get_users' )->justReturn(
+			array(
+				(object) array( 'ID' => 3, 'display_name' => 'John', 'user_email' => 'j@e.com' ),
+			)
+		);
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_search_users() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame(
+			array( array( 'id' => 3, 'name' => 'John', 'email' => 'j@e.com' ) ),
+			$this->responses[0]['data']
+		);
+	}
+
+	// ── get_environments ───────────────────────────────────────────────
+
+	public function test_get_environments_empty_for_invalid_schedule(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'schedule_id' => '0' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_environments() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array(), $this->responses[0]['data'] );
+	}
+
+	public function test_get_environments_maps_results(): void {
+		$this->mockUtils();
+		$_POST = array( 'nonce' => 'n', 'schedule_id' => '5' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceEnvironmentRepository' );
+		$repo->shouldReceive( 'get_by_schedule' )->with( 5 )->andReturn(
+			array( (object) array( 'id' => 8, 'name' => 'Room' ) )
+		);
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_get_environments() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array( array( 'id' => 8, 'name' => 'Room' ) ), $this->responses[0]['data'] );
+	}
+
+	// ── add_user_permission ────────────────────────────────────────────
+
+	public function test_add_user_permission_rejects_missing_params(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Missing required parameters', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_add_user_permission_reports_calendar_not_found(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Calendar not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_add_user_permission_reports_user_not_found(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'id' => 5 ) );
+		Functions\when( 'get_userdata' )->justReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'User not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_add_user_permission_rejects_existing_access(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'id' => 5 ) );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn( (object) array( 'can_book' => 1 ) );
+		Functions\when( 'get_userdata' )->justReturn( (object) array( 'ID' => 7, 'display_name' => 'U', 'user_email' => 'u@e.com' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'already has access', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_add_user_permission_reports_set_failure(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'id' => 5 ) );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn( null );
+		$repo->shouldReceive( 'set_user_permissions' )->andReturn( false );
+		Functions\when( 'get_userdata' )->justReturn( (object) array( 'ID' => 7, 'display_name' => 'U', 'user_email' => 'u@e.com' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Error adding user permissions', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_add_user_permission_succeeds_with_html(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 5 )->andReturn( (object) array( 'id' => 5 ) );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn( null );
+		$repo->shouldReceive( 'set_user_permissions' )->andReturn( true );
+		Functions\when( 'get_userdata' )->justReturn( (object) array( 'ID' => 7, 'display_name' => 'Jane', 'user_email' => 'jane@e.com' ) );
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_html_e' )->alias( static function ( $t ) { echo $t; } );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_add_user_permission() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Jane', $this->responses[0]['data']['html'] );
+		$this->assertStringContainsString( 'jane@e.com', $this->responses[0]['data']['html'] );
+	}
+
+	// ── update_user_permission ─────────────────────────────────────────
+
+	public function test_update_user_permission_rejects_missing_params(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_update_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Missing required parameters', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_update_user_permission_rejects_invalid_permission(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7', 'permission' => 'bad' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_update_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid permission', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_update_user_permission_reports_no_access(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7', 'permission' => 'can_book' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_update_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'does not have access', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_update_user_permission_succeeds(): void {
+		$this->mockUtils();
+		$_POST = array(
+			'_wpnonce'    => 'n',
+			'schedule_id' => '5',
+			'user_id'     => '7',
+			'permission'  => 'can_cancel_others',
+			'value'       => '1',
+		);
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn(
+			(object) array( 'can_book' => 1, 'can_cancel_others' => 0, 'can_override_conflicts' => 0 )
+		);
+		$repo->shouldReceive( 'set_user_permissions' )
+			->with( 5, 7, array( 'can_book' => 1, 'can_cancel_others' => 1, 'can_override_conflicts' => 0 ) )
+			->andReturn( true );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_update_user_permission() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+	}
+
+	public function test_update_user_permission_reports_set_failure(): void {
+		$this->mockUtils();
+		$_POST = array(
+			'_wpnonce'    => 'n',
+			'schedule_id' => '5',
+			'user_id'     => '7',
+			'permission'  => 'can_book',
+			'value'       => '0',
+		);
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'get_user_permissions' )->with( 5, 7 )->andReturn(
+			(object) array( 'can_book' => 1, 'can_cancel_others' => 0, 'can_override_conflicts' => 0 )
+		);
+		$repo->shouldReceive( 'set_user_permissions' )->andReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_update_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Error updating permission', $this->responses[0]['data']['message'] );
+	}
+
+	// ── remove_user_permission ─────────────────────────────────────────
+
+	public function test_remove_user_permission_rejects_missing_params(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_remove_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Missing required parameters', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_remove_user_permission_reports_failure(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'remove_user_permissions' )->with( 5, 7 )->andReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_remove_user_permission() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Error removing user access', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_remove_user_permission_succeeds(): void {
+		$this->mockUtils();
+		$_POST = array( '_wpnonce' => 'n', 'schedule_id' => '5', 'user_id' => '7' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceScheduleRepository' );
+		$repo->shouldReceive( 'remove_user_permissions' )->with( 5, 7 )->andReturn( true );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_remove_user_permission() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+	}
+
+	// ── delete_custom_field ────────────────────────────────────────────
+
+	public function test_delete_custom_field_rejects_invalid_id(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_delete_custom_field() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid field ID', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_delete_custom_field_reports_not_found(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n', 'field_id' => '3' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 3 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_delete_custom_field() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Field not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_delete_custom_field_blocks_standard(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n', 'field_id' => '3' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 3 )->andReturn( (object) array( 'field_source' => 'standard' ) );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_delete_custom_field() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'cannot be deleted', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_delete_custom_field_reports_failure(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n', 'field_id' => '3' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 3 )->andReturn( (object) array( 'field_source' => 'custom' ) );
+		$repo->shouldReceive( 'delete' )->with( 3 )->andReturn( false );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_delete_custom_field() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Failed to delete', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_delete_custom_field_succeeds(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n', 'field_id' => '3' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 3 )->andReturn( (object) array( 'field_source' => 'custom' ) );
+		$repo->shouldReceive( 'delete' )->with( 3 )->andReturn( true );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_delete_custom_field() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'deleted successfully', $this->responses[0]['data']['message'] );
+	}
+
+	// ── replicate_field_options ────────────────────────────────────────
+
+	public function test_replicate_field_options_rejects_invalid_id(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_replicate_field_options() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid data', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_replicate_field_options_reports_audience_not_found(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$_POST = array( 'nonce' => 'n', 'audience_id' => '4' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_replicate_field_options() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Audience not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_replicate_field_options_succeeds(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( '_n' )->alias( static fn( $s, $p, $n ) => $n === 1 ? $s : $p );
+		$_POST = array( 'nonce' => 'n', 'audience_id' => '4' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+
+		$seeder = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationStandardFieldsSeeder' );
+		$seeder->shouldReceive( 'replicate_field_options_to_descendants' )->with( 4 )->andReturn( 2 );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_replicate_field_options() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( 2, $this->responses[0]['data']['updated'] );
+	}
+
+	// ── save_custom_fields ─────────────────────────────────────────────
+
+	public function test_save_custom_fields_rejects_invalid_json(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )->shouldIgnoreMissing();
+		Functions\when( 'wp_unslash' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => 'not-json' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid field data format', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_save_custom_fields_rejects_missing_audience(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'audience_id' => '0', 'fields' => '[]' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Invalid data', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_save_custom_fields_reports_audience_not_found(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		$_POST = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => '[]' );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( null );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Audience not found', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_save_custom_fields_creates_new_field(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		$fields = json_encode(
+			array(
+				array(
+					'id'      => 'new_1',
+					'label'   => 'My Field',
+					'key'     => 'my_field',
+					'type'    => 'text',
+					'choices' => array( 'A', '', 'B' ),
+				),
+			)
+		);
+		$_POST  = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => $fields );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+
+		$cfr = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$cfr->shouldReceive( 'create' )->once()->andReturn( 99 );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array( 99 ), $this->responses[0]['data']['saved_ids'] );
+	}
+
+	public function test_save_custom_fields_reports_label_error(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		$fields = json_encode(
+			array(
+				array( 'id' => 'new_1', 'label' => '', 'type' => 'text' ),
+			)
+		);
+		$_POST  = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => $fields );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+		Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'label is required', $this->responses[0]['data']['message'] );
+	}
+
+	public function test_save_custom_fields_updates_existing_field(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		$fields = json_encode(
+			array(
+				array( 'id' => 12, 'label' => 'Updated', 'type' => 'text' ),
+			)
+		);
+		$_POST  = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => $fields );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+
+		$cfr = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$cfr->shouldReceive( 'get_by_id' )->with( 12 )->andReturn( (object) array( 'field_source' => 'custom' ) );
+		$cfr->shouldReceive( 'update' )->with( 12, Mockery::type( 'array' ) )->andReturn( 1 );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+		$this->assertSame( array( 12 ), $this->responses[0]['data']['saved_ids'] );
+	}
+
+	public function test_save_custom_fields_locks_standard_field(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		$fields = json_encode(
+			array(
+				array(
+					'id'      => 12,
+					'label'   => 'Std',
+					'type'    => 'text',
+					'key'     => 'should_be_dropped',
+					'choices' => array( 'X' ),
+				),
+			)
+		);
+		$_POST  = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => $fields );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+
+		$cfr      = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$existing = (object) array( 'field_source' => 'standard', 'field_options' => null );
+		$cfr->shouldReceive( 'get_by_id' )->with( 12 )->andReturn( $existing );
+		$cfr->shouldReceive( 'update' )->once()->with(
+			12,
+			Mockery::on(
+				static function ( $data ) {
+					// Locked standard field: key must be stripped, label retained.
+					return ! array_key_exists( 'field_key', $data )
+						&& array_key_exists( 'field_label', $data )
+						&& array_key_exists( 'field_options', $data );
+				}
+			)
+		)->andReturn( 1 );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertTrue( $this->responses[0]['ok'] );
+	}
+
+	public function test_save_custom_fields_reports_create_failure(): void {
+		$this->mockUtils();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		$fields = json_encode(
+			array(
+				array( 'id' => 'new_1', 'label' => 'Fail', 'type' => 'text' ),
+			)
+		);
+		$_POST  = array( 'nonce' => 'n', 'audience_id' => '4', 'fields' => $fields );
+
+		$repo = Mockery::mock( 'alias:FreeFormCertificate\Audience\AudienceRepository' );
+		$repo->shouldReceive( 'get_by_id' )->with( 4 )->andReturn( (object) array( 'id' => 4 ) );
+
+		$cfr = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+		$cfr->shouldReceive( 'create' )->andReturn( 0 );
+
+		$this->dispatch( fn() => ( new AudienceAjaxController() )->ajax_save_custom_fields() );
+
+		$this->assertFalse( $this->responses[0]['ok'] );
+		$this->assertStringContainsString( 'Failed to create', $this->responses[0]['data']['message'] );
 	}
 
 	// ── Custom-fields helpers (moved verbatim from AudienceLoader) ──────


### PR DESCRIPTION
## Fase 2 — cobertura PHP do subsistema Audience

Estende os testes unitários do subsistema audience para cobrir lógica (pulando render HTML puro):
- `AudienceAjaxController` — endpoints, validação, dispatch, checagem de conflitos
- `AudienceAdminAudience` / `AudienceAdminEnvironment` / `AudienceAdminCalendar` — handlers CRUD, preparação de dados, montagem de query

**108 testes verdes** localmente (pcov). Nenhum source (`includes/`) alterado. Sem mudança de floor (bump central no fim da Fase 1+2). A % exata por arquivo será confirmada pela CI.

Parte do campanha Fase 1+2 (alvo global ~75–80%). PHPStan analisa só `includes/`, então os arquivos de teste não são gated por PHPStan; WPCS limpo.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_