### PR TITLE
Device fingerprint: two-tier match to stop homogeneous-audience false blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Device Fingerprint limit — **Minimum strong signals** setting (Settings → Rate Limit → Device Fingerprint, with a per-form override in the form editor and an auto-save slot). On top of the match threshold, a fuzzy "same device" match now additionally requires this many high-entropy *strong* signals (canvas, WebGL, audio, fonts, plugins, permissions) to corroborate. The "Signals collected" UI now groups signals visually as **Strong** vs **Weak** (with per-signal badges) so operators can see which signals carry real distinguishing power. Default 2; 0 restores the legacy single-tier behavior.
+
+### Fixed
+
+- Device Fingerprint limit no longer mass-false-blocks legitimate first-time submitters in homogeneous audiences (e.g. an event where most people use the same phone model / browser). The previous single-tier rule treated two visits as the same physical device whenever **any** N-of-13 signals matched, but the *weak* signals (user agent, screen, timezone, CPU/memory, media queries, math precision) are identical across whole fleets of same-model devices — so distinct people collided and everyone after the first was blocked. Matching is now **two-tier**: the threshold count **and** a minimum number of *strong* signals must match before a fuzzy block fires. Submissions that cannot emit enough strong signals (privacy browsers blocking canvas/WebGL) fall back to the cookie path only and are never blocked on weak signals alone; such near-misses are recorded in the rate-limit log (action `suppressed`) for operator visibility. The per-form scoping, the cookie OR-path, the whitelist/manager bypasses, and the reprint exemption are all unchanged.
+
 ## [6.11.0] (2026-06-07) — `d753ac3`
 
 ### Added

--- a/includes/admin/class-ffc-form-editor-device-limit-metabox.php
+++ b/includes/admin/class-ffc-form-editor-device-limit-metabox.php
@@ -109,6 +109,7 @@ class FormEditorDeviceLimitMetabox {
 		$enabled         = (string) get_post_meta( $post->ID, '_ffc_device_limit_enabled', true );
 		$max             = (string) get_post_meta( $post->ID, '_ffc_device_limit_max', true );
 		$threshold       = (string) get_post_meta( $post->ID, '_ffc_device_match_threshold', true );
+		$strong_min      = (string) get_post_meta( $post->ID, '_ffc_device_strong_min', true );
 		$message         = (string) get_post_meta( $post->ID, '_ffc_device_limit_message', true );
 		$global_active   = $this->is_global_subsystem_active();
 		$global_defaults = $this->get_global_device_defaults();
@@ -164,6 +165,28 @@ class FormEditorDeviceLimitMetabox {
 
 			<tr class="ffc-device-limit-sub">
 				<th scope="row">
+					<label for="ffc_device_strong_min"><?php esc_html_e( 'Minimum strong signals (0-6)', 'ffcertificate' ); ?></label>
+				</th>
+				<td>
+					<input type="number"
+						name="ffc_device_limit[strong_min]"
+						id="ffc_device_strong_min"
+						min="0"
+						max="6"
+						value="<?php echo esc_attr( $strong_min ); ?>"
+						placeholder="<?php esc_attr_e( 'Inherit from global', 'ffcertificate' ); ?>">
+					<?php
+					$this->render_inherit_hint(
+						/* translators: %s: highlighted current global default — minimum strong signals. */
+						esc_html__( 'How many STRONG signals (canvas, WebGL, audio, fonts, plugins, permissions) must match in addition to the threshold. Higher = fewer false positives but easier to evade; 0 disables the strong tier. Leave empty to inherit the global default — currently %s.', 'ffcertificate' ),
+						(string) $global_defaults['strong_min']
+					);
+					?>
+				</td>
+			</tr>
+
+			<tr class="ffc-device-limit-sub">
+				<th scope="row">
 					<label for="ffc_device_limit_message"><?php esc_html_e( 'Block message', 'ffcertificate' ); ?></label>
 				</th>
 				<td>
@@ -207,12 +230,13 @@ class FormEditorDeviceLimitMetabox {
 	 * so the operator sees what an empty field will inherit. Falls back to the
 	 * shipped defaults (2 / 7) when the subsystem class isn't available.
 	 *
-	 * @return array{max: int, threshold: int, message: string}
+	 * @return array{max: int, threshold: int, strong_min: int, message: string}
 	 */
 	private function get_global_device_defaults(): array {
-		$max = 2;
-		$thr = 7;
-		$msg = '';
+		$max    = 2;
+		$thr    = 7;
+		$strong = 2;
+		$msg    = '';
 		if ( class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
 			$device = \FreeFormCertificate\Security\RateLimiter::get_settings()['device'] ?? array();
 			if ( isset( $device['max_per_form'] ) ) {
@@ -221,14 +245,18 @@ class FormEditorDeviceLimitMetabox {
 			if ( isset( $device['match_threshold'] ) ) {
 				$thr = max( 3, min( 12, (int) $device['match_threshold'] ) );
 			}
+			if ( isset( $device['match_strong_min'] ) ) {
+				$strong = max( 0, min( 6, (int) $device['match_strong_min'] ) );
+			}
 			if ( isset( $device['message'] ) && is_string( $device['message'] ) ) {
 				$msg = trim( $device['message'] );
 			}
 		}
 		return array(
-			'max'       => $max,
-			'threshold' => $thr,
-			'message'   => $msg,
+			'max'        => $max,
+			'threshold'  => $thr,
+			'strong_min' => $strong,
+			'message'    => $msg,
 		);
 	}
 

--- a/includes/admin/class-ffc-form-editor-save-handler.php
+++ b/includes/admin/class-ffc-form-editor-save-handler.php
@@ -466,6 +466,16 @@ class FormEditorSaveHandler {
 					update_post_meta( $post_id, '_ffc_device_match_threshold', max( 3, min( 12, absint( $thr_raw ) ) ) );
 				}
 
+				// Minimum strong signals (two-tier match). Empty inherits the
+				// global default; 0 is a valid explicit value (disables the
+				// strong tier for this form).
+				$strong_raw = isset( $device_raw['strong_min'] ) ? trim( (string) $device_raw['strong_min'] ) : '';
+				if ( '' === $strong_raw ) {
+					delete_post_meta( $post_id, '_ffc_device_strong_min' );
+				} else {
+					update_post_meta( $post_id, '_ffc_device_strong_min', max( 0, min( 6, absint( $strong_raw ) ) ) );
+				}
+
 				$msg_raw = isset( $device_raw['message'] ) ? sanitize_textarea_field( (string) $device_raw['message'] ) : '';
 				if ( '' === $msg_raw ) {
 					delete_post_meta( $post_id, '_ffc_device_limit_message' );

--- a/includes/admin/class-ffc-settings-ajax-endpoint.php
+++ b/includes/admin/class-ffc-settings-ajax-endpoint.php
@@ -360,7 +360,7 @@ class SettingsAjaxEndpoint {
 
 		// Rate-limit nested non-boolean fields.
 		$rate_limit_typed = array(
-			'ip_max_per_hour'        => array(
+			'ip_max_per_hour'         => array(
 				array( 'ip', 'max_per_hour' ),
 				'int',
 				array(
@@ -368,7 +368,7 @@ class SettingsAjaxEndpoint {
 					'max' => 1000,
 				),
 			),
-			'ip_max_per_day'         => array(
+			'ip_max_per_day'          => array(
 				array( 'ip', 'max_per_day' ),
 				'int',
 				array(
@@ -376,7 +376,7 @@ class SettingsAjaxEndpoint {
 					'max' => 10000,
 				),
 			),
-			'ip_cooldown_seconds'    => array(
+			'ip_cooldown_seconds'     => array(
 				array( 'ip', 'cooldown_seconds' ),
 				'int',
 				array(
@@ -384,22 +384,22 @@ class SettingsAjaxEndpoint {
 					'max' => 3600,
 				),
 			),
-			'ip_apply_to'            => array( array( 'ip', 'apply_to' ), 'string', array() ),
-			'ip_message'             => array( array( 'ip', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
-			'email_max_per_day'      => array( array( 'email', 'max_per_day' ), 'int', array( 'min' => 1 ) ),
-			'email_max_per_week'     => array( array( 'email', 'max_per_week' ), 'int', array( 'min' => 1 ) ),
-			'email_max_per_month'    => array( array( 'email', 'max_per_month' ), 'int', array( 'min' => 1 ) ),
-			'email_message'          => array( array( 'email', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
-			'cpf_max_per_month'      => array( array( 'cpf', 'max_per_month' ), 'int', array( 'min' => 1 ) ),
-			'cpf_max_per_year'       => array( array( 'cpf', 'max_per_year' ), 'int', array( 'min' => 1 ) ),
-			'cpf_block_threshold'    => array( array( 'cpf', 'block_threshold' ), 'int', array( 'min' => 1 ) ),
-			'cpf_block_hours'        => array( array( 'cpf', 'block_hours' ), 'int', array( 'min' => 1 ) ),
-			'cpf_block_duration'     => array( array( 'cpf', 'block_duration' ), 'int', array( 'min' => 1 ) ),
-			'cpf_message'            => array( array( 'cpf', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
-			'global_max_per_minute'  => array( array( 'global', 'max_per_minute' ), 'int', array( 'min' => 1 ) ),
-			'global_max_per_hour'    => array( array( 'global', 'max_per_hour' ), 'int', array( 'min' => 1 ) ),
-			'global_message'         => array( array( 'global', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
-			'device_max_per_form'    => array(
+			'ip_apply_to'             => array( array( 'ip', 'apply_to' ), 'string', array() ),
+			'ip_message'              => array( array( 'ip', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'email_max_per_day'       => array( array( 'email', 'max_per_day' ), 'int', array( 'min' => 1 ) ),
+			'email_max_per_week'      => array( array( 'email', 'max_per_week' ), 'int', array( 'min' => 1 ) ),
+			'email_max_per_month'     => array( array( 'email', 'max_per_month' ), 'int', array( 'min' => 1 ) ),
+			'email_message'           => array( array( 'email', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'cpf_max_per_month'       => array( array( 'cpf', 'max_per_month' ), 'int', array( 'min' => 1 ) ),
+			'cpf_max_per_year'        => array( array( 'cpf', 'max_per_year' ), 'int', array( 'min' => 1 ) ),
+			'cpf_block_threshold'     => array( array( 'cpf', 'block_threshold' ), 'int', array( 'min' => 1 ) ),
+			'cpf_block_hours'         => array( array( 'cpf', 'block_hours' ), 'int', array( 'min' => 1 ) ),
+			'cpf_block_duration'      => array( array( 'cpf', 'block_duration' ), 'int', array( 'min' => 1 ) ),
+			'cpf_message'             => array( array( 'cpf', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'global_max_per_minute'   => array( array( 'global', 'max_per_minute' ), 'int', array( 'min' => 1 ) ),
+			'global_max_per_hour'     => array( array( 'global', 'max_per_hour' ), 'int', array( 'min' => 1 ) ),
+			'global_message'          => array( array( 'global', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'device_max_per_form'     => array(
 				array( 'device', 'max_per_form' ),
 				'int',
 				array(
@@ -407,7 +407,7 @@ class SettingsAjaxEndpoint {
 					'max' => 100,
 				),
 			),
-			'device_match_threshold' => array(
+			'device_match_threshold'  => array(
 				array( 'device', 'match_threshold' ),
 				'int',
 				array(
@@ -415,7 +415,15 @@ class SettingsAjaxEndpoint {
 					'max' => 12,
 				),
 			),
-			'device_retention_days'  => array(
+			'device_match_strong_min' => array(
+				array( 'device', 'match_strong_min' ),
+				'int',
+				array(
+					'min' => 0,
+					'max' => 6,
+				),
+			),
+			'device_retention_days'   => array(
 				array( 'device', 'retention_days' ),
 				'int',
 				array(
@@ -423,10 +431,10 @@ class SettingsAjaxEndpoint {
 					'max' => 3650,
 				),
 			),
-			'device_message'         => array( array( 'device', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
-			'logging_retention_days' => array( array( 'logging', 'retention_days' ), 'int', array( 'min' => 1 ) ),
-			'logging_max_logs'       => array( array( 'logging', 'max_logs' ), 'int', array( 'min' => 100 ) ),
-			'read_message'           => array( array( 'read', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'device_message'          => array( array( 'device', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
+			'logging_retention_days'  => array( array( 'logging', 'retention_days' ), 'int', array( 'min' => 1 ) ),
+			'logging_max_logs'        => array( array( 'logging', 'max_logs' ), 'int', array( 'min' => 100 ) ),
+			'read_message'            => array( array( 'read', 'message' ), 'string', array( 'as' => 'multiline_text' ) ),
 		);
 
 		// Per-endpoint numeric thresholds under read.endpoints.<ep>.{max_per_minute,max_per_hour}.

--- a/includes/security/class-ffc-rate-limit-checker.php
+++ b/includes/security/class-ffc-rate-limit-checker.php
@@ -24,6 +24,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class RateLimitChecker {
 
 	/**
+	 * Strong device signals — high-entropy probes that rarely coincide
+	 * between two distinct physical devices and survive incognito /
+	 * cleared-storage sessions (they are hardware/software bound, not
+	 * stored client-side). The two-tier device match requires at least
+	 * `match_strong_min` of these to corroborate a fuzzy match before it
+	 * counts as the "same device", so matching only weak signals (which
+	 * are identical across whole fleets of same-model devices) can no
+	 * longer trigger a block on its own. Fixed in code by design.
+	 *
+	 * @since 6.7.8
+	 * @var string[]
+	 */
+	public const STRONG_SIGNALS = array( 'canvas', 'webgl', 'audio', 'fonts', 'plugins', 'permissions' );
+
+	/**
+	 * Weak device signals — low-entropy probes that are commonly identical
+	 * across many devices of the same model / OS / browser / locale, so a
+	 * match among these alone does not indicate the same physical device.
+	 * Listed for documentation + the admin grouping UI; the matcher derives
+	 * "weak" as "present non-cookie signal that is not in STRONG_SIGNALS".
+	 *
+	 * @since 6.7.8
+	 * @var string[]
+	 */
+	public const WEAK_SIGNALS = array( 'ua', 'screen', 'tz', 'concurrency', 'memory', 'mediaqueries', 'math' );
+
+	/**
 	 * Cached settings for the current request
 	 *
 	 * @since 4.6.13
@@ -84,6 +111,13 @@ final class RateLimitChecker {
 				// Existing installs keep their saved value; this default only
 				// applies to fresh installs that have never persisted the array.
 				'match_threshold'           => 7,
+				// 6.7.8: two-tier match. On top of `match_threshold` (total
+				// signals matched), a fuzzy block additionally requires at
+				// least this many STRONG_SIGNALS to match — so matching only
+				// weak signals (identical across same-model fleets) can no
+				// longer trigger a false block. 0 disables the strong tier
+				// (legacy behavior). Capped at count(STRONG_SIGNALS) = 6.
+				'match_strong_min'          => 2,
 				'signals_enabled'           => array( 'cookie', 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts', 'plugins', 'permissions', 'mediaqueries', 'math' ),
 				'bypass_logged_in_managers' => true,
 				'bypass_whitelist_signals'  => array(),
@@ -431,22 +465,30 @@ final class RateLimitChecker {
 	 * post-meta overrides on top of the global device.* values.
 	 *
 	 * @param int $form_id Form post ID.
-	 * @return array{max: int, threshold: int, message: string}
+	 * @return array{max: int, threshold: int, strong_min: int, message: string}
 	 */
 	public static function get_device_effective_settings( int $form_id ): array {
-		$d        = self::get_settings()['device'];
-		$max_meta = get_post_meta( $form_id, '_ffc_device_limit_max', true );
-		$thr_meta = get_post_meta( $form_id, '_ffc_device_match_threshold', true );
-		$msg_meta = get_post_meta( $form_id, '_ffc_device_limit_message', true );
+		$d           = self::get_settings()['device'];
+		$max_meta    = get_post_meta( $form_id, '_ffc_device_limit_max', true );
+		$thr_meta    = get_post_meta( $form_id, '_ffc_device_match_threshold', true );
+		$strong_meta = get_post_meta( $form_id, '_ffc_device_strong_min', true );
+		$msg_meta    = get_post_meta( $form_id, '_ffc_device_limit_message', true );
 
-		$max = ( '' !== $max_meta ) ? max( 1, (int) $max_meta ) : (int) $d['max_per_form'];
-		$thr = ( '' !== $thr_meta ) ? max( 3, min( 12, (int) $thr_meta ) ) : (int) $d['match_threshold'];
-		$msg = ( is_string( $msg_meta ) && '' !== $msg_meta ) ? $msg_meta : (string) $d['message'];
+		$strong_cap    = count( self::STRONG_SIGNALS );
+		$global_strong = isset( $d['match_strong_min'] ) ? (int) $d['match_strong_min'] : 2;
+
+		$max    = ( '' !== $max_meta ) ? max( 1, (int) $max_meta ) : (int) $d['max_per_form'];
+		$thr    = ( '' !== $thr_meta ) ? max( 3, min( 12, (int) $thr_meta ) ) : (int) $d['match_threshold'];
+		$strong = ( '' !== $strong_meta )
+			? max( 0, min( $strong_cap, (int) $strong_meta ) )
+			: max( 0, min( $strong_cap, $global_strong ) );
+		$msg    = ( is_string( $msg_meta ) && '' !== $msg_meta ) ? $msg_meta : (string) $d['message'];
 
 		return array(
-			'max'       => $max,
-			'threshold' => $thr,
-			'message'   => $msg,
+			'max'        => $max,
+			'threshold'  => $thr,
+			'strong_min' => $strong,
+			'message'    => $msg,
 		);
 	}
 
@@ -455,7 +497,16 @@ final class RateLimitChecker {
 	 *
 	 * Treats two submissions as "same device" when:
 	 *   (a) their cookie hash matches, OR
-	 *   (b) at least <threshold> non-cookie signal hashes match.
+	 *   (b) (two-tier) at least <threshold> non-cookie signals match AND
+	 *       at least <strong_min> of those are STRONG_SIGNALS.
+	 *
+	 * The strong tier exists because weak signals (ua/screen/tz/…) are
+	 * identical across whole fleets of same-model devices, so matching the
+	 * threshold on weak signals alone produced mass false positives. When
+	 * the incoming submission carries fewer strong signals than
+	 * <strong_min> the fuzzy tier cannot be corroborated, so we fall back
+	 * to the cookie path only (lenient) and never block on weak signals
+	 * alone — a near-miss is recorded in the log for operator visibility.
 	 *
 	 * Counts how many prior submissions of this form match the incoming
 	 * signal set; blocks if the count reaches the configured maximum.
@@ -494,20 +545,27 @@ final class RateLimitChecker {
 
 		$effective = self::get_device_effective_settings( $form_id );
 
-		$signal_keys = array( 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts', 'plugins', 'permissions', 'mediaqueries', 'math' );
-		$sum_parts   = array();
-		$values      = array();
+		$signal_keys   = array( 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts', 'plugins', 'permissions', 'mediaqueries', 'math' );
+		$sum_parts     = array();
+		$values        = array();
+		$strong_parts  = array();
+		$strong_values = array();
 		foreach ( $signal_keys as $k ) {
 			if ( ! empty( $signals[ $k ] ) ) {
 				$col         = 'sig_' . $k;
 				$sum_parts[] = "({$col} = %s)";
 				$values[]    = $signals[ $k ];
+				if ( in_array( $k, self::STRONG_SIGNALS, true ) ) {
+					$strong_parts[]  = "({$col} = %s)";
+					$strong_values[] = $signals[ $k ];
+				}
 			}
 		}
 
-		$threshold = $effective['threshold'];
-		$max       = $effective['max'];
-		$table     = $wpdb->prefix . 'ffc_device_signals';
+		$threshold  = $effective['threshold'];
+		$strong_min = $effective['strong_min'];
+		$max        = $effective['max'];
+		$table      = $wpdb->prefix . 'ffc_device_signals';
 
 		$count = 0;
 		if ( $cookie && empty( $sum_parts ) ) {
@@ -515,17 +573,52 @@ final class RateLimitChecker {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE form_id = %d AND sig_cookie = %s', $table, $form_id, $cookie ) );
 		} elseif ( ! empty( $sum_parts ) ) {
-			$sum_sql = implode( ' + ', $sum_parts );
-			if ( $cookie ) {
-				$where_sql = "form_id = %d AND ( sig_cookie = %s OR ( {$sum_sql} ) >= %d )";
-				$args      = array_merge( array( $table, $form_id, $cookie ), $values, array( $threshold ) );
+			$sum_sql         = implode( ' + ', $sum_parts );
+			$fuzzy_blockable = ( 0 === $strong_min ) || ( count( $strong_parts ) >= $strong_min );
+
+			if ( $fuzzy_blockable ) {
+				// Two-tier fuzzy condition: total threshold, plus (when the
+				// strong tier is active) a minimum of corroborating strong
+				// signals so weak-only matches can no longer block.
+				$fuzzy_sql  = "( {$sum_sql} ) >= %d";
+				$fuzzy_args = array_merge( $values, array( $threshold ) );
+				if ( $strong_min > 0 ) {
+					$strong_sql = implode( ' + ', $strong_parts );
+					$fuzzy_sql .= " AND ( {$strong_sql} ) >= %d";
+					$fuzzy_args = array_merge( $values, array( $threshold ), $strong_values, array( $strong_min ) );
+				}
+				if ( $cookie ) {
+					$where_sql = "form_id = %d AND ( sig_cookie = %s OR ( {$fuzzy_sql} ) )";
+					$args      = array_merge( array( $table, $form_id, $cookie ), $fuzzy_args );
+				} else {
+					$where_sql = "form_id = %d AND ( {$fuzzy_sql} )";
+					$args      = array_merge( array( $table, $form_id ), $fuzzy_args );
+				}
+				$sql = "SELECT COUNT(*) FROM %i WHERE {$where_sql}";
+                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+				$count = (int) $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
 			} else {
-				$where_sql = "form_id = %d AND ( {$sum_sql} ) >= %d";
-				$args      = array_merge( array( $table, $form_id ), $values, array( $threshold ) );
+				// Lenient: too few strong signals present to corroborate a
+				// fuzzy match. Rely on the cookie path only; never block on
+				// weak signals alone.
+				if ( $cookie ) {
+                    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+					$count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE form_id = %d AND sig_cookie = %s', $table, $form_id, $cookie ) );
+				}
+				// Visibility guard: weak signals alone would have crossed the
+				// total threshold (a near-miss the legacy 1-tier logic would
+				// have blocked). Record it so operators can spot low-entropy
+				// devices / strong-signal evasion in the rate-limit log.
+				if ( ! empty( $d['log_blocks'] ) && count( $sum_parts ) >= $threshold ) {
+					// $signals is a non-empty array of non-empty-string hashes
+					// here, so reset() always yields a usable identifier.
+					$d_id = $cookie ?? reset( $signals );
+					// Action 'suppressed' (not 'allowed') so it bypasses the
+					// log_allowed gate and is recorded whenever logging is on —
+					// this near-miss is the diagnostic signal operators need.
+					RateLimitLogger::log_attempt( 'device', (string) $d_id, 'suppressed', 'strong_signals_insufficient', $form_id );
+				}
 			}
-			$sql = "SELECT COUNT(*) FROM %i WHERE {$where_sql}";
-            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			$count = (int) $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
 		}
 
 		if ( $count >= $max ) {

--- a/includes/settings/tabs/class-ffc-tab-rate-limit.php
+++ b/includes/settings/tabs/class-ffc-tab-rate-limit.php
@@ -97,6 +97,7 @@ class TabRateLimit extends SettingsTab {
 				'enabled'                   => false,
 				'max_per_form'              => 1,
 				'match_threshold'           => 7,
+				'match_strong_min'          => 2,
 				'signals_enabled'           => array( 'cookie', 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts', 'plugins', 'permissions', 'mediaqueries', 'math' ),
 				'bypass_logged_in_managers' => true,
 				'bypass_whitelist_signals'  => array(),
@@ -241,6 +242,7 @@ class TabRateLimit extends SettingsTab {
 				'enabled'                   => isset( $_POST['device_enabled'] ),
 				'max_per_form'              => max( 1, absint( wp_unslash( $_POST['device_max_per_form'] ?? 1 ) ) ),
 				'match_threshold'           => max( 3, min( 12, absint( wp_unslash( $_POST['device_match_threshold'] ?? 7 ) ) ) ),
+				'match_strong_min'          => max( 0, min( 6, absint( wp_unslash( $_POST['device_match_strong_min'] ?? 2 ) ) ) ),
 				'signals_enabled'           => isset( $_POST['device_signals_enabled'] ) && is_array( $_POST['device_signals_enabled'] )
 					? array_values(
 						array_intersect(

--- a/includes/settings/views/ffc-tab-rate-limit.php
+++ b/includes/settings/views/ffc-tab-rate-limit.php
@@ -266,7 +266,7 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 
 <div class="card">
 	<h2 class="ffc-icon-shield"><?php esc_html_e( 'Device Fingerprint', 'ffcertificate' ); ?></h2>
-	<p class="description" data-ffc-section="rl-device"><?php esc_html_e( 'Limit submissions from the same physical device by combining a persistent cookie with multiple browser signals. The "N of M" rule treats two visits as the same device when at least the configured number of non-cookie signals match.', 'ffcertificate' ); ?></p>
+	<p class="description" data-ffc-section="rl-device"><?php esc_html_e( 'Limit submissions from the same physical device by combining a persistent cookie with multiple browser signals. Two visits count as the same device when (a) their cookie matches, or (b) they match at least the threshold number of signals AND at least the minimum number of STRONG signals. The strong-signal tier prevents false blocks across same-model devices in homogeneous audiences, where weak signals (browser/OS/screen/timezone) are identical between different people.', 'ffcertificate' ); ?></p>
 	<p>
 		<?php
 		\FreeFormCertificate\Admin\AdminUI::render_toggle(
@@ -293,7 +293,18 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 		<tr>
 			<th><?php esc_html_e( 'Match threshold (N of 13)', 'ffcertificate' ); ?></th>
 			<td><input type="number" name="device_match_threshold" value="<?php echo esc_attr( $ffcertificate_s['device']['match_threshold'] ); ?>" min="3" max="12" data-ffc-autosave-key="device_match_threshold">
-				<p class="description"><?php esc_html_e( 'How many non-cookie signals must match to consider it the same device. Lower = more aggressive (more false positives). Higher = harder to bypass but easier to evade. The default is 7 of 13.', 'ffcertificate' ); ?></p>
+				<p class="description"><?php esc_html_e( 'How many non-cookie signals (strong + weak) must match to consider it the same device. Lower = more aggressive (more false positives). Higher = harder to bypass but easier to evade. The default is 7 of 13.', 'ffcertificate' ); ?></p>
+			</td>
+		</tr>
+		<tr>
+			<th><?php esc_html_e( 'Minimum strong signals (0-6)', 'ffcertificate' ); ?></th>
+			<td><input type="number" name="device_match_strong_min" value="<?php echo esc_attr( $ffcertificate_s['device']['match_strong_min'] ?? 2 ); ?>" min="0" max="6" data-ffc-autosave-key="device_match_strong_min">
+				<p class="description">
+					<?php esc_html_e( 'On top of the threshold above, at least this many STRONG signals (canvas, WebGL, audio, fonts, plugins, permissions) must match before two visits count as the same device. Strong signals rarely coincide between different physical devices, so requiring them is what stops false blocks across same-model devices in a homogeneous audience.', 'ffcertificate' ); ?>
+					<br>
+					<strong><?php esc_html_e( 'Consequences of changing this:', 'ffcertificate' ); ?></strong>
+					<?php esc_html_e( 'Higher = fewer false positives, but easier to evade (a device only needs to differ on a few strong signals to escape). Lower = closer to the old behavior and more aggressive. 0 disables the strong tier entirely (block on the raw threshold alone — the legacy behavior that over-blocked homogeneous audiences). Submissions that cannot emit this many strong signals (e.g. privacy browsers blocking canvas/WebGL) fall back to the cookie only and are never blocked on weak signals alone. Default is 2.', 'ffcertificate' ); ?>
+				</p>
 			</td>
 		</tr>
 		<tr>
@@ -316,28 +327,79 @@ $ffcertificate_stats = \FreeFormCertificate\Security\RateLimiter::get_stats();
 					'mediaqueries' => __( 'Media queries (color scheme, reduced motion, …)', 'ffcertificate' ),
 					'math'         => __( 'Math precision probes (CPU/SO-specific IEEE-754 quirks)', 'ffcertificate' ),
 				);
-				foreach ( $ffcertificate_signals_options as $ffcertificate_sig_key => $ffcertificate_sig_label ) :
-					$ffcertificate_sig_checked = in_array( $ffcertificate_sig_key, (array) $ffcertificate_s['device']['signals_enabled'], true );
-					?>
-					<p>
-						<?php
-						\FreeFormCertificate\Admin\AdminUI::render_toggle(
-							array(
-								'name'    => 'device_signals_enabled[]',
-								'id'      => 'device_signal_' . $ffcertificate_sig_key,
-								'value'   => $ffcertificate_sig_key,
-								'checked' => $ffcertificate_sig_checked,
-								'label'   => $ffcertificate_sig_label,
-								'data'    => array(
-									'ffc-autosave-key'   => 'device_signals_enabled',
-									'ffc-autosave-multi' => '1',
-								),
-							)
-						);
-						?>
-					</p>
+
+				$ffcertificate_strong_keys = \FreeFormCertificate\Security\RateLimitChecker::STRONG_SIGNALS;
+
+				// Classify each signal into one of three visual groups so the
+				// admin can see which signals carry real distinguishing power.
+				$ffcertificate_signal_groups = array(
+					'cookie' => array(),
+					'strong' => array(),
+					'weak'   => array(),
+				);
+				foreach ( $ffcertificate_signals_options as $ffcertificate_sig_key => $ffcertificate_sig_label ) {
+					if ( 'cookie' === $ffcertificate_sig_key ) {
+						$ffcertificate_signal_groups['cookie'][ $ffcertificate_sig_key ] = $ffcertificate_sig_label;
+					} elseif ( in_array( $ffcertificate_sig_key, $ffcertificate_strong_keys, true ) ) {
+						$ffcertificate_signal_groups['strong'][ $ffcertificate_sig_key ] = $ffcertificate_sig_label;
+					} else {
+						$ffcertificate_signal_groups['weak'][ $ffcertificate_sig_key ] = $ffcertificate_sig_label;
+					}
+				}
+
+				// Inline styles keep the badge self-contained (no CSS rebuild).
+				$ffcertificate_badge_styles = array(
+					'cookie' => 'background:#cfe2ff;color:#084298;',
+					'strong' => 'background:#d1e7dd;color:#0f5132;',
+					'weak'   => 'background:#e2e3e5;color:#41464b;',
+				);
+				$ffcertificate_badge_labels = array(
+					'cookie' => __( 'Cookie', 'ffcertificate' ),
+					'strong' => __( 'Strong', 'ffcertificate' ),
+					'weak'   => __( 'Weak', 'ffcertificate' ),
+				);
+
+				$ffcertificate_render_signal = static function ( $key, $label, $group ) use ( $ffcertificate_s, $ffcertificate_badge_styles, $ffcertificate_badge_labels ) {
+					$checked = in_array( $key, (array) $ffcertificate_s['device']['signals_enabled'], true );
+					echo '<p class="ffc-device-signal-row">';
+					\FreeFormCertificate\Admin\AdminUI::render_toggle(
+						array(
+							'name'    => 'device_signals_enabled[]',
+							'id'      => 'device_signal_' . $key,
+							'value'   => $key,
+							'checked' => $checked,
+							'label'   => $label,
+							'data'    => array(
+								'ffc-autosave-key'   => 'device_signals_enabled',
+								'ffc-autosave-multi' => '1',
+							),
+						)
+					);
+					printf(
+						' <span class="ffc-signal-badge ffc-signal-badge--%1$s" style="%2$s display:inline-block;padding:1px 7px;border-radius:9px;font-size:11px;font-weight:600;vertical-align:middle;">%3$s</span>',
+						esc_attr( $group ),
+						esc_attr( $ffcertificate_badge_styles[ $group ] ),
+						esc_html( $ffcertificate_badge_labels[ $group ] )
+					);
+					echo '</p>';
+				};
+				?>
+
+				<?php foreach ( $ffcertificate_signal_groups['cookie'] as $ffcertificate_sig_key => $ffcertificate_sig_label ) : ?>
+					<?php $ffcertificate_render_signal( $ffcertificate_sig_key, $ffcertificate_sig_label, 'cookie' ); ?>
 				<?php endforeach; ?>
-				<p class="description"><?php esc_html_e( 'Disable canvas/audio/fonts for a privacy-minimal profile (lower entropy, easier to bypass).', 'ffcertificate' ); ?></p>
+
+				<p class="ffc-signal-group-heading" style="margin-bottom:2px;"><strong><?php esc_html_e( 'Strong signals', 'ffcertificate' ); ?></strong> — <span class="description"><?php esc_html_e( 'high entropy; hard to coincide between different physical devices and resistant to incognito. The strong-signal minimum is counted from these.', 'ffcertificate' ); ?></span></p>
+				<?php foreach ( $ffcertificate_signal_groups['strong'] as $ffcertificate_sig_key => $ffcertificate_sig_label ) : ?>
+					<?php $ffcertificate_render_signal( $ffcertificate_sig_key, $ffcertificate_sig_label, 'strong' ); ?>
+				<?php endforeach; ?>
+
+				<p class="ffc-signal-group-heading" style="margin-bottom:2px;"><strong><?php esc_html_e( 'Weak signals', 'ffcertificate' ); ?></strong> — <span class="description"><?php esc_html_e( 'low entropy; commonly identical across many devices of the same model/OS/browser, so matching these alone does not indicate the same device.', 'ffcertificate' ); ?></span></p>
+				<?php foreach ( $ffcertificate_signal_groups['weak'] as $ffcertificate_sig_key => $ffcertificate_sig_label ) : ?>
+					<?php $ffcertificate_render_signal( $ffcertificate_sig_key, $ffcertificate_sig_label, 'weak' ); ?>
+				<?php endforeach; ?>
+
+				<p class="description"><?php esc_html_e( 'Disabling strong signals lowers entropy and makes the limit easier to bypass. If you disable so many strong signals that fewer than the configured minimum remain, the strong tier can never be satisfied and only the cookie/threshold will apply.', 'ffcertificate' ); ?></p>
 			</td>
 		</tr>
 		<tr>

--- a/tests/Unit/FormEditorDeviceLimitMetaboxTest.php
+++ b/tests/Unit/FormEditorDeviceLimitMetaboxTest.php
@@ -97,13 +97,13 @@ class FormEditorDeviceLimitMetaboxTest extends TestCase {
     public function test_render_surfaces_inherited_global_defaults_with_highlight(): void {
         $html = $this->render();
 
-        // Each of the three sub-option descriptions (max / threshold / message)
-        // shows the value an empty field inherits from global, wrapped in the
-        // subtle-highlight `.ffc-global-default` span.
+        // Each of the four sub-option descriptions (max / threshold /
+        // strong_min / message) shows the value an empty field inherits from
+        // global, wrapped in the subtle-highlight `.ffc-global-default` span.
         $this->assertSame(
-            3,
+            4,
             substr_count( $html, 'ffc-global-default' ),
-            'max, threshold and message must each surface their inherited global value'
+            'max, threshold, strong_min and message must each surface their inherited global value'
         );
         $this->assertStringContainsString( 'inherit the global default', $html );
         $this->assertStringContainsString( 'inherit the global block message', $html );

--- a/tests/Unit/FormEditorSaveHandlerTest.php
+++ b/tests/Unit/FormEditorSaveHandlerTest.php
@@ -681,6 +681,63 @@ class FormEditorSaveHandlerTest extends TestCase {
     }
 
     /**
+     * Device Fingerprint: a blank "Minimum strong signals" inherits the global
+     * default (delete the meta), same inherit-from-global semantic as max /
+     * threshold.
+     */
+    public function test_device_limit_blank_strong_min_inherits_global(): void {
+        $bag     = $this->stub_for_save();
+        $written = &$bag[0];
+
+        $deleted = array();
+        Functions\when( 'delete_post_meta' )->alias(
+            static function ( $id, $key ) use ( &$deleted ): bool {
+                $deleted[] = $key;
+                return true;
+            }
+        );
+        Functions\when( 'get_post_meta' )->alias( static fn( $id, $key ) => array() );
+
+        $_POST = array(
+            'ffc_form_nonce'   => 'ok',
+            'ffc_config'       => array( 'pdf_layout' => '{{auth_code}} {{name}} {{cpf_rf}}' ),
+            'ffc_device_limit' => array(
+                'enabled'    => '1',
+                'strong_min' => '',
+            ),
+        );
+
+        $this->handler->save_form_data( 10 );
+
+        $this->assertArrayNotHasKey( '_ffc_device_strong_min', $written, 'blank strong_min must not be force-written' );
+        $this->assertContains( '_ffc_device_strong_min', $deleted, 'blank strong_min must delete the meta so the global default is inherited' );
+    }
+
+    /**
+     * Device Fingerprint: an explicit strong_min is persisted, and 0 (disable
+     * the strong tier) is a valid stored value — not treated as "inherit".
+     */
+    public function test_device_limit_explicit_strong_min_is_persisted(): void {
+        $bag     = $this->stub_for_save();
+        $written = &$bag[0];
+
+        Functions\when( 'get_post_meta' )->alias( static fn( $id, $key ) => array() );
+
+        $_POST = array(
+            'ffc_form_nonce'   => 'ok',
+            'ffc_config'       => array( 'pdf_layout' => '{{auth_code}} {{name}} {{cpf_rf}}' ),
+            'ffc_device_limit' => array(
+                'enabled'    => '1',
+                'strong_min' => '0',
+            ),
+        );
+
+        $this->handler->save_form_data( 10 );
+
+        $this->assertSame( 0, $written['_ffc_device_strong_min'] );
+    }
+
+    /**
      * Public Operator Access: a blank Download Limit inherits the global default
      * (delete the meta) instead of force-saving the resolved global value.
      */

--- a/tests/Unit/RateLimiterTest.php
+++ b/tests/Unit/RateLimiterTest.php
@@ -490,6 +490,69 @@ class RateLimiterTest extends TestCase {
         $this->assertSame( 12, $eff['threshold'], 'Threshold above 12 must clamp to 12 (raised from 8 in 6.3.2 to match the 13-signal palette).' );
     }
 
+    public function test_get_device_effective_settings_default_strong_min_is_2(): void {
+        $this->stub_default_settings(
+            array( 'device' => array( 'enabled' => true, 'match_threshold' => 7, 'max_per_form' => 1 ) )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        $eff = RateLimiter::get_device_effective_settings( 42 );
+
+        $this->assertSame( 2, $eff['strong_min'] );
+    }
+
+    public function test_get_device_effective_settings_inherits_global_strong_min(): void {
+        $this->stub_default_settings(
+            array( 'device' => array( 'enabled' => true, 'match_strong_min' => 4, 'max_per_form' => 1 ) )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        $eff = RateLimiter::get_device_effective_settings( 42 );
+
+        $this->assertSame( 4, $eff['strong_min'] );
+    }
+
+    public function test_get_device_effective_settings_form_meta_overrides_strong_min(): void {
+        $this->stub_default_settings(
+            array( 'device' => array( 'enabled' => true, 'match_strong_min' => 2, 'max_per_form' => 1 ) )
+        );
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key ) {
+            return '_ffc_device_strong_min' === $key ? '5' : '';
+        } );
+
+        $eff = RateLimiter::get_device_effective_settings( 42 );
+
+        $this->assertSame( 5, $eff['strong_min'] );
+    }
+
+    public function test_get_device_effective_settings_clamps_strong_min(): void {
+        $this->stub_default_settings(
+            array( 'device' => array( 'enabled' => true, 'match_strong_min' => 2, 'max_per_form' => 1 ) )
+        );
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key ) {
+            return '_ffc_device_strong_min' === $key ? '99' : '';
+        } );
+
+        $eff = RateLimiter::get_device_effective_settings( 42 );
+
+        $this->assertSame( 6, $eff['strong_min'], 'Strong-min above 6 must clamp to count(STRONG_SIGNALS) = 6.' );
+    }
+
+    public function test_get_device_effective_settings_strong_min_zero_is_respected(): void {
+        // 0 is a valid explicit value (disables the strong tier), distinct
+        // from empty (inherit from global).
+        $this->stub_default_settings(
+            array( 'device' => array( 'enabled' => true, 'match_strong_min' => 3, 'max_per_form' => 1 ) )
+        );
+        Functions\when( 'get_post_meta' )->alias( function ( $post_id, $key ) {
+            return '_ffc_device_strong_min' === $key ? '0' : '';
+        } );
+
+        $eff = RateLimiter::get_device_effective_settings( 42 );
+
+        $this->assertSame( 0, $eff['strong_min'] );
+    }
+
     // ------------------------------------------------------------------
     // device.* — check_device_limit()
     // ------------------------------------------------------------------
@@ -550,6 +613,175 @@ class RateLimiterTest extends TestCase {
 
         $this->assertFalse( $result['allowed'] );
         $this->assertSame( 'device_limit', $result['reason'] );
+    }
+
+    public function test_check_device_limit_suppresses_fuzzy_when_strong_signals_insufficient(): void {
+        // Two-tier (6.7.8): weak signals alone — even when they meet the
+        // total threshold — must NOT block, because they are identical
+        // across same-model devices in a homogeneous audience.
+        global $wpdb;
+        $wpdb->shouldReceive( 'get_var' )->andReturn( '5' ); // Would block if consulted.
+
+        $this->stub_default_settings(
+            array(
+                'device' => array(
+                    'enabled'          => true,
+                    'max_per_form'     => 1,
+                    'match_threshold'  => 7,
+                    'match_strong_min' => 2,
+                    'log_blocks'       => true,
+                ),
+            )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        // Seven WEAK signals, zero strong, no cookie -> strong tier cannot
+        // be satisfied -> fuzzy suppressed -> allowed.
+        $result = RateLimiter::check_device_limit(
+            42,
+            array(
+                'ua'           => str_repeat( 'a', 64 ),
+                'screen'       => str_repeat( 'b', 64 ),
+                'tz'           => str_repeat( 'c', 64 ),
+                'concurrency'  => str_repeat( 'd', 64 ),
+                'memory'       => str_repeat( 'e', 64 ),
+                'mediaqueries' => str_repeat( 'f', 64 ),
+                'math'         => str_repeat( '0', 64 ),
+            )
+        );
+
+        $this->assertTrue( $result['allowed'] );
+    }
+
+    public function test_check_device_limit_blocks_when_strong_minimum_met_without_cookie(): void {
+        global $wpdb;
+        $wpdb->shouldReceive( 'get_var' )->andReturn( '2' );
+
+        $this->stub_default_settings(
+            array(
+                'device' => array(
+                    'enabled'          => true,
+                    'max_per_form'     => 1,
+                    'match_threshold'  => 5,
+                    'match_strong_min' => 2,
+                    'message'          => 'blocked!',
+                ),
+            )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        // 3 weak + 2 strong = 5 total (>= threshold) with 2 strong (>= min),
+        // no cookie -> fuzzy tier blockable -> blocked.
+        $result = RateLimiter::check_device_limit(
+            42,
+            array(
+                'ua'     => str_repeat( 'a', 64 ),
+                'screen' => str_repeat( 'b', 64 ),
+                'tz'     => str_repeat( 'c', 64 ),
+                'canvas' => str_repeat( 'd', 64 ),
+                'webgl'  => str_repeat( 'e', 64 ),
+            )
+        );
+
+        $this->assertFalse( $result['allowed'] );
+        $this->assertSame( 'device_limit', $result['reason'] );
+    }
+
+    public function test_check_device_limit_blocks_when_strong_minimum_met_with_cookie(): void {
+        global $wpdb;
+        $wpdb->shouldReceive( 'get_var' )->andReturn( '1' );
+
+        $this->stub_default_settings(
+            array(
+                'device' => array(
+                    'enabled'          => true,
+                    'max_per_form'     => 1,
+                    'match_threshold'  => 5,
+                    'match_strong_min' => 2,
+                    'message'          => 'blocked!',
+                ),
+            )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        // Cookie present + 3 weak + 2 strong -> exercises the cookie OR
+        // (threshold AND strong) branch.
+        $result = RateLimiter::check_device_limit(
+            42,
+            array(
+                'cookie' => str_repeat( '9', 64 ),
+                'ua'     => str_repeat( 'a', 64 ),
+                'screen' => str_repeat( 'b', 64 ),
+                'tz'     => str_repeat( 'c', 64 ),
+                'canvas' => str_repeat( 'd', 64 ),
+                'webgl'  => str_repeat( 'e', 64 ),
+            )
+        );
+
+        $this->assertFalse( $result['allowed'] );
+    }
+
+    public function test_check_device_limit_strong_min_zero_blocks_on_threshold_alone(): void {
+        // strong_min = 0 disables the strong tier (legacy single-tier
+        // behavior): weak signals meeting the threshold block again.
+        global $wpdb;
+        $wpdb->shouldReceive( 'get_var' )->andReturn( '1' );
+
+        $this->stub_default_settings(
+            array(
+                'device' => array(
+                    'enabled'          => true,
+                    'max_per_form'     => 1,
+                    'match_threshold'  => 3,
+                    'match_strong_min' => 0,
+                    'message'          => 'blocked!',
+                ),
+            )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        $result = RateLimiter::check_device_limit(
+            42,
+            array(
+                'ua'     => str_repeat( 'a', 64 ),
+                'screen' => str_repeat( 'b', 64 ),
+                'tz'     => str_repeat( 'c', 64 ),
+            )
+        );
+
+        $this->assertFalse( $result['allowed'] );
+    }
+
+    public function test_check_device_limit_lenient_still_blocks_via_cookie(): void {
+        // When strong signals are insufficient the fuzzy tier is suppressed,
+        // but a matching cookie is still authoritative and blocks.
+        global $wpdb;
+        $wpdb->shouldReceive( 'get_var' )->andReturn( '3' );
+
+        $this->stub_default_settings(
+            array(
+                'device' => array(
+                    'enabled'          => true,
+                    'max_per_form'     => 1,
+                    'match_threshold'  => 7,
+                    'match_strong_min' => 2,
+                    'message'          => 'blocked!',
+                ),
+            )
+        );
+        Functions\when( 'get_post_meta' )->justReturn( '' );
+
+        $result = RateLimiter::check_device_limit(
+            42,
+            array(
+                'cookie' => str_repeat( 'a', 64 ),
+                'ua'     => str_repeat( 'b', 64 ),
+                'screen' => str_repeat( 'c', 64 ),
+                'tz'     => str_repeat( 'd', 64 ),
+            )
+        );
+
+        $this->assertFalse( $result['allowed'] );
     }
 
     // ------------------------------------------------------------------

--- a/tests/Unit/TabRateLimitTest.php
+++ b/tests/Unit/TabRateLimitTest.php
@@ -335,6 +335,7 @@ class TabRateLimitTest extends TestCase {
         $_POST['email_check_database'] = '1';
         $_POST['device_max_per_form']  = '0';            // clamped to >= 1
         $_POST['device_match_threshold'] = '99';          // clamped to <= 12
+        $_POST['device_match_strong_min'] = '99';         // clamped to <= 6
         $_POST['device_signals_enabled'] = array( 'cookie', 'bogus', 'ua' );
         $_POST['whitelist_ips']      = "1.1.1.1\n2.2.2.2\n";
 
@@ -358,6 +359,7 @@ class TabRateLimitTest extends TestCase {
         // device clamps.
         $this->assertSame( 1, $saved['device']['max_per_form'] );
         $this->assertSame( 12, $saved['device']['match_threshold'] );
+        $this->assertSame( 6, $saved['device']['match_strong_min'] );
         // Only known signals survive the intersect; 'bogus' dropped.
         $this->assertSame( array( 'cookie', 'ua' ), $saved['device']['signals_enabled'] );
         // Whitelist split + trimmed, empty trailing line filtered out.
@@ -368,7 +370,8 @@ class TabRateLimitTest extends TestCase {
         unset(
             $_POST['ip_enabled'], $_POST['ip_max_per_hour'], $_POST['ip_apply_to'],
             $_POST['email_check_database'], $_POST['device_max_per_form'],
-            $_POST['device_match_threshold'], $_POST['device_signals_enabled'],
+            $_POST['device_match_threshold'], $_POST['device_match_strong_min'],
+            $_POST['device_signals_enabled'],
             $_POST['whitelist_ips']
         );
     }


### PR DESCRIPTION
## Problem

In an audience of ~250 people with the certificate form limited to "1 per device", about **half were falsely blocked** by the device fingerprint as if a certificate had already been generated on their device — even though each person used their **own** device.

Root cause (confirmed in code, not a scoping leak): the matcher treated two visits as the **same physical device** whenever **any N-of-13 signals matched** (default 7). But the *weak* signals (`ua`, `screen`, `tz`, `concurrency`, `memory`, `mediaqueries`, `math`) are identical across whole fleets of same-model devices/browsers, so distinct first-time submitters collided and everyone after the first was blocked. With `max_per_form = 1` there was zero margin.

The per-form scoping, the cookie path, the bypasses, and the reprint exemption were all already correct — only the fuzzy matching was too loose.

## Fix — two-tier match

A fuzzy "same device" match now requires **both**:
1. at least `match_threshold` total signals match (unchanged), **and**
2. at least `match_strong_min` **strong** signals match — high-entropy probes that rarely coincide between different physical devices and survive incognito: `canvas`, `webgl`, `audio`, `fonts`, `plugins`, `permissions`.

Matching only weak signals can no longer trigger a block.

### Missing strong signals (lenient + guard + log)

If a submission cannot emit enough strong signals (e.g. a privacy browser blocking canvas/WebGL), the strong tier cannot be corroborated, so it falls back to the **cookie path only** and is never blocked on weak signals alone. When the weak signals alone *would* have crossed the threshold (a near-miss the legacy logic would have blocked), it is recorded in the rate-limit log with action `suppressed` for operator visibility.

## Configuration

- New **`match_strong_min`** setting: global default **2**, per-form override (`_ffc_device_strong_min`), auto-save slot, clamp **0–6**. `0` restores the legacy single-tier behavior.
- `STRONG_SIGNALS` / `WEAK_SIGNALS` are **fixed in code** (constants).
- Admin **"Signals collected"** UI now groups signals as **Strong** vs **Weak** with per-signal badges and explains the consequences of changing the knob.

## Tests

- `RateLimiterTest`: strong-min resolution (default / inherit / per-form override / clamp / explicit 0) and `check_device_limit` two-tier behavior (weak-only suppressed → allowed; strong met → blocked, with/without cookie; `strong_min=0` legacy block; lenient still blocks via cookie).
- `TabRateLimitTest`: global sanitizer clamp for `device_match_strong_min`.
- `FormEditorSaveHandlerTest`: per-form blank-inherits + explicit (incl. `0`) persistence.
- `FormEditorDeviceLimitMetaboxTest`: inherited-default chip count updated for the new field.

Full unit suite green (5424 tests). PHPCS + PHPStan (level 8) clean on changed files. No JS/CSS changes (assets gate unaffected). Targets `develop`; no `FFC_VERSION` bump per the develop workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_