### PR TITLE
fix(develop): restore 6.11.1 baseline after accidental merge revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [6.11.1] (2026-06-17)
+
 ### Added
 
 - Device Fingerprint limit — **Minimum strong signals** setting (Settings → Rate Limit → Device Fingerprint, with a per-form override in the form editor and an auto-save slot). On top of the match threshold, a fuzzy "same device" match now additionally requires this many high-entropy *strong* signals (canvas, WebGL, audio, fonts, plugins, permissions) to corroborate. The "Signals collected" UI now groups signals visually as **Strong** vs **Weak** (with per-signal badges) so operators can see which signals carry real distinguishing power. Default 2; 0 restores the legacy single-tier behavior.

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.11.0
+ * Version:            6.11.1
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.11.0' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.11.1' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 7.0
-Stable tag: 6.11.0
+Stable tag: 6.11.1
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Fix develop after accidental merge revert

After the 6.11.1 release sync (force-push `develop` → `main`), a **stale local `develop` was merged back** (merge commit `a5f74a5`, "Merge branch 'develop' … into develop"). That merge reverted:
- `FFC_VERSION` 6.11.1 → **6.11.0** (plugin header + constant)
- `readme.txt` Stable tag 6.11.1 → 6.11.0
- `CHANGELOG.md` — moved the device-fingerprint entries back under `[Unreleased]` instead of the cut `[6.11.1]` section

This restores those three files to `main`'s 6.11.1 state. After merge, `develop`'s tree is **byte-identical to `main`** (verified locally) — the bumped baseline the next batch should build on.

No code changes; version/changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_