### PR TITLE
Release 6.11.0 — version bump + CHANGELOG consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [6.11.0] (2026-06-07)
+
 ### Added
 
 - Privacy Policy Guide: the plugin now contributes suggested privacy-policy text to **Settings → Privacy → Policy Guide** via `wp_add_privacy_policy_content()`. Covers the personal data FFC processes (name, e-mail, CPF/RF, phone, IP, custom fields), encryption at rest, the configured activity-log retention window, who has access, and the data-subject export/erase rights already served by the existing privacy exporters/erasers. Complements the LGPD/GDPR tooling in `PrivacyHandler`.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.10.0
+ * Version:            6.11.0
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.10.0' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.11.0' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 6.9
-Stable tag: 6.10.0
+Stable tag: 6.11.0
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Release-prep for **6.11.0** — lands the version bump on `develop` so the `develop → main` release PR carries it (per the develop-branch workflow in `CLAUDE.md`).

Contains **only**:
- `FFC_VERSION` 6.10.0 → 6.11.0 across the three sync sites (plugin header, constant, `readme.txt` Stable tag).
- CHANGELOG: `[Unreleased]` → `[6.11.0] (2026-06-07)`, with a fresh empty `[Unreleased]` opened above.

No source changes; the batch itself (#509–#544) is already on `develop`. Minified assets verified in sync (`npm run build` produces no diff).

https://claude.ai/code/session_01Jqq1AipSx1UCCcdhRdu9Rv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqq1AipSx1UCCcdhRdu9Rv)_