### PR TITLE
docs(changelog): backfill [Unreleased] security entry for #564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Reregistration admin — fixed a stored-XSS vector (CodeQL `js/xss-through-dom`) in the audience transfer list. Audience name/color/id read from a DOM `data-` attribute were string-concatenated into HTML and injected with `.append()` (both the *selected* and *available* branches), so a malicious audience name or color stored by a delegated audience manager could execute script in the reregistration admin screen. The list is now built with `jQuery('<el>', {…})` + `.text()`/`.attr()` (every value escaped; the color is applied only when it matches a hex pattern). DOM shape, `data-id` and hidden-input values are unchanged. Also hardened `ffc-geofence-admin.js` field-key derivation (CodeQL `js/incomplete-sanitization`) — not exploitable (hardcoded allowlist input) but cleared for good. (#564)
+
 ### Changed
 
-- Vendored thumbmarkjs 1.9.0 → 1.9.1 (MIT, `libs/js/`). Patch release; the server algorithm, fingerprint schema, contract and LGPD posture are unchanged, and the telemetry beacon stays unconditionally disabled.
+- Vendored thumbmarkjs 1.9.0 → 1.9.1 (MIT, `libs/js/`). Patch release; the server algorithm, fingerprint schema, contract and LGPD posture are unchanged, and the telemetry beacon stays unconditionally disabled. (#571)
 
 ## [6.11.1] (2026-06-17)
 


### PR DESCRIPTION
## What

The CodeQL fix **#564** (`js/xss-through-dom` + `js/incomplete-sanitization`) merged to `develop` after the 6.11.1 release **without a CHANGELOG entry**. This backfills it under `[Unreleased] → Security` so the next release PR (`develop → main`) consolidates it correctly.

## Changes

- **`CHANGELOG.md`** — new `[Unreleased] → Security` bullet documenting the stored-XSS fix in the reregistration admin audience transfer list, plus the `ffc-geofence-admin.js` sanitization hardening. (#564)
- Added the `(#571)` PR ref to the existing thumbmarkjs 1.9.1 line for parity.

## Scope

Documentation only — no code, no asset, no version change. The fix itself already shipped to `develop` in #564.

### Audit of post-6.11.1 commits (what's intentionally *not* changelogged)

- **#562** — develop-only housekeeping (restore version/CHANGELOG after an accidental merge revert). Not user-facing.
- **#565–#569** — Dependabot **dev/CI tooling** bumps (`actions/checkout`, `vitest`, `@vitest/coverage-v8`, `js-yaml`, `undici`). Consistent with 6.11.1, which also did not changelog its tooling batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_