### PR TITLE
release: 6.11.1 — version bump + CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [6.11.1] (2026-06-17)
+
 ### Added
 
 - Device Fingerprint limit — **Minimum strong signals** setting (Settings → Rate Limit → Device Fingerprint, with a per-form override in the form editor and an auto-save slot). On top of the match threshold, a fuzzy "same device" match now additionally requires this many high-entropy *strong* signals (canvas, WebGL, audio, fonts, plugins, permissions) to corroborate. The "Signals collected" UI now groups signals visually as **Strong** vs **Weak** (with per-signal badges) so operators can see which signals carry real distinguishing power. Default 2; 0 restores the legacy single-tier behavior.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.11.0
+ * Version:            6.11.1
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.11.0' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.11.1' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 7.0
-Stable tag: 6.11.0
+Stable tag: 6.11.1
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Release cut for 6.11.1

Prepares the consolidated `develop → main` release per the CLAUDE.md release workflow. This PR lands the version bump + CHANGELOG cut on `develop`; the release PR `develop → main` follows once this merges.

### Changes
- Bump `FFC_VERSION` **6.11.0 → 6.11.1** across the three sync sites (plugin header, `FFC_VERSION` constant, `readme.txt` `Stable tag`).
- Rename `[Unreleased]` → `## [6.11.1] (2026-06-17)` and add a fresh empty `[Unreleased]`.

### Batch contents (since 6.11.0)
- **User-facing:** device-fingerprint two-tier match that stops homogeneous-audience false blocks + the new "Minimum strong signals" setting (#557).
- **Tooling/docs:** dependency bumps, stylelint 17 migration, CSS dedup, CHANGELOG heading standardization, readme refresh (#548, #552–#556).

Patch version per maintainer decision. No JS/CSS source changed in this PR (assets already in sync on develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_