### PR TITLE
test(php): raise cross-cutting coverage — REST, repos, validators, generators

### DIFF
--- a/tests/Unit/BlockedDateRepositoryTest.php
+++ b/tests/Unit/BlockedDateRepositoryTest.php
@@ -22,6 +22,9 @@ class BlockedDateRepositoryTest extends TestCase {
     /** @var BlockedDateRepository */
     private $repository;
 
+    /** @var \Mockery\MockInterface&\wpdb */
+    private $wpdb;
+
     protected function setUp(): void {
         parent::setUp();
         Monkey\setUp();
@@ -29,11 +32,19 @@ class BlockedDateRepositoryTest extends TestCase {
         Functions\when( 'wp_cache_get' )->justReturn( false );
         Functions\when( 'wp_cache_set' )->justReturn( true );
         Functions\when( 'wp_cache_delete' )->justReturn( true );
+        Functions\when( 'wp_cache_flush' )->justReturn( true );
+        Functions\when( 'current_time' )->justReturn( '2030-01-01 00:00:00' );
+        Functions\when( 'get_current_user_id' )->justReturn( 7 );
+        Functions\when( 'wp_json_encode' )->alias( fn ( $v ) => json_encode( $v ) );
 
         // Provide a mock $wpdb global for AbstractRepository
         global $wpdb;
         $wpdb = Mockery::mock( 'wpdb' )->makePartial();
         $wpdb->prefix = 'wp_';
+        $wpdb->last_error = '';
+        $wpdb->insert_id = 0;
+
+        $this->wpdb = $wpdb;
 
         $this->repository = new BlockedDateRepository();
     }
@@ -173,5 +184,179 @@ class BlockedDateRepositoryTest extends TestCase {
         $pattern = array( 'type' => 'weekly', 'days' => array( 6 ) );
         $this->assertTrue( $this->matchesPattern( '2030-01-12', '09:00', $pattern ) );
         $this->assertTrue( $this->matchesPattern( '2030-01-12', null, $pattern ) );
+    }
+
+    // ==================================================================
+    // getGlobalBlocks
+    // ==================================================================
+
+    public function test_get_global_blocks_returns_rows(): void {
+        $rows = array( array( 'id' => 1, 'calendar_id' => null, 'block_type' => 'full_day' ) );
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+        $this->assertSame( $rows, $this->repository->getGlobalBlocks() );
+    }
+
+    public function test_get_global_blocks_returns_empty_on_null(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( null );
+
+        $this->assertSame( array(), $this->repository->getGlobalBlocks() );
+    }
+
+    // ==================================================================
+    // findByCalendar (delegates to findAll)
+    // ==================================================================
+
+    public function test_find_by_calendar_returns_rows(): void {
+        $rows = array( array( 'id' => 5, 'calendar_id' => 3 ) );
+        $this->wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+        $this->assertSame( $rows, $this->repository->findByCalendar( 3 ) );
+    }
+
+    // ==================================================================
+    // getBlockedDatesInRange / getUpcomingBlocks
+    // ==================================================================
+
+    public function test_get_blocked_dates_in_range_returns_rows(): void {
+        $rows = array( array( 'id' => 1 ), array( 'id' => 2 ) );
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+        $this->assertSame( $rows, $this->repository->getBlockedDatesInRange( 1, '2030-01-01', '2030-02-01' ) );
+    }
+
+    public function test_get_blocked_dates_in_range_returns_empty_on_null(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( null );
+
+        $this->assertSame( array(), $this->repository->getBlockedDatesInRange( 1, '2030-01-01', '2030-02-01' ) );
+    }
+
+    public function test_get_upcoming_blocks_delegates_to_range(): void {
+        $rows = array( array( 'id' => 9 ) );
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( $rows );
+
+        $this->assertSame( $rows, $this->repository->getUpcomingBlocks( 4, 14 ) );
+    }
+
+    // ==================================================================
+    // isDateBlocked — block type branches
+    // ==================================================================
+
+    public function test_is_date_blocked_full_day(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+            array( array( 'block_type' => 'full_day' ) )
+        );
+
+        $this->assertTrue( $this->repository->isDateBlocked( 1, '2030-05-20' ) );
+    }
+
+    public function test_is_date_blocked_time_range_inside_window(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+            array( array( 'block_type' => 'time_range', 'start_time' => '09:00', 'end_time' => '12:00' ) )
+        );
+
+        $this->assertTrue( $this->repository->isDateBlocked( 1, '2030-05-20', '10:00' ) );
+    }
+
+    public function test_is_date_blocked_time_range_outside_window(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+            array( array( 'block_type' => 'time_range', 'start_time' => '09:00', 'end_time' => '12:00' ) )
+        );
+
+        $this->assertFalse( $this->repository->isDateBlocked( 1, '2030-05-20', '13:00' ) );
+    }
+
+    public function test_is_date_blocked_recurring_match(): void {
+        // 2030-01-12 is a Saturday (6).
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn(
+            array(
+                array(
+                    'block_type'        => 'recurring',
+                    'recurring_pattern' => json_encode( array( 'type' => 'weekly', 'days' => array( 6 ) ) ),
+                ),
+            )
+        );
+
+        $this->assertTrue( $this->repository->isDateBlocked( 1, '2030-01-12' ) );
+    }
+
+    public function test_is_date_blocked_returns_false_when_no_blocks(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+
+        $this->assertFalse( $this->repository->isDateBlocked( 1, '2030-05-20' ) );
+    }
+
+    public function test_is_date_blocked_handles_null_results(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SQL' );
+        $this->wpdb->shouldReceive( 'get_results' )->once()->andReturn( null );
+
+        $this->assertFalse( $this->repository->isDateBlocked( 1, '2030-05-20' ) );
+    }
+
+    // ==================================================================
+    // create* helpers (delegate to AbstractRepository::insert)
+    // ==================================================================
+
+    public function test_create_full_day_block_returns_insert_id(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+        $this->wpdb->insert_id = 55;
+
+        $this->assertSame( 55, $this->repository->createFullDayBlock( null, '2030-05-20', '2030-05-21', 'maint' ) );
+    }
+
+    public function test_create_time_range_block_returns_insert_id(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+        $this->wpdb->insert_id = 77;
+
+        $this->assertSame( 77, $this->repository->createTimeRangeBlock( 2, '2030-05-20', '09:00', '12:00' ) );
+    }
+
+    public function test_create_recurring_block_returns_insert_id(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+        $this->wpdb->insert_id = 88;
+
+        $result = $this->repository->createRecurringBlock( null, '2030-05-20', array( 'type' => 'weekly', 'days' => array( 0, 6 ) ) );
+        $this->assertSame( 88, $result );
+    }
+
+    public function test_create_full_day_block_returns_false_on_failure(): void {
+        $this->wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+
+        $this->assertFalse( $this->repository->createFullDayBlock( 1, '2030-05-20' ) );
+    }
+
+    // ==================================================================
+    // deleteExpiredBlocks
+    // ==================================================================
+
+    public function test_delete_expired_blocks_returns_row_count(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'DELETE SQL' );
+        $this->wpdb->shouldReceive( 'query' )->once()->andReturn( 4 );
+
+        $this->assertSame( 4, $this->repository->deleteExpiredBlocks( 30 ) );
+    }
+
+    public function test_delete_expired_blocks_returns_false_when_prepare_fails(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( null );
+
+        $this->assertFalse( $this->repository->deleteExpiredBlocks() );
+    }
+
+    public function test_delete_expired_blocks_returns_false_on_query_failure(): void {
+        $this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'DELETE SQL' );
+        $this->wpdb->shouldReceive( 'query' )->once()->andReturn( false );
+
+        $this->assertFalse( $this->repository->deleteExpiredBlocks() );
     }
 }

--- a/tests/Unit/CsvDownloadValidatorTest.php
+++ b/tests/Unit/CsvDownloadValidatorTest.php
@@ -1,0 +1,372 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Frontend\CsvDownloadValidator;
+use FreeFormCertificate\Frontend\PublicCsvDownload;
+
+/**
+ * Tests for CsvDownloadValidator: the form-access gate (steps 5–9), the
+ * hash-only subset, the per-form CPF gate (none/audit/whitelist/owner/
+ * participants/unknown) and the audit-log writer.
+ *
+ * Runs in separate processes: the CPF gate + audit writer call the real
+ * DocumentFormatter / Encryption / Utils statics, and a leaked global
+ * function expectation from an earlier same-process test (e.g. a torn-down
+ * `wp_unslash` mock) would otherwise poison `Utils::get_user_ip()`. Process
+ * isolation guarantees a clean function table per test.
+ *
+ * @covers \FreeFormCertificate\Frontend\CsvDownloadValidator
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CsvDownloadValidatorTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var CsvDownloadValidator */
+    private $validator;
+
+    /** @var array<string, mixed> post-meta store keyed by "post_id:key" */
+    private $meta_store = array();
+
+    /** @var array<string, int> update_post_meta call counts */
+    private $meta_updates = array();
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->meta_store   = array();
+        $this->meta_updates = array();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'wp_unslash' )->returnArg();
+        // Utils::get_user_ip() calls sanitize_text_field()/wp_unslash()
+        // unqualified from the Core namespace. Define them as plain stable
+        // passthroughs (NOT Brain\Monkey stubs) so they survive tearDown
+        // without leaving a torn-down expectation that would poison a later
+        // test running in the same process (e.g. DecryptFailureLoggingTest's
+        // ActivityLog::log() which also resolves Core\sanitize_text_field).
+        self::define_core_passthrough( 'sanitize_text_field' );
+        self::define_core_passthrough( 'wp_unslash' );
+        Functions\when( 'wp_timezone' )->alias( fn () => new \DateTimeZone( 'UTC' ) );
+        Functions\when( 'get_post_type' )->justReturn( 'ffc_form' );
+        Functions\when( 'get_option' )->justReturn( array() );
+
+        Functions\when( 'get_post_meta' )->alias(
+            function ( $post_id, $key, $single = false ) {
+                return $this->meta_store[ (int) $post_id . ':' . $key ] ?? '';
+            }
+        );
+        Functions\when( 'update_post_meta' )->alias(
+            function ( $post_id, $key, $value ) {
+                $sk                       = (int) $post_id . ':' . $key;
+                $this->meta_store[ $sk ]    = $value;
+                $this->meta_updates[ $sk ]  = ( $this->meta_updates[ $sk ] ?? 0 ) + 1;
+                return true;
+            }
+        );
+        Functions\when( 'get_post_field' )->alias(
+            function ( $field, $post_id ) {
+                return $this->meta_store[ (int) $post_id . ':__field_' . $field ] ?? 0;
+            }
+        );
+        Functions\when( 'get_user_meta' )->alias(
+            function ( $user_id, $key, $single = false ) {
+                return $this->meta_store[ 'user_' . (int) $user_id . ':' . $key ] ?? '';
+            }
+        );
+
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.5';
+
+        $this->validator = new CsvDownloadValidator();
+    }
+
+    protected function tearDown(): void {
+        $_SERVER = array();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Define a passthrough function in the FreeFormCertificate\Core namespace
+     * once per process. Idempotent: subsequent calls are no-ops. Unlike a
+     * Brain\Monkey namespaced stub, this leaves no expectation to be torn
+     * down, so it can't poison later same-process tests.
+     */
+    private static function define_core_passthrough( string $name ): void {
+        $fqn = 'FreeFormCertificate\\Core\\' . $name;
+        if ( ! function_exists( $fqn ) ) {
+            eval( "namespace FreeFormCertificate\\Core; function {$name}( \$v ) { return \$v; }" );
+        }
+    }
+
+    /** Seed meta so validate_form_access passes every gate by default. */
+    private function seed_access( int $form_id, array $overrides = array() ): void {
+        $cfg = array_merge(
+            array(
+                'type'        => 'ffc_form',
+                'enabled'     => '1',
+                'hash'        => 'storedhash',
+                'download'    => '1',
+                'limit'       => 5,
+                'count'       => 0,
+                'date_end'    => '2000-01-01',
+                'time_end'    => '00:00:00',
+            ),
+            $overrides
+        );
+        Functions\when( 'get_post_type' )->justReturn( $cfg['type'] );
+        $this->meta_store[ $form_id . ':' . PublicCsvDownload::META_ENABLED ]        = $cfg['enabled'];
+        $this->meta_store[ $form_id . ':' . PublicCsvDownload::META_HASH ]           = $cfg['hash'];
+        $this->meta_store[ $form_id . ':_ffc_csv_public_download_enabled' ]          = $cfg['download'];
+        $this->meta_store[ $form_id . ':' . PublicCsvDownload::META_LIMIT ]          = $cfg['limit'];
+        $this->meta_store[ $form_id . ':' . PublicCsvDownload::META_COUNT ]          = $cfg['count'];
+        $this->meta_store[ $form_id . ':_ffc_geofence_config' ]                      = array(
+            'date_end' => $cfg['date_end'],
+            'time_end' => $cfg['time_end'],
+        );
+    }
+
+    // ==================================================================
+    // validate_form_access
+    // ==================================================================
+
+    public function test_form_access_success(): void {
+        $this->seed_access( 42 );
+        $this->assertNull( $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_wrong_post_type(): void {
+        $this->seed_access( 42, array( 'type' => 'post' ) );
+        $this->assertSame( 'Form not found.', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_feature_disabled(): void {
+        $this->seed_access( 42, array( 'enabled' => '0' ) );
+        $this->assertStringContainsString( 'not enabled', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_hash_mismatch(): void {
+        $this->seed_access( 42 );
+        $this->assertSame( 'Invalid access hash.', $this->validator->validate_form_access( 42, 'wronghash' ) );
+    }
+
+    public function test_form_access_rejects_empty_stored_hash(): void {
+        $this->seed_access( 42, array( 'hash' => '' ) );
+        $this->assertSame( 'Invalid access hash.', $this->validator->validate_form_access( 42, '' ) );
+    }
+
+    public function test_form_access_rejects_download_disabled(): void {
+        $this->seed_access( 42, array( 'download' => '0' ) );
+        $this->assertStringContainsString( 'CSV download is disabled', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_empty_download_meta_defaults_enabled(): void {
+        $this->seed_access( 42, array( 'download' => '' ) );
+        $this->assertNull( $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_when_no_end_date(): void {
+        $this->seed_access( 42 );
+        // Remove geofence config so Geofence::get_form_end_timestamp() returns null.
+        $this->meta_store[ '42:_ffc_geofence_config' ] = '';
+        $this->assertStringContainsString( 'no end date', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_when_form_still_active(): void {
+        $this->seed_access( 42, array( 'date_end' => '2999-01-01', 'time_end' => '00:00:00' ) );
+        $this->assertStringContainsString( 'still active', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_rejects_when_quota_reached(): void {
+        $this->seed_access( 42, array( 'limit' => 2, 'count' => 2 ) );
+        $this->assertStringContainsString( 'maximum number of downloads', $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    public function test_form_access_falls_back_to_default_limit_when_zero(): void {
+        // limit meta 0 → falls back; SettingsReader::get_int returns 0 (no option)
+        // → effective limit 1. count 0 < 1 passes.
+        $this->seed_access( 42, array( 'limit' => 0, 'count' => 0 ) );
+        $this->assertNull( $this->validator->validate_form_access( 42, 'storedhash' ) );
+    }
+
+    // ==================================================================
+    // validate_hash_only
+    // ==================================================================
+
+    public function test_hash_only_success(): void {
+        $this->seed_access( 7 );
+        $this->assertNull( $this->validator->validate_hash_only( 7, 'storedhash' ) );
+    }
+
+    public function test_hash_only_rejects_non_positive_id(): void {
+        $this->assertSame( 'Form not found.', $this->validator->validate_hash_only( 0, 'x' ) );
+    }
+
+    public function test_hash_only_rejects_wrong_type(): void {
+        $this->seed_access( 7, array( 'type' => 'page' ) );
+        $this->assertSame( 'Form not found.', $this->validator->validate_hash_only( 7, 'storedhash' ) );
+    }
+
+    public function test_hash_only_rejects_disabled(): void {
+        $this->seed_access( 7, array( 'enabled' => '0' ) );
+        $this->assertStringContainsString( 'not enabled', $this->validator->validate_hash_only( 7, 'storedhash' ) );
+    }
+
+    public function test_hash_only_rejects_hash_mismatch(): void {
+        $this->seed_access( 7 );
+        $this->assertSame( 'Invalid access hash.', $this->validator->validate_hash_only( 7, 'nope' ) );
+    }
+
+    // ==================================================================
+    // validate_cpf_requirement — none / audit / whitelist / owner
+    // ==================================================================
+
+    public function test_cpf_none_mode_returns_null(): void {
+        // No mode meta → defaults to 'none'.
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '' ) );
+    }
+
+    public function test_cpf_none_mode_audits_voluntary_valid_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'none';
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '111.444.777-35' ) );
+        // A voluntary audit row was written.
+        $this->assertSame( 1, $this->meta_updates[ '10:' . PublicCsvDownload::META_DOWNLOAD_LOG ] ?? 0 );
+    }
+
+    public function test_cpf_none_mode_drops_junk_silently(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'none';
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '123' ) );
+        $this->assertArrayNotHasKey( '10:' . PublicCsvDownload::META_DOWNLOAD_LOG, $this->meta_updates );
+    }
+
+    public function test_cpf_audit_mode_requires_missing_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'audit';
+        $msg = $this->validator->validate_cpf_requirement( 10, '' );
+        $this->assertStringContainsString( 'CPF is required', $msg );
+    }
+
+    public function test_cpf_audit_mode_rejects_bad_format(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'audit';
+        $this->assertSame( 'Invalid CPF.', $this->validator->validate_cpf_requirement( 10, '00000000000' ) );
+    }
+
+    public function test_cpf_audit_mode_passes_valid_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'audit';
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '11144477735' ) );
+    }
+
+    public function test_cpf_whitelist_allows_listed_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ]      = 'whitelist';
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_WHITELIST ] = "529.982.247-25\n111.444.777-35";
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '11144477735' ) );
+    }
+
+    public function test_cpf_whitelist_blocks_unlisted_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ]      = 'whitelist';
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_WHITELIST ] = '529.982.247-25';
+        $msg = $this->validator->validate_cpf_requirement( 10, '11144477735' );
+        $this->assertStringContainsString( 'not authorized', $msg );
+    }
+
+    public function test_cpf_owner_blocks_when_no_author(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'owner';
+        $this->meta_store[ '10:__field_post_author' ]                = 0;
+        $msg = $this->validator->validate_cpf_requirement( 10, '11144477735' );
+        $this->assertStringContainsString( 'no author', $msg );
+    }
+
+    public function test_cpf_owner_matches_author_cpf(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'owner';
+        $this->meta_store[ '10:__field_post_author' ]                = 88;
+        $this->meta_store[ 'user_88:ffc_user_cpf' ]                  = '111.444.777-35';
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '11144477735' ) );
+    }
+
+    public function test_cpf_owner_blocks_on_mismatch(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'owner';
+        $this->meta_store[ '10:__field_post_author' ]                = 88;
+        $this->meta_store[ 'user_88:ffc_user_cpf' ]                  = '529.982.247-25';
+        $msg = $this->validator->validate_cpf_requirement( 10, '11144477735' );
+        $this->assertStringContainsString( 'does not match', $msg );
+    }
+
+    public function test_cpf_unknown_mode_fails_closed(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'bogus';
+        $msg = $this->validator->validate_cpf_requirement( 10, '11144477735' );
+        $this->assertStringContainsString( 'misconfigured', $msg );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_cpf_participants_mode_passes_when_submission_found(): void {
+        $repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\SubmissionRepository' );
+        $repo->shouldReceive( 'countByFormAndCpfHash' )->once()->andReturn( 1 );
+
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'participants';
+        $this->assertNull( $this->validator->validate_cpf_requirement( 10, '11144477735' ) );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_cpf_participants_mode_blocks_when_no_submission(): void {
+        $repo = Mockery::mock( 'overload:FreeFormCertificate\Repositories\SubmissionRepository' );
+        $repo->shouldReceive( 'countByFormAndCpfHash' )->once()->andReturn( 0 );
+
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'participants';
+        $msg = $this->validator->validate_cpf_requirement( 10, '11144477735' );
+        $this->assertStringContainsString( 'No submission with this CPF', $msg );
+    }
+
+    public function test_cpf_silent_audit_suppresses_log_row(): void {
+        $this->meta_store[ '10:' . PublicCsvDownload::META_CPF_MODE ] = 'audit';
+        $this->validator->validate_cpf_requirement( 10, '11144477735', true );
+        $this->assertArrayNotHasKey( '10:' . PublicCsvDownload::META_DOWNLOAD_LOG, $this->meta_updates );
+    }
+
+    // ==================================================================
+    // record_download_log_entry — ring buffer + encryption
+    // ==================================================================
+
+    public function test_record_download_log_entry_appends_row(): void {
+        $this->validator->record_download_log_entry( 10, 'access', '', 'fail_other' );
+        $log = $this->meta_store[ '10:' . PublicCsvDownload::META_DOWNLOAD_LOG ];
+        $this->assertCount( 1, $log );
+        $this->assertSame( 'fail_other', $log[0]['result'] );
+        $this->assertSame( 'access', $log[0]['mode'] );
+    }
+
+    public function test_record_download_log_entry_encrypts_cpf_when_digits_present(): void {
+        // Encryption is configured in the unit bootstrap, so cpf_encrypted
+        // should be a non-empty ciphertext.
+        $this->validator->record_download_log_entry( 10, 'audit', '11144477735', 'audit_pass' );
+        $log = $this->meta_store[ '10:' . PublicCsvDownload::META_DOWNLOAD_LOG ];
+        $this->assertNotSame( '', $log[0]['cpf_encrypted'] );
+    }
+
+    public function test_record_download_log_entry_prunes_to_max(): void {
+        // Pre-seed DOWNLOAD_LOG_MAX rows, then append one more.
+        $rows = array_fill( 0, PublicCsvDownload::DOWNLOAD_LOG_MAX, array( 'result' => 'old' ) );
+        $this->meta_store[ '10:' . PublicCsvDownload::META_DOWNLOAD_LOG ] = $rows;
+
+        $this->validator->record_download_log_entry( 10, 'access', '', 'success' );
+
+        $log = $this->meta_store[ '10:' . PublicCsvDownload::META_DOWNLOAD_LOG ];
+        $this->assertCount( PublicCsvDownload::DOWNLOAD_LOG_MAX, $log );
+        // The oldest row is dropped; the new row is last.
+        $this->assertSame( 'success', $log[ PublicCsvDownload::DOWNLOAD_LOG_MAX - 1 ]['result'] );
+    }
+}

--- a/tests/Unit/DecryptFailureLoggingTest.php
+++ b/tests/Unit/DecryptFailureLoggingTest.php
@@ -26,7 +26,12 @@ use FreeFormCertificate\Core\Encryption;
 use FreeFormCertificate\Core\SensitiveFieldRegistry;
 
 /**
- * @coversNothing
+ * The single method under test is Encryption::decrypt — these tests pin its
+ * decrypt-failure audit emission. ActivityLog and SensitiveFieldRegistry are
+ * exercised only as collaborators (the buffer sink + the sensitivity gate),
+ * so attribution belongs to Encryption.
+ *
+ * @covers \FreeFormCertificate\Core\Encryption
  */
 class DecryptFailureLoggingTest extends TestCase {
 

--- a/tests/Unit/LoaderMigrationsTest.php
+++ b/tests/Unit/LoaderMigrationsTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Loader;
+
+/**
+ * Tests for Loader's one-shot capability migrations (the `ensure_*` helpers)
+ * and `register_ffc_roles_safe()`.
+ *
+ * Each helper is version-flagged: it reads an option flag, runs a
+ * CapabilityManager migration once, then writes the flag. CapabilityManager
+ * is alias-mocked, so these run in separate processes.
+ *
+ * @covers \FreeFormCertificate\Loader
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class LoaderMigrationsTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        // Constructor wiring — irrelevant here, stub so `new Loader()` is cheap.
+        Functions\when( 'add_action' )->justReturn( true );
+        Functions\when( 'register_activation_hook' )->justReturn( true );
+        Functions\when( 'register_deactivation_hook' )->justReturn( true );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /** Invoke a private Loader method via Reflection. */
+    private function invoke_private( Loader $loader, string $method ) {
+        $ref = new \ReflectionMethod( Loader::class, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $loader, array() );
+    }
+
+    /**
+     * @dataProvider migration_method_provider
+     */
+    public function test_ensure_migration_skips_when_flag_already_set( string $method, string $flag, string $cap_method ): void {
+        $loader = new Loader();
+
+        Functions\when( 'get_option' )->justReturn( '1' );
+        $updated = array();
+        Functions\when( 'update_option' )->alias(
+            function ( $key, $value ) use ( &$updated ) {
+                $updated[ $key ] = $value;
+                return true;
+            }
+        );
+
+        $cm = Mockery::mock( 'alias:FreeFormCertificate\UserDashboard\CapabilityManager' );
+        $cm->shouldReceive( $cap_method )->never();
+
+        $this->invoke_private( $loader, $method );
+
+        $this->assertArrayNotHasKey( $flag, $updated, 'No re-write when already migrated.' );
+    }
+
+    /**
+     * @dataProvider migration_method_provider
+     */
+    public function test_ensure_migration_runs_and_sets_flag( string $method, string $flag, string $cap_method ): void {
+        $loader = new Loader();
+
+        Functions\when( 'get_option' )->justReturn( '' );
+        $updated = array();
+        Functions\when( 'update_option' )->alias(
+            function ( $key, $value ) use ( &$updated ) {
+                $updated[ $key ] = $value;
+                return true;
+            }
+        );
+
+        $cm = Mockery::mock( 'alias:FreeFormCertificate\UserDashboard\CapabilityManager' );
+        $cm->shouldReceive( $cap_method )->once();
+
+        $this->invoke_private( $loader, $method );
+
+        $this->assertSame( '1', $updated[ $flag ] ?? null, 'Flag must be set after migration.' );
+    }
+
+    /**
+     * @return array<string, array{0:string,1:string,2:string}>
+     */
+    public static function migration_method_provider(): array {
+        return array(
+            'legacy caps'  => array( 'ensure_legacy_caps_renamed', 'ffc_legacy_caps_renamed_v1', 'migrate_legacy_certificate_caps' ),
+            'taxonomy'     => array( 'ensure_taxonomy_renamed', 'ffc_taxonomy_caps_renamed_v1', 'migrate_taxonomy_renames' ),
+            'delete caps'  => array( 'ensure_delete_caps_granted', 'ffc_delete_caps_granted_v1', 'migrate_delete_caps_grant' ),
+            'export caps'  => array( 'ensure_export_caps_granted', 'ffc_export_caps_granted_v1', 'migrate_export_caps_grant' ),
+            'import caps'  => array( 'ensure_import_caps_granted', 'ffc_import_caps_granted_v1', 'migrate_import_caps_grant' ),
+            'reasons caps' => array( 'ensure_reasons_caps_wired', 'ffc_reasons_caps_wired_v1', 'migrate_reasons_caps_grant' ),
+        );
+    }
+
+    // ==================================================================
+    // register_ffc_roles_safe()
+    // ==================================================================
+
+    public function test_register_ffc_roles_safe_registers_roles_and_relabel_hook(): void {
+        $loader = new Loader();
+
+        $cm = Mockery::mock( 'alias:FreeFormCertificate\UserDashboard\CapabilityManager' );
+        $cm->shouldReceive( 'register_role' )->once();
+        $cm->shouldReceive( 'register_module_roles' )->once();
+
+        $added = array();
+        Functions\when( 'add_action' )->alias(
+            function ( $hook ) use ( &$added ) {
+                $added[] = $hook;
+            }
+        );
+
+        $loader->register_ffc_roles_safe();
+
+        $this->assertContains( 'wp_roles_init', $added, 'Should hook relabel_ffc_roles onto wp_roles_init.' );
+    }
+}

--- a/tests/Unit/PdfGeneratorTest.php
+++ b/tests/Unit/PdfGeneratorTest.php
@@ -455,4 +455,157 @@ class PdfGeneratorTest extends TestCase {
         $this->assertSame( '08:30', $s, 'start falls through to class_time when override is null' );
         $this->assertSame( '17:00', $e, 'end takes the override' );
     }
+
+    // ==================================================================
+    // generate_html()
+    // ==================================================================
+
+    /** Stub the WP funcs that generate_html() / its placeholder helpers need. */
+    private function stub_html_funcs(): void {
+        Functions\when( 'wp_kses' )->alias( fn ( $v ) => (string) $v );
+        Functions\when( 'get_bloginfo' )->justReturn( 'Test Site' );
+        Functions\when( 'get_home_url' )->justReturn( 'https://example.com' );
+        Functions\when( 'untrailingslashit' )->alias( fn ( $u ) => rtrim( (string) $u, '/' ) );
+        Functions\when( 'site_url' )->alias( fn ( $p = '' ) => 'https://example.com/' . ltrim( (string) $p, '/' ) );
+        Functions\when( 'apply_filters' )->alias( fn ( $tag, $value = '' ) => $value );
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'wp_normalize_path' )->alias( fn ( $p ) => str_replace( '\\', '/', (string) $p ) );
+        Functions\when( 'get_template_directory' )->justReturn( '/tmp/theme' );
+        Functions\when( 'get_stylesheet_directory' )->justReturn( '/tmp/theme' );
+        // Generators-namespaced fallbacks (the PdfGenerator class calls these unqualified).
+        Functions\when( 'FreeFormCertificate\Generators\wp_normalize_path' )->alias( fn ( $p ) => str_replace( '\\', '/', (string) $p ) );
+        Functions\when( 'FreeFormCertificate\Generators\get_template_directory' )->justReturn( '/tmp/theme' );
+        Functions\when( 'FreeFormCertificate\Generators\get_stylesheet_directory' )->justReturn( '/tmp/theme' );
+        Functions\when( 'FreeFormCertificate\Generators\apply_filters' )->alias( fn ( $tag, $value = '' ) => $value );
+        Functions\when( 'FreeFormCertificate\Generators\site_url' )->alias( fn ( $p = '' ) => 'https://example.com/' . ltrim( (string) $p, '/' ) );
+        Functions\when( 'FreeFormCertificate\Generators\untrailingslashit' )->alias( fn ( $u ) => rtrim( (string) $u, '/' ) );
+        Functions\when( 'FreeFormCertificate\Generators\get_bloginfo' )->justReturn( 'Test Site' );
+        Functions\when( 'FreeFormCertificate\Generators\get_home_url' )->justReturn( 'https://example.com' );
+        Functions\when( 'FreeFormCertificate\Generators\wp_kses' )->alias( fn ( $v ) => (string) $v );
+        Functions\when( 'FreeFormCertificate\Generators\esc_url' )->returnArg();
+        // build_pdf_filename() (Utils, Core namespace) uses _x().
+        Functions\when( '_x' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\_x' )->returnArg();
+    }
+
+    public function test_generate_html_falls_back_to_default_when_no_layout(): void {
+        $this->stub_html_funcs();
+        $html = $this->invoke( 'generate_html', array( array( 'name' => 'Alice' ), 'My Event', array() ) );
+        $this->assertStringContainsString( 'My Event', $html );
+        $this->assertStringContainsString( 'Alice', $html );
+    }
+
+    public function test_generate_html_replaces_field_placeholders(): void {
+        $this->stub_html_funcs();
+        $config = array( 'pdf_layout' => '<p>Hello {{name}} - {{form_title}}</p>' );
+        $html   = $this->invoke( 'generate_html', array( array( 'name' => 'Bob' ), 'Cert', $config ) );
+        $this->assertStringContainsString( 'Bob', $html );
+        $this->assertStringContainsString( 'Cert', $html );
+        $this->assertStringNotContainsString( '{{name}}', $html );
+    }
+
+    public function test_generate_html_maps_email_and_quiz_aliases(): void {
+        $this->stub_html_funcs();
+        $config = array( 'pdf_layout' => '<p>{{email}} {{score}} {{score_percent}}</p>' );
+        $data   = array(
+            'user_email'    => 'x@y.com',
+            '_quiz_score'   => 8,
+            '_quiz_percent' => 80,
+        );
+        $html = $this->invoke( 'generate_html', array( $data, 'T', $config ) );
+        $this->assertStringContainsString( 'x@y.com', $html );
+        $this->assertStringContainsString( '8', $html );
+        $this->assertStringContainsString( '80', $html );
+    }
+
+    public function test_generate_html_processes_validation_url_placeholder(): void {
+        $this->stub_html_funcs();
+        Functions\when( 'esc_url' )->returnArg();
+        $config = array( 'pdf_layout' => '<p>{{validation_url link:v>v}}</p>' );
+        $html   = $this->invoke( 'generate_html', array( array(), 'T', $config ) );
+        $this->assertStringContainsString( '<a href=', $html );
+        $this->assertStringContainsString( 'ffc-validation-link', $html );
+    }
+
+    // ==================================================================
+    // process_validation_url_placeholders()
+    // ==================================================================
+
+    public function test_validation_url_default_uses_valid_url_fallback(): void {
+        $this->stub_html_funcs();
+        $layout = '{{validation_url}}';
+        $html   = $this->invoke( 'process_validation_url_placeholders', array( $layout, array() ) );
+        // No magic token → both href and text fall back to the /valid URL.
+        $this->assertStringContainsString( 'https://example.com/valid', $html );
+        $this->assertStringNotContainsString( '{{validation_url', $html );
+    }
+
+    public function test_validation_url_custom_text_target_and_color(): void {
+        $this->stub_html_funcs();
+        $layout = '{{validation_url link:v>"ClickHere" target:_blank color:red}}';
+        $html   = $this->invoke( 'process_validation_url_placeholders', array( $layout, array() ) );
+        $this->assertStringContainsString( 'ClickHere', $html );
+        $this->assertStringContainsString( 'target="_blank"', $html );
+        $this->assertStringContainsString( 'color: red', $html );
+    }
+
+    // ==================================================================
+    // get_qr_code_target_url()
+    // ==================================================================
+
+    public function test_qr_target_url_falls_back_to_valid_without_token(): void {
+        $this->stub_html_funcs();
+        $url = $this->invoke( 'get_qr_code_target_url', array( array() ) );
+        $this->assertSame( 'https://example.com/valid', $url );
+    }
+
+    // ==================================================================
+    // generate_appointment_pdf_data()
+    // ==================================================================
+
+    public function test_generate_appointment_pdf_data_assembles_array(): void {
+        $this->stub_html_funcs();
+        Functions\when( 'esc_url' )->returnArg();
+
+        if ( ! defined( 'FFC_PLUGIN_DIR' ) ) {
+            define( 'FFC_PLUGIN_DIR', \dirname( __DIR__, 2 ) . '/' );
+        }
+
+        $appointment = array(
+            'name'             => 'Carlos',
+            'appointment_date' => '2030-05-20',
+            'start_time'       => '09:00:00',
+            'end_time'         => '10:00:00',
+            'created_at'       => '2030-05-01 12:00:00',
+            'status'           => 'confirmed',
+            'validation_code'  => 'ABC123',
+            'id'               => 5,
+        );
+        $calendar = array( 'id' => 7, 'title' => 'Consulta' );
+
+        $result = $this->invoke( 'generate_appointment_pdf_data', array( $appointment, $calendar ) );
+
+        $this->assertIsArray( $result );
+        $this->assertArrayHasKey( 'html', $result );
+        $this->assertArrayHasKey( 'filename', $result );
+        $this->assertSame( 'appointment_receipt', $result['type'] );
+        $this->assertSame( 'Consulta', $result['form_title'] );
+        $this->assertNotEmpty( $result['html'] );
+    }
+
+    public function test_generate_appointment_pdf_data_handles_missing_optional_fields(): void {
+        $this->stub_html_funcs();
+        Functions\when( 'esc_url' )->returnArg();
+
+        if ( ! defined( 'FFC_PLUGIN_DIR' ) ) {
+            define( 'FFC_PLUGIN_DIR', \dirname( __DIR__, 2 ) . '/' );
+        }
+
+        // No date/time/status/code → falls back to N/A labels, empty codes.
+        $result = $this->invoke( 'generate_appointment_pdf_data', array( array(), array() ) );
+
+        $this->assertIsArray( $result );
+        $this->assertSame( 'appointment_receipt', $result['type'] );
+        $this->assertArrayHasKey( 'html', $result );
+    }
 }

--- a/tests/Unit/PublicCsvExporterTest.php
+++ b/tests/Unit/PublicCsvExporterTest.php
@@ -316,4 +316,72 @@ class PublicCsvExporterTest extends TestCase {
 
         $this->assertSame( 3500, PublicCsvExporter::get_sync_max_rows() );
     }
+
+    // ==================================================================
+    // get_form_title_cached()
+    // ==================================================================
+
+    public function test_get_form_title_cached_returns_title(): void {
+        Functions\when( 'get_the_title' )->justReturn( 'Form X' );
+        $this->assertSame( 'Form X', $this->invoke( 'get_form_title_cached', array( 5 ) ) );
+    }
+
+    public function test_get_form_title_cached_uses_placeholder_for_deleted(): void {
+        Functions\when( 'get_the_title' )->justReturn( '' );
+        $this->assertSame( '(Deleted)', $this->invoke( 'get_form_title_cached', array( 99 ) ) );
+    }
+
+    public function test_get_form_title_cached_memoizes_lookup(): void {
+        // First lookup populates the cache; second must not call get_the_title
+        // again (we flip the stub to a sentinel that would fail the assert).
+        Functions\when( 'get_the_title' )->justReturn( 'Cached Title' );
+        $first = $this->invoke( 'get_form_title_cached', array( 7 ) );
+
+        Functions\when( 'get_the_title' )->justReturn( 'DIFFERENT' );
+        $second = $this->invoke( 'get_form_title_cached', array( 7 ) );
+
+        $this->assertSame( 'Cached Title', $first );
+        $this->assertSame( 'Cached Title', $second );
+    }
+
+    // ==================================================================
+    // scan_dynamic_keys() — paginated key harvesting
+    // ==================================================================
+
+    /** Inject a mock SubmissionRepository into the protected property. */
+    private function set_repository( $repo ): void {
+        $prop = new \ReflectionProperty( PublicCsvExporter::class, 'repository' );
+        $prop->setAccessible( true );
+        $prop->setValue( $this->exporter, $repo );
+    }
+
+    public function test_scan_dynamic_keys_merges_unique_keys_across_batches(): void {
+        $repo = \Mockery::mock( 'FreeFormCertificate\Repositories\SubmissionRepository' );
+        // First batch returns two rows, second batch empty → loop terminates.
+        $repo->shouldReceive( 'getExportKeysBatch' )
+            ->twice()
+            ->andReturn(
+                array(
+                    array( 'id' => 10, 'data' => '{"name":"A","city":"SP"}' ),
+                    array( 'id' => 20, 'data' => '{"name":"B","age":"30"}' ),
+                ),
+                array()
+            );
+
+        $this->set_repository( $repo );
+
+        $keys = $this->invoke( 'scan_dynamic_keys', array( array( 1 ), 'publish' ) );
+
+        sort( $keys );
+        $this->assertSame( array( 'age', 'city', 'name' ), $keys );
+    }
+
+    public function test_scan_dynamic_keys_returns_empty_when_no_rows(): void {
+        $repo = \Mockery::mock( 'FreeFormCertificate\Repositories\SubmissionRepository' );
+        $repo->shouldReceive( 'getExportKeysBatch' )->once()->andReturn( array() );
+
+        $this->set_repository( $repo );
+
+        $this->assertSame( array(), $this->invoke( 'scan_dynamic_keys', array( array( 1 ), 'publish' ) ) );
+    }
 }

--- a/tests/Unit/RateLimitRepositoryTest.php
+++ b/tests/Unit/RateLimitRepositoryTest.php
@@ -1,0 +1,266 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Security\RateLimitRepository;
+
+/**
+ * Tests for RateLimitRepository: the raw $wpdb persistence helpers behind
+ * RateLimitChecker — counter read/increment, submission counting, temporary
+ * blocks, and the window start/end calculators.
+ *
+ * @covers \FreeFormCertificate\Security\RateLimitRepository
+ */
+class RateLimitRepositoryTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    /** @var \Mockery\MockInterface&\wpdb */
+    private $wpdb;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( 'current_time' )->justReturn( '2026-05-20 12:00:00' );
+
+        global $wpdb;
+        $wpdb = Mockery::mock( 'wpdb' )->makePartial();
+        $wpdb->prefix = 'wp_';
+        // %i pre-prepared form clauses; default prepare returns the SQL untouched.
+        $wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+            function ( $sql ) {
+                return $sql;
+            }
+        )->byDefault();
+        $this->wpdb = $wpdb;
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // get_count_from_db
+    // ------------------------------------------------------------------
+
+    public function test_get_count_from_db_returns_int(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '5' );
+
+        $this->assertSame( 5, RateLimitRepository::get_count_from_db( 'ip', '1.1.1.1', 'hour', null ) );
+    }
+
+    public function test_get_count_from_db_returns_zero_when_null(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+        $this->assertSame( 0, RateLimitRepository::get_count_from_db( 'ip', '1.1.1.1', 'hour', null ) );
+    }
+
+    public function test_get_count_from_db_uses_form_clause_when_form_id_set(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '2' );
+
+        $this->assertSame( 2, RateLimitRepository::get_count_from_db( 'ip', '1.1.1.1', 'day', 42 ) );
+    }
+
+    // ------------------------------------------------------------------
+    // increment_counter
+    // ------------------------------------------------------------------
+
+    public function test_increment_counter_updates_existing_row(): void {
+        $this->wpdb->shouldReceive( 'get_row' )->once()->andReturn(
+            (object) array( 'id' => 9, 'count' => 3 )
+        );
+        $this->wpdb->shouldReceive( 'update' )
+            ->once()
+            ->with(
+                'wp_ffc_rate_limits',
+                Mockery::on(
+                    function ( $data ) {
+                        return 4 === $data['count'];
+                    }
+                ),
+                array( 'id' => 9 ),
+                array( '%d', '%s' ),
+                array( '%d' )
+            )
+            ->andReturn( 1 );
+
+        RateLimitRepository::increment_counter( 'ip', '1.1.1.1', 'hour', null );
+    }
+
+    public function test_increment_counter_inserts_new_row_when_absent(): void {
+        $this->wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+        $this->wpdb->shouldReceive( 'insert' )
+            ->once()
+            ->with(
+                'wp_ffc_rate_limits',
+                Mockery::on(
+                    function ( $data ) {
+                        return 1 === $data['count'] && 'ip' === $data['type'] && 7 === $data['form_id'];
+                    }
+                ),
+                Mockery::type( 'array' )
+            )
+            ->andReturn( 1 );
+
+        RateLimitRepository::increment_counter( 'ip', '1.1.1.1', 'hour', 7 );
+    }
+
+    // ------------------------------------------------------------------
+    // get_submission_count
+    // ------------------------------------------------------------------
+
+    public function test_get_submission_count_email_uses_sha256_fallback_when_encryption_unavailable(): void {
+        // With no Encryption configured the method hashes via sha256 and queries.
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '4' );
+
+        $count = RateLimitRepository::get_submission_count( 'email', 'a@b.com', 'day', null );
+        $this->assertSame( 4, $count );
+    }
+
+    public function test_get_submission_count_email_week_period(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '1' );
+
+        $this->assertSame( 1, RateLimitRepository::get_submission_count( 'email', 'a@b.com', 'week', 12 ) );
+    }
+
+    public function test_get_submission_count_email_month_period(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '9' );
+
+        $this->assertSame( 9, RateLimitRepository::get_submission_count( 'email', 'a@b.com', 'month', null ) );
+    }
+
+    public function test_get_submission_count_cpf_eleven_digits_uses_cpf_hash_column(): void {
+        // 11 digits → cpf_hash column path; Encryption is configured in the
+        // unit bootstrap so the method hashes + queries.
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '2' );
+
+        $this->assertSame( 2, RateLimitRepository::get_submission_count( 'cpf', '123.456.789-09', 'year', 3 ) );
+    }
+
+    public function test_get_submission_count_cpf_seven_digits_uses_rf_hash_column(): void {
+        // 7 digits → rf_hash column path.
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '1' );
+
+        $this->assertSame( 1, RateLimitRepository::get_submission_count( 'cpf', '1234567', 'day', null ) );
+    }
+
+    public function test_get_submission_count_unknown_field_returns_zero(): void {
+        $this->assertSame( 0, RateLimitRepository::get_submission_count( 'phone', '999', 'day', null ) );
+    }
+
+    // ------------------------------------------------------------------
+    // is_temporarily_blocked
+    // ------------------------------------------------------------------
+
+    public function test_is_temporarily_blocked_true_when_row_present(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( '2026-05-20 13:00:00' );
+
+        $this->assertTrue( RateLimitRepository::is_temporarily_blocked( 'ip', '1.1.1.1', null ) );
+    }
+
+    public function test_is_temporarily_blocked_false_when_no_row(): void {
+        $this->wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+
+        $this->assertFalse( RateLimitRepository::is_temporarily_blocked( 'ip', '1.1.1.1', 5 ) );
+    }
+
+    // ------------------------------------------------------------------
+    // block_temporarily
+    // ------------------------------------------------------------------
+
+    public function test_block_temporarily_inserts_block_row(): void {
+        $this->wpdb->shouldReceive( 'insert' )
+            ->once()
+            ->with(
+                'wp_ffc_rate_limits',
+                Mockery::on(
+                    function ( $data ) {
+                        return 1 === $data['is_blocked']
+                            && 999 === $data['count']
+                            && 'abuse' === $data['blocked_reason'];
+                    }
+                ),
+                Mockery::type( 'array' )
+            )
+            ->andReturn( 1 );
+
+        RateLimitRepository::block_temporarily( 'ip', '1.1.1.1', null, 24 );
+    }
+
+    // ------------------------------------------------------------------
+    // get_window_start
+    // ------------------------------------------------------------------
+
+    public function test_get_window_start_minute(): void {
+        $this->assertSame( gmdate( 'Y-m-d H:i:00' ), RateLimitRepository::get_window_start( 'minute' ) );
+    }
+
+    public function test_get_window_start_hour(): void {
+        $this->assertSame( gmdate( 'Y-m-d H:00:00' ), RateLimitRepository::get_window_start( 'hour' ) );
+    }
+
+    public function test_get_window_start_day(): void {
+        $this->assertSame( gmdate( 'Y-m-d 00:00:00' ), RateLimitRepository::get_window_start( 'day' ) );
+    }
+
+    public function test_get_window_start_week_is_monday(): void {
+        $expected = gmdate( 'Y-m-d 00:00:00', strtotime( 'monday this week' ) );
+        $this->assertSame( $expected, RateLimitRepository::get_window_start( 'week' ) );
+    }
+
+    public function test_get_window_start_month(): void {
+        $this->assertSame( gmdate( 'Y-m-01 00:00:00' ), RateLimitRepository::get_window_start( 'month' ) );
+    }
+
+    public function test_get_window_start_year(): void {
+        $this->assertSame( gmdate( 'Y-01-01 00:00:00' ), RateLimitRepository::get_window_start( 'year' ) );
+    }
+
+    public function test_get_window_start_default(): void {
+        $result = RateLimitRepository::get_window_start( 'something_else' );
+        // Default branch renders a full datetime; assert shape.
+        $this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result );
+    }
+
+    // ------------------------------------------------------------------
+    // get_window_end
+    // ------------------------------------------------------------------
+
+    public function test_get_window_end_minute(): void {
+        $this->assertSame( gmdate( 'Y-m-d H:i:59' ), RateLimitRepository::get_window_end( 'minute' ) );
+    }
+
+    public function test_get_window_end_hour(): void {
+        $this->assertSame( gmdate( 'Y-m-d H:59:59' ), RateLimitRepository::get_window_end( 'hour' ) );
+    }
+
+    public function test_get_window_end_day(): void {
+        $this->assertSame( gmdate( 'Y-m-d 23:59:59' ), RateLimitRepository::get_window_end( 'day' ) );
+    }
+
+    public function test_get_window_end_week_is_sunday(): void {
+        $expected = gmdate( 'Y-m-d 23:59:59', strtotime( 'sunday this week' ) );
+        $this->assertSame( $expected, RateLimitRepository::get_window_end( 'week' ) );
+    }
+
+    public function test_get_window_end_month(): void {
+        $this->assertSame( gmdate( 'Y-m-t 23:59:59' ), RateLimitRepository::get_window_end( 'month' ) );
+    }
+
+    public function test_get_window_end_year(): void {
+        $this->assertSame( gmdate( 'Y-12-31 23:59:59' ), RateLimitRepository::get_window_end( 'year' ) );
+    }
+
+    public function test_get_window_end_default(): void {
+        $result = RateLimitRepository::get_window_end( 'something_else' );
+        $this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result );
+    }
+}

--- a/tests/Unit/SubmissionRestControllerTest.php
+++ b/tests/Unit/SubmissionRestControllerTest.php
@@ -12,7 +12,12 @@ use FreeFormCertificate\API\SubmissionRestController;
 use FreeFormCertificate\Repositories\SubmissionRepository;
 
 /**
- * Tests for SubmissionRestController: route registration, permission checks, verify endpoint.
+ * Tests for SubmissionRestController: route registration, permission checks,
+ * the list / single / verify handlers, and the admin permission gate.
+ *
+ * The static collaborators (Encryption, DocumentFormatter, Utils, RateLimiter)
+ * run as the real autoloaded classes — the unit bootstrap configures
+ * encryption keys and the handlers only need WP-function + $wpdb stubs.
  */
 class SubmissionRestControllerTest extends TestCase {
 
@@ -35,6 +40,11 @@ class SubmissionRestControllerTest extends TestCase {
                 'args'      => $args,
             );
         });
+
+        // Stubs for the route-registration + null-repo + not-found tests.
+        // These paths do not reach the real static collaborators.
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'rest_ensure_response' )->alias( fn ( $data ) => $data );
     }
 
     protected function tearDown(): void {
@@ -138,5 +148,63 @@ class SubmissionRestControllerTest extends TestCase {
 
         $result = $ctrl->get_submissions( $request );
         $this->assertInstanceOf( \WP_Error::class, $result );
+    }
+
+    public function test_get_submission_returns_error_without_repo(): void {
+        $ctrl    = new SubmissionRestController( 'ffc/v1', null );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'id' )->andReturn( 5 );
+
+        $result = $ctrl->get_submission( $request );
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'repository_not_found', $result->get_error_code() );
+    }
+
+    // Note: the verify_certificate() handler-path tests (which exercise the
+    // real RateLimiter / Encryption / DocumentFormatter statics) live in the
+    // separate-process SubmissionVerifyRestControllerTest so they get a clean
+    // function table immune to leaked global/namespaced mocks from earlier
+    // same-process tests.
+
+    // ------------------------------------------------------------------
+    // check_admin_permission (delegates to Utils::current_user_can_admin_or)
+    // ------------------------------------------------------------------
+
+    public function test_check_admin_permission_true_for_admin(): void {
+        Functions\when( 'current_user_can' )->alias( fn ( $cap ) => 'manage_options' === $cap );
+
+        $ctrl = new SubmissionRestController( 'ffc/v1', null );
+        $this->assertTrue( $ctrl->check_admin_permission() );
+    }
+
+    public function test_check_admin_permission_true_for_granular_cap(): void {
+        Functions\when( 'current_user_can' )->alias( fn ( $cap ) => 'ffc_view_certificates' === $cap );
+
+        $ctrl = new SubmissionRestController( 'ffc/v1', null );
+        $this->assertTrue( $ctrl->check_admin_permission() );
+    }
+
+    public function test_check_admin_permission_false_without_caps(): void {
+        Functions\when( 'current_user_can' )->justReturn( false );
+
+        $ctrl = new SubmissionRestController( 'ffc/v1', null );
+        $this->assertFalse( $ctrl->check_admin_permission() );
+    }
+
+    // ------------------------------------------------------------------
+    // get_submission() — not-found (no real statics on this path)
+    // ------------------------------------------------------------------
+
+    public function test_get_submission_returns_not_found(): void {
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findById' )->once()->with( 7 )->andReturn( null );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'id' )->andReturn( 7 );
+
+        $result = $ctrl->get_submission( $request );
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'submission_not_found', $result->get_error_code() );
     }
 }

--- a/tests/Unit/SubmissionVerifyRestControllerTest.php
+++ b/tests/Unit/SubmissionVerifyRestControllerTest.php
@@ -1,0 +1,197 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\API\SubmissionRestController;
+use FreeFormCertificate\Repositories\SubmissionRepository;
+
+/**
+ * Handler-path tests for SubmissionRestController: get_submissions(),
+ * get_submission() happy path, and verify_certificate(). These exercise the
+ * real static collaborators (Encryption / DocumentFormatter / Utils /
+ * RateLimiter); process isolation gives each test a clean function table so a
+ * leaked global/namespaced mock from an earlier same-process test can't poison
+ * Utils::get_user_ip() or the rate-limit settings read.
+ *
+ * @covers \FreeFormCertificate\API\SubmissionRestController
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SubmissionVerifyRestControllerTest extends TestCase {
+
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'rest_ensure_response' )->alias( fn ( $data ) => $data );
+        // RateLimiter::check_verification → RateLimitChecker::get_settings()
+        // reads get_option(); empty settings ⇒ "allowed" with no DB access.
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'wp_cache_get' )->justReturn( false );
+        Functions\when( 'wp_cache_set' )->justReturn( true );
+        Functions\when( 'wp_parse_args' )->alias(
+            fn ( $args, $defaults = array() ) => array_merge( $defaults, is_array( $args ) ? $args : array() )
+        );
+        // Utils::get_user_ip() sanitizes $_SERVER via Core-namespaced funcs.
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\sanitize_text_field' )->returnArg();
+        Functions\when( 'FreeFormCertificate\Core\wp_unslash' )->returnArg();
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+    }
+
+    protected function tearDown(): void {
+        $_SERVER = array();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // get_submissions()
+    // ------------------------------------------------------------------
+
+    public function test_get_submissions_maps_items(): void {
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findPaginated' )->once()->andReturn(
+            array(
+                'items' => array(
+                    array(
+                        'id'              => 3,
+                        'form_id'         => 9,
+                        'auth_code'       => 'RAWCODE12345',
+                        'submission_date' => '2030-01-01',
+                        'status'          => 'publish',
+                        'data'            => '{"name":"Ana"}',
+                    ),
+                ),
+                'total' => 1,
+                'pages' => 1,
+            )
+        );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'page' )->andReturn( 1 );
+        $request->shouldReceive( 'get_param' )->with( 'per_page' )->andReturn( 20 );
+        $request->shouldReceive( 'get_param' )->with( 'status' )->andReturn( 'publish' );
+        $request->shouldReceive( 'get_param' )->with( 'search' )->andReturn( '' );
+
+        $result = $ctrl->get_submissions( $request );
+
+        $this->assertIsArray( $result );
+        $this->assertSame( 1, $result['total'] );
+        $this->assertSame( 3, $result['items'][0]['id'] );
+        $this->assertSame( 'Ana', $result['items'][0]['data']['name'] );
+    }
+
+    // ------------------------------------------------------------------
+    // get_submission() happy path
+    // ------------------------------------------------------------------
+
+    public function test_get_submission_happy_path(): void {
+        Functions\when( 'get_post' )->justReturn( (object) array( 'post_title' => 'My Form' ) );
+
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findById' )->once()->andReturn(
+            array(
+                'id'              => 11,
+                'form_id'         => 2,
+                'auth_code'       => 'RAWCODE99999',
+                'submission_date' => '2030-02-02',
+                'status'          => 'publish',
+                'data'            => '{"city":"SP"}',
+            )
+        );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'id' )->andReturn( 11 );
+
+        $result = $ctrl->get_submission( $request );
+
+        $this->assertIsArray( $result );
+        $this->assertSame( 11, $result['id'] );
+        $this->assertSame( 'My Form', $result['form_title'] );
+        $this->assertSame( 'SP', $result['data']['city'] );
+    }
+
+    // ------------------------------------------------------------------
+    // verify_certificate()
+    // ------------------------------------------------------------------
+
+    public function test_verify_certificate_returns_error_without_repo(): void {
+        $ctrl    = new SubmissionRestController( 'ffc/v1', null );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'auth_code' )->andReturn( 'ABCD-EFGH-IJKL' );
+
+        $result = $ctrl->verify_certificate( $request );
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'repository_not_found', $result->get_error_code() );
+    }
+
+    public function test_verify_certificate_not_found(): void {
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findByAuthCode' )->once()->andReturn( null );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'auth_code' )->andReturn( 'CLEANCODE123' );
+
+        $result = $ctrl->verify_certificate( $request );
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'certificate_not_found', $result->get_error_code() );
+    }
+
+    public function test_verify_certificate_rejects_trashed(): void {
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findByAuthCode' )->once()->andReturn(
+            array( 'id' => 1, 'form_id' => 1, 'status' => 'trash' )
+        );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'auth_code' )->andReturn( 'CLEANCODE123' );
+
+        $result = $ctrl->verify_certificate( $request );
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertSame( 'certificate_deleted', $result->get_error_code() );
+    }
+
+    public function test_verify_certificate_happy_path(): void {
+        Functions\when( 'get_post' )->justReturn( (object) array( 'post_title' => 'Cert Form' ) );
+
+        $repo = Mockery::mock( SubmissionRepository::class );
+        $repo->shouldReceive( 'findByAuthCode' )->once()->andReturn(
+            array(
+                'id'              => 22,
+                'form_id'         => 4,
+                'status'          => 'publish',
+                'submission_date' => '2030-03-03',
+                'data'            => '{"name":"Bia"}',
+                'email'           => 'bia@x.com',
+                'cpf_rf'          => '11144477735',
+            )
+        );
+
+        $ctrl    = new SubmissionRestController( 'ffc/v1', $repo );
+        $request = Mockery::mock( 'WP_REST_Request' );
+        $request->shouldReceive( 'get_param' )->with( 'auth_code' )->andReturn( 'CLEANCODE123' );
+
+        $result = $ctrl->verify_certificate( $request );
+
+        $this->assertIsArray( $result );
+        $this->assertTrue( $result['valid'] );
+        $this->assertSame( 22, $result['certificate']['id'] );
+        $this->assertSame( 'Cert Form', $result['certificate']['form_title'] );
+        $this->assertSame( 'bia@x.com', $result['certificate']['email'] );
+    }
+}

--- a/tests/Unit/TabRateLimitTest.php
+++ b/tests/Unit/TabRateLimitTest.php
@@ -220,4 +220,177 @@ class TabRateLimitTest extends TestCase {
 
         $this->assertSame( 'default_val', $this->tab->get_option( 'missing', 'default_val' ) );
     }
+
+    // ==================================================================
+    // Helpers + sanitize/save logic
+    // ==================================================================
+
+    private function invoke_private( string $method ) {
+        $ref = new \ReflectionMethod( TabRateLimit::class, $method );
+        $ref->setAccessible( true );
+        return $ref->invokeArgs( $this->tab, array() );
+    }
+
+    /** Stub the input-sanitizing WP funcs used by save_settings(). */
+    private function stub_save_funcs(): void {
+        Functions\when( 'absint' )->alias( fn ( $v ) => abs( (int) $v ) );
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'sanitize_text_field' )->returnArg();
+        Functions\when( 'sanitize_textarea_field' )->returnArg();
+        Functions\when( 'sanitize_key' )->alias( fn ( $v ) => strtolower( (string) $v ) );
+        // Utils::get_post_string (Core namespace) uses these unqualified.
+        // Plain stable passthroughs (NOT Brain\Monkey stubs) so they survive
+        // tearDown without leaving a torn-down expectation that could poison a
+        // later same-process test.
+        self::define_core_passthrough( 'wp_unslash' );
+        self::define_core_passthrough( 'sanitize_text_field' );
+    }
+
+    /** Define a stable passthrough in the Core namespace, once per process. */
+    private static function define_core_passthrough( string $name ): void {
+        $fqn = 'FreeFormCertificate\\Core\\' . $name;
+        if ( ! function_exists( $fqn ) ) {
+            eval( "namespace FreeFormCertificate\\Core; function {$name}( \$v ) { return \$v; }" );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // get_settings()
+    // ------------------------------------------------------------------
+
+    public function test_get_settings_returns_defaults_when_option_empty(): void {
+        Functions\when( 'get_option' )->justReturn( array() );
+        Functions\when( 'wp_parse_args' )->alias(
+            fn ( $args, $defaults ) => array_merge( $defaults, is_array( $args ) ? $args : array() )
+        );
+
+        $settings = $this->invoke_private( 'get_settings' );
+
+        $this->assertIsArray( $settings );
+        $this->assertTrue( $settings['ip']['enabled'] );
+        $this->assertSame( 5, $settings['ip']['max_per_hour'] );
+        $this->assertFalse( $settings['cpf']['enabled'] );
+        $this->assertArrayHasKey( 'read', $settings );
+        $this->assertArrayHasKey( 'device', $settings );
+    }
+
+    public function test_get_settings_merges_stored_overrides(): void {
+        Functions\when( 'get_option' )->justReturn( array( 'ip' => array( 'enabled' => false, 'max_per_hour' => 99 ) ) );
+        Functions\when( 'wp_parse_args' )->alias(
+            fn ( $args, $defaults ) => array_merge( $defaults, is_array( $args ) ? $args : array() )
+        );
+
+        $settings = $this->invoke_private( 'get_settings' );
+        $this->assertFalse( $settings['ip']['enabled'] );
+        $this->assertSame( 99, $settings['ip']['max_per_hour'] );
+    }
+
+    // ------------------------------------------------------------------
+    // parse_read_endpoints_post()
+    // ------------------------------------------------------------------
+
+    public function test_parse_read_endpoints_defaults_when_no_post(): void {
+        $this->stub_save_funcs();
+        $out = $this->invoke_private( 'parse_read_endpoints_post' );
+
+        $this->assertSame( array( 'calendar_slots', 'calendar_list', 'calendar_detail' ), array_keys( $out ) );
+        foreach ( $out as $endpoint ) {
+            $this->assertFalse( $endpoint['enabled'] );
+            $this->assertSame( 0, $endpoint['max_per_minute'] );
+            $this->assertSame( 0, $endpoint['max_per_hour'] );
+        }
+    }
+
+    public function test_parse_read_endpoints_reads_posted_values(): void {
+        $this->stub_save_funcs();
+        $_POST['read_endpoint_calendar_slots_enabled']        = '1';
+        $_POST['read_endpoint_calendar_slots_max_per_minute'] = '5';
+        $_POST['read_endpoint_calendar_slots_max_per_hour']   = '120';
+
+        $out = $this->invoke_private( 'parse_read_endpoints_post' );
+
+        $this->assertTrue( $out['calendar_slots']['enabled'] );
+        $this->assertSame( 5, $out['calendar_slots']['max_per_minute'] );
+        $this->assertSame( 120, $out['calendar_slots']['max_per_hour'] );
+        // Untouched endpoint stays disabled.
+        $this->assertFalse( $out['calendar_list']['enabled'] );
+
+        unset(
+            $_POST['read_endpoint_calendar_slots_enabled'],
+            $_POST['read_endpoint_calendar_slots_max_per_minute'],
+            $_POST['read_endpoint_calendar_slots_max_per_hour']
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // save_settings()
+    // ------------------------------------------------------------------
+
+    public function test_save_settings_persists_normalized_settings(): void {
+        $this->stub_save_funcs();
+
+        $_POST['ip_enabled']         = '1';
+        $_POST['ip_max_per_hour']    = '15';
+        $_POST['ip_apply_to']        = 'guests';
+        $_POST['email_check_database'] = '1';
+        $_POST['device_max_per_form']  = '0';            // clamped to >= 1
+        $_POST['device_match_threshold'] = '99';          // clamped to <= 12
+        $_POST['device_signals_enabled'] = array( 'cookie', 'bogus', 'ua' );
+        $_POST['whitelist_ips']      = "1.1.1.1\n2.2.2.2\n";
+
+        $saved = null;
+        Functions\when( 'update_option' )->alias(
+            function ( $key, $value ) use ( &$saved ) {
+                if ( 'ffc_rate_limit_settings' === $key ) {
+                    $saved = $value;
+                }
+                return true;
+            }
+        );
+
+        $this->invoke_private( 'save_settings' );
+
+        $this->assertIsArray( $saved );
+        $this->assertTrue( $saved['ip']['enabled'] );
+        $this->assertSame( 15, $saved['ip']['max_per_hour'] );
+        $this->assertSame( 'guests', $saved['ip']['apply_to'] );
+        $this->assertTrue( $saved['email']['check_database'] );
+        // device clamps.
+        $this->assertSame( 1, $saved['device']['max_per_form'] );
+        $this->assertSame( 12, $saved['device']['match_threshold'] );
+        // Only known signals survive the intersect; 'bogus' dropped.
+        $this->assertSame( array( 'cookie', 'ua' ), $saved['device']['signals_enabled'] );
+        // Whitelist split + trimmed, empty trailing line filtered out.
+        $this->assertSame( array( '1.1.1.1', '2.2.2.2' ), array_values( $saved['whitelist']['ips'] ) );
+        // read.endpoints comes from parse_read_endpoints_post().
+        $this->assertArrayHasKey( 'calendar_slots', $saved['read']['endpoints'] );
+
+        unset(
+            $_POST['ip_enabled'], $_POST['ip_max_per_hour'], $_POST['ip_apply_to'],
+            $_POST['email_check_database'], $_POST['device_max_per_form'],
+            $_POST['device_match_threshold'], $_POST['device_signals_enabled'],
+            $_POST['whitelist_ips']
+        );
+    }
+
+    public function test_save_settings_defaults_when_post_empty(): void {
+        $this->stub_save_funcs();
+
+        $saved = null;
+        Functions\when( 'update_option' )->alias(
+            function ( $key, $value ) use ( &$saved ) {
+                $saved = $value;
+                return true;
+            }
+        );
+
+        $this->invoke_private( 'save_settings' );
+
+        $this->assertIsArray( $saved );
+        // Checkboxes absent → false; numeric fields fall back to documented defaults.
+        $this->assertFalse( $saved['ip']['enabled'] );
+        $this->assertSame( 5, $saved['ip']['max_per_hour'] );
+        $this->assertSame( 'all', $saved['ip']['apply_to'] );
+        $this->assertSame( array(), $saved['device']['signals_enabled'] );
+    }
 }


### PR DESCRIPTION
## Fase 2 — cobertura PHP: cross-cutting (REST / repos / validators / generators)

Estende testes unitários para lógica (pulando render HTML / streaming CSV / I/O que termina em `exit`):

| Classe | Antes | Depois |
|---|---|---|
| `BlockedDateRepository` | 18.7% | **99.2%** |
| `RateLimitRepository` | 47.5% | **97.0%** |
| `CsvDownloadValidator` | baixo | **97.7%** |
| `TabRateLimit` | 2.8% | **94.0%** |
| `SubmissionRestController` | 26.9% | **81.0%** |
| `Loader` | 19.1% | **37.7%** (resto é init/asset/markup) |
| `PdfGenerator` | 14.3% | **28.2%** (QR/markup delegado fora de escopo) |
| `PublicCsvExporter` | 23.7% | **24.9%** (stream/echo/exit fora; helpers cobertos) |

**+~120 testes; suíte completa verde (5138 testes); WPCS limpo.** Nenhum `includes/` alterado; sem mudança de floor (bump central no fim).

⚠️ **Anotação:** `DecryptFailureLoggingTest` teve `@coversNothing` → `@covers \FreeFormCertificate\Core\Encryption` (o método sob teste é `Encryption::decrypt`; ActivityLog/registry são só sink/gate). `SensitiveFieldPolicyTest` **mantido** `@coversNothing` (é caracterização integração across 2 write-paths — sem FQCN único). Alinhado com a análise de `@coversNothing` que faremos a seguir; sinalizado para revisão.

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_