### PR TITLE
test(php): raise self-scheduling + reregistration coverage (logic paths)

### DIFF
--- a/tests/Unit/AppointmentCancellationHandlerTest.php
+++ b/tests/Unit/AppointmentCancellationHandlerTest.php
@@ -197,4 +197,247 @@ class AppointmentCancellationHandlerTest extends TestCase {
 		$handler->handle_cancellation_request();
 		$this->assertTrue( true );
 	}
+
+	// ---- handle_cancellation_request routing -------------------------
+	//
+	// The render_*() methods all funnel into render_page(), which calls
+	// Utils::asset_suffix() and then exit(). We alias-mock Utils::asset_suffix
+	// to throw a sentinel so the routing + render entry are exercised without
+	// the process-ending exit(), then assert the correct branch was taken via
+	// the captured page title / message routed through __().
+
+	/**
+	 * Capture which message render_page() received by intercepting __().
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_handle_request_routes_invalid_link_for_missing_id(): void {
+		// Truthy-but-non-numeric query var → passes the `! get_query_var` guard
+		// yet absint()s to 0, triggering the invalid_link branch.
+		Functions\when( 'get_query_var' )->alias(
+			static function ( $var ) {
+				return AppointmentCancellationHandler::QUERY_VAR === $var ? 'abc' : '';
+			}
+		);
+		Functions\when( 'absint' )->alias( static fn( $v ) => abs( (int) $v ) );
+
+		$captured = $this->stub_render_capture();
+
+		$handler = $this->make_handler();
+		try {
+			$handler->handle_cancellation_request();
+			$this->fail( 'Expected render to short-circuit via Utils::asset_suffix.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'render-page', $e->getMessage() );
+		}
+
+		$this->assert_captured_contains( $captured, 'Invalid cancellation link.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_handle_request_routes_already_cancelled(): void {
+		Functions\when( 'get_query_var' )->alias(
+			static function ( $var ) {
+				if ( AppointmentCancellationHandler::QUERY_VAR === $var ) {
+					return '42';
+				}
+				return 'tok';
+			}
+		);
+		Functions\when( 'absint' )->alias( static fn( $v ) => abs( (int) $v ) );
+
+		$appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+		$appt_repo->shouldReceive( 'findById' )->with( 42 )->andReturn(
+			array( 'confirmation_token' => 'tok', 'status' => 'cancelled' )
+		);
+
+		$captured = $this->stub_render_capture();
+
+		$handler = $this->make_handler();
+		try {
+			$handler->handle_cancellation_request();
+			$this->fail( 'Expected render to short-circuit.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'render-page', $e->getMessage() );
+		}
+
+		$this->assert_captured_contains( $captured, 'Already cancelled' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_handle_request_renders_confirm_form_with_calendar(): void {
+		Functions\when( 'get_query_var' )->alias(
+			static function ( $var ) {
+				if ( AppointmentCancellationHandler::QUERY_VAR === $var ) {
+					return '42';
+				}
+				return 'tok';
+			}
+		);
+		Functions\when( 'absint' )->alias( static fn( $v ) => abs( (int) $v ) );
+		Functions\when( 'wp_nonce_field' )->justReturn( '' );
+
+		$appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+		$appt_repo->shouldReceive( 'findById' )->with( 42 )->andReturn(
+			array(
+				'confirmation_token' => 'tok',
+				'status'             => 'confirmed',
+				'calendar_id'        => 9,
+				'appointment_date'   => '2026-05-20',
+				'start_time'         => '09:00:00',
+			)
+		);
+
+		$cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+		$cal_repo->shouldReceive( 'findById' )->with( 9 )->andReturn( array( 'title' => 'Clinic' ) );
+
+		Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' )
+			->shouldReceive( 'format_wallclock_date' )->andReturn( '20/05/2026' )
+			->shouldReceive( 'format_wallclock_time' )->andReturn( '09:00' );
+
+		$captured = $this->stub_render_capture();
+
+		$handler = $this->make_handler();
+		try {
+			$handler->handle_cancellation_request();
+			$this->fail( 'Expected render to short-circuit.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'render-page', $e->getMessage() );
+		}
+
+		// Confirm form heading routed through esc_html_e / __.
+		$this->assert_captured_contains( $captured, 'Cancel appointment' );
+	}
+
+	// ---- process_cancellation ----------------------------------------
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_process_cancellation_renders_error_on_wp_error(): void {
+		$error = Mockery::mock( 'WP_Error' );
+		$error->shouldReceive( 'get_error_message' )->andReturn( 'too late' );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+
+		$appt_handler = Mockery::mock( 'FreeFormCertificate\SelfScheduling\AppointmentHandler' );
+		$appt_handler->shouldReceive( 'cancel_appointment' )->with( 42, 'tok', '' )->andReturn( $error );
+
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'add_action' )->justReturn( true );
+		$handler = new AppointmentCancellationHandler( $appt_handler );
+
+		$captured = $this->stub_render_capture();
+
+		try {
+			$this->invoke_process_cancellation( $handler, 42, 'tok' );
+			$this->fail( 'Expected render to short-circuit.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'render-page', $e->getMessage() );
+		}
+
+		$this->assert_captured_contains( $captured, 'Could not cancel' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_process_cancellation_renders_success(): void {
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		$_POST['ffc_cancel_reason'] = 'changed plans';
+
+		$appt_handler = Mockery::mock( 'FreeFormCertificate\SelfScheduling\AppointmentHandler' );
+		$appt_handler->shouldReceive( 'cancel_appointment' )->with( 42, 'tok', 'changed plans' )->andReturn( true );
+
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'add_action' )->justReturn( true );
+		$handler = new AppointmentCancellationHandler( $appt_handler );
+
+		$captured = $this->stub_render_capture();
+
+		try {
+			$this->invoke_process_cancellation( $handler, 42, 'tok' );
+			$this->fail( 'Expected render to short-circuit.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'render-page', $e->getMessage() );
+		}
+
+		$this->assert_captured_contains( $captured, 'Appointment cancelled' );
+
+		unset( $_POST['ffc_cancel_reason'] );
+	}
+
+	/**
+	 * Wire up the render-path WP function stubs and capture every string that
+	 * reaches __()/esc_html_e(); make Utils::asset_suffix() throw so render_page
+	 * stops before exit().
+	 *
+	 * @return array{strings: list<string>}
+	 */
+	private function stub_render_capture(): \ArrayObject {
+		// An ArrayObject so the closures and the returned handle share one
+		// instance — a plain array would be copied on return and the test would
+		// never observe the captured strings.
+		$captured = new \ArrayObject();
+
+		// Capture every label that reaches the render layer. render_notice()
+		// passes title+body through esc_html(); render_confirm_form() emits its
+		// headings via esc_html_e(). Neither is stubbed in setUp(), so these are
+		// the first (and only) definitions in the test process.
+		Functions\when( 'esc_html' )->alias(
+			static function ( $text ) use ( $captured ) {
+				$captured->append( $text );
+				return $text;
+			}
+		);
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_html_e' )->alias(
+			static function ( $text ) use ( $captured ) {
+				$captured->append( $text );
+			}
+		);
+		Functions\when( 'get_language_attributes' )->justReturn( 'lang="en"' );
+		Functions\when( 'get_bloginfo' )->justReturn( 'Site' );
+		Functions\when( 'nocache_headers' )->justReturn( null );
+		Functions\when( 'status_header' )->justReturn( null );
+
+		// render_page() reads Utils::asset_suffix() before emitting the page
+		// body; throw there to exercise the full routing + render entry without
+		// the process-ending exit() or any echoed HTML.
+		Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+			->shouldReceive( 'asset_suffix' )
+			->andReturnUsing(
+				static function () {
+					throw new \RuntimeException( 'render-page' );
+				}
+			);
+
+		return $captured;
+	}
+
+	/**
+	 * @param \ArrayObject<int, string> $captured Captured render-layer strings.
+	 */
+	private function assert_captured_contains( \ArrayObject $captured, string $needle ): void {
+		$this->assertContains( $needle, $captured->getArrayCopy() );
+	}
+
+	/**
+	 * Invoke the private process_cancellation().
+	 */
+	private function invoke_process_cancellation( AppointmentCancellationHandler $handler, int $id, string $token ): void {
+		$ref = new \ReflectionMethod( AppointmentCancellationHandler::class, 'process_cancellation' );
+		$ref->setAccessible( true );
+		$ref->invoke( $handler, $id, $token );
+	}
 }

--- a/tests/Unit/AppointmentReceiptHandlerTest.php
+++ b/tests/Unit/AppointmentReceiptHandlerTest.php
@@ -107,4 +107,173 @@ class AppointmentReceiptHandlerTest extends TestCase {
         $url = AppointmentReceiptHandler::get_receipt_url( 42, 'abc123' );
         $this->assertIsString( $url );
     }
+
+    // ==================================================================
+    // handle_receipt_request() — appointment not found
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_receipt_request_dies_when_not_found(): void {
+        $this->stub_query_var( '7', '' );
+        Functions\when( 'wp_die' )->alias( fn( $msg ) => throw new \RuntimeException( $msg ) );
+
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' )
+            ->shouldReceive( 'findById' )->with( 7 )->andReturn( null );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        $handler = new AppointmentReceiptHandler();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Appointment not found.' );
+        $handler->handle_receipt_request();
+    }
+
+    // ==================================================================
+    // handle_receipt_request() — no access (wrong token, not owner/admin)
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_receipt_request_dies_without_access(): void {
+        $this->stub_query_var( '7', 'wrong-token' );
+        Functions\when( 'wp_die' )->alias( fn( $msg ) => throw new \RuntimeException( $msg ) );
+        Functions\when( 'current_user_can' )->justReturn( false );
+        Functions\when( 'is_user_logged_in' )->justReturn( false );
+        Functions\when( 'get_current_user_id' )->justReturn( 0 );
+
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' )
+            ->shouldReceive( 'findById' )->with( 7 )->andReturn(
+                array( 'id' => 7, 'confirmation_token' => 'real-token', 'status' => 'confirmed', 'user_id' => 5 )
+            );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        $handler = new AppointmentReceiptHandler();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'do not have permission' );
+        $handler->handle_receipt_request();
+    }
+
+    // ==================================================================
+    // handle_receipt_request() — pending appointment blocked for non-admin
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_receipt_request_blocks_pending_for_non_admin(): void {
+        $this->stub_query_var( '7', 'tok' );
+        Functions\when( 'wp_die' )->alias( fn( $msg ) => throw new \RuntimeException( $msg ) );
+        Functions\when( 'current_user_can' )->justReturn( false );
+        Functions\when( 'is_user_logged_in' )->justReturn( false );
+        Functions\when( 'get_current_user_id' )->justReturn( 0 );
+
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' )
+            ->shouldReceive( 'findById' )->with( 7 )->andReturn(
+                array( 'id' => 7, 'confirmation_token' => 'tok', 'status' => 'pending', 'user_id' => 5 )
+            );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        $handler = new AppointmentReceiptHandler();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'awaiting admin approval' );
+        $handler->handle_receipt_request();
+    }
+
+    // ==================================================================
+    // handle_receipt_request() — success renders + uses deleted-calendar
+    //                            placeholder, decryption + date formatting
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_receipt_request_renders_receipt_for_admin(): void {
+        $this->stub_query_var( '7', '' );
+        Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'is_user_logged_in' )->justReturn( true );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'language_attributes' )->justReturn( null );
+        Functions\when( 'bloginfo' )->justReturn( null );
+        Functions\when( 'get_bloginfo' )->justReturn( 'Site' );
+        Functions\when( 'wp_enqueue_script' )->justReturn( true );
+        Functions\when( 'wp_print_scripts' )->justReturn( true );
+
+        // Calendar deleted (calendar_id empty) → placeholder branch.
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' )
+            ->shouldReceive( 'findById' )->with( 7 )->andReturn(
+                array(
+                    'id'              => 7,
+                    'status'          => 'confirmed',
+                    'user_id'         => 1,
+                    'name'            => 'Alice',
+                    'email_encrypted' => 'ENC_EMAIL',
+                    'phone_encrypted' => 'ENC_PHONE',
+                    'appointment_date' => '2026-05-20',
+                    'start_time'      => '09:00:00',
+                    'end_time'        => '10:00:00',
+                    'created_at'      => '2026-05-01 12:00:00',
+                    'validation_code' => 'AC1234567890',
+                    'user_notes'      => "line1\nline2",
+                    'calendar_id'     => 0,
+                )
+            );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'asset_suffix' )->andReturn( '.min' );
+        Mockery::mock( 'alias:FreeFormCertificate\Generators\PdfGenerator' )
+            ->shouldReceive( 'generate_appointment_pdf_data' )->andReturn( 'PDFDATA' );
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' )
+            ->shouldReceive( 'decrypt' )->with( 'ENC_EMAIL' )->andReturn( 'alice@example.com' )
+            ->shouldReceive( 'decrypt' )->with( 'ENC_PHONE' )->andReturn( '+5511999990000' );
+        Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' )
+            ->shouldReceive( 'format_wallclock_date' )->andReturn( '20/05/2026' )
+            ->shouldReceive( 'format_wallclock_time' )->andReturn( '09:00' )
+            ->shouldReceive( 'format_datetime' )->andReturn( '01/05/2026 12:00' );
+        // DocumentFormatter is pure (no DB) and exposes PREFIX_APPOINTMENT as a
+        // real const the handler references — use the real class.
+
+        // wp_localize_script runs near the end of display_receipt(), after all
+        // the data prep + markup; throw there to stop before the caller's exit.
+        Functions\when( 'wp_localize_script' )->alias(
+            static function () {
+                throw new \RuntimeException( 'localized' );
+            }
+        );
+
+        $handler = new AppointmentReceiptHandler();
+
+        ob_start();
+        try {
+            $handler->handle_receipt_request();
+            ob_end_clean();
+            $this->fail( 'Expected display_receipt to short-circuit at wp_localize_script.' );
+        } catch ( \RuntimeException $e ) {
+            ob_end_clean();
+            $this->assertSame( 'localized', $e->getMessage() );
+        }
+    }
+
+    /**
+     * Stub get_query_var to return the receipt id + token.
+     */
+    private function stub_query_var( string $id, string $token ): void {
+        Functions\when( 'get_query_var' )->alias(
+            static function ( $var ) use ( $id, $token ) {
+                if ( 'ffc_appointment_receipt' === $var ) {
+                    return $id;
+                }
+                if ( 'token' === $var ) {
+                    return $token;
+                }
+                return '';
+            }
+        );
+    }
 }

--- a/tests/Unit/AppointmentsListTableTest.php
+++ b/tests/Unit/AppointmentsListTableTest.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\SelfScheduling\AppointmentsListTable;
+
+/**
+ * Tests for the self-scheduling appointments WP_List_Table.
+ *
+ * Focus: the column data/formatting logic, prepare_items() query assembly, and
+ * the filter dropdown nav. column_id() is skipped — it builds row-action HTML
+ * via the parent's row_actions() (unavailable in the bootstrap stub) and is
+ * pure markup/url assembly.
+ *
+ * @covers \FreeFormCertificate\SelfScheduling\AppointmentsListTable
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class AppointmentsListTableTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var Mockery\MockInterface */
+    private $appt_repo;
+
+    /** @var Mockery\MockInterface */
+    private $cal_repo;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $t ) { echo $t; } );
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'admin_url' )->alias( fn( $p = '' ) => 'https://example.com/wp-admin/' . $p );
+        Functions\when( 'absint' )->alias( fn( $v ) => abs( (int) $v ) );
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( null );
+
+        // Constructor instantiates both repositories with `new`.
+        $this->appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $this->appt_repo->shouldReceive( 'findAll' )->andReturn( array() )->byDefault();
+        $this->appt_repo->shouldReceive( 'count' )->andReturn( 0 )->byDefault();
+        $this->cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $this->cal_repo->shouldReceive( 'findById' )->andReturn( null )->byDefault();
+        $this->cal_repo->shouldReceive( 'getActiveCalendars' )->andReturn( array() )->byDefault();
+    }
+
+    protected function tearDown(): void {
+        unset( $_GET['calendar_id'], $_GET['status'] );
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function call_protected( AppointmentsListTable $table, string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( $table, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $table, $args );
+    }
+
+    public function test_get_columns_declares_expected_keys(): void {
+        $table = new AppointmentsListTable();
+        $cols  = $table->get_columns();
+
+        $this->assertSame(
+            array( 'cb', 'id', 'calendar', 'name', 'email', 'appointment_date', 'time', 'status', 'created_at' ),
+            array_keys( $cols )
+        );
+    }
+
+    public function test_get_sortable_columns_declares_sortable_set(): void {
+        $table    = new AppointmentsListTable();
+        $sortable = $table->get_sortable_columns();
+
+        $this->assertSame(
+            array( 'id', 'calendar', 'appointment_date', 'status', 'created_at' ),
+            array_keys( $sortable )
+        );
+        $this->assertSame( array( 'id', true ), $sortable['id'] );
+    }
+
+    public function test_column_default_returns_value_or_dash(): void {
+        $table = new AppointmentsListTable();
+
+        $this->assertSame( 'abc', $table->column_default( array( 'foo' => 'abc' ), 'foo' ) );
+        $this->assertSame( '-', $table->column_default( array(), 'missing' ) );
+    }
+
+    public function test_column_cb_emits_checkbox_with_id(): void {
+        $table = new AppointmentsListTable();
+        $html  = $table->column_cb( array( 'id' => 33 ) );
+
+        $this->assertStringContainsString( 'name="appointment[]"', $html );
+        $this->assertStringContainsString( 'value="33"', $html );
+    }
+
+    public function test_column_calendar_links_to_post_when_found(): void {
+        $this->cal_repo->shouldReceive( 'findById' )->with( 9 )->andReturn(
+            array( 'post_id' => 100, 'title' => 'Clinic' )
+        );
+
+        $table = new AppointmentsListTable();
+        $out   = $table->column_calendar( array( 'calendar_id' => 9 ) );
+
+        $this->assertStringContainsString( 'post=100', $out );
+        $this->assertStringContainsString( 'Clinic', $out );
+    }
+
+    public function test_column_calendar_deleted_when_missing(): void {
+        $this->cal_repo->shouldReceive( 'findById' )->with( 9 )->andReturn( null );
+
+        $table = new AppointmentsListTable();
+        $this->assertSame( '(Deleted)', $table->column_calendar( array( 'calendar_id' => 9 ) ) );
+    }
+
+    public function test_column_name_prefers_user_display_name(): void {
+        Functions\when( 'get_user_by' )->justReturn( (object) array( 'display_name' => 'Alice' ) );
+
+        $table = new AppointmentsListTable();
+        $this->assertSame( 'Alice', $table->column_name( array( 'user_id' => 5, 'name' => 'Fallback' ) ) );
+    }
+
+    public function test_column_name_falls_back_to_name_field(): void {
+        $table = new AppointmentsListTable();
+        $this->assertSame( 'Guest Joe', $table->column_name( array( 'user_id' => 0, 'name' => 'Guest Joe' ) ) );
+    }
+
+    public function test_column_name_guest_placeholder_when_no_name(): void {
+        $table = new AppointmentsListTable();
+        $this->assertSame( '(Guest)', $table->column_name( array( 'user_id' => 0 ) ) );
+    }
+
+    public function test_column_email_decrypts_and_dashes_when_empty(): void {
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' )
+            ->shouldReceive( 'decrypt_field' )->andReturn( 'a@b.com', '' );
+
+        $table = new AppointmentsListTable();
+        $this->assertSame( 'a@b.com', $table->column_email( array( 'email_encrypted' => 'X' ) ) );
+        $this->assertSame( '-', $table->column_email( array() ) );
+    }
+
+    public function test_column_time_formats_range(): void {
+        Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' )
+            ->shouldReceive( 'format_wallclock_time' )->andReturn( '09:00', '10:00' );
+
+        $table = new AppointmentsListTable();
+        $this->assertSame(
+            '09:00 - 10:00',
+            $table->column_time( array( 'start_time' => '09:00:00', 'end_time' => '10:00:00' ) )
+        );
+    }
+
+    public function test_column_status_known_label_and_fallback(): void {
+        $table = new AppointmentsListTable();
+
+        $this->assertStringContainsString( 'ffc-status-confirmed', $table->column_status( array( 'status' => 'confirmed' ) ) );
+        // Unknown status → escaped raw value.
+        $this->assertSame( 'weird', $table->column_status( array( 'status' => 'weird' ) ) );
+    }
+
+    public function test_prepare_items_builds_conditions_and_pagination(): void {
+        $_GET['calendar_id'] = '9';
+        $_GET['status']      = 'confirmed';
+
+        Functions\when( 'get_user_by' )->justReturn( false );
+
+        $captured = array();
+        $this->appt_repo->shouldReceive( 'findAll' )->andReturnUsing(
+            function ( $conditions ) use ( &$captured ) {
+                $captured = $conditions;
+                return array( array( 'id' => 1 ) );
+            }
+        );
+        $this->appt_repo->shouldReceive( 'count' )->andReturn( 5 );
+
+        // Utils::get_get_string for the status filter.
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( 'confirmed' );
+
+        $table = new AppointmentsListTable();
+        $table->prepare_items();
+
+        $this->assertSame( 9, $captured['calendar_id'] );
+        $this->assertSame( 'confirmed', $captured['status'] );
+    }
+
+    public function test_extra_tablenav_returns_early_when_not_top(): void {
+        $table = new AppointmentsListTable();
+
+        ob_start();
+        $this->call_protected( $table, 'extra_tablenav', array( 'bottom' ) );
+        $out = ob_get_clean();
+
+        $this->assertSame( '', $out );
+    }
+
+    public function test_extra_tablenav_renders_calendar_options(): void {
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( '' );
+        $this->cal_repo->shouldReceive( 'getActiveCalendars' )->andReturn(
+            array( array( 'id' => 1, 'title' => 'Cal One' ) )
+        );
+
+        $table = new AppointmentsListTable();
+
+        ob_start();
+        $this->call_protected( $table, 'extra_tablenav', array( 'top' ) );
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString( 'Cal One', $out );
+        $this->assertStringContainsString( 'All Statuses', $out );
+    }
+}

--- a/tests/Unit/AppointmentsListViewTest.php
+++ b/tests/Unit/AppointmentsListViewTest.php
@@ -1,0 +1,239 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for includes/self-scheduling/views/appointments-list.php.
+ *
+ * The view is a procedural admin template: a permission gate, the
+ * confirm/cancel mutation handlers (redirect + exit), the single-appointment
+ * detail branch (data prep + render), and the default list branch. We include
+ * the file under different $_GET states with the WP surface stubbed, asserting
+ * the branch-selecting logic — pure markup rows are incidental.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class AppointmentsListViewTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    private const VIEW = '/includes/self-scheduling/views/appointments-list.php';
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'esc_html' )->returnArg();
+        Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'esc_url' )->returnArg();
+        Functions\when( 'esc_html_e' )->alias( function ( $t ) { echo $t; } );
+        Functions\when( 'esc_html__' )->returnArg();
+        Functions\when( 'esc_attr__' )->returnArg();
+        Functions\when( 'admin_url' )->alias( fn( $p = '' ) => 'https://example.com/wp-admin/' . $p );
+        Functions\when( 'add_query_arg' )->justReturn( 'https://example.com/wp-admin/admin.php?page=ffc-appointments' );
+        Functions\when( 'absint' )->alias( fn( $v ) => abs( (int) $v ) );
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_transient' )->justReturn( false );
+        Functions\when( 'set_transient' )->justReturn( true );
+        Functions\when( 'delete_transient' )->justReturn( true );
+        Functions\when( 'do_action' )->justReturn( null );
+        Functions\when( 'selected' )->justReturn( '' );
+        Functions\when( 'submit_button' )->justReturn( null );
+
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', '/tmp/' );
+        }
+    }
+
+    protected function tearDown(): void {
+        unset( $_GET['appointment'], $_GET['ffc_action'], $_GET['reason'] );
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function include_view(): void {
+        include FFC_PLUGIN_DIR . self::VIEW;
+    }
+
+    // ==================================================================
+    // Permission gate
+    // ==================================================================
+
+    public function test_view_dies_without_permission_on_specific_appointment(): void {
+        $_GET['appointment'] = '5';
+        Functions\when( 'wp_die' )->alias( fn( $msg ) => throw new \RuntimeException( $msg ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( false );
+
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'do not have permission' );
+        $this->include_view();
+    }
+
+    // ==================================================================
+    // Confirm mutation
+    // ==================================================================
+
+    public function test_view_confirm_success_redirects(): void {
+        $_GET['appointment'] = '5';
+        $_GET['ffc_action']  = 'confirm';
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturnUsing( fn( $k ) => 'ffc_action' === $k ? 'confirm' : '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'confirm' )->with( 5, 1 )->andReturn( true );
+        $appt_repo->shouldReceive( 'findById' )->with( 5 )->andReturn(
+            array( 'id' => 5, 'calendar_id' => 7 )
+        );
+
+        $cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $cal_repo->shouldReceive( 'findById' )->with( 7 )->andReturn( array( 'id' => 7, 'title' => 'Cal' ) );
+
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->include_view();
+    }
+
+    public function test_view_confirm_failure_redirects(): void {
+        $_GET['appointment'] = '5';
+        $_GET['ffc_action']  = 'confirm';
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturnUsing( fn( $k ) => 'ffc_action' === $k ? 'confirm' : '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'confirm' )->with( 5, 1 )->andReturn( false );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->include_view();
+    }
+
+    // ==================================================================
+    // Cancel mutation
+    // ==================================================================
+
+    public function test_view_cancel_success_redirects(): void {
+        $_GET['appointment'] = '5';
+        $_GET['ffc_action']  = 'cancel';
+        $_GET['reason']      = 'Admin closed slot';
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'sanitize_textarea_field' )->returnArg();
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturnUsing( fn( $k ) => 'ffc_action' === $k ? 'cancel' : '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'cancel' )->with( 5, 1, 'Admin closed slot' )->andReturn( true );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->include_view();
+    }
+
+    // ==================================================================
+    // Detail view
+    // ==================================================================
+
+    public function test_view_renders_appointment_detail(): void {
+        $_GET['appointment'] = '5';
+        Functions\when( 'get_user_by' )->justReturn( false );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt = array(
+            'id'               => 5,
+            'status'           => 'confirmed',
+            'calendar_id'      => 7,
+            'appointment_date' => '2026-05-20',
+            'start_time'       => '09:00:00',
+            'end_time'         => '10:00:00',
+            'name'             => 'Alice',
+            'created_at'       => '2026-05-01',
+            'custom_data'      => '{"field_a":"v","field_b":["x","y"]}',
+        );
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'findById' )->with( 5 )->andReturn( $appt );
+
+        $cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $cal_repo->shouldReceive( 'findById' )->with( 7 )->andReturn( array( 'id' => 7, 'title' => 'Clinic' ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' )
+            ->shouldReceive( 'decrypt_appointment' )->andReturnUsing( fn( $a ) => $a );
+
+        ob_start();
+        $this->include_view();
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString( 'Appointment Details', $out );
+        $this->assertStringContainsString( 'Clinic', $out );
+        $this->assertStringContainsString( 'Alice', $out );
+    }
+
+    public function test_view_detail_not_found_shows_notice(): void {
+        $_GET['appointment'] = '5';
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'findById' )->with( 5 )->andReturn( null );
+        Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+
+        ob_start();
+        $this->include_view();
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString( 'Appointment not found.', $out );
+    }
+
+    // ==================================================================
+    // List view (default, no specific appointment)
+    // ==================================================================
+
+    public function test_view_renders_list_table_by_default(): void {
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_get_string' )->andReturn( '' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'findAll' )->andReturn( array() );
+        $appt_repo->shouldReceive( 'count' )->andReturn( 0 );
+
+        $cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $cal_repo->shouldReceive( 'getActiveCalendars' )->andReturn( array() );
+
+        ob_start();
+        $this->include_view();
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString( 'Appointments', $out );
+        $this->assertStringContainsString( 'Export CSV', $out );
+    }
+}

--- a/tests/Unit/ReregistrationAdminTest.php
+++ b/tests/Unit/ReregistrationAdminTest.php
@@ -76,7 +76,7 @@ class ReregistrationAdminTest extends TestCase {
 
     protected function tearDown(): void {
         unset( $_GET['page'], $_GET['view'], $_GET['id'], $_GET['message'], $_GET['action'], $_GET['_wpnonce'] );
-        unset( $_POST['ffc_action'], $_POST['audience_ids'] );
+        unset( $_POST['ffc_action'], $_POST['audience_ids'], $_POST['reregistration_id'], $_POST['rereg_status'], $_POST['rereg_audience_ids'] );
         Monkey\tearDown();
         parent::tearDown();
     }
@@ -312,5 +312,188 @@ class ReregistrationAdminTest extends TestCase {
 
         $this->assertSame( 'success', $this->json_responses[0]['type'] );
         $this->assertSame( 0, $this->json_responses[0]['data']['count'] );
+    }
+
+    // ==================================================================
+    // handle_save() / handle_delete()
+    // ==================================================================
+
+    private function invoke_private( ReregistrationAdmin $admin, string $method, array $args = array() ) {
+        $ref = new \ReflectionMethod( ReregistrationAdmin::class, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $admin, $args );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_save_creates_active_campaign_and_redirects(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( true );
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        $_POST['ffc_action']         = 'save_reregistration';
+        $_POST['reregistration_id']  = 0;
+        $_POST['rereg_status']       = 'active';
+        $_POST['rereg_audience_ids'] = array( '3', '4' );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true )
+            ->shouldReceive( 'get_post_string' )->andReturnUsing(
+                function ( $key, $default = '' ) {
+                    $map = array(
+                        'rereg_title'      => 'My Campaign',
+                        'rereg_start_date' => '2026-01-01',
+                        'rereg_end_date'   => '2026-12-31',
+                        'rereg_status'     => 'active',
+                    );
+                    return $map[ $key ] ?? $default;
+                }
+            );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationRepository' )
+            ->shouldReceive( 'create' )->once()->andReturn( 55 )
+            ->shouldReceive( 'set_audience_ids' )->once()->with( 55, array( 3, 4 ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationSubmissionRepository' )
+            ->shouldReceive( 'create_for_audience_members' )->once()->with( 55, array( 3, 4 ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationEmailHandler' )
+            ->shouldReceive( 'send_invitations' )->once()->with( 55 )->andReturn( 0 );
+
+        $admin = new ReregistrationAdmin();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->invoke_private( $admin, 'handle_save' );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_save_updates_existing_draft_campaign(): void {
+        Functions\when( 'wp_verify_nonce' )->justReturn( true );
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        $_POST['ffc_action']        = 'save_reregistration';
+        $_POST['reregistration_id'] = 9;
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true )
+            ->shouldReceive( 'get_post_string' )->andReturnUsing(
+                function ( $key, $default = '' ) {
+                    $map = array(
+                        'rereg_title'      => 'Updated',
+                        'rereg_start_date' => '2026-01-01',
+                        'rereg_end_date'   => '2026-12-31',
+                        'rereg_status'     => 'draft',
+                    );
+                    return $map[ $key ] ?? $default;
+                }
+            );
+
+        // Existing campaign already draft → no membership/invitation side effects.
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationRepository' )
+            ->shouldReceive( 'get_by_id' )->with( 9 )->andReturn( (object) array( 'status' => 'draft' ) )
+            ->shouldReceive( 'update' )->once()->with( 9, Mockery::type( 'array' ) )
+            ->shouldReceive( 'set_audience_ids' )->once()->with( 9, array() );
+
+        $admin = new ReregistrationAdmin();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->invoke_private( $admin, 'handle_save' );
+    }
+
+    public function test_handle_save_returns_early_without_action(): void {
+        unset( $_POST['ffc_action'] );
+        $admin = new ReregistrationAdmin();
+        $this->invoke_private( $admin, 'handle_save' );
+        $this->assertTrue( true );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_save_returns_early_on_bad_nonce(): void {
+        $_POST['ffc_action'] = 'save_reregistration';
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'get_post_string' )->andReturn( '' );
+
+        $admin = new ReregistrationAdmin();
+        $this->invoke_private( $admin, 'handle_save' );
+        $this->assertTrue( true );
+    }
+
+    public function test_handle_delete_returns_early_without_action(): void {
+        unset( $_GET['action'] );
+        $admin = new ReregistrationAdmin();
+        $this->invoke_private( $admin, 'handle_delete' );
+        $this->assertTrue( true );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_delete_dies_without_delete_cap(): void {
+        $_GET['action'] = 'delete';
+        $_GET['id']     = '5';
+        Functions\when( 'wp_die' )->alias( fn( $msg ) => throw new \RuntimeException( $msg ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'current_user_can_admin_or' )->with( 'ffc_delete_reregistration' )->andReturn( false );
+
+        $admin = new ReregistrationAdmin();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'permission to delete' );
+        $this->invoke_private( $admin, 'handle_delete' );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_delete_deletes_and_redirects(): void {
+        $_GET['action']   = 'delete';
+        $_GET['id']       = '5';
+        $_GET['_wpnonce'] = 'good';
+        Functions\when( 'wp_verify_nonce' )->justReturn( true );
+        Functions\when( 'wp_safe_redirect' )->alias( fn() => throw new \RuntimeException( 'redirected' ) );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true )
+            ->shouldReceive( 'get_get_string' )->andReturn( 'good' );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationRepository' )
+            ->shouldReceive( 'delete' )->once()->with( 5 );
+
+        $admin = new ReregistrationAdmin();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $this->invoke_private( $admin, 'handle_delete' );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_delete_returns_early_on_bad_nonce(): void {
+        $_GET['action']   = 'delete';
+        $_GET['id']       = '5';
+        $_GET['_wpnonce'] = 'bad';
+        Functions\when( 'wp_verify_nonce' )->justReturn( false );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' )
+            ->shouldReceive( 'current_user_can_admin_or' )->andReturn( true )
+            ->shouldReceive( 'get_get_string' )->andReturn( 'bad' );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationRepository' )
+            ->shouldReceive( 'delete' )->never();
+
+        $admin = new ReregistrationAdmin();
+        $this->invoke_private( $admin, 'handle_delete' );
+        $this->assertTrue( true );
     }
 }

--- a/tests/Unit/ReregistrationCsvExporterTest.php
+++ b/tests/Unit/ReregistrationCsvExporterTest.php
@@ -125,4 +125,207 @@ class ReregistrationCsvExporterTest extends TestCase {
         ReregistrationCsvExporter::handle_export();
         $this->assertTrue( true );
     }
+
+    // ==================================================================
+    // Reflection helpers
+    // ==================================================================
+
+    /**
+     * Invoke a private static method by name.
+     *
+     * @param string            $method Method name.
+     * @param array<int, mixed> $args   Positional args.
+     * @return mixed
+     */
+    private function invoke_static( string $method, array $args ) {
+        $ref = new \ReflectionMethod( ReregistrationCsvExporter::class, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( null, $args );
+    }
+
+    // ==================================================================
+    // stringify_value() — checkbox
+    // ==================================================================
+
+    public function test_stringify_value_checkbox_truthy_returns_yes(): void {
+        $field = (object) array( 'field_type' => 'checkbox', 'field_key' => 'agree' );
+
+        $this->assertSame( 'Yes', $this->invoke_static( 'stringify_value', array( $field, '1' ) ) );
+        $this->assertSame( 'Yes', $this->invoke_static( 'stringify_value', array( $field, 1 ) ) );
+        $this->assertSame( 'Yes', $this->invoke_static( 'stringify_value', array( $field, true ) ) );
+    }
+
+    public function test_stringify_value_checkbox_falsy_returns_no(): void {
+        $field = (object) array( 'field_type' => 'checkbox', 'field_key' => 'agree' );
+
+        $this->assertSame( 'No', $this->invoke_static( 'stringify_value', array( $field, '0' ) ) );
+        $this->assertSame( 'No', $this->invoke_static( 'stringify_value', array( $field, '' ) ) );
+    }
+
+    // ==================================================================
+    // stringify_value() — dependent_select
+    // ==================================================================
+
+    public function test_stringify_value_dependent_select_from_json(): void {
+        $field = (object) array( 'field_type' => 'dependent_select', 'field_key' => 'loc' );
+        $json  = wp_json_encode( array( 'parent' => 'SP', 'child' => 'Centro' ) );
+
+        $this->assertSame( 'SP / Centro', $this->invoke_static( 'stringify_value', array( $field, $json ) ) );
+    }
+
+    public function test_stringify_value_dependent_select_from_array(): void {
+        $field = (object) array( 'field_type' => 'dependent_select', 'field_key' => 'loc' );
+
+        $this->assertSame(
+            'SP / Centro',
+            $this->invoke_static( 'stringify_value', array( $field, array( 'parent' => 'SP', 'child' => 'Centro' ) ) )
+        );
+    }
+
+    public function test_stringify_value_dependent_select_parent_only_trims_separator(): void {
+        $field = (object) array( 'field_type' => 'dependent_select', 'field_key' => 'loc' );
+
+        $this->assertSame(
+            'SP',
+            $this->invoke_static( 'stringify_value', array( $field, array( 'parent' => 'SP', 'child' => '' ) ) )
+        );
+    }
+
+    public function test_stringify_value_dependent_select_non_array_returns_empty(): void {
+        $field = (object) array( 'field_type' => 'dependent_select', 'field_key' => 'loc' );
+
+        $this->assertSame( '', $this->invoke_static( 'stringify_value', array( $field, 'not-json' ) ) );
+    }
+
+    // ==================================================================
+    // stringify_value() — working_hours
+    // ==================================================================
+
+    public function test_stringify_value_working_hours_empty_json_returns_empty(): void {
+        $field = (object) array( 'field_type' => 'working_hours', 'field_key' => 'wh' );
+
+        $this->assertSame( '', $this->invoke_static( 'stringify_value', array( $field, '[]' ) ) );
+    }
+
+    public function test_stringify_value_working_hours_keeps_raw_json_string(): void {
+        $field = (object) array( 'field_type' => 'working_hours', 'field_key' => 'wh' );
+
+        $this->assertSame( '{"mon":"9-5"}', $this->invoke_static( 'stringify_value', array( $field, '{"mon":"9-5"}' ) ) );
+    }
+
+    public function test_stringify_value_working_hours_array_encodes_json(): void {
+        $field = (object) array( 'field_type' => 'working_hours', 'field_key' => 'wh' );
+
+        $this->assertSame(
+            '{"mon":"9-5"}',
+            $this->invoke_static( 'stringify_value', array( $field, array( 'mon' => '9-5' ) ) )
+        );
+    }
+
+    // ==================================================================
+    // stringify_value() — default
+    // ==================================================================
+
+    public function test_stringify_value_default_scalar(): void {
+        $field = (object) array( 'field_type' => 'text', 'field_key' => 'name' );
+
+        $this->assertSame( 'Alice', $this->invoke_static( 'stringify_value', array( $field, 'Alice' ) ) );
+        $this->assertSame( '42', $this->invoke_static( 'stringify_value', array( $field, 42 ) ) );
+    }
+
+    public function test_stringify_value_default_array_imploded(): void {
+        $field = (object) array( 'field_type' => 'multiselect', 'field_key' => 'tags' );
+
+        $this->assertSame(
+            'a, b, c',
+            $this->invoke_static( 'stringify_value', array( $field, array( 'a', 'b', 'c' ) ) )
+        );
+    }
+
+    public function test_stringify_value_default_non_scalar_returns_empty(): void {
+        $field = (object) array( 'field_type' => 'text', 'field_key' => 'x' );
+
+        $this->assertSame( '', $this->invoke_static( 'stringify_value', array( $field, new \stdClass() ) ) );
+    }
+
+    // ==================================================================
+    // decrypt_sensitive()
+    // ==================================================================
+
+    public function test_decrypt_sensitive_skips_non_sensitive_and_decrypts_sensitive(): void {
+        $enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+        $enc->shouldReceive( 'decrypt' )->with( 'ENC' )->andReturn( '123.456.789-00' );
+
+        $fields = array(
+            (object) array( 'field_key' => 'cpf', 'is_sensitive' => 1 ),
+            (object) array( 'field_key' => 'name', 'is_sensitive' => 0 ),
+            (object) array( 'field_key' => 'rf', 'is_sensitive' => 1 ),
+        );
+        $values = array(
+            'cpf'  => 'ENC',
+            'name' => 'Alice',
+            // rf missing → skipped.
+        );
+
+        $out = $this->invoke_static( 'decrypt_sensitive', array( $fields, $values ) );
+
+        $this->assertSame( '123.456.789-00', $out['cpf'] );
+        $this->assertSame( 'Alice', $out['name'] );
+    }
+
+    public function test_decrypt_sensitive_keeps_value_when_decrypt_returns_null(): void {
+        $enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+        $enc->shouldReceive( 'decrypt' )->with( 'BAD' )->andReturn( null );
+
+        $fields = array( (object) array( 'field_key' => 'cpf', 'is_sensitive' => 1 ) );
+        $values = array( 'cpf' => 'BAD' );
+
+        $out = $this->invoke_static( 'decrypt_sensitive', array( $fields, $values ) );
+        $this->assertSame( 'BAD', $out['cpf'] );
+    }
+
+    public function test_decrypt_sensitive_skips_empty_or_non_string_values(): void {
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+
+        $fields = array(
+            (object) array( 'field_key' => 'cpf', 'is_sensitive' => 1 ),
+            (object) array( 'field_key' => 'rf', 'is_sensitive' => 1 ),
+        );
+        $values = array(
+            'cpf' => '',
+            'rf'  => 12345,
+        );
+
+        $out = $this->invoke_static( 'decrypt_sensitive', array( $fields, $values ) );
+        $this->assertSame( '', $out['cpf'] );
+        $this->assertSame( 12345, $out['rf'] );
+    }
+
+    // ==================================================================
+    // get_custom_fields_for_reregistration() — de-dups by field id
+    // ==================================================================
+
+    public function test_get_custom_fields_dedups_across_audiences(): void {
+        $reregMock = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\ReregistrationRepository' );
+        $reregMock->shouldReceive( 'get_audience_ids' )->with( 7 )->andReturn( array( 1, 2 ) );
+
+        $field_a = (object) array( 'id' => 10, 'field_label' => 'A' );
+        $field_b = (object) array( 'id' => 20, 'field_label' => 'B' );
+
+        $cfMock = Mockery::mock( 'alias:FreeFormCertificate\Reregistration\CustomFieldRepository' );
+        $cfMock->shouldReceive( 'get_by_audience_with_parents' )
+            ->with( 1, true )
+            ->andReturn( array( $field_a, $field_b ) );
+        $cfMock->shouldReceive( 'get_by_audience_with_parents' )
+            ->with( 2, true )
+            // Field A repeats → must be de-duped.
+            ->andReturn( array( $field_a ) );
+
+        $rereg = (object) array( 'id' => 7 );
+        $out   = $this->invoke_static( 'get_custom_fields_for_reregistration', array( $rereg ) );
+
+        $this->assertCount( 2, $out );
+        $this->assertSame( 10, $out[0]->id );
+        $this->assertSame( 20, $out[1]->id );
+    }
 }

--- a/tests/Unit/ReregistrationEmailHandlerTest.php
+++ b/tests/Unit/ReregistrationEmailHandlerTest.php
@@ -65,12 +65,16 @@ class ReregistrationEmailHandlerTest extends TestCase {
         global $wpdb;
         $wpdb = Mockery::mock('wpdb');
         $wpdb->prefix = 'wp_';
+        $wpdb->users = 'wp_users';
         $wpdb->last_error = '';
         $this->wpdb = $wpdb;
 
         Functions\when('wp_cache_get')->justReturn(false);
         Functions\when('wp_cache_set')->justReturn(true);
         Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('wp_parse_args')->alias(function ($args, $defaults = array()) {
+            return array_merge((array) $defaults, (array) $args);
+        });
     }
 
     protected function tearDown(): void {
@@ -239,5 +243,146 @@ class ReregistrationEmailHandlerTest extends TestCase {
 
         ReregistrationEmailHandler::run_automated_reminders();
         $this->assertTrue(true);
+    }
+
+    public function test_run_automated_reminders_dispatches_per_campaign(): void {
+        $this->wpdb->shouldReceive('prepare')->andReturn('query');
+        $this->wpdb->shouldReceive('get_results')->andReturn(
+            array( (object) array( 'id' => 11 ), (object) array( 'id' => 22 ) )
+        );
+        // Each send_reminders() call re-enters get_by_id (get_row). Return a
+        // campaign with reminders disabled so the inner method short-circuits
+        // after the dispatch — we only need to prove the loop fans out.
+        $this->wpdb->shouldReceive('get_row')->andReturn(
+            (object) array(
+                'id'                     => 11,
+                'email_reminder_enabled' => 0,
+                'title'                  => 'C',
+                'start_date'             => '2026-01-01',
+                'end_date'               => '2026-12-31',
+            )
+        );
+
+        ReregistrationEmailHandler::run_automated_reminders();
+        $this->assertTrue(true);
+    }
+
+    // ==================================================================
+    // send_invitations() — full success path through send_to_user
+    // ==================================================================
+
+    public function test_send_invitations_sends_to_pending_members(): void {
+        $rereg = (object) array(
+            'id'                       => 1,
+            'title'                    => 'Campaign',
+            'email_invitation_enabled' => 1,
+            'audience_name'            => 'Teachers',
+            'start_date'               => '2026-01-01',
+            'end_date'                 => '2026-12-31',
+        );
+
+        // get_by_id() → rereg; get_by_reregistration() (pending) → submissions.
+        $this->wpdb->shouldReceive('prepare')->andReturn('query');
+        $this->wpdb->shouldReceive('get_row')->andReturn($rereg);
+        $this->wpdb->shouldReceive('get_results')->andReturn(
+            array(
+                (object) array( 'user_id' => 10 ),
+                (object) array( 'user_id' => 20 ),
+            )
+        );
+
+        Functions\when('get_userdata')->alias(function ($id) {
+            return (object) array(
+                'display_name' => 'User ' . $id,
+                'user_email'   => 'user' . $id . '@example.com',
+            );
+        });
+
+        Mockery::mock('alias:FreeFormCertificate\Scheduling\EmailTemplateService')
+            ->shouldReceive('format_date')->andReturn('2026-01-01')
+            ->shouldReceive('render_template')->andReturnUsing(fn($t) => $t)
+            ->shouldReceive('send')->andReturn(true);
+
+        $count = ReregistrationEmailHandler::send_invitations(1);
+        $this->assertSame(2, $count);
+    }
+
+    // ==================================================================
+    // send_reminders() — explicit user IDs filtered by status
+    // ==================================================================
+
+    public function test_send_reminders_with_explicit_user_ids(): void {
+        $rereg = (object) array(
+            'id'                     => 1,
+            'title'                  => 'Campaign',
+            'email_reminder_enabled' => 1,
+            'start_date'             => '2026-01-01',
+            'end_date'               => '2099-12-31',
+        );
+
+        // First get_row → rereg; subsequent get_row → per-user submission.
+        $this->wpdb->shouldReceive('prepare')->andReturn('query');
+        $this->wpdb->shouldReceive('get_row')->andReturn(
+            $rereg,
+            (object) array( 'user_id' => 10, 'status' => 'pending' ),
+            // User 20 already submitted → filtered out.
+            (object) array( 'user_id' => 20, 'status' => 'submitted' )
+        );
+
+        Functions\when('get_userdata')->alias(fn($id) => (object) array(
+            'display_name' => 'U' . $id,
+            'user_email'   => 'u' . $id . '@example.com',
+        ));
+
+        Mockery::mock('alias:FreeFormCertificate\Scheduling\EmailTemplateService')
+            ->shouldReceive('format_date')->andReturn('2026-01-01')
+            ->shouldReceive('render_template')->andReturnUsing(fn($t) => $t)
+            ->shouldReceive('send')->andReturn(true);
+
+        $count = ReregistrationEmailHandler::send_reminders(1, array(10, 20));
+        $this->assertSame(1, $count);
+    }
+
+    // ==================================================================
+    // send_confirmation() — full success path with magic link + auth code
+    // ==================================================================
+
+    public function test_send_confirmation_success_with_magic_link(): void {
+        $submission = (object) array(
+            'id'                => 1,
+            'reregistration_id' => 5,
+            'user_id'           => 10,
+            'status'            => 'submitted',
+            'magic_token'       => 'tok123',
+            'auth_code'         => 'AC99',
+        );
+        $rereg = (object) array(
+            'id'                         => 5,
+            'title'                      => 'Campaign',
+            'email_confirmation_enabled' => 1,
+            'start_date'                 => '2026-01-01',
+            'end_date'                   => '2026-12-31',
+        );
+
+        // Two get_by_id() lookups via wpdb: the submission, then its campaign.
+        // get_status_label() is pure (no DB), so the real repository is fine.
+        $this->wpdb->shouldReceive('prepare')->andReturn('query');
+        $this->wpdb->shouldReceive('get_row')->andReturn($submission, $rereg);
+
+        Functions\when('get_userdata')->justReturn((object) array(
+            'display_name' => 'Alice',
+            'user_email'   => 'alice@example.com',
+        ));
+
+        Mockery::mock('alias:FreeFormCertificate\Generators\MagicLinkHelper')
+            ->shouldReceive('generate_magic_link')->with('tok123')->andReturn('https://example.com/m/tok123');
+
+        Mockery::mock('alias:FreeFormCertificate\Scheduling\EmailTemplateService')
+            ->shouldReceive('format_date')->andReturn('2026-01-01')
+            ->shouldReceive('render_template')->andReturnUsing(fn($t) => $t)
+            ->shouldReceive('send')->andReturn(true);
+
+        $result = ReregistrationEmailHandler::send_confirmation(1);
+        $this->assertTrue($result);
     }
 }

--- a/tests/Unit/SelfSchedulingCPTTest.php
+++ b/tests/Unit/SelfSchedulingCPTTest.php
@@ -45,6 +45,7 @@ class SelfSchedulingCPTTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        unset( $_GET['post'] );
         Monkey\tearDown();
         parent::tearDown();
     }
@@ -160,6 +161,301 @@ class SelfSchedulingCPTTest extends TestCase {
         $cpt = new SelfSchedulingCPT();
         $post = (object) array( 'post_type' => 'post' );
         $cpt->cleanup_calendar_data( 1, $post );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // handle_calendar_duplication() — invalid calendar
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_calendar_duplication_dies_for_invalid_calendar(): void {
+        Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'get_post' )->justReturn( null );
+        Functions\when( 'wp_die' )->alias( function ( $msg ) {
+            throw new \RuntimeException( $msg );
+        } );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )
+            ->shouldReceive( 'log_self_scheduling' )->andReturnNull();
+
+        $_GET['post'] = '5';
+
+        $cpt = new SelfSchedulingCPT();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'Invalid calendar.' );
+        $cpt->handle_calendar_duplication();
+    }
+
+    // ==================================================================
+    // handle_calendar_duplication() — success copies metadata + redirects
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_calendar_duplication_copies_metadata_and_redirects(): void {
+        Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'get_current_user_id' )->justReturn( 7 );
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'get_post' )->justReturn(
+            (object) array( 'ID' => 5, 'post_type' => 'ffc_self_scheduling', 'post_title' => 'My Cal' )
+        );
+        Functions\when( 'is_wp_error' )->justReturn( false );
+        Functions\when( 'wp_insert_post' )->justReturn( 99 );
+
+        $meta = array(
+            '_ffc_self_scheduling_config'        => array( 'slot_duration' => 30 ),
+            '_ffc_self_scheduling_working_hours' => array( 'mon' => '9-5' ),
+            '_ffc_self_scheduling_email_config'  => array( 'enabled' => 1 ),
+        );
+        Functions\when( 'get_post_meta' )->alias( function ( $id, $key ) use ( $meta ) {
+            return $meta[ $key ] ?? '';
+        } );
+
+        $updated = array();
+        Functions\when( 'update_post_meta' )->alias( function ( $id, $key, $val ) use ( &$updated ) {
+            $updated[] = $key;
+            return true;
+        } );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )
+            ->shouldReceive( 'log_self_scheduling' )->andReturnNull();
+
+        // wp_safe_redirect → exit; throw to stop before exit.
+        Functions\when( 'wp_safe_redirect' )->alias( function () {
+            throw new \RuntimeException( 'redirected' );
+        } );
+
+        $_GET['post'] = '5';
+
+        $cpt = new SelfSchedulingCPT();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'redirected' );
+        $cpt->handle_calendar_duplication();
+    }
+
+    // ==================================================================
+    // handle_calendar_duplication() — insert failure dies with error
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_handle_calendar_duplication_dies_on_insert_error(): void {
+        Functions\when( 'current_user_can' )->justReturn( true );
+        Functions\when( 'get_current_user_id' )->justReturn( 7 );
+        Functions\when( 'check_admin_referer' )->justReturn( true );
+        Functions\when( 'get_post' )->justReturn(
+            (object) array( 'ID' => 5, 'post_type' => 'ffc_self_scheduling', 'post_title' => 'My Cal' )
+        );
+        Functions\when( 'is_wp_error' )->justReturn( true );
+
+        $error = Mockery::mock( 'WP_Error' );
+        $error->shouldReceive( 'get_error_message' )->andReturn( 'insert failed' );
+        Functions\when( 'wp_insert_post' )->justReturn( $error );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )
+            ->shouldReceive( 'log_self_scheduling' )->andReturnNull();
+
+        Functions\when( 'wp_die' )->alias( function ( $msg ) {
+            throw new \RuntimeException( $msg );
+        } );
+
+        $_GET['post'] = '5';
+
+        $cpt = new SelfSchedulingCPT();
+        $this->expectException( \RuntimeException::class );
+        $this->expectExceptionMessage( 'insert failed' );
+        $cpt->handle_calendar_duplication();
+    }
+
+    // ==================================================================
+    // sync_calendar_data() — revision skip
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_sync_calendar_data_skips_revision(): void {
+        Functions\when( 'wp_is_post_revision' )->justReturn( true );
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_status' => 'publish', 'post_title' => 'X' );
+        $cpt->sync_calendar_data( 1, $post, true );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // sync_calendar_data() — non-publish skip
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_sync_calendar_data_skips_non_publish(): void {
+        Functions\when( 'wp_is_post_revision' )->justReturn( false );
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_status' => 'draft', 'post_title' => 'X' );
+        $cpt->sync_calendar_data( 1, $post, true );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // sync_calendar_data() — creates a new record when none exists
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_sync_calendar_data_creates_new_record(): void {
+        Functions\when( 'wp_is_post_revision' )->justReturn( false );
+        Functions\when( 'current_time' )->justReturn( '2026-01-01 00:00:00' );
+        Functions\when( 'get_current_user_id' )->justReturn( 3 );
+        Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+        $config = wp_json_encode( array( 'description' => 'desc', 'slot_duration' => 45 ) );
+        Functions\when( 'get_post_meta' )->alias( function ( $id, $key ) use ( $config ) {
+            if ( '_ffc_self_scheduling_config' === $key ) {
+                return $config;
+            }
+            if ( '_ffc_self_scheduling_working_hours' === $key ) {
+                return array( 'mon' => '9-5' );
+            }
+            return array( 'enabled' => 1 );
+        } );
+
+        $repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $repo->shouldReceive( 'findByPostId' )->with( 12 )->andReturn( null );
+        $repo->shouldReceive( 'createFromPost' )
+            ->once()
+            ->with(
+                12,
+                Mockery::on( function ( $data ) {
+                    return 'desc' === $data['description']
+                        && 45 === $data['slot_duration']
+                        && 'New Cal' === $data['title']
+                        && isset( $data['created_at'], $data['created_by'] );
+                } )
+            )
+            ->andReturn( 1 );
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_status' => 'publish', 'post_title' => 'New Cal' );
+        $cpt->sync_calendar_data( 12, $post, false );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // sync_calendar_data() — updates an existing record
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_sync_calendar_data_updates_existing_record(): void {
+        Functions\when( 'wp_is_post_revision' )->justReturn( false );
+        Functions\when( 'current_time' )->justReturn( '2026-01-01 00:00:00' );
+        Functions\when( 'get_current_user_id' )->justReturn( 3 );
+        Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        $repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $repo->shouldReceive( 'findByPostId' )->with( 12 )->andReturn( array( 'id' => 88 ) );
+        $repo->shouldReceive( 'update' )->once()->with( 88, Mockery::type( 'array' ) )->andReturn( true );
+        $repo->shouldReceive( 'createFromPost' )->never();
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_status' => 'publish', 'post_title' => 'Existing' );
+        $cpt->sync_calendar_data( 12, $post, true );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // cleanup_calendar_data() — deletes record + cancels appointments
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_cleanup_calendar_data_deletes_and_cancels_future(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 3 );
+        Functions\when( 'current_time' )->justReturn( '2026-01-01' );
+        Functions\when( 'apply_filters' )->alias( function ( $hook, $value ) {
+            return $value;
+        } );
+        Functions\when( 'is_email' )->justReturn( true );
+        Functions\when( 'get_bloginfo' )->justReturn( 'Site' );
+        Functions\when( 'wp_mail' )->justReturn( true );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Debug' )
+            ->shouldReceive( 'log_self_scheduling' )->andReturnNull();
+        Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' )
+            ->shouldReceive( 'decrypt_field' )->andReturn( 'user@example.com' );
+
+        $cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $cal_repo->shouldReceive( 'findByPostId' )->with( 20 )->andReturn( array( 'id' => 5, 'title' => 'Cal A' ) );
+        $cal_repo->shouldReceive( 'delete' )->once()->with( 5 )->andReturn( true );
+
+        $appt_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\AppointmentRepository' );
+        $appt_repo->shouldReceive( 'findByCalendarAfterWithStatus' )
+            ->with( 5, '2026-01-01' )
+            ->andReturn(
+                array(
+                    array(
+                        'id'               => 100,
+                        'appointment_date' => '2026-02-01',
+                        'start_time'       => '09:00:00',
+                    ),
+                )
+            );
+        $appt_repo->shouldReceive( 'cancel' )->once()->andReturn( true );
+
+        Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' )
+            ->shouldReceive( 'format_wallclock_date' )->andReturn( '01/02/2026' )
+            ->shouldReceive( 'format_wallclock_time' )->andReturn( '09:00' );
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_type' => 'ffc_self_scheduling' );
+        $cpt->cleanup_calendar_data( 20, $post );
+
+        $this->assertTrue( true );
+    }
+
+    // ==================================================================
+    // cleanup_calendar_data() — no calendar record found (no-op)
+    // ==================================================================
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_cleanup_calendar_data_noop_when_no_record(): void {
+        $cal_repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\CalendarRepository' );
+        $cal_repo->shouldReceive( 'findByPostId' )->with( 20 )->andReturn( null );
+        $cal_repo->shouldReceive( 'delete' )->never();
+
+        $cpt  = new SelfSchedulingCPT();
+        $post = (object) array( 'post_type' => 'ffc_self_scheduling' );
+        $cpt->cleanup_calendar_data( 20, $post );
 
         $this->assertTrue( true );
     }


### PR DESCRIPTION
## Fase 2 — cobertura PHP: self-scheduling + reregistration

Estende testes unitários para lógica (pulando render HTML):

| Classe | Antes | Depois |
|---|---|---|
| `SelfSchedulingCPT` | 23.6% | **97.5%** |
| `ReregistrationEmailHandler` | 21.9% | **91.1%** |
| `AppointmentReceiptHandler` | 7.9% | **89.7%** |
| `AppointmentCancellationHandler` | 23.8% | **83.6%** |
| `views/appointments-list.php` | 0% | **74.3%** (gate de permissão + mutações + data-prep) |
| `AppointmentsListTable` | 0% | **59.4%** |
| `ReregistrationCsvExporter` | 10% | **50%** |
| `ReregistrationAdmin` | 19.3% | **26.2%** (resto é `render_*` markup) |

**+68 testes; suíte completa verde (5081 testes).** Nenhum `includes/` alterado; sem mudança de floor (bump central no fim). Não toca arquivos do piloto #531. Render-heavy / I/O-streaming (`handle_export` que termina em `exit`, `column_id` via `WP_List_Table::row_actions`) deixados de fora por escopo.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_