### PR TITLE
Release 6.11.2: bump version + cut CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [6.11.2] (2026-06-21)
+
 ### Security
 
 - Reregistration admin — fixed a stored-XSS vector (CodeQL `js/xss-through-dom`) in the audience transfer list. Audience name/color/id read from a DOM `data-` attribute were string-concatenated into HTML and injected with `.append()` (both the *selected* and *available* branches), so a malicious audience name or color stored by a delegated audience manager could execute script in the reregistration admin screen. The list is now built with `jQuery('<el>', {…})` + `.text()`/`.attr()` (every value escaped; the color is applied only when it matches a hex pattern). DOM shape, `data-id` and hidden-input values are unchanged. Also hardened `ffc-geofence-admin.js` field-key derivation (CodeQL `js/incomplete-sanitization`) — not exploitable (hardcoded allowlist input) but cleared for good. (#564)

--- a/ffcertificate.php
+++ b/ffcertificate.php
@@ -3,7 +3,7 @@
  * Plugin Name:        Free Form Certificate
  * Plugin URI:         https://github.com/rpgmem/ffcertificate
  * Description:        Allows creation of dynamic forms, saves submissions, generates a PDF certificate, and enables CSV export.
- * Version:            6.11.1
+ * Version:            6.11.2
  * Requires PHP:       8.3
  * Author:             Alex Meusburger
  * Author URI:         https://github.com/rpgmem
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Centralized version management
  */
-define( 'FFC_VERSION', '6.11.1' );                 // Plugin version (WordPress Plugin Check compliance)
+define( 'FFC_VERSION', '6.11.2' );                 // Plugin version (WordPress Plugin Check compliance)
 // External libraries versions.
 define( 'FFC_HTML2CANVAS_VERSION', '1.4.1' );   // html2canvas - https://html2canvas.hertzen.com/.
 define( 'FFC_JSPDF_VERSION', '4.2.1' );         // jsPDF - https://github.com/parallax/jsPDF.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexmeusburger
 Tags: certificate, form builder, pdf generation, verification, validation
 Requires at least: 6.2
 Tested up to: 7.0
-Stable tag: 6.11.1
+Stable tag: 6.11.2
 Requires PHP: 8.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## What

Release prep for **6.11.2**, merged onto `develop` ahead of the `develop → main` release PR (per the CLAUDE.md release workflow: the bump lands on develop first, then the release PR ships the batch).

## Changes

- **`FFC_VERSION` 6.11.1 → 6.11.2** across the three sync sites: plugin header, `FFC_VERSION` constant, `readme.txt` `Stable tag`.
- **`CHANGELOG.md`** — renamed `[Unreleased]` → `[6.11.2] (2026-06-21)`, fresh empty `[Unreleased]` added above.

## Batch shipping in 6.11.2

- **Security** — CodeQL `js/xss-through-dom` + `js/incomplete-sanitization` hardening in the reregistration admin audience transfer list and the geofence field-key derivation. (#564)
- **Changed** — vendored thumbmarkjs 1.9.0 → 1.9.1. (#571)

Dev/CI-only Dependabot bumps (#565–#569) and docs-only / housekeeping PRs (#562, #570, #572) ship in the batch but are intentionally not changelogged, consistent with prior releases.

## Next step

Once this merges, I open the **`develop → main`** release PR (squash subject `6.11.2 — …`), then rebase `develop` onto the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_