### PR TITLE
Add suggested privacy-policy text to the WordPress Privacy Policy Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Privacy Policy Guide: the plugin now contributes suggested privacy-policy text to **Settings → Privacy → Policy Guide** via `wp_add_privacy_policy_content()`. Covers the personal data FFC processes (name, e-mail, CPF/RF, phone, IP, custom fields), encryption at rest, the configured activity-log retention window, who has access, and the data-subject export/erase rights already served by the existing privacy exporters/erasers. Complements the LGPD/GDPR tooling in `PrivacyHandler`.
+- Operator access info screen reorganised: the download quota and a short "Open form" link now live in the top summary card, and "Availability Period" + "Event Schedule (Reference)" are merged into one Access-vs-Reference comparison table (single column when only one applies).
 - Schedule exception: the operator now sees the participant-form page URL **at validation time** — a clickable preview line ("The participant form opens at: …") rendered on the info screen as soon as the form is validated, before staging the exception. The URL is pre-resolved server-side (`schedule_form_url` in the info payload) via the same resolver the hand-off uses; opening it does not stage or consume a token. #366 Sprint 5.
 
 ### Changed

--- a/includes/privacy/class-ffc-privacy-handler.php
+++ b/includes/privacy/class-ffc-privacy-handler.php
@@ -42,6 +42,76 @@ class PrivacyHandler {
 	public static function init(): void {
 		add_filter( 'wp_privacy_personal_data_exporters', array( __CLASS__, 'register_exporters' ) );
 		add_filter( 'wp_privacy_personal_data_erasers', array( __CLASS__, 'register_erasers' ) );
+		// Suggested privacy-policy text for Settings → Privacy → Policy Guide.
+		// wp_add_privacy_policy_content() must be called on admin_init (it
+		// flags _doing_it_wrong otherwise), so we defer to that hook.
+		add_action( 'admin_init', array( __CLASS__, 'add_privacy_policy_content' ) );
+	}
+
+	/**
+	 * Contribute suggested privacy-policy text to the WordPress Privacy
+	 * Policy Guide (Settings → Privacy → Policy Guide). The administrator
+	 * can copy and adapt it for the site's own privacy page.
+	 *
+	 * @return void
+	 */
+	public static function add_privacy_policy_content(): void {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+
+		$retention_days = \FreeFormCertificate\Settings\SettingsReader::activity_log_retention_days();
+
+		wp_add_privacy_policy_content(
+			'Free Form Certificate',
+			wp_kses_post( self::build_privacy_policy_content( $retention_days ) )
+		);
+	}
+
+	/**
+	 * Build the suggested privacy-policy HTML. Each suggested sentence is
+	 * prefixed with a `privacy-policy-tutorial`-classed label, which the
+	 * Policy Guide shows as guidance but excludes from the "copy" output —
+	 * matching WordPress core's own default-content convention.
+	 *
+	 * @param int $retention_days Configured activity-log retention window.
+	 * @return string Privacy-policy HTML (sanitised by the caller).
+	 */
+	private static function build_privacy_policy_content( int $retention_days ): string {
+		$hint = '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'ffcertificate' ) . ' </strong>';
+
+		// Whole-paragraph guidance — never copied (entire node is tutorial).
+		$content = '<p class="privacy-policy-tutorial">' . esc_html__( 'This text is suggested by the Free Form Certificate plugin to help you describe how it processes personal data. Review and adapt it to your organisation and to the modules you actually use (form submissions and certificates, appointment scheduling, audiences, re-registration and recruitment). Delete any section that does not apply.', 'ffcertificate' ) . '</p>';
+
+		$content .= '<h2>' . esc_html__( 'What personal data we collect and why', 'ffcertificate' ) . '</h2>';
+
+		$content .= '<p>' . $hint . esc_html__( 'When you submit a form, request a certificate, book an appointment, join an audience or take part in a re-registration or recruitment process through this site, we collect the personal data you provide. Depending on how each form is configured, this may include your name, e-mail address, telephone number, national identification numbers (such as CPF and RF), free-text answers and any custom fields defined by the administrator.', 'ffcertificate' ) . '</p>';
+
+		$content .= '<p>' . $hint . esc_html__( 'We use this data to issue and verify certificates, manage appointments and audiences, run re-registration and recruitment processes, prevent abuse, and comply with our legal obligations under applicable data-protection law (including the Brazilian LGPD where it applies).', 'ffcertificate' ) . '</p>';
+
+		$content .= '<p>' . $hint . esc_html__( 'For security and accountability we also record your IP address and basic browser information, together with the actions you perform, in an activity log.', 'ffcertificate' ) . '</p>';
+
+		$content .= '<h2>' . esc_html__( 'How your data is stored', 'ffcertificate' ) . '</h2>';
+
+		$content .= '<p>' . $hint . esc_html__( 'Sensitive identifiers such as e-mail addresses and CPF/RF numbers are stored encrypted at rest. Where consent is required, the date and time you gave it are recorded. One-way hashes of some identifiers are kept so records can be located without exposing the original values.', 'ffcertificate' ) . '</p>';
+
+		$content .= '<h2>' . esc_html__( 'How long we keep your data', 'ffcertificate' ) . '</h2>';
+
+		$content .= '<p>' . $hint . sprintf(
+			/* translators: %d: number of days activity-log entries are retained. */
+			esc_html__( 'Submission, certificate, appointment and audience records are kept for as long as needed to provide the service and to allow previously issued certificates to remain verifiable. Activity-log entries (including IP and browser information) are retained for %d days and then removed automatically.', 'ffcertificate' ),
+			$retention_days
+		) . '</p>';
+
+		$content .= '<h2>' . esc_html__( 'Who has access to your data', 'ffcertificate' ) . '</h2>';
+
+		$content .= '<p>' . $hint . esc_html__( 'Your data is accessible to the site administrators and to the authorised operators who manage the relevant forms. We do not sell your personal data.', 'ffcertificate' ) . '</p>';
+
+		$content .= '<h2>' . esc_html__( 'Your rights over your data', 'ffcertificate' ) . '</h2>';
+
+		$content .= '<p>' . $hint . esc_html__( 'You can request a copy of your personal data or ask for it to be erased. The administrator can fulfil these requests from the WordPress "Export Personal Data" and "Erase Personal Data" tools, which cover the data this plugin stores. Certificate authentication codes and verification tokens may be retained in anonymised form so that certificates already issued remain verifiable after erasure.', 'ffcertificate' ) . '</p>';
+
+		return $content;
 	}
 
 	/**

--- a/tests/Unit/PrivacyHandlerTest.php
+++ b/tests/Unit/PrivacyHandlerTest.php
@@ -141,7 +141,55 @@ class PrivacyHandlerTest extends TestCase {
             ->once()
             ->with('wp_privacy_personal_data_erasers', [PrivacyHandler::class, 'register_erasers']);
 
+        Functions\expect('add_action')
+            ->once()
+            ->with('admin_init', [PrivacyHandler::class, 'add_privacy_policy_content']);
+
         PrivacyHandler::init();
+    }
+
+    // ==================================================================
+    // add_privacy_policy_content()
+    // ==================================================================
+
+    public function test_add_privacy_policy_content_registers_suggested_text(): void {
+        Functions\when('esc_html__')->returnArg();
+        Functions\when('wp_kses_post')->returnArg();
+        Functions\when('get_option')->justReturn(['activity_log_retention_days' => 45]);
+
+        $captured = null;
+        Functions\expect('wp_add_privacy_policy_content')
+            ->once()
+            ->andReturnUsing(function ($name, $content) use (&$captured) {
+                $captured = [$name, $content];
+            });
+
+        PrivacyHandler::add_privacy_policy_content();
+
+        $this->assertSame('Free Form Certificate', $captured[0]);
+        // Covers the key PII categories and the configured retention window.
+        $this->assertStringContainsString('CPF', $captured[1]);
+        $this->assertStringContainsString('45 days', $captured[1]);
+        // The tutorial-classed guidance is present (excluded from the copy
+        // button by the Policy Guide, but emitted in the markup).
+        $this->assertStringContainsString('privacy-policy-tutorial', $captured[1]);
+    }
+
+    /**
+     * Runs in a separate process because once Brain Monkey defines
+     * wp_add_privacy_policy_content() in another test, PHP keeps it defined
+     * for the rest of the process and function_exists() can no longer be
+     * false. A fresh process guarantees the core function is absent.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_add_privacy_policy_content_noop_when_core_function_missing(): void {
+        // wp_add_privacy_policy_content is intentionally NOT stubbed here, so
+        // function_exists() is false and the method must return without error
+        // (and without touching settings).
+        PrivacyHandler::add_privacy_policy_content();
+        $this->assertTrue(true);
     }
 
     // ==================================================================


### PR DESCRIPTION
## Contexto

O WordPress tem o **Guia de política de privacidade** (Configurações → Privacidade → aba "Guia") onde plugins podem contribuir com texto sugerido, via `wp_add_privacy_policy_content()`, com botão "Copiar texto sugerido".

O FFC **já** integra com as Ferramentas de Privacidade do WP (exporters + erasers de dados pessoais no `PrivacyHandler`, para LGPD/GDPR), mas **não** contribuía com texto sugerido. Esta PR adiciona isso.

## O que faz

- `PrivacyHandler::init()` passa a registrar `add_action( 'admin_init', … )` (o contrato de `wp_add_privacy_policy_content()` exige `admin_init`).
- `add_privacy_policy_content()` chama a função do core com o nome do plugin e o texto sugerido.
- `build_privacy_policy_content()` monta texto estruturado e traduzível cobrindo:
  - **dados coletados** (nome, e-mail, CPF/RF, telefone, IP, campos personalizados);
  - **finalidade** (certificados, agendamentos, audiências, rerregistro, recrutamento) e base legal/LGPD;
  - **criptografia em repouso** e hashes de busca;
  - **retenção** — usa o valor configurado via `SettingsReader::activity_log_retention_days()`;
  - **quem tem acesso** (admins/operadores);
  - **direitos do titular** — exportar/apagar via as Ferramentas do WP, que já funcionam graças ao `PrivacyHandler`.
- Cada frase sugerida leva o rótulo `privacy-policy-tutorial`, que o Guia exibe como orientação mas **exclui do botão "copiar"** (mesma convenção do core).

## Decisões (alinhadas com você)

- **Inglês + i18n** (`__()`), tradução pt_BR via .po/.mo.
- **Retenção com o valor configurado** (não genérico).
- **Bloco completo** cobrindo todos os módulos, com subtítulos que o admin apara.

## Testes

`PrivacyHandlerTest`: `init()` registra o hook `admin_init`; `add_privacy_policy_content()` chama o core com o nome do plugin + conteúdo (contém "CPF" e a janela de retenção configurada); no-op (processo isolado) quando a função do core não existe.

Verde local: PHPUnit (suíte completa, **5412 testes**), PHPStan (lvl 8, sem erros), WPCS. Sem mudança de JS/CSS.

> Nota: incluí no CHANGELOG também a linha da reorganização da tela do operador (#543), que havia mesclado sem entrada no `[Unreleased]`.

https://claude.ai/code/session_01Jqq1AipSx1UCCcdhRdu9Rv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqq1AipSx1UCCcdhRdu9Rv)_