### PR TITLE
test(php): raise recruitment coverage (logic paths)

### DIFF
--- a/tests/Unit/RecruitmentAdminPageTest.php
+++ b/tests/Unit/RecruitmentAdminPageTest.php
@@ -102,4 +102,41 @@ class RecruitmentAdminPageTest extends TestCase {
         $this->assertStringContainsString( '[BADGE:', $html );
         $this->assertStringContainsString( 'preliminary', $html );
     }
+
+    public function test_notice_status_badge_falls_back_to_neutral_color_for_unknown_status(): void {
+        $html = RecruitmentAdminPage::notice_status_badge( 'bogus' );
+
+        // Unknown status → the `?? '#e9ecef'` neutral fallback color.
+        $this->assertStringContainsString( '#e9ecef', $html );
+    }
+
+    public function test_adjutancy_badge_returns_empty_string_for_null(): void {
+        $this->assertSame( '', RecruitmentAdminPage::adjutancy_badge( null ) );
+    }
+
+    public function test_adjutancy_badge_uses_row_color_when_present(): void {
+        $adjutancy = (object) array(
+            'name'  => 'Matemática',
+            'color' => '#123456',
+        );
+
+        $html = RecruitmentAdminPage::adjutancy_badge( $adjutancy );
+
+        $this->assertStringContainsString( '#123456', $html );
+        $this->assertStringContainsString( 'Matemática', $html );
+    }
+
+    public function test_adjutancy_badge_falls_back_to_default_color_when_blank(): void {
+        $adjutancy = (object) array(
+            'name'  => 'Português',
+            'color' => '',
+        );
+
+        $html = RecruitmentAdminPage::adjutancy_badge( $adjutancy );
+
+        $this->assertStringContainsString(
+            \FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository::DEFAULT_COLOR,
+            $html
+        );
+    }
 }

--- a/tests/Unit/RecruitmentCandidateEditPageHandlersTest.php
+++ b/tests/Unit/RecruitmentCandidateEditPageHandlersTest.php
@@ -1,0 +1,367 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCandidateEditPage;
+
+/**
+ * Behavior tests for the RecruitmentCandidateEditPage admin-post handlers:
+ * handle_save (general fields + email re-encrypt + diff log), handle_delete
+ * (success / blocked), handle_link_user / handle_unlink_user (user-pointer
+ * mutation), and the resolve_user() lookup strategy. The terminal
+ * wp_safe_redirect()/exit and wp_die() are replaced by marker exceptions so
+ * each branch is observable.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCandidateEditPage
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentCandidateEditPageHandlersTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var \Mockery\MockInterface */
+	private $utils;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'absint' )->alias( static fn ( $v ) => (int) $v );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_textarea_field' )->returnArg();
+		Functions\when( 'sanitize_email' )->returnArg();
+		Functions\when( 'check_admin_referer' )->justReturn( true );
+		Functions\when( 'admin_url' )->returnArg();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'add_query_arg' )->alias(
+			static fn ( $args ) => 'admin.php?' . http_build_query( (array) $args )
+		);
+		Functions\when( 'wp_die' )->alias(
+			static function ( $msg = '' ) {
+				throw new \RuntimeException( 'WP_DIE:' . $msg );
+			}
+		);
+		Functions\when( 'wp_safe_redirect' )->alias(
+			static function ( $url ) {
+				throw new \RuntimeException( 'REDIRECT:' . $url );
+			}
+		);
+
+		// Utils::current_user_can_admin_or — used by handle_delete's cap gate.
+		$this->utils = Mockery::mock( 'alias:FreeFormCertificate\Core\Utils' );
+		$this->utils->shouldReceive( 'current_user_can_admin_or' )->andReturn( true )->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		unset(
+			$_POST['candidate_id'],
+			$_POST['name'],
+			$_POST['email'],
+			$_POST['phone'],
+			$_POST['notes'],
+			$_POST['user_lookup']
+		);
+		parent::tearDown();
+	}
+
+	private function capture( callable $fn ): string {
+		try {
+			$fn();
+		} catch ( \RuntimeException $e ) {
+			return $e->getMessage();
+		}
+		return '';
+	}
+
+	private function candidate_before(): object {
+		return (object) array(
+			'id'         => '5',
+			'name'       => 'Old Name',
+			'phone'      => '111',
+			'notes'      => null,
+			'email_hash' => 'old-hash',
+		);
+	}
+
+	// ==================================================================
+	// handle_save()
+	// ==================================================================
+
+	public function test_handle_save_dies_without_cap(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_save' ) );
+
+		$this->assertStringStartsWith( 'WP_DIE:', $msg );
+	}
+
+	public function test_handle_save_redirects_to_list_when_id_zero(): void {
+		$_POST['candidate_id'] = '0';
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_save' ) );
+
+		$this->assertStringContainsString( 'tab=candidates', $msg );
+		$this->assertStringNotContainsString( 'action=edit-candidate', $msg );
+	}
+
+	public function test_handle_save_updates_fields_clears_email_and_logs_diff(): void {
+		$_POST['candidate_id'] = '5';
+		$_POST['name']         = 'New Name';
+		$_POST['email']        = '';
+		$_POST['phone']        = '';
+		$_POST['notes']        = 'A note';
+
+		$repo     = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$repo->shouldReceive( 'get_by_id' )->andReturn( $this->candidate_before() );
+		$captured = null;
+		$repo->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $id, $data ) use ( &$captured ) {
+				$captured = array( $id, $data );
+				return 1;
+			}
+		);
+
+		$logger      = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+		$logged_diff = null;
+		$logger->shouldReceive( 'candidate_fields_edited' )->once()->andReturnUsing(
+			function ( $id, $changes ) use ( &$logged_diff ) {
+				$logged_diff = $changes;
+				return null;
+			}
+		);
+
+		$enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$enc->shouldReceive( 'hash' )->andReturnUsing( static fn ( $v ) => 'h:' . $v );
+		$enc->shouldReceive( 'encrypt' )->andReturnUsing( static fn ( $v ) => 'e:' . $v );
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_save' ) );
+
+		$this->assertSame( 5, $captured[0] );
+		$this->assertSame( 'New Name', $captured[1]['name'] );
+		$this->assertNull( $captured[1]['phone'], 'empty phone clears to null' );
+		$this->assertSame( 'A note', $captured[1]['notes'] );
+		$this->assertNull( $captured[1]['email_encrypted'], 'empty email clears encrypted column' );
+		$this->assertNull( $captured[1]['email_hash'] );
+		// Diff: name changed, phone changed (111 → ''), notes changed (null → A note),
+		// email_hash changed (old-hash → '').
+		$this->assertArrayHasKey( 'name', $logged_diff );
+		$this->assertArrayHasKey( 'phone', $logged_diff );
+		$this->assertArrayHasKey( 'notes', $logged_diff );
+		$this->assertArrayHasKey( 'email_hash', $logged_diff );
+		$this->assertStringContainsString( 'ffc_msg=saved', $msg );
+	}
+
+	public function test_handle_save_encrypts_new_email(): void {
+		$_POST['candidate_id'] = '5';
+		$_POST['name']         = 'Old Name';
+		$_POST['email']        = 'new@example.test';
+		$_POST['phone']        = '111';
+		$_POST['notes']        = '';
+
+		$repo     = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$repo->shouldReceive( 'get_by_id' )->andReturn( $this->candidate_before() );
+		$captured = null;
+		$repo->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $id, $data ) use ( &$captured ) {
+				$captured = $data;
+				return 1;
+			}
+		);
+
+		$logger = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+		$logger->shouldReceive( 'candidate_fields_edited' )->andReturn( null );
+
+		$enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$enc->shouldReceive( 'hash' )->andReturnUsing( static fn ( $v ) => 'h:' . $v );
+		$enc->shouldReceive( 'encrypt' )->andReturnUsing( static fn ( $v ) => 'e:' . $v );
+
+		$this->capture( array( RecruitmentCandidateEditPage::class, 'handle_save' ) );
+
+		$this->assertSame( 'e:new@example.test', $captured['email_encrypted'] );
+		$this->assertSame( 'h:new@example.test', $captured['email_hash'] );
+	}
+
+	// ==================================================================
+	// handle_delete()
+	// ==================================================================
+
+	public function test_handle_delete_dies_without_delete_cap(): void {
+		// Override the permissive byDefault() with a strict false expectation.
+		$this->utils->shouldReceive( 'current_user_can_admin_or' )
+			->with( 'ffc_delete_recruitment' )
+			->andReturn( false );
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_delete' ) );
+
+		$this->assertStringStartsWith( 'WP_DIE:', $msg );
+	}
+
+	public function test_handle_delete_redirects_to_candidates_tab_on_success(): void {
+		$_POST['candidate_id'] = '5';
+
+		$svc = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentDeleteService' );
+		$svc->shouldReceive( 'delete_candidate' )->once()->with( 5 )->andReturn(
+			array(
+				'success' => true,
+				'errors'  => array(),
+			)
+		);
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_delete' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=deleted', $msg );
+		$this->assertStringContainsString( 'tab=candidates', $msg );
+		$this->assertStringNotContainsString( 'action=edit-candidate', $msg );
+	}
+
+	public function test_handle_delete_flashes_blocked_on_failure(): void {
+		$_POST['candidate_id'] = '5';
+
+		$svc = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentDeleteService' );
+		$svc->shouldReceive( 'delete_candidate' )->once()->andReturn(
+			array(
+				'success' => false,
+				'errors'  => array( 'blocked' ),
+			)
+		);
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_delete' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=delete-blocked', $msg );
+		$this->assertStringContainsString( 'action=edit-candidate', $msg );
+	}
+
+	// ==================================================================
+	// handle_link_user() / handle_unlink_user()
+	// ==================================================================
+
+	public function test_handle_link_user_flashes_not_found_for_unknown_lookup(): void {
+		$_POST['candidate_id'] = '5';
+		$_POST['user_lookup']  = 'ghost';
+
+		Functions\when( 'get_user_by' )->justReturn( false );
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_link_user' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=link-user-not-found', $msg );
+	}
+
+	public function test_handle_link_user_sets_pointer_and_flashes_ok(): void {
+		$_POST['candidate_id'] = '5';
+		$_POST['user_lookup']  = '42';
+
+		$user     = Mockery::mock( \WP_User::class );
+		$user->ID = 42;
+		Functions\when( 'get_user_by' )->justReturn( $user );
+
+		$repo    = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$set_uid = null;
+		$repo->shouldReceive( 'set_user_id' )->once()->andReturnUsing(
+			function ( $id, $uid ) use ( &$set_uid ) {
+				$set_uid = array( $id, $uid );
+				return true;
+			}
+		);
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_link_user' ) );
+
+		$this->assertSame( array( 5, 42 ), $set_uid );
+		$this->assertStringContainsString( 'ffc_msg=link-user-ok', $msg );
+	}
+
+	public function test_handle_unlink_user_clears_pointer(): void {
+		$_POST['candidate_id'] = '5';
+
+		$repo    = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$cleared = false;
+		$repo->shouldReceive( 'set_user_id' )->once()->andReturnUsing(
+			function ( $id, $uid ) use ( &$cleared ) {
+				$cleared = ( 5 === $id && null === $uid );
+				return true;
+			}
+		);
+
+		$msg = $this->capture( array( RecruitmentCandidateEditPage::class, 'handle_unlink_user' ) );
+
+		$this->assertTrue( $cleared );
+		$this->assertStringContainsString( 'ffc_msg=unlink-user-ok', $msg );
+	}
+
+	// ==================================================================
+	// resolve_user() — lookup strategy (via reflection)
+	// ==================================================================
+
+	private function resolve_user( string $lookup ) {
+		$ref = new \ReflectionClass( RecruitmentCandidateEditPage::class );
+		$m   = $ref->getMethod( 'resolve_user' );
+		$m->setAccessible( true );
+		return $m->invoke( null, $lookup );
+	}
+
+	public function test_resolve_user_returns_null_for_empty(): void {
+		$this->assertNull( $this->resolve_user( '' ) );
+	}
+
+	public function test_resolve_user_uses_id_strategy_for_numeric(): void {
+		$user = Mockery::mock( \WP_User::class );
+		$seen = null;
+		Functions\when( 'get_user_by' )->alias(
+			static function ( $by, $value ) use ( $user, &$seen ) {
+				$seen = array( $by, $value );
+				return $user;
+			}
+		);
+
+		$out = $this->resolve_user( '42' );
+
+		$this->assertSame( $user, $out );
+		$this->assertSame( 'id', $seen[0] );
+	}
+
+	public function test_resolve_user_uses_email_strategy_when_at_present(): void {
+		$user = Mockery::mock( \WP_User::class );
+		$seen = null;
+		Functions\when( 'get_user_by' )->alias(
+			static function ( $by, $value ) use ( $user, &$seen ) {
+				$seen = $by;
+				return $user;
+			}
+		);
+
+		$this->resolve_user( 'a@b.test' );
+
+		$this->assertSame( 'email', $seen );
+	}
+
+	public function test_resolve_user_uses_login_strategy_otherwise(): void {
+		$user = Mockery::mock( \WP_User::class );
+		$seen = null;
+		Functions\when( 'get_user_by' )->alias(
+			static function ( $by, $value ) use ( $user, &$seen ) {
+				$seen = $by;
+				return $user;
+			}
+		);
+
+		$this->resolve_user( 'alice' );
+
+		$this->assertSame( 'login', $seen );
+	}
+
+	public function test_resolve_user_returns_null_when_not_wp_user(): void {
+		Functions\when( 'get_user_by' )->justReturn( false );
+
+		$this->assertNull( $this->resolve_user( 'alice' ) );
+	}
+}

--- a/tests/Unit/RecruitmentCsvImporterBatchedTest.php
+++ b/tests/Unit/RecruitmentCsvImporterBatchedTest.php
@@ -1,0 +1,597 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentCsvImporter;
+
+/**
+ * Coverage for the staging-based batched import flow (V10) of
+ * RecruitmentCsvImporter: ingest_job → validate_job → promote_batch →
+ * commit_job, plus the import_definitive entry point.
+ *
+ * These exercise the SQL-driven state machine against a mocked `$wpdb`
+ * and alias-stubbed recruitment repositories. Process-isolated so the
+ * alias mocks for the static repositories / Encryption / PcdHasher don't
+ * leak into sibling tests.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentCsvImporter
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentCsvImporterBatchedTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var Mockery\MockInterface */
+	private $wpdb;
+
+	private const HEADER = "name,cpf,rf,email,adjutancy,rank,score,pcd\n";
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		global $wpdb;
+		$wpdb            = Mockery::mock( 'wpdb' )->makePartial();
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = 0;
+		$this->wpdb      = $wpdb;
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'wp_cache_get' )->justReturn( false );
+		Functions\when( 'wp_cache_set' )->justReturn( true );
+		Functions\when( 'wp_cache_delete' )->justReturn( true );
+		Functions\when( 'current_time' )->justReturn( '2026-05-01 10:00:00' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'do_action' )->justReturn( null );
+		Functions\when( 'wp_generate_uuid4' )->justReturn( 'job-uuid-1234' );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing( static fn ( $sql ) => $sql )
+			->byDefault();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function notice_stub( string $status ): object {
+		return (object) array(
+			'id'     => '5',
+			'code'   => 'EDITAL',
+			'name'   => 'Edital',
+			'status' => $status,
+		);
+	}
+
+	/**
+	 * Wire NoticeRepository / NoticeAdjutancyRepository / AdjutancyRepository
+	 * for the ingest path so build_adjutancy_map() resolves `mat` → 2.
+	 *
+	 * @param object|null $notice Notice stub or null.
+	 * @param array<int>  $ids    Adjutancy ids for the notice.
+	 * @return void
+	 */
+	private function wire_repos( ?object $notice, array $ids = array( 2 ) ): void {
+		$notice_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeRepository' );
+		$notice_repo->shouldReceive( 'get_by_id' )->andReturn( $notice );
+
+		$junction = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeAdjutancyRepository' );
+		$junction->shouldReceive( 'get_adjutancy_ids_for_notice' )->andReturn( $ids );
+
+		$adj = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository' );
+		$adj->shouldReceive( 'get_by_id' )->andReturnUsing(
+			static function ( $id ) {
+				return (object) array(
+					'id'   => (string) $id,
+					'slug' => 'mat',
+					'name' => 'Matemática',
+				);
+			}
+		);
+	}
+
+	// ==================================================================
+	// ingest_job()
+	// ==================================================================
+
+	public function test_ingest_job_rejects_unknown_notice(): void {
+		$this->wire_repos( null );
+
+		$out = RecruitmentCsvImporter::ingest_job( 999, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_notice_not_found', $out['errors'] );
+	}
+
+	public function test_ingest_job_rejects_preview_when_notice_not_eligible(): void {
+		$this->wire_repos( $this->notice_stub( 'active' ) );
+
+		$out = RecruitmentCsvImporter::ingest_job( 5, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_invalid_state_for_preview_import', $out['errors'] );
+	}
+
+	public function test_ingest_job_rejects_parse_errors(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ) );
+
+		$out = RecruitmentCsvImporter::ingest_job( 5, 'name,cpf', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertStringContainsString( 'recruitment_csv_missing_headers', $out['errors'][0] );
+	}
+
+	public function test_ingest_job_rejects_empty_rows(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ) );
+
+		// Header only — no data rows.
+		$out = RecruitmentCsvImporter::ingest_job( 5, self::HEADER, 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_csv_empty', $out['errors'] );
+	}
+
+	public function test_ingest_job_rejects_when_notice_has_no_adjutancies(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ), array() );
+
+		$out = RecruitmentCsvImporter::ingest_job( 5, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_notice_has_no_adjutancies', $out['errors'] );
+	}
+
+	public function test_ingest_job_inserts_job_and_staging_rows(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ) );
+
+		// cleanup_stale_staging_jobs: two DELETE queries (query()).
+		// Then the job-row insert and the staging mass-insert query().
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 0 )->byDefault();
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::ingest_job(
+			5,
+			self::HEADER . "Alice,12345678901,,a@b.test,mat,1,90,Sim\nBob,98765432100,,b@b.test,mat,2,80,Não",
+			'preview'
+		);
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertSame( 'job-uuid-1234', $out['job_id'] );
+		$this->assertSame( 2, $out['total'] );
+	}
+
+	public function test_ingest_job_returns_error_when_job_insert_fails(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ) );
+
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 0 )->byDefault();
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+		$out = RecruitmentCsvImporter::ingest_job( 5, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_insert_failed', $out['errors'] );
+	}
+
+	public function test_ingest_job_rolls_back_when_staging_insert_fails(): void {
+		$this->wire_repos( $this->notice_stub( 'draft' ) );
+
+		$this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		// cleanup DELETEs (2 query()) succeed; the staging INSERT query() fails.
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 0, 0, false );
+		$this->wpdb->shouldReceive( 'delete' )->twice()->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::ingest_job( 5, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim', 'preview' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_staging_insert_failed', $out['errors'] );
+	}
+
+	// ==================================================================
+	// validate_job()
+	// ==================================================================
+
+	public function test_validate_job_rejects_unknown_job(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$out = RecruitmentCsvImporter::validate_job( 'missing' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_not_found', $out['errors'] );
+	}
+
+	public function test_validate_job_rejects_invalid_state(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id' => 'j1',
+				'status' => 'committed',
+			)
+		);
+
+		$out = RecruitmentCsvImporter::validate_job( 'j1' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_invalid_state_for_validate', $out['errors'] );
+	}
+
+	public function test_validate_job_marks_validated_when_no_errors(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id' => 'j1',
+				'status' => 'ingested',
+			)
+		);
+		// Rules 1 + 2 use get_col (empty), rules 3 / 4 / 5 use get_results (empty).
+		$this->wpdb->shouldReceive( 'get_col' )->andReturn( array() );
+		$this->wpdb->shouldReceive( 'get_results' )->andReturn( array() );
+
+		$updated = null;
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $table, $data ) use ( &$updated ) {
+				$updated = $data['status'];
+				return 1;
+			}
+		);
+
+		$out = RecruitmentCsvImporter::validate_job( 'j1' );
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertSame( array(), $out['errors'] );
+		$this->assertSame( 'validated', $updated );
+	}
+
+	public function test_validate_job_collects_errors_and_marks_invalid(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id' => 'j1',
+				'status' => 'ingested',
+			)
+		);
+
+		// Rule 1 (missing cpf/rf) returns line 3; rule 2 (missing adjutancy) empty.
+		$this->wpdb->shouldReceive( 'get_col' )->andReturn( array( 3 ), array() );
+		// Rule 3 (adjutancy_not_in_notice), then three duplicate passes, then divergence.
+		$this->wpdb->shouldReceive( 'get_results' )->andReturn(
+			array( (object) array( 'line_no' => 4, 'adjutancy_slug' => 'bogus' ) ), // rule 3
+			array( (object) array( 'csv_lines' => '5,6' ) ),                        // rule 4 cpf dup
+			array(),                                                                // rule 4 rf
+			array(),                                                                // rule 4 email
+			array(                                                                  // rule 5 divergence
+				(object) array(
+					'csv_lines' => '7,8',
+					'd_name'    => 2,
+					'd_email'   => 1,
+					'd_rf'      => 1,
+					'd_phone'   => 1,
+					'd_pcd'     => 1,
+				),
+			)
+		);
+
+		$updated = null;
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $table, $data ) use ( &$updated ) {
+				$updated = $data['status'];
+				return 1;
+			}
+		);
+
+		$out = RecruitmentCsvImporter::validate_job( 'j1' );
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertSame( 'invalid', $updated );
+		$joined = implode( ' | ', $out['errors'] );
+		$this->assertStringContainsString( 'recruitment_csv_missing_cpf_or_rf', $joined );
+		$this->assertStringContainsString( 'recruitment_csv_adjutancy_not_in_notice: bogus', $joined );
+		$this->assertStringContainsString( 'duplicate_candidate_adjutancy: matches line 5', $joined );
+		$this->assertStringContainsString( 'candidate_field_divergence: field=name, ref_line=7', $joined );
+	}
+
+	// ==================================================================
+	// promote_batch()
+	// ==================================================================
+
+	public function test_promote_batch_rejects_unknown_job(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$out = RecruitmentCsvImporter::promote_batch( 'missing', 50 );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_not_found', $out['errors'] );
+	}
+
+	public function test_promote_batch_rejects_invalid_state(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'          => 'j1',
+				'status'          => 'ingested',
+				'processed_count' => '0',
+				'total'           => '2',
+			)
+		);
+
+		$out = RecruitmentCsvImporter::promote_batch( 'j1', 50 );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_invalid_state_for_promote', $out['errors'] );
+	}
+
+	public function test_promote_batch_returns_done_when_no_unprocessed_rows(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'          => 'j1',
+				'status'          => 'promoting',
+				'processed_count' => '2',
+				'total'           => '2',
+			)
+		);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+		$out = RecruitmentCsvImporter::promote_batch( 'j1', 50 );
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertTrue( $out['done'] );
+		$this->assertSame( 2, $out['processed'] );
+		$this->assertSame( 2, $out['total'] );
+	}
+
+	public function test_promote_batch_processes_rows_and_flips_state(): void {
+		// upsert_candidate path → no existing candidate, then create.
+		$cand_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$cand_repo->shouldReceive( 'get_by_cpf_hash' )->andReturn( null );
+		$cand_repo->shouldReceive( 'get_by_rf_hash' )->andReturn( null );
+		$cand_repo->shouldReceive( 'create' )->andReturn( 100 );
+		$cand_repo->shouldReceive( 'get_table_name' )->andReturn( 'wp_ffc_recruitment_candidate' );
+		$cand_repo->shouldReceive( 'set_user_id' )->andReturn( true );
+
+		$enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$enc->shouldReceive( 'hash' )->andReturnUsing( static fn ( $v ) => 'h:' . $v );
+		$enc->shouldReceive( 'encrypt' )->andReturnUsing( static fn ( $v ) => 'e:' . $v );
+
+		$pcd = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentPcdHasher' );
+		$pcd->shouldReceive( 'compute' )->andReturn( 'pcd-hash' );
+
+		$logger = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+		$logger->shouldReceive( 'candidate_promoted' )->andReturn( null );
+
+		// UserCreator returns 0 (no promotion) so maybe_promote stays quiet.
+		$user_creator = Mockery::mock( 'alias:FreeFormCertificate\UserDashboard\UserCreator' );
+		$user_creator->shouldReceive( 'get_or_create_user_dual' )->andReturn( 0 );
+
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'          => 'j1',
+				'status'          => 'validated',
+				'processed_count' => '0',
+				'total'           => '1',
+			)
+		);
+		$this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+			array(
+				(object) array(
+					'id'             => '11',
+					'name'           => 'Alice',
+					'cpf_normalized' => '12345678901',
+					'rf_normalized'  => '',
+					'email'          => 'a@b.test',
+					'phone'          => '',
+					'pcd'            => '0',
+				),
+			)
+		);
+		// update() called for: refresh_pcd_hash (candidate), staging row,
+		// the 'validated'→'promoting' flip. query() bumps processed_count.
+		$this->wpdb->shouldReceive( 'update' )->andReturn( 1 );
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::promote_batch( 'j1', 50 );
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertSame( 1, $out['processed'] );
+		$this->assertSame( 1, $out['total'] );
+		$this->assertTrue( $out['done'] );
+	}
+
+	// ==================================================================
+	// commit_job()
+	// ==================================================================
+
+	public function test_commit_job_rejects_unknown_job(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+
+		$out = RecruitmentCsvImporter::commit_job( 'missing' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_not_found', $out['errors'] );
+	}
+
+	public function test_commit_job_rejects_invalid_state(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'    => 'j1',
+				'status'    => 'validated',
+				'notice_id' => '5',
+				'list_type' => 'preview',
+			)
+		);
+
+		$out = RecruitmentCsvImporter::commit_job( 'j1' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_invalid_state_for_commit', $out['errors'] );
+	}
+
+	public function test_commit_job_rejects_when_rows_unpromoted(): void {
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'    => 'j1',
+				'status'    => 'promoting',
+				'notice_id' => '5',
+				'list_type' => 'preview',
+			)
+		);
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 3 );
+
+		$out = RecruitmentCsvImporter::commit_job( 'j1' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_job_not_finished', $out['errors'] );
+	}
+
+	public function test_commit_job_swaps_staging_into_classifications(): void {
+		$cls_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentClassificationRepository' );
+		$cls_repo->shouldReceive( 'delete_all_for_notice_list' )->andReturn( 0 );
+
+		$logger = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+		$logger->shouldReceive( 'csv_imported' )->andReturn( null );
+
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'    => 'j1',
+				'status'    => 'promoting',
+				'notice_id' => '5',
+				'list_type' => 'preview',
+			)
+		);
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 0 );
+		// START TRANSACTION, the INSERT..SELECT, COMMIT.
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1, 4, 1 );
+		$this->wpdb->shouldReceive( 'update' )->once()->andReturn( 1 );
+		$this->wpdb->shouldReceive( 'delete' )->twice()->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::commit_job( 'j1' );
+
+		$this->assertTrue( $out['ok'] );
+		$this->assertSame( 4, $out['inserted'] );
+	}
+
+	public function test_commit_job_rolls_back_on_swap_failure(): void {
+		$cls_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentClassificationRepository' );
+		$cls_repo->shouldReceive( 'delete_all_for_notice_list' )->andReturn( 0 );
+
+		$this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+			(object) array(
+				'job_id'    => 'j1',
+				'status'    => 'promoting',
+				'notice_id' => '5',
+				'list_type' => 'preview',
+			)
+		);
+		$this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 0 );
+		// START TRANSACTION (1), INSERT..SELECT fails (false), ROLLBACK (0).
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 1, false, 0 );
+
+		$out = RecruitmentCsvImporter::commit_job( 'j1' );
+
+		$this->assertFalse( $out['ok'] );
+		$this->assertContains( 'recruitment_import_swap_failed', $out['errors'] );
+	}
+
+	// ==================================================================
+	// import_definitive()
+	// ==================================================================
+
+	public function test_import_definitive_rejects_unknown_notice(): void {
+		$this->wire_repos( null );
+
+		$out = RecruitmentCsvImporter::import_definitive( 999, self::HEADER . 'A,12345678901,,a@b.test,mat,1,90,Sim' );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertContains( 'recruitment_notice_not_found', $out['errors'] );
+	}
+
+	// ==================================================================
+	// run() — single-request happy path + rollback (via import_definitive)
+	// ==================================================================
+
+	/**
+	 * Wire the candidate / classification / encryption / pcd / logger /
+	 * user-creator statics shared by the single-request run() tests.
+	 *
+	 * @param int|false $classification_id Return of ClassificationRepository::create.
+	 * @return void
+	 */
+	private function wire_run_writers( $classification_id = 200 ): void {
+		$cand_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$cand_repo->shouldReceive( 'get_by_cpf_hash' )->andReturn( null );
+		$cand_repo->shouldReceive( 'get_by_rf_hash' )->andReturn( null );
+		$cand_repo->shouldReceive( 'create' )->andReturn( 100 );
+		$cand_repo->shouldReceive( 'get_table_name' )->andReturn( 'wp_ffc_recruitment_candidate' );
+		$cand_repo->shouldReceive( 'set_user_id' )->andReturn( true );
+
+		$cls_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentClassificationRepository' );
+		$cls_repo->shouldReceive( 'delete_all_for_notice_list' )->andReturn( 0 );
+		$cls_repo->shouldReceive( 'create' )->andReturn( $classification_id );
+
+		$enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$enc->shouldReceive( 'hash' )->andReturnUsing( static fn ( $v ) => 'h:' . $v );
+		$enc->shouldReceive( 'encrypt' )->andReturnUsing( static fn ( $v ) => 'e:' . $v );
+
+		$pcd = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentPcdHasher' );
+		$pcd->shouldReceive( 'compute' )->andReturn( 'pcd-hash' );
+
+		$logger = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentActivityLogger' );
+		$logger->shouldReceive( 'csv_imported' )->andReturn( null );
+		$logger->shouldReceive( 'candidate_promoted' )->andReturn( null );
+
+		$user_creator = Mockery::mock( 'alias:FreeFormCertificate\UserDashboard\UserCreator' );
+		$user_creator->shouldReceive( 'get_or_create_user_dual' )->andReturn( 0 );
+	}
+
+	public function test_import_definitive_commits_rows_on_happy_path(): void {
+		$this->wire_repos( $this->notice_stub( 'definitive' ) );
+		$this->wire_run_writers( 200 );
+
+		// START TRANSACTION, COMMIT — both query(). refresh_pcd_hash uses update().
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 0 );
+		$this->wpdb->shouldReceive( 'update' )->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::import_definitive(
+			5,
+			self::HEADER . "Alice,12345678901,,a@b.test,mat,1,90,Sim\nBob,98765432100,,b@b.test,mat,2,80,Não"
+		);
+
+		$this->assertTrue( $out['success'] );
+		$this->assertSame( 2, $out['inserted'] );
+		$this->assertSame( array(), $out['errors'] );
+	}
+
+	public function test_import_definitive_rolls_back_when_classification_insert_fails(): void {
+		$this->wire_repos( $this->notice_stub( 'definitive' ) );
+		// ClassificationRepository::create returns false → rollback.
+		$this->wire_run_writers( false );
+
+		$this->wpdb->shouldReceive( 'query' )->andReturn( 0 );
+		$this->wpdb->shouldReceive( 'update' )->andReturn( 1 );
+
+		$out = RecruitmentCsvImporter::import_definitive(
+			5,
+			self::HEADER . 'Alice,12345678901,,a@b.test,mat,1,90,Sim'
+		);
+
+		$this->assertFalse( $out['success'] );
+		$this->assertContains( 'recruitment_classification_insert_failed', $out['errors'] );
+	}
+
+	public function test_import_definitive_propagates_validation_errors(): void {
+		$this->wire_repos( $this->notice_stub( 'definitive' ) );
+
+		// Row references an adjutancy slug not attached to the notice.
+		$out = RecruitmentCsvImporter::import_definitive(
+			5,
+			self::HEADER . 'Alice,12345678901,,a@b.test,nope,1,90,Sim'
+		);
+
+		$this->assertFalse( $out['success'] );
+		$joined = implode( ' | ', $out['errors'] );
+		$this->assertStringContainsString( 'recruitment_csv_adjutancy_not_in_notice: nope', $joined );
+	}
+}

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -390,13 +390,14 @@ class RecruitmentCsvImporterTest extends TestCase {
 
 	/**
 	 * @param list<array<string, mixed>> $rows
+	 * @param array<string, int>         $map  Adjutancy slug → id.
 	 * @return list<string>
 	 */
-	private function validate_rows( array $rows ): array {
+	private function validate_rows( array $rows, array $map = array( 'mat' => 1 ) ): array {
 		$ref = new \ReflectionClass( RecruitmentCsvImporter::class );
 		$m   = $ref->getMethod( 'validate' );
 		$m->setAccessible( true );
-		return $m->invoke( null, $rows, 1, 'preview', array( 'mat' => 1 ) );
+		return $m->invoke( null, $rows, 1, 'preview', $map );
 	}
 
 	private function csv_row( array $overrides = array() ): array {
@@ -509,5 +510,129 @@ class RecruitmentCsvImporterTest extends TestCase {
 		// of both offending rows so we know both made it through.
 		$this->assertStringContainsString( 'line=3', $lines );
 		$this->assertStringContainsString( 'line=4', $lines );
+	}
+
+	// ------------------------------------------------------------------
+	// validate() — per-row field-shape rules.
+	// ------------------------------------------------------------------
+
+	public function test_validate_rejects_row_with_no_cpf_or_rf(): void {
+		$rows   = array( $this->csv_row( array( 'cpf' => '', 'rf' => '' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'recruitment_csv_missing_cpf_or_rf', $errors[0] );
+	}
+
+	public function test_validate_rejects_cpf_too_long(): void {
+		$rows   = array( $this->csv_row( array( 'cpf' => '123456789012345' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_cpf_too_long', $errors[0] );
+	}
+
+	public function test_validate_rejects_rf_too_long(): void {
+		$rows   = array( $this->csv_row( array( 'cpf' => '', 'rf' => '123456789' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_rf_too_long', $errors[0] );
+	}
+
+	public function test_validate_rejects_missing_score(): void {
+		$rows   = array( $this->csv_row( array( 'score' => '' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_missing_score', $errors[0] );
+	}
+
+	public function test_validate_rejects_comma_decimal_score(): void {
+		$rows   = array( $this->csv_row( array( 'score' => '90,5' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_score_uses_comma_decimal', $errors[0] );
+	}
+
+	public function test_validate_rejects_non_numeric_score(): void {
+		$rows   = array( $this->csv_row( array( 'score' => 'abc' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_score_invalid_format', $errors[0] );
+	}
+
+	public function test_validate_rejects_zero_rank(): void {
+		$rows   = array( $this->csv_row( array( 'rank' => '0' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_rank_invalid', $errors[0] );
+	}
+
+	public function test_validate_rejects_non_numeric_rank(): void {
+		$rows   = array( $this->csv_row( array( 'rank' => 'x' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_rank_invalid', $errors[0] );
+	}
+
+	public function test_validate_rejects_comma_decimal_time_points(): void {
+		$rows   = array( $this->csv_row( array( 'time_points' => '1,5' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_time_points_uses_comma_decimal', $errors[0] );
+	}
+
+	public function test_validate_rejects_invalid_time_points_format(): void {
+		$rows   = array( $this->csv_row( array( 'time_points' => 'abc' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_time_points_invalid_format', $errors[0] );
+	}
+
+	public function test_validate_accepts_valid_time_points(): void {
+		$rows   = array( $this->csv_row( array( 'time_points' => '12.5' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_rejects_missing_adjutancy_slug(): void {
+		$rows   = array( $this->csv_row( array( 'adjutancy' => '' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_missing_adjutancy', $errors[0] );
+	}
+
+	public function test_validate_rejects_adjutancy_not_in_notice(): void {
+		$rows   = array( $this->csv_row( array( 'adjutancy' => 'unknown' ) ) );
+		$errors = $this->validate_rows( $rows );
+
+		$this->assertStringContainsString( 'recruitment_csv_adjutancy_not_in_notice: unknown', $errors[0] );
+	}
+
+	public function test_validate_detects_candidate_field_divergence_same_cpf(): void {
+		// Same CPF in two rows but a different name. The rows sit in
+		// DIFFERENT adjutancies (both in the map) so the duplicate-pair
+		// check passes and the candidate-field divergence rule fires: the
+		// first row is the reference, the second diverges on `name`.
+		$rows = array(
+			$this->csv_row( array( '_line' => 2, 'cpf' => '12345678901', 'name' => 'Alice', 'adjutancy' => 'mat' ) ),
+			$this->csv_row( array( '_line' => 3, 'cpf' => '12345678901', 'name' => 'Alicia', 'adjutancy' => 'por' ) ),
+		);
+
+		$errors = $this->validate_rows(
+			$rows,
+			array(
+				'mat' => 1,
+				'por' => 2,
+			)
+		);
+
+		$div = array_filter( $errors, static fn ( $e ) => false !== strpos( $e, 'candidate_field_divergence' ) );
+		$this->assertNotEmpty( $div );
+		$this->assertStringContainsString( 'field=name', implode( '', $div ) );
+	}
+
+	public function test_validate_accepts_clean_single_row(): void {
+		$errors = $this->validate_rows( array( $this->csv_row() ) );
+		$this->assertEmpty( $errors );
 	}
 }

--- a/tests/Unit/RecruitmentEmailDispatcherSendTest.php
+++ b/tests/Unit/RecruitmentEmailDispatcherSendTest.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentEmailDispatcher;
+
+/**
+ * Happy-path coverage for RecruitmentEmailDispatcher::send_for_call() —
+ * the full render + send flow with the repositories, Encryption,
+ * RecruitmentPcdHasher, DocumentFormatter, DateFormatter and
+ * RecruitmentSettings stubbed via alias mocks.
+ *
+ * Kept in its own file so the alias-backed static stubs run under a
+ * dedicated process (the sibling RecruitmentEmailDispatcherTest exercises
+ * the early-return branches against real helper classes and must NOT be
+ * process-isolated).
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentEmailDispatcher
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentEmailDispatcherSendTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+		Functions\when( 'wp_specialchars_decode' )->returnArg();
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'remove_filter' )->justReturn( true );
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = '' ) {
+				if ( 'blogname' === $key ) {
+					return 'Test Site';
+				}
+				if ( 'siteurl' === $key ) {
+					return 'https://example.test';
+				}
+				return $default;
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function call_stub(): object {
+		return (object) array(
+			'id'                => '7',
+			'classification_id' => '10',
+			'called_at'         => 1777968000,
+			'date_to_assume'    => '2026-06-01',
+			'time_to_assume'    => '08:00:00',
+			'notes'             => 'Bring documents',
+		);
+	}
+
+	private function classification_stub(): object {
+		return (object) array(
+			'id'           => '10',
+			'candidate_id' => '100',
+			'adjutancy_id' => '2',
+			'notice_id'    => '5',
+			'rank'         => '1',
+			'score'        => '90.0000',
+		);
+	}
+
+	private function candidate_stub(): object {
+		return (object) array(
+			'id'              => '100',
+			'name'            => 'Alice',
+			'cpf_encrypted'   => 'cpf-cipher',
+			'rf_encrypted'    => 'rf-cipher',
+			'email_encrypted' => 'email-cipher',
+			'pcd_hash'        => 'pcd-hash',
+		);
+	}
+
+	private function notice_stub(): object {
+		return (object) array(
+			'id'   => '5',
+			'code' => 'EDITAL-2026-01',
+			'name' => 'Edital de 2026',
+		);
+	}
+
+	private function adjutancy_stub(): object {
+		return (object) array(
+			'id'   => '2',
+			'slug' => 'matematica',
+			'name' => 'Matemática',
+		);
+	}
+
+	/**
+	 * Wire the alias mocks shared by the send tests.
+	 *
+	 * @param array<string, mixed> $settings Settings::all() return.
+	 * @param bool                 $is_pcd   PcdHasher::verify return.
+	 * @return void
+	 */
+	private function wire_helpers( array $settings, bool $is_pcd ): void {
+		$call_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCallRepository' );
+		$call_repo->shouldReceive( 'get_by_id' )->andReturn( $this->call_stub() );
+
+		$cls_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentClassificationRepository' );
+		$cls_repo->shouldReceive( 'get_by_id' )->andReturn( $this->classification_stub() );
+
+		$cand_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentCandidateRepository' );
+		$cand_repo->shouldReceive( 'get_by_id' )->andReturn( $this->candidate_stub() );
+
+		$notice_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeRepository' );
+		$notice_repo->shouldReceive( 'get_by_id' )->andReturn( $this->notice_stub() );
+
+		$adj_repo = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository' );
+		$adj_repo->shouldReceive( 'get_by_id' )->andReturn( $this->adjutancy_stub() );
+
+		$enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+		$enc->shouldReceive( 'decrypt' )->andReturnUsing(
+			static function ( $cipher ) {
+				$map = array(
+					'cpf-cipher'   => '12345678909',
+					'rf-cipher'    => '1234567',
+					'email-cipher' => 'alice@example.test',
+				);
+				return $map[ $cipher ] ?? null;
+			}
+		);
+
+		$pcd = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentPcdHasher' );
+		$pcd->shouldReceive( 'verify' )->andReturn( $is_pcd );
+
+		$doc = Mockery::mock( 'alias:FreeFormCertificate\Core\DocumentFormatter' );
+		$doc->shouldReceive( 'mask_cpf' )->andReturn( '***.***.***-09' );
+		$doc->shouldReceive( 'mask_rf' )->andReturn( '***4567' );
+		$doc->shouldReceive( 'mask_email' )->andReturn( 'a***@example.test' );
+
+		$date = Mockery::mock( 'alias:FreeFormCertificate\Core\DateFormatter' );
+		$date->shouldReceive( 'format_datetime' )->andReturn( '05/05/2026 00:00' );
+
+		$settings_mock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentSettings' );
+		$settings_mock->shouldReceive( 'all' )->andReturn( $settings );
+	}
+
+	public function test_sends_email_with_resolved_tokens_and_from_header(): void {
+		$this->wire_helpers(
+			array(
+				'email_subject'      => 'Convocação {{name}} — {{notice_code}}',
+				'email_body_html'    => '<p>{{name}}, CPF {{cpf_masked}}, PCD {{is_pcd}}, em {{date_to_assume}} às {{time_to_assume}}. Notas: {{notes}}. {{called_at}} {{site_name}} {{site_url}}</p>',
+				'email_from_address' => 'rh@example.test',
+				'email_from_name'    => 'Recursos Humanos',
+			),
+			true
+		);
+
+		$captured = array();
+		Functions\when( 'wp_mail' )->alias(
+			static function ( $to, $subject, $body, $headers ) use ( &$captured ) {
+				$captured = compact( 'to', 'subject', 'body', 'headers' );
+				return true;
+			}
+		);
+
+		$result = RecruitmentEmailDispatcher::send_for_call( 7 );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'alice@example.test', $captured['to'] );
+		$this->assertSame( 'Convocação Alice — EDITAL-2026-01', $captured['subject'] );
+		$this->assertStringContainsString( '***.***.***-09', $captured['body'] );
+		$this->assertStringContainsString( 'PCD Yes', $captured['body'] );
+		$this->assertStringContainsString( '2026-06-01', $captured['body'] );
+		$this->assertStringContainsString( 'Bring documents', $captured['body'] );
+		$this->assertStringContainsString( 'Test Site', $captured['body'] );
+		$this->assertContains( 'Content-Type: text/html; charset=UTF-8', $captured['headers'] );
+		$this->assertContains( 'From: "Recursos Humanos" <rh@example.test>', $captured['headers'] );
+	}
+
+	public function test_sends_email_with_no_from_header_when_address_blank(): void {
+		$this->wire_helpers(
+			array(
+				'email_subject'      => 'Sub',
+				'email_body_html'    => '<p>{{is_pcd}}</p>',
+				'email_from_address' => '',
+				'email_from_name'    => 'Ignored',
+			),
+			false
+		);
+
+		$captured = array();
+		Functions\when( 'wp_mail' )->alias(
+			static function ( $to, $subject, $body, $headers ) use ( &$captured ) {
+				$captured = compact( 'headers', 'body' );
+				return true;
+			}
+		);
+
+		$this->assertTrue( RecruitmentEmailDispatcher::send_for_call( 7 ) );
+		// Only the Content-Type header; no From: line.
+		$this->assertCount( 1, $captured['headers'] );
+		$this->assertStringContainsString( 'No', $captured['body'], 'is_pcd false resolves to "No"' );
+	}
+
+	public function test_uses_bare_address_when_from_name_blank(): void {
+		$this->wire_helpers(
+			array(
+				'email_subject'      => 'Sub',
+				'email_body_html'    => '<p>body</p>',
+				'email_from_address' => 'noreply@example.test',
+				'email_from_name'    => '',
+			),
+			false
+		);
+
+		$captured = array();
+		Functions\when( 'wp_mail' )->alias(
+			static function ( $to, $subject, $body, $headers ) use ( &$captured ) {
+				$captured = $headers;
+				return true;
+			}
+		);
+
+		$this->assertTrue( RecruitmentEmailDispatcher::send_for_call( 7 ) );
+		$this->assertContains( 'From: noreply@example.test', $captured );
+	}
+}

--- a/tests/Unit/RecruitmentNoticeEditPageHandlersTest.php
+++ b/tests/Unit/RecruitmentNoticeEditPageHandlersTest.php
@@ -1,0 +1,229 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Recruitment\RecruitmentNoticeEditPage;
+
+/**
+ * Behavior tests for RecruitmentNoticeEditPage::handle_save() and
+ * handle_transition() — the admin-post handlers. The terminal
+ * wp_safe_redirect()/exit is replaced by a marker exception so the flash
+ * key (and the repository / state-machine call) is observable without
+ * killing the process. wp_die is likewise short-circuited.
+ *
+ * @covers \FreeFormCertificate\Recruitment\RecruitmentNoticeEditPage
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RecruitmentNoticeEditPageHandlersTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'absint' )->alias( static fn ( $v ) => (int) $v );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'check_admin_referer' )->justReturn( true );
+		Functions\when( 'admin_url' )->returnArg();
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'add_query_arg' )->alias(
+			static fn ( $args ) => 'admin.php?' . http_build_query( (array) $args )
+		);
+		Functions\when( 'wp_die' )->alias(
+			static function ( $msg = '' ) {
+				throw new \RuntimeException( 'WP_DIE:' . $msg );
+			}
+		);
+		Functions\when( 'wp_safe_redirect' )->alias(
+			static function ( $url ) {
+				throw new \RuntimeException( 'REDIRECT:' . $url );
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		unset( $_POST['notice_id'], $_POST['name'], $_POST['public_columns'], $_POST['target_status'], $_POST['reason'] );
+		parent::tearDown();
+	}
+
+	private function capture( callable $fn ): string {
+		try {
+			$fn();
+		} catch ( \RuntimeException $e ) {
+			return $e->getMessage();
+		}
+		return '';
+	}
+
+	// ==================================================================
+	// handle_save()
+	// ==================================================================
+
+	public function test_handle_save_dies_without_cap(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_save' ) );
+
+		$this->assertStringStartsWith( 'WP_DIE:', $msg );
+	}
+
+	public function test_handle_save_redirects_to_list_when_notice_id_zero(): void {
+		$_POST['notice_id'] = '0';
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_save' ) );
+
+		$this->assertStringStartsWith( 'REDIRECT:', $msg );
+		$this->assertStringContainsString( 'tab=notices', $msg );
+		// No edit-notice action segment on the back-to-list URL.
+		$this->assertStringNotContainsString( 'action=edit-notice', $msg );
+	}
+
+	public function test_handle_save_persists_name_and_columns_then_flashes_saved(): void {
+		$_POST['notice_id']      = '5';
+		$_POST['name']           = 'New Name';
+		$_POST['public_columns'] = array(
+			'score' => '1',
+			'email' => '1',
+		);
+
+		// Renderer supplies the column label map keys.
+		$renderer = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeEditPageRenderer' );
+		$renderer->shouldReceive( 'columns_label_map' )->andReturn(
+			array(
+				'rank'  => 'Rank',
+				'name'  => 'Name',
+				'score' => 'Score',
+				'email' => 'Email',
+				'phone' => 'Phone',
+			)
+		);
+
+		$repo     = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeRepository' );
+		$captured = null;
+		$repo->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $id, $data ) use ( &$captured ) {
+				$captured = array( $id, $data );
+				return 1;
+			}
+		);
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_save' ) );
+
+		$this->assertSame( 5, $captured[0] );
+		$this->assertSame( 'New Name', $captured[1]['name'] );
+		$config = json_decode( $captured[1]['public_columns_config'], true );
+		$this->assertTrue( $config['rank'], 'rank forced true' );
+		$this->assertTrue( $config['name'], 'name forced true' );
+		$this->assertTrue( $config['score'] );
+		$this->assertTrue( $config['email'] );
+		$this->assertFalse( $config['phone'], 'unchecked column → false' );
+		$this->assertStringContainsString( 'ffc_msg=saved', $msg );
+		$this->assertStringContainsString( 'action=edit-notice', $msg );
+	}
+
+	// ==================================================================
+	// handle_transition()
+	// ==================================================================
+
+	public function test_handle_transition_dies_without_cap(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_transition' ) );
+
+		$this->assertStringStartsWith( 'WP_DIE:', $msg );
+	}
+
+	public function test_handle_transition_flashes_invalid_target_for_unknown_status(): void {
+		$_POST['notice_id']     = '5';
+		$_POST['target_status'] = 'bogus';
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_transition' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=transition-invalid-target', $msg );
+	}
+
+	public function test_handle_transition_flashes_transitioned_on_success(): void {
+		$_POST['notice_id']     = '5';
+		$_POST['target_status'] = 'preliminary';
+
+		$sm = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeStateMachine' );
+		$sm->shouldReceive( 'transition_to' )->once()->andReturn(
+			array(
+				'success' => true,
+				'errors'  => array(),
+			)
+		);
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_transition' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=transitioned', $msg );
+	}
+
+	/**
+	 * @dataProvider error_code_provider
+	 */
+	public function test_handle_transition_maps_state_machine_errors_to_flash_keys( string $error_code, string $expected_flash ): void {
+		$_POST['notice_id']     = '5';
+		$_POST['target_status'] = 'preliminary';
+
+		$sm = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeStateMachine' );
+		$sm->shouldReceive( 'transition_to' )->once()->andReturn(
+			array(
+				'success' => false,
+				'errors'  => array( $error_code ),
+			)
+		);
+
+		$msg = $this->capture( array( RecruitmentNoticeEditPage::class, 'handle_transition' ) );
+
+		$this->assertStringContainsString( 'ffc_msg=' . $expected_flash, $msg );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function error_code_provider(): array {
+		return array(
+			'blocked by calls' => array( 'recruitment_definitive_to_preliminary_blocked_by_calls', 'transition-blocked-by-calls' ),
+			'reason required'  => array( 'recruitment_transition_reason_required', 'transition-reason-required' ),
+			'race lost'        => array( 'recruitment_transition_race_lost', 'transition-race-lost' ),
+			'generic failure'  => array( 'recruitment_invalid_transition: draft->closed', 'transition-failed' ),
+		);
+	}
+
+	public function test_handle_transition_passes_reason_through_to_state_machine(): void {
+		$_POST['notice_id']     = '5';
+		$_POST['target_status'] = 'closed';
+		$_POST['reason']        = 'Concluded';
+
+		$sm           = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentNoticeStateMachine' );
+		$seen_reason  = 'unset';
+		$sm->shouldReceive( 'transition_to' )->once()->andReturnUsing(
+			function ( $id, $target, $reason ) use ( &$seen_reason ) {
+				$seen_reason = $reason;
+				return array(
+					'success' => true,
+					'errors'  => array(),
+				);
+			}
+		);
+
+		$this->capture( array( RecruitmentNoticeEditPage::class, 'handle_transition' ) );
+
+		$this->assertSame( 'Concluded', $seen_reason );
+	}
+}

--- a/tests/Unit/RecruitmentNoticesListTableTest.php
+++ b/tests/Unit/RecruitmentNoticesListTableTest.php
@@ -135,4 +135,84 @@ class RecruitmentNoticesListTableTest extends TestCase {
         $out = $this->call_protected( 'column_default', array( array(), 'missing' ) );
         $this->assertSame( '', $out );
     }
+
+    public function test_column_created_at_echoes_raw_value(): void {
+        $out = $this->call_protected( 'column_created_at', array( array( 'created_at' => '2026-05-01 10:00:00' ) ) );
+        $this->assertSame( '2026-05-01 10:00:00', $out );
+    }
+
+    // ------------------------------------------------------------------
+    // convert_rows() — stdClass → array shape (static private)
+    // ------------------------------------------------------------------
+
+    private function call_static_private( string $method, array $args ) {
+        $ref = new \ReflectionMethod( RecruitmentNoticesListTable::class, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( null, $args );
+    }
+
+    public function test_convert_rows_maps_object_fields_into_array_shape(): void {
+        $rows = array(
+            (object) array(
+                'id'           => '7',
+                'code'         => 'EDITAL-7',
+                'name'         => 'Concurso',
+                'status'       => 'draft',
+                'was_reopened' => '1',
+                'created_at'   => '2026-05-01 10:00:00',
+            ),
+        );
+
+        $out = $this->call_static_private( 'convert_rows', array( $rows ) );
+
+        $this->assertSame( 7, $out[0]['id'] );
+        $this->assertSame( 'EDITAL-7', $out[0]['code'] );
+        $this->assertSame( 'Concurso', $out[0]['name'] );
+        $this->assertSame( 'draft', $out[0]['status'] );
+        $this->assertSame( '1', $out[0]['was_reopened'] );
+        $this->assertSame( '2026-05-01 10:00:00', $out[0]['created_at'] );
+    }
+
+    public function test_convert_rows_returns_empty_for_empty_input(): void {
+        $this->assertSame( array(), $this->call_static_private( 'convert_rows', array( array() ) ) );
+    }
+
+    // ------------------------------------------------------------------
+    // sort_rows() — in-memory natural-case sort (static private)
+    // ------------------------------------------------------------------
+
+    private function rows_for_sort(): array {
+        return array(
+            array( 'code' => 'B', 'name' => 'beta', 'status' => 'draft', 'created_at' => '2026-01-02' ),
+            array( 'code' => 'A', 'name' => 'alpha', 'status' => 'closed', 'created_at' => '2026-01-01' ),
+            array( 'code' => 'C', 'name' => 'gamma', 'status' => 'definitive', 'created_at' => '2026-01-03' ),
+        );
+    }
+
+    public function test_sort_rows_ascending_by_code(): void {
+        $out = $this->call_static_private( 'sort_rows', array( $this->rows_for_sort(), 'code', 'asc' ) );
+        $this->assertSame( array( 'A', 'B', 'C' ), array_column( $out, 'code' ) );
+    }
+
+    public function test_sort_rows_descending_by_code(): void {
+        $out = $this->call_static_private( 'sort_rows', array( $this->rows_for_sort(), 'code', 'desc' ) );
+        $this->assertSame( array( 'C', 'B', 'A' ), array_column( $out, 'code' ) );
+    }
+
+    public function test_sort_rows_falls_back_to_created_at_for_disallowed_orderby(): void {
+        // 'status' IS allowed; 'id' is NOT → falls back to created_at asc.
+        $out = $this->call_static_private( 'sort_rows', array( $this->rows_for_sort(), 'id', 'asc' ) );
+        $this->assertSame(
+            array( '2026-01-01', '2026-01-02', '2026-01-03' ),
+            array_column( $out, 'created_at' )
+        );
+    }
+
+    public function test_sort_rows_allows_status_orderby(): void {
+        $out = $this->call_static_private( 'sort_rows', array( $this->rows_for_sort(), 'status', 'asc' ) );
+        $this->assertSame(
+            array( 'closed', 'definitive', 'draft' ),
+            array_column( $out, 'status' )
+        );
+    }
 }

--- a/tests/Unit/RecruitmentPublicShortcodeRendererTest.php
+++ b/tests/Unit/RecruitmentPublicShortcodeRendererTest.php
@@ -176,4 +176,162 @@ class RecruitmentPublicShortcodeRendererTest extends TestCase {
         $this->assertStringContainsString( '&lt;script&gt;', $out );
         $this->assertStringContainsString( '&quot;2026&quot;', $out );
     }
+
+    // ------------------------------------------------------------------
+    // Private logic helpers — invoked via reflection.
+    // ------------------------------------------------------------------
+
+    /**
+     * @return mixed
+     */
+    private function invoke( string $method, ...$args ) {
+        $ref = new \ReflectionClass( RecruitmentPublicShortcodeRenderer::class );
+        $m   = $ref->getMethod( $method );
+        $m->setAccessible( true );
+        return $m->invoke( null, ...$args );
+    }
+
+    public function test_status_label_maps_known_and_unknown_values(): void {
+        $this->assertSame( 'Waiting', $this->invoke( 'status_label', 'empty' ) );
+        $this->assertSame( 'Called', $this->invoke( 'status_label', 'called' ) );
+        // accepted is rendered as "Called" for the public view (§5.2).
+        $this->assertSame( 'Called', $this->invoke( 'status_label', 'accepted' ) );
+        $this->assertSame( 'Did not show up', $this->invoke( 'status_label', 'not_shown' ) );
+        $this->assertSame( 'Hired', $this->invoke( 'status_label', 'hired' ) );
+        $this->assertSame( 'Withdrew', $this->invoke( 'status_label', 'withdrew' ) );
+        $this->assertSame( 'weird', $this->invoke( 'status_label', 'weird' ) );
+    }
+
+    public function test_preview_status_label_maps_known_and_unknown_values(): void {
+        $this->assertSame( 'Empty', $this->invoke( 'preview_status_label', 'empty' ) );
+        $this->assertSame( 'Denied', $this->invoke( 'preview_status_label', 'denied' ) );
+        $this->assertSame( 'Granted', $this->invoke( 'preview_status_label', 'granted' ) );
+        $this->assertSame( 'Appeal denied', $this->invoke( 'preview_status_label', 'appeal_denied' ) );
+        $this->assertSame( 'Appeal granted', $this->invoke( 'preview_status_label', 'appeal_granted' ) );
+        $this->assertSame( 'mystery', $this->invoke( 'preview_status_label', 'mystery' ) );
+    }
+
+    public function test_format_date_br_reformats_iso_to_d_m_y(): void {
+        $this->assertSame( '20-05-2026', $this->invoke( 'format_date_br', '2026-05-20' ) );
+    }
+
+    public function test_format_date_br_returns_empty_for_empty_input(): void {
+        $this->assertSame( '', $this->invoke( 'format_date_br', '' ) );
+    }
+
+    public function test_format_date_br_passes_through_unparseable_input(): void {
+        $this->assertSame( 'not-a-date', $this->invoke( 'format_date_br', 'not-a-date' ) );
+    }
+
+    public function test_format_time_hm_strips_seconds(): void {
+        $this->assertSame( '09:30', $this->invoke( 'format_time_hm', '09:30:00' ) );
+    }
+
+    public function test_format_time_hm_returns_empty_for_empty_input(): void {
+        $this->assertSame( '', $this->invoke( 'format_time_hm', '' ) );
+    }
+
+    public function test_decrypt_field_returns_null_for_blank_or_non_string(): void {
+        $this->assertNull( $this->invoke( 'decrypt_field', '' ) );
+        $this->assertNull( $this->invoke( 'decrypt_field', null ) );
+        $this->assertNull( $this->invoke( 'decrypt_field', 123 ) );
+    }
+
+    public function test_decrypt_field_delegates_to_encryption(): void {
+        $enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+        $enc->shouldReceive( 'decrypt' )->with( 'cipher' )->andReturn( 'plain' );
+
+        $this->assertSame( 'plain', $this->invoke( 'decrypt_field', 'cipher' ) );
+    }
+
+    public function test_decrypt_field_returns_null_when_decrypt_fails(): void {
+        $enc = Mockery::mock( 'alias:FreeFormCertificate\Core\Encryption' );
+        $enc->shouldReceive( 'decrypt' )->andReturn( null );
+
+        $this->assertNull( $this->invoke( 'decrypt_field', 'cipher' ) );
+    }
+
+    public function test_render_adjutancy_badge_returns_empty_for_null(): void {
+        $this->assertSame( '', $this->invoke( 'render_adjutancy_badge', null ) );
+    }
+
+    public function test_render_adjutancy_badge_uses_color_and_falls_back(): void {
+        $badge = Mockery::mock( 'alias:FreeFormCertificate\Core\BadgeHtml' );
+        $badge->shouldReceive( 'render' )->andReturnUsing(
+            fn( $base, $cls, $color, $label ) => "[$color|$label]"
+        );
+
+        $this->assertSame(
+            '[#abcabc|Mat]',
+            $this->invoke( 'render_adjutancy_badge', (object) array( 'name' => 'Mat', 'color' => '#abcabc' ) )
+        );
+        // Blank color → repository default.
+        $out = $this->invoke( 'render_adjutancy_badge', (object) array( 'name' => 'Por', 'color' => '' ) );
+        $this->assertStringContainsString(
+            \FreeFormCertificate\Recruitment\RecruitmentAdjutancyRepository::DEFAULT_COLOR,
+            $out
+        );
+    }
+
+    public function test_render_subscription_badge_pcd_and_geral(): void {
+        $this->settingsMock->shouldReceive( 'all' )->andReturn(
+            array(
+                'subscription_color_pcd'   => '#pcd',
+                'subscription_color_geral' => '#geral',
+            )
+        );
+        $badge = Mockery::mock( 'alias:FreeFormCertificate\Core\BadgeHtml' );
+        $badge->shouldReceive( 'render' )->andReturnUsing(
+            fn( $base, $cls, $color, $label ) => "[$cls|$color|$label]"
+        );
+
+        $pcd   = RecruitmentPublicShortcodeRenderer::render_subscription_badge( true );
+        $geral = RecruitmentPublicShortcodeRenderer::render_subscription_badge( false );
+
+        $this->assertStringContainsString( 'pcd', $pcd );
+        $this->assertStringContainsString( '#pcd', $pcd );
+        $this->assertStringContainsString( 'geral', $geral );
+        $this->assertStringContainsString( '#geral', $geral );
+    }
+
+    public function test_render_status_badge_maps_color_by_status(): void {
+        $this->settingsMock->shouldReceive( 'all' )->andReturn(
+            array(
+                'status_color_empty'     => '#e1',
+                'status_color_called'    => '#c1',
+                'status_color_hired'     => '#h1',
+                'status_color_not_shown' => '#n1',
+                'status_color_withdrew'  => '#w1',
+            )
+        );
+        $badge = Mockery::mock( 'alias:FreeFormCertificate\Core\BadgeHtml' );
+        $badge->shouldReceive( 'render' )->andReturnUsing(
+            fn( $base, $cls, $color, $label ) => "[$color]"
+        );
+
+        $this->assertSame( '[#c1]', $this->invoke( 'render_status_badge', 'called' ) );
+        // accepted shares the called color.
+        $this->assertSame( '[#c1]', $this->invoke( 'render_status_badge', 'accepted' ) );
+        // Unknown status → neutral fallback.
+        $this->assertSame( '[#e9ecef]', $this->invoke( 'render_status_badge', 'bogus' ) );
+    }
+
+    public function test_render_preview_status_badge_maps_color_and_passes_reason(): void {
+        $this->settingsMock->shouldReceive( 'all' )->andReturn(
+            array(
+                'preview_color_empty'          => '#pe',
+                'preview_color_denied'         => '#pd',
+                'preview_color_granted'        => '#pg',
+                'preview_color_appeal_denied'  => '#pad',
+                'preview_color_appeal_granted' => '#pag',
+            )
+        );
+        $badge = Mockery::mock( 'alias:FreeFormCertificate\Core\BadgeHtml' );
+        $badge->shouldReceive( 'render' )->andReturnUsing(
+            fn( $base, $cls, $color, $label, $reason = '' ) => "[$color|$label|$reason]"
+        );
+
+        $this->assertSame( '[#pg|Granted|]', $this->invoke( 'render_preview_status_badge', 'granted', '' ) );
+        $this->assertSame( '[#e9ecef|weird|hint]', $this->invoke( 'render_preview_status_badge', 'weird', 'hint' ) );
+    }
 }


### PR DESCRIPTION
## Fase 2 — cobertura PHP: recruitment

Estende testes unitários para lógica (pulando render HTML / streaming CSV):

| Classe | Antes | Depois |
|---|---|---|
| `RecruitmentCsvImporter` | 25.2% | **91.9%** |
| `RecruitmentEmailDispatcher` | 25.0% | **94.4%** |
| `RecruitmentNoticeEditPage` | 2.6% | **61.7%** |
| `RecruitmentCandidateEditPage` | 7.1% | **32.1%** |
| `RecruitmentPublicShortcodeRenderer` | 12.1% | **37.9%** |
| `RecruitmentNoticesListTable` | 26.0% | **40.4%** |
| `RecruitmentAdminPage` | 7.5% | **9.8%** (resto é `render_*` markup) |

**+~70 testes; suíte completa verde (5108 testes); PHPCS limpo.** Nenhum `includes/` alterado; sem mudança de floor (bump central no fim). Render markup / `prepare_items`/`process_bulk_action` (stub de `WP_List_Table` no bootstrap não tem `row_actions`/`current_action`) e CSV-streaming que termina em `exit` deixados de fora por escopo.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_