### PR TITLE
ci: ratchet PHP coverage floor 55 → 66 (campaign 61.17%→69.82%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,16 @@ jobs:
     # and the §7.4a Recruitment slice (#316, REST × 4 + trait + Reason
     # repository). Conservative 5pp bump leaves headroom for the
     # in-flight §7.4b (#317) and §7.4c (#318) follow-ups.
+    #
+    # 55 → 66 — PHP coverage campaign (Fase 1+2): direct unit tests added
+    # across the logic layer (self-scheduling CPT/handlers, reregistration
+    # email/csv, recruitment csv-importer/dispatcher, audience ajax/admin,
+    # repositories, REST controllers, validators, rate-limit, pdf data
+    # assembly), skipping HTML-render/markup boilerplate by design. Overall
+    # statement coverage 61.17% → 69.82% (31113/44564). Bump to 66 keeps a
+    # ~3.8pp buffer under the measured number (≤5pp policy — see CLAUDE.md).
     env:
-      COVERAGE_FLOOR_LINES: '55'
+      COVERAGE_FLOOR_LINES: '66'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-composer

--- a/tests/Unit/SensitiveFieldPolicyTest.php
+++ b/tests/Unit/SensitiveFieldPolicyTest.php
@@ -34,7 +34,12 @@ use FreeFormCertificate\Repositories\AppointmentRepository;
 use FreeFormCertificate\Submissions\SubmissionHandler;
 
 /**
- * @coversNothing
+ * @coversNothing Cross-class characterization test (SubmissionHandler +
+ * AppointmentRepository + Encryption) — no single class is its subject, so
+ * there is no honest @covers target. The classes it exercises are each
+ * covered directly by their own suites (EncryptionTest, AppointmentRepositoryTest,
+ * SubmissionHandler tests), so suppressing attribution here loses no unique
+ * coverage; it only stops this contract test from inflating those numbers.
  * @runClassInSeparateProcess
  * @preserveGlobalState disabled
  */


### PR DESCRIPTION
## Bump do floor de cobertura PHP — fechamento da Fase 1+2

A campanha de cobertura PHP (Fase 1+2) elevou a cobertura de statements do projeto:

**61.17% → 69.82%** (31113/44564) · **5402 testes** verdes (+389) · floor era 55.

Testes unitários diretos adicionados na camada de **lógica** (self-scheduling CPT/handlers, reregistration email/csv, recruitment csv-importer/dispatcher, audience ajax/admin, repositories, REST controllers, validators, rate-limit, pdf data-assembly), pulando boilerplate de render/markup por design (esse é o gap restante até ~75-80%).

**`COVERAGE_FLOOR_LINES` 55 → 66** — buffer ~3.8pp sob o medido, dentro da política ≤5pp (CLAUDE.md). Gate validado local: 69.82% ≥ 66 ✅. Nota de auditoria adicionada ao bloco do `ci.yml`.

PRs da campanha: #531 (piloto), #532 (audience), #533 (self-sched+rereg), #534 (recruitment), #535 (cross-cutting).

https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_015oyFHBoKYyRez9F3ARZjvD)_