### PR TITLE
docs(claude): document Dependabot security-update retargeting to develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,16 @@ develop   ─o─o─o─o─o─o─o─o─o─o─o─/             ← TESTE
 4. CHANGELOG entries go under the `[Unreleased]` section at the top of `CHANGELOG.md` — they stay there across multiple PRs.
 5. Auto-merge enabled (SQUASH). Once merged, `deploy-develop.yml` pushes the new HEAD to the testes server within ~1 minute.
 
+### Dependabot PRs
+
+Dependabot is configured with `target-branch: develop` for all three ecosystems (`composer`, `npm`, `github-actions`) in `.github/dependabot.yml`, so **version updates** open against `develop` correctly.
+
+**Security updates are the exception:** GitHub always raises Dependabot *security* updates against the repository's default branch (`main`), ignoring `target-branch` — this is not configurable. The default branch is intentionally kept as `main` (changing it would have repo-wide side effects), so security-update PRs will keep being born against `main`.
+
+**Rule — retarget to `develop`:** whenever a Dependabot PR opens against `main` (in practice, always a security update), change its base to `develop` and leave a one-line comment stating the reason (*correct flow: every change funnels through `develop` and ships in the consolidated release PR, never as an out-of-band `main` commit*). Then comment `@dependabot rebase` so the lockfile diff is recomputed against `develop`. The PR then rides the normal develop batch with auto-merge like any other.
+
+**Exception — genuine hotfix:** if the security fix is in a **runtime dependency** (shipped inside the plugin, not dev/CI tooling) *and* is severe enough to ship to production immediately, treat it as a hotfix (`hotfix/* → main`) instead of retargeting, then sync develop per "Sync `develop` with `main`". Dev/CI-only deps (`vitest`, `@vitest/coverage-v8`, `undici`, `js-yaml`, PHPStan, etc.) never qualify — they always ride the develop batch.
+
 ### Release PR (`develop → main`)
 
 When the batch on develop is validated against the testes site and ready to ship to prod:


### PR DESCRIPTION
## Why

Dependabot **version updates** already open against `develop` (`target-branch: develop` is set for all three ecosystems in `.github/dependabot.yml`). But **security updates** always target the repository's default branch (`main`), ignoring `target-branch` — this is fixed GitHub behavior, not configurable. We saw this with #568 (`js-yaml`) and #569 (`undici`), which were both born against `main`.

Rather than change the default branch (repo-wide side effects), we keep `main` as default and formalize the manual retargeting as a documented rule, so the release flow stays clean — every change funnels through `develop` and ships in the consolidated release PR, never as an out-of-band `main` commit.

## What

Adds a **"Dependabot PRs"** subsection to `CLAUDE.md` under "Develop branch workflow":

- Explains the version-update vs. security-update routing difference.
- **Rule:** retarget any Dependabot PR that opens against `main` to `develop`, leave a one-line reason comment, then `·@·d·ependabot r·ebase`.
- **Exception:** a CVE in a *runtime* dependency severe enough for prod ships as a `hotfix/* → main` instead; dev/CI-only deps (`vitest`, `undici`, `js-yaml`, PHPStan, …) always ride the develop batch.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_