### PR TITLE
#563 Sprint 1 (PR 1a): extract FormProcessor entry guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [6.11.2] (2026-06-21)
+### Changed
+
+- Internal refactor (#563 Sprint 1, PR 1a) — the 740-line `FormProcessor::handle_submission_ajax()` god-method now delegates its entry stages (schedule-exception bridge, IP throttle, nonce, CAPTCHA/honeypot, form-config resolution, preflight, field sanitization, device-signal resolution, geofence, consolidated rate-limit, access restrictions) to discrete, unit-testable guard classes under `FreeFormCertificate\Frontend\Submission\`. Each guard either populates a shared `SubmissionContext` or throws `SubmissionRejected` carrying the exact `wp_send_json_error()` payload; a thin orchestrator runs them in order and translates a rejection into the single JSON error response. Behavior-preserving: the JSON contract, gate ordering, and exit semantics are unchanged (pinned by the existing FormProcessor characterization tests plus a new per-guard suite). The quiz/normal save, PDF, and success stages remain inline pending PR 1b.
 
 ### Security
 

--- a/includes/frontend/class-ffc-form-processor.php
+++ b/includes/frontend/class-ffc-form-processor.php
@@ -18,8 +18,6 @@ declare(strict_types=1);
 
 namespace FreeFormCertificate\Frontend;
 
-use FreeFormCertificate\Core\Utils;
-
 use FreeFormCertificate\Submissions\SubmissionHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -53,435 +51,42 @@ class FormProcessor {
 	 * Handle form submission via AJAX
 	 */
 	public function handle_submission_ajax(): void {
-		// Schedule exception bridge (#366 Sprint 6). Read + verify the
-		// hidden-input token Sprint 5 embedded in the form. A valid
-		// payload means an operator staged this submission as an
-		// exception; downstream we (a) skip the IP rate-limit gate,
-		// (b) persist the override TIME columns, (c) emit two audit
-		// rows. Done before the IP gate so the operator's bypass takes
-		// effect even when the venue's network has saturated the
-		// per-IP throttle.
-		//
-		// The token IS a signed credential (HMAC over the payload + 30
-		// min expiry + form_id binding), so verifying it before the WP
-		// nonce check is safe — the token is the auth for the exception
-		// path, not the nonce.
-		$has_exception              = false;
-		$schedule_exception_payload = null;
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- token verified via HMAC immediately below; form_id sanitized via absint.
-		if ( isset( $_POST['ffc_schedule_exception_token'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- HMAC verifies integrity.
-			$token_raw = (string) wp_unslash( $_POST['ffc_schedule_exception_token'] );
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$token_form                 = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
-			$schedule_exception_payload = self::live_exception_payload( $token_raw, $token_form );
-			$has_exception              = null !== $schedule_exception_payload;
+		$ctx = new Submission\SubmissionContext();
+
+		// Entry pipeline (#563 Sprint 1): each guard validates or resolves
+		// one concern, populating the context or throwing SubmissionRejected
+		// carrying the exact wp_send_json_error payload the monolith used to
+		// emit inline. The orchestrator stays thin: run the guards in order,
+		// translate a rejection into the single JSON error response. Stages
+		// 14+ (quiz / normal save, PDF, success) remain inline below pending
+		// Sprint 1 PR 1b.
+		try {
+			( new Submission\ScheduleExceptionGuard() )->apply( $ctx );
+			( new Submission\IpRateLimitGuard() )->apply( $ctx );
+			( new Submission\NonceGuard() )->apply( $ctx );
+			( new Submission\SecurityFieldsGuard() )->apply( $ctx );
+			( new Submission\FormConfigResolver() )->apply( $ctx );
+			( new Submission\PreflightGuard() )->apply( $ctx );
+			( new Submission\FieldSanitizer() )->apply( $ctx );
+			( new Submission\DeviceSignalsResolver() )->apply( $ctx );
+			( new Submission\GeofenceGuard() )->apply( $ctx );
+			( new Submission\RateLimitGuard() )->apply( $ctx );
+			( new Submission\AccessRestrictionGuard() )->apply( $ctx );
+		} catch ( Submission\SubmissionRejected $rejected ) {
+			wp_send_json_error( $rejected->get_payload() );
 		}
 
-		// Rate limit by IP — run BEFORE nonce/CAPTCHA to prevent brute-force.
-		// and DoS attacks from consuming server resources on expensive checks.
-		//
-		// Skipped on the exception path: operators handing tablets at a
-		// venue routinely concentrate submissions on one outbound IP, and
-		// the signed token already binds the bypass to a 30-minute
-		// operator-issued window. Per-CPF rate-limits (in
-		// `RateLimiter::check_all()` below) still apply normally so a
-		// single participant can't replay the token across submissions.
-		if ( ! $has_exception && class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
-			$user_ip    = \FreeFormCertificate\Core\Utils::get_user_ip();
-			$rate_check = \FreeFormCertificate\Security\RateLimiter::check_ip_limit( $user_ip );
-			if ( ! $rate_check['allowed'] ) {
-				wp_send_json_error(
-					array(
-						'message'      => $rate_check['message'] ?? __( 'Too many requests. Please wait.', 'ffcertificate' ),
-						'rate_limit'   => true,
-						'wait_seconds' => $rate_check['wait_seconds'] ?? 0,
-					)
-				);
-			}
-		}
-
-		// Verify nonce.
-		//
-		// 6.6.3 — when the nonce check fails, hand back a fresh nonce
-		// keyed to the visitor's current session cookie so the client
-		// (FFC.request) can transparently retry once. This works around:
-		//
-		// - cached HTML carrying another visitor's nonce on shared
-		// hosts (cache-bust on assets doesn't help because the page
-		// HTML itself is what's cached);
-		// - iOS Safari ITP / iCloud Private Relay rotating the session
-		// cookie between page render and submit;
-		// - ffc-dynamic-fragments silently failing on some networks
-		// (the catch in that script swallows XHR errors).
-		//
-		// Safety: a stale-nonce auto-refresh is not a CSRF weakening.
-		// The fresh nonce is bound to the cookie of the request that
-		// asks for it; an attacker who can't present a valid cookie
-		// can't use the returned nonce. Callers are also guarded
-		// against retry loops (options._ffcNonceRetried in ffc-core.js).
-		if ( ! wp_verify_nonce( Utils::get_post_string( 'nonce' ), 'ffc_frontend_nonce' ) ) {
-			wp_send_json_error(
-				array(
-					'message'       => __( 'Security check failed. Please refresh the page.', 'ffcertificate' ),
-					'refresh_nonce' => true,
-					'new_nonce'     => wp_create_nonce( 'ffc_frontend_nonce' ),
-				)
-			);
-		}
-
-        // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above via wp_verify_nonce.
-
-		// ===== DEBUG CAPTCHA =====.
-		\FreeFormCertificate\Core\Debug::log_form( '===== CAPTCHA DEBUG =====' );
-		\FreeFormCertificate\Core\Debug::log_form( 'Answer received', Utils::get_post_string( 'ffc_captcha_ans', 'NOT SET' ) );
-		\FreeFormCertificate\Core\Debug::log_form( 'Hash received', Utils::get_post_string( 'ffc_captcha_hash', 'NOT SET' ) );
-
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- isset() check only; values sanitized inside block.
-		if ( isset( $_POST['ffc_captcha_ans'] ) && isset( $_POST['ffc_captcha_hash'] ) ) {
-			$test_answer    = trim( Utils::get_post_string( 'ffc_captcha_ans' ) );
-			$received_hash  = Utils::get_post_string( 'ffc_captcha_hash' );
-			$generated_hash = wp_hash( $test_answer . 'ffc_math_salt' );
-
-			\FreeFormCertificate\Core\Debug::log_form( 'Trimmed answer', $test_answer );
-			\FreeFormCertificate\Core\Debug::log_form( 'Generated hash from answer', $generated_hash );
-			\FreeFormCertificate\Core\Debug::log_form( 'Hashes match', $generated_hash === $received_hash ? 'YES' : 'NO' );
-
-			// Test with different variations.
-			\FreeFormCertificate\Core\Debug::log_form( 'Test with (int)', wp_hash( (int) $test_answer . 'ffc_math_salt' ) );
-			\FreeFormCertificate\Core\Debug::log_form( 'Test with (string)', wp_hash( (string) $test_answer . 'ffc_math_salt' ) );
-		}
-		\FreeFormCertificate\Core\Debug::log_form( '===== END CAPTCHA DEBUG =====' );
-		// ===== END DEBUG =====.
-
-		// Validate security fields using FFC_Utils.
-		$security_check = \FreeFormCertificate\Core\SecurityService::validate_security_fields( $_POST );
-		if ( true !== $security_check ) {
-			// Generate new captcha for retry.
-			$new_captcha = \FreeFormCertificate\Core\SecurityService::generate_simple_captcha();
-			wp_send_json_error(
-				array(
-					'message'         => $security_check,
-					'refresh_captcha' => true,
-					'new_label'       => $new_captcha['label'],
-					'new_hash'        => $new_captcha['hash'],
-				)
-			);
-		}
-
-		$form_id = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
-		if ( ! $form_id ) {
-			wp_send_json_error( array( 'message' => __( 'Invalid Form ID.', 'ffcertificate' ) ) );
-		}
-
-		$form_config = get_post_meta( $form_id, '_ffc_form_config', true );
-		if ( ! is_array( $form_config ) ) {
-			$form_config = array();
-		}
-
-		$fields_config = get_post_meta( $form_id, '_ffc_form_fields', true );
-		if ( ! $fields_config ) {
-			// 6.6.4 Sprint 7 — empathetic rewording. The original
-			// "Form configuration not found." reads like a 404 from
-			// the database to a non-technical user. This is always an
-			// admin-side state (deleted form / unsaved config), never
-			// the user's fault — point them at the organizer.
-			wp_send_json_error( array( 'message' => __( 'This form is not available right now. Please contact the organizer.', 'ffcertificate' ) ) );
-		}
-
-		// 6.6.4 Sprint 4 — cheap presence checks BEFORE the field
-		// validation loop. LGPD consent + email presence are O(1)
-		// checks (no CPF checksum, no regex per field); running them
-		// up front lets the user get both errors in a single response
-		// instead of fixing CPF first, then resubmitting, then seeing
-		// the LGPD error. The combined errors array on the wp_send_json
-		// payload mirrors the existing refresh_captcha shape so the
-		// client doesn't need a new code path.
-		$preflight_errors = array();
-
-		// LGPD: trivial string compare, no field loop dependency.
-		if ( Utils::get_post_string( 'ffc_lgpd_consent' ) !== '1' ) {
-			$preflight_errors[] = __( 'You must agree to the Privacy Policy to continue.', 'ffcertificate' );
-		}
-
-		// Email presence: peek at $_POST for any field whose admin-
-		// configured type is 'email'. Catches the empty-email case
-		// without running the full field loop (which does CPF
-		// checksum etc.). Multiple email fields are rare but
-		// supported: if ANY of them is empty the form was incomplete.
-		$email_field_names = array();
-		foreach ( $fields_config as $field ) {
-			if ( isset( $field['type'], $field['name'] ) && 'email' === $field['type'] ) {
-				$email_field_names[] = $field['name'];
-			}
-		}
-		if ( ! empty( $email_field_names ) ) {
-			$email_missing = false;
-			foreach ( $email_field_names as $email_field ) {
-				$raw_email = Utils::get_post_string( $email_field );
-				if ( '' === trim( $raw_email ) ) {
-					$email_missing = true;
-					break;
-				}
-			}
-			if ( $email_missing ) {
-				$preflight_errors[] = __( 'Email address is required.', 'ffcertificate' );
-			}
-		}
-
-		if ( ! empty( $preflight_errors ) ) {
-			wp_send_json_error(
-				array(
-					// Backward-compatible: legacy single-error consumers
-					// read `message` (first error). New consumers can
-					// read the full `errors` array to surface every
-					// missing field at once.
-					'message' => $preflight_errors[0],
-					'errors'  => $preflight_errors,
-				)
-			);
-		}
-
-		// Process and sanitize form fields using FFC_Utils.
-		$submission_data = array();
-		$user_email      = '';
-
-		// Name fields that should be normalized (capitalized with lowercase connectives).
-		$name_fields = array( 'nome_completo', 'nome', 'name', 'full_name', 'ffc_nome', 'participante' );
-
-		foreach ( $fields_config as $field ) {
-			// Skip display-only field types (no user input).
-			if ( isset( $field['type'] ) && in_array( $field['type'], array( 'info', 'embed' ), true ) ) {
-				continue;
-			}
-
-			$name = $field['name'];
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- isset() check only; value unslashed and sanitized below.
-			if ( isset( $_POST[ $name ] ) ) {
-				$value = \FreeFormCertificate\Core\DataSanitizer::recursive_sanitize( wp_unslash( $_POST[ $name ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via recursive_sanitize().
-
-				// Normalize name fields (proper capitalization with lowercase connectives).
-				if ( in_array( $name, $name_fields, true ) && is_string( $value ) && ! empty( $value ) ) {
-					$value = \FreeFormCertificate\Core\DataSanitizer::normalize_brazilian_name( $value );
-				}
-
-				// Special validation for CPF/RF.
-				if ( 'cpf_rf' === $name ) {
-					$value = preg_replace( '/\D/', '', $value );
-
-					// Validate length.
-					if ( strlen( $value ) !== 7 && strlen( $value ) !== 11 ) {
-						wp_send_json_error( array( 'message' => __( 'CPF/RF must be exactly 7 or 11 digits.', 'ffcertificate' ) ) );
-					}
-
-					// Validate CPF (11 digits) using official algorithm.
-					if ( strlen( $value ) === 11 ) {
-						if ( ! \FreeFormCertificate\Core\DocumentFormatter::validate_cpf( $value ) ) {
-							wp_send_json_error( array( 'message' => __( 'Invalid CPF. Please check the number and try again.', 'ffcertificate' ) ) );
-						}
-					}
-
-					// Validate RF (7 digits) - must be numeric.
-					if ( strlen( $value ) === 7 ) {
-						if ( ! \FreeFormCertificate\Core\DocumentFormatter::validate_rf( $value ) ) {
-							wp_send_json_error( array( 'message' => __( 'Invalid RF. Must contain only numbers.', 'ffcertificate' ) ) );
-						}
-					}
-				}
-
-				$submission_data[ $name ] = $value;
-
-				if ( isset( $field['type'] ) && 'email' === $field['type'] ) {
-					// Normalize email to lowercase for consistent storage and lookups.
-					$user_email = strtolower( sanitize_email( $value ) );
-				}
-			}
-		}
-
-		// Defensive: after the field loop ran, the email field may
-		// have failed sanitize_email() despite passing the preflight
-		// presence check (e.g. user typed "not an email"). Keep this
-		// gate as a fallback so $user_email is never empty downstream.
-		if ( empty( $user_email ) ) {
-			wp_send_json_error( array( 'message' => __( 'Email address is required.', 'ffcertificate' ) ) );
-		}
-
-		// LGPD already validated up-front (Sprint 4 pre-flight); just
-		// stamp the consent on the submission data.
-		$submission_data['ffc_lgpd_consent'] = '1';
-
-		// Capture restriction fields (password/ticket) from POST.
-		$val_password = trim( Utils::get_post_string( 'ffc_password' ) );
-		$val_ticket   = strtoupper( trim( Utils::get_post_string( 'ffc_ticket' ) ) );
-
-		$val_cpf = isset( $submission_data['cpf_rf'] ) ? trim( $submission_data['cpf_rf'] ) : '';
-
-		// Step 8.5: Resolve device fingerprint signals + role bypass before
-		// the consolidated rate-limit check. The actual N-of-M test runs
-		// inside RateLimiter::check_all().
-		$device_signals = null;
-		$skip_device    = false;
-		if ( class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
-			$rl_settings         = \FreeFormCertificate\Security\RateLimiter::get_settings();
-			$device_globally_on  = ! empty( $rl_settings['device']['enabled'] );
-			$device_form_enabled = '1' === (string) get_post_meta( $form_id, '_ffc_device_limit_enabled', true );
-
-			if ( $device_globally_on && $device_form_enabled ) {
-				if ( \FreeFormCertificate\Security\RateLimiter::should_bypass_for_manager() ) {
-					$skip_device = true;
-					\FreeFormCertificate\Security\RateLimiter::log_attempt(
-						'device',
-						(string) get_current_user_id(),
-						'allowed',
-						'manager_bypass',
-						$form_id
-					);
-				} else {
-                    // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified earlier in handle_submission_ajax().
-					$raw_signals = isset( $_POST['ffc_device_signals'] ) ? wp_unslash( $_POST['ffc_device_signals'] ) : '';
-					if ( is_string( $raw_signals ) && '' !== $raw_signals ) {
-						$decoded = json_decode( $raw_signals, true );
-						if ( is_array( $decoded ) ) {
-							$clean_signals = array();
-							foreach ( array( 'cookie', 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts' ) as $sig_key ) {
-								if ( isset( $decoded[ $sig_key ] ) && is_string( $decoded[ $sig_key ] ) && preg_match( '/^[a-f0-9]{64}$/i', $decoded[ $sig_key ] ) ) {
-									$clean_signals[ $sig_key ] = strtolower( $decoded[ $sig_key ] );
-								}
-							}
-							if ( ! empty( $clean_signals ) ) {
-								$device_signals = $clean_signals;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// Geofence validation (date/time + geolocation).
-		//
-		// 6.6.4 Sprint 5 — moved BEFORE the consolidated rate-limit
-		// check. Geofence::can_access_form is read-only (single
-		// get_post_meta + optional IP geolocation lookup); the
-		// rate-limit block, in contrast, calls record_attempt() which
-		// writes to the counters. A visitor outside the geofence
-		// (e.g. legitimate user on the edge of the allowed radius
-		// whose GPS imprecision puts them slightly outside) used to
-		// burn rate-limit budget on every fail. Doing the cheaper
-		// read-only check first preserves their budget for the next
-		// legitimate retry.
-		//
-		// Cheap → expensive ordering. Rate-limit IP at the very top
-		// of the handler (step 1) still catches the DoS case before
-		// geofence — geofence isn't a DoS gate, it's an authorization
-		// gate.
-		if ( class_exists( '\FreeFormCertificate\Security\Geofence' ) ) {
-			// Get form geofence config to check if IP validation is enabled.
-			$geofence_config    = \FreeFormCertificate\Security\Geofence::get_form_config( $form_id );
-			$should_validate_ip = false;
-
-			// Backend validation logic:
-			// - Always validate datetime (server-side is authoritative)
-			// - Only validate IP geolocation if explicitly enabled.
-			// - GPS validation happens on frontend (browser geolocation API)
-			// Note: GPS-only mode relies on frontend validation; backend cannot verify GPS.
-			if ( $geofence_config && ! empty( $geofence_config['geo_enabled'] ) && ! empty( $geofence_config['geo_ip_enabled'] ) ) {
-				$should_validate_ip = true;
-			}
-
-			$geofence_check = \FreeFormCertificate\Security\Geofence::can_access_form(
-				$form_id,
-				array(
-					'check_datetime' => true,        // Always validate date/time server-side.
-					'check_geo'      => $should_validate_ip, // Only validate IP if explicitly enabled.
-				)
-			);
-
-			if ( ! $geofence_check['allowed'] ) {
-				wp_send_json_error(
-					array(
-						'message'          => $geofence_check['message'] ?? '',
-						'geofence_blocked' => true,
-						'reason'           => $geofence_check['reason'] ?? '',
-					)
-				);
-			}
-		}
-
-		// Rate Limit Check.
-		if ( class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
-			$ip    = \FreeFormCertificate\Core\Utils::get_user_ip();
-			$email = $user_email;
-			$cpf   = $val_cpf;
-
-			// 6.3.10: a successful reprint of an already-issued certificate
-			// must not be blocked by the per-device limit — that gate is
-			// meant to stop the same device creating multiple FRESH
-			// submissions for different CPFs, not to lock the user out of
-			// re-downloading their own certificate from the same device.
-			// We pre-run ReprintDetector::detect() here (it also runs at
-			// the canonical step ~492 for the actual flow); when it
-			// signals a reprint, we whitelist the device check via the
-			// existing $skip_device flag (same flag that the manager
-			// bypass already uses, so RateLimiter::check_all stays
-			// untouched).
-			if ( ! $skip_device
-				&& '' !== $val_cpf
-				&& class_exists( '\FreeFormCertificate\Frontend\ReprintDetector' ) ) {
-				$reprint_preview = ReprintDetector::detect( $form_id, $val_cpf, $val_ticket );
-				if ( ! empty( $reprint_preview['is_reprint'] ) ) {
-					$skip_device = true;
-				}
-			}
-
-			$rate_check = \FreeFormCertificate\Security\RateLimiter::check_all( $ip, $email, $cpf, $form_id, $device_signals, $skip_device );
-
-			if ( ! $rate_check['allowed'] ) {
-				wp_send_json_error(
-					array(
-						'message'      => $rate_check['message'] ?? 'Rate limit exceeded.',
-						'rate_limit'   => true,
-						'wait_seconds' => $rate_check['wait_seconds'] ?? 0,
-					)
-				);
-			}
-
-			// Record attempt.
-			\FreeFormCertificate\Security\RateLimiter::record_attempt( 'ip', $ip, $form_id );
-			\FreeFormCertificate\Security\RateLimiter::record_attempt( 'email', $email, $form_id );
-			if ( $cpf ) {
-				\FreeFormCertificate\Security\RateLimiter::record_attempt( 'cpf', \FreeFormCertificate\Core\DataSanitizer::normalize_cpf_rf( $cpf ), $form_id );
-			}
-
-			// Persist device fingerprint hashes once the submission row has
-			// been created (so submission_id FK is available). Skipped when
-			// the manager bypass fired or when no usable signals arrived.
-			if ( ! $skip_device && is_array( $device_signals ) ) {
-				$signals_to_record = $device_signals;
-				$target_form_id    = $form_id;
-				add_action(
-					'ffcertificate_after_submission_save',
-					static function ( $submission_id, $saved_form_id ) use ( $signals_to_record, $target_form_id ) {
-						if ( (int) $saved_form_id !== (int) $target_form_id ) {
-							return;
-						}
-						\FreeFormCertificate\Security\RateLimiter::record_device_signals(
-							is_numeric( $submission_id ) ? (int) $submission_id : null,
-							(int) $saved_form_id,
-							$signals_to_record
-						);
-					},
-					10,
-					2
-				);
-			}
-		}
-
-		// Check restrictions (whitelist/denylist/tickets) — delegated to AccessRestrictionChecker.
-		$restriction_result = AccessRestrictionChecker::check( $form_config, $val_cpf, $val_ticket, $form_id );
-
-		if ( ! $restriction_result['allowed'] ) {
-			wp_send_json_error( array( 'message' => $restriction_result['message'] ) );
-		}
+		// Rehydrate the locals the remaining inline stages still read.
+		$form_id                    = $ctx->form_id;
+		$form_config                = $ctx->form_config;
+		$fields_config              = $ctx->fields_config;
+		$submission_data            = $ctx->submission_data;
+		$user_email                 = $ctx->user_email;
+		$val_cpf                    = $ctx->val_cpf;
+		$val_ticket                 = $ctx->val_ticket;
+		$has_exception              = $ctx->has_exception;
+		$schedule_exception_payload = $ctx->schedule_exception_payload;
+		$restriction_result         = $ctx->restriction_result;
 
 		// === Quiz Mode Processing (v4.9.0) ===.
 		$is_quiz         = ! empty( $form_config['quiz_enabled'] ) && '1' === $form_config['quiz_enabled'];
@@ -755,8 +360,6 @@ class FormProcessor {
 				: __( 'Congratulations! Quiz passed. Certificate generated.', 'ffcertificate' );
 		}
 
-        // phpcs:enable WordPress.Security.NonceVerification.Missing
-
 		$response = array(
 			'message'  => $msg,
 			'pdf_data' => $pdf_data,
@@ -876,31 +479,6 @@ class FormProcessor {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Resolve a posted schedule-exception token to its payload IFF it is
-	 * still "live" — signature + expiry valid, scoped to the posted form,
-	 * and its `jti` not already in the consumed ledger (#Item11). Returns
-	 * null otherwise, which the caller treats as "no exception" (no IP-limit
-	 * bypass, no override). The authoritative atomic claim still happens at
-	 * persist time, so a double-click race resolves to one adjusted cert;
-	 * this early check only spares a known-spent token the bypass.
-	 *
-	 * @param string $token_raw  Raw token from the form body.
-	 * @param int    $token_form Posted form id the token must be scoped to.
-	 * @return array<string, mixed>|null Verified payload, or null when not live.
-	 */
-	private static function live_exception_payload( string $token_raw, int $token_form ): ?array {
-		$verified = \FreeFormCertificate\Frontend\ScheduleExceptionSession::verify_token( $token_raw );
-		if ( null === $verified || $token_form <= 0 || (int) ( $verified['form_id'] ?? 0 ) !== $token_form ) {
-			return null;
-		}
-		$jti = (string) ( $verified['jti'] ?? '' );
-		if ( '' === $jti || \FreeFormCertificate\Frontend\ScheduleExceptionSession::is_jti_consumed( $jti ) ) {
-			return null;
-		}
-		return $verified;
 	}
 
 	/**

--- a/includes/frontend/submission/class-ffc-access-restriction-guard.php
+++ b/includes/frontend/submission/class-ffc-access-restriction-guard.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * AccessRestrictionGuard — pipeline stage 13 (#563 Sprint 1).
+ *
+ * Checks the form's access restrictions (whitelist / denylist / tickets)
+ * via AccessRestrictionChecker and stores the result on the context so a
+ * later stage can consume a one-use ticket on a successful new submission.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Whitelist / denylist / ticket access gate.
+ */
+class AccessRestrictionGuard {
+
+	/**
+	 * Reject the request when access restrictions deny it.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When access is denied.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		$restriction_result = \FreeFormCertificate\Frontend\AccessRestrictionChecker::check( $ctx->form_config, $ctx->val_cpf, $ctx->val_ticket, $ctx->form_id );
+
+		if ( ! $restriction_result['allowed'] ) {
+			throw new SubmissionRejected( array( 'message' => $restriction_result['message'] ) );
+		}
+
+		$ctx->restriction_result = $restriction_result;
+	}
+}

--- a/includes/frontend/submission/class-ffc-device-signals-resolver.php
+++ b/includes/frontend/submission/class-ffc-device-signals-resolver.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * DeviceSignalsResolver — pipeline stage 10 (#563 Sprint 1).
+ *
+ * Resolves the device-fingerprint signals + role bypass before the
+ * consolidated rate-limit check. The actual N-of-M test runs inside
+ * RateLimiter::check_all(); this guard only decodes/validates the posted
+ * signals and decides whether the per-device gate is bypassed for a
+ * manager. Never rejects.
+ *
+ * Runs after NonceGuard, so the $_POST read here is nonce-verified.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Device-fingerprint signal resolution (no rejection).
+ */
+class DeviceSignalsResolver {
+
+	/**
+	 * Populate device signals + skip-device flag on the context.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		$device_signals = null;
+		$skip_device    = false;
+		if ( class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
+			$rl_settings         = \FreeFormCertificate\Security\RateLimiter::get_settings();
+			$device_globally_on  = ! empty( $rl_settings['device']['enabled'] );
+			$device_form_enabled = '1' === (string) get_post_meta( $ctx->form_id, '_ffc_device_limit_enabled', true );
+
+			if ( $device_globally_on && $device_form_enabled ) {
+				if ( \FreeFormCertificate\Security\RateLimiter::should_bypass_for_manager() ) {
+					$skip_device = true;
+					\FreeFormCertificate\Security\RateLimiter::log_attempt(
+						'device',
+						(string) get_current_user_id(),
+						'allowed',
+						'manager_bypass',
+						$ctx->form_id
+					);
+				} else {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- nonce verified upstream by NonceGuard; signals validated by strict hex regex below.
+					$raw_signals = isset( $_POST['ffc_device_signals'] ) ? wp_unslash( $_POST['ffc_device_signals'] ) : '';
+					if ( is_string( $raw_signals ) && '' !== $raw_signals ) {
+						$decoded = json_decode( $raw_signals, true );
+						if ( is_array( $decoded ) ) {
+							$clean_signals = array();
+							foreach ( array( 'cookie', 'ua', 'screen', 'tz', 'concurrency', 'memory', 'canvas', 'audio', 'webgl', 'fonts' ) as $sig_key ) {
+								if ( isset( $decoded[ $sig_key ] ) && is_string( $decoded[ $sig_key ] ) && preg_match( '/^[a-f0-9]{64}$/i', $decoded[ $sig_key ] ) ) {
+									$clean_signals[ $sig_key ] = strtolower( $decoded[ $sig_key ] );
+								}
+							}
+							if ( ! empty( $clean_signals ) ) {
+								$device_signals = $clean_signals;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		$ctx->device_signals = $device_signals;
+		$ctx->skip_device    = $skip_device;
+	}
+}

--- a/includes/frontend/submission/class-ffc-field-sanitizer.php
+++ b/includes/frontend/submission/class-ffc-field-sanitizer.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * FieldSanitizer — pipeline stages 8–9 (#563 Sprint 1).
+ *
+ * Processes + sanitizes every submitted field into `submission_data`,
+ * resolves the submitter email, validates CPF/RF, stamps the LGPD consent,
+ * and captures the restriction inputs (password / ticket / cpf) onto the
+ * context. Rejects on an invalid CPF/RF or an empty (post-sanitize) email.
+ *
+ * Runs after NonceGuard, so the $_POST reads here are nonce-verified.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+use FreeFormCertificate\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Field sanitization + CPF/RF validation gate.
+ */
+class FieldSanitizer {
+
+	/**
+	 * Build sanitized submission data + restriction inputs on the context.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When CPF/RF is invalid or email is empty.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		$submission_data = array();
+		$user_email      = '';
+
+		// Name fields that should be normalized (capitalized with lowercase connectives).
+		$name_fields = array( 'nome_completo', 'nome', 'name', 'full_name', 'ffc_nome', 'participante' );
+
+		foreach ( $ctx->fields_config as $field ) {
+			// Skip display-only field types (no user input).
+			if ( isset( $field['type'] ) && in_array( $field['type'], array( 'info', 'embed' ), true ) ) {
+				continue;
+			}
+
+			$name = $field['name'];
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- nonce verified upstream; value unslashed and sanitized below.
+			if ( isset( $_POST[ $name ] ) ) {
+				$value = \FreeFormCertificate\Core\DataSanitizer::recursive_sanitize( wp_unslash( $_POST[ $name ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via recursive_sanitize().
+
+				// Normalize name fields (proper capitalization with lowercase connectives).
+				if ( in_array( $name, $name_fields, true ) && is_string( $value ) && ! empty( $value ) ) {
+					$value = \FreeFormCertificate\Core\DataSanitizer::normalize_brazilian_name( $value );
+				}
+
+				// Special validation for CPF/RF.
+				if ( 'cpf_rf' === $name ) {
+					$value = preg_replace( '/\D/', '', $value );
+
+					// Validate length.
+					if ( strlen( $value ) !== 7 && strlen( $value ) !== 11 ) {
+						throw new SubmissionRejected( array( 'message' => __( 'CPF/RF must be exactly 7 or 11 digits.', 'ffcertificate' ) ) );
+					}
+
+					// Validate CPF (11 digits) using official algorithm.
+					if ( strlen( $value ) === 11 ) {
+						if ( ! \FreeFormCertificate\Core\DocumentFormatter::validate_cpf( $value ) ) {
+							throw new SubmissionRejected( array( 'message' => __( 'Invalid CPF. Please check the number and try again.', 'ffcertificate' ) ) );
+						}
+					}
+
+					// Validate RF (7 digits) - must be numeric.
+					if ( strlen( $value ) === 7 ) {
+						if ( ! \FreeFormCertificate\Core\DocumentFormatter::validate_rf( $value ) ) {
+							throw new SubmissionRejected( array( 'message' => __( 'Invalid RF. Must contain only numbers.', 'ffcertificate' ) ) );
+						}
+					}
+				}
+
+				$submission_data[ $name ] = $value;
+
+				if ( isset( $field['type'] ) && 'email' === $field['type'] ) {
+					// Normalize email to lowercase for consistent storage and lookups.
+					$user_email = strtolower( sanitize_email( $value ) );
+				}
+			}
+		}
+
+		// Defensive: after the field loop ran, the email field may have
+		// failed sanitize_email() despite passing the preflight presence
+		// check (e.g. user typed "not an email"). Keep this gate as a
+		// fallback so $user_email is never empty downstream.
+		if ( empty( $user_email ) ) {
+			throw new SubmissionRejected( array( 'message' => __( 'Email address is required.', 'ffcertificate' ) ) );
+		}
+
+		// LGPD already validated up-front (PreflightGuard); just stamp the
+		// consent on the submission data.
+		$submission_data['ffc_lgpd_consent'] = '1';
+
+		// Capture restriction fields (password/ticket) from POST.
+		$val_password = trim( Utils::get_post_string( 'ffc_password' ) );
+		$val_ticket   = strtoupper( trim( Utils::get_post_string( 'ffc_ticket' ) ) );
+		$val_cpf      = isset( $submission_data['cpf_rf'] ) ? trim( (string) $submission_data['cpf_rf'] ) : '';
+
+		$ctx->submission_data = $submission_data;
+		$ctx->user_email      = $user_email;
+		$ctx->val_password    = $val_password;
+		$ctx->val_ticket      = $val_ticket;
+		$ctx->val_cpf         = $val_cpf;
+	}
+}

--- a/includes/frontend/submission/class-ffc-form-config-resolver.php
+++ b/includes/frontend/submission/class-ffc-form-config-resolver.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * FormConfigResolver — pipeline stage 6 (#563 Sprint 1).
+ *
+ * Resolves the posted form id and loads its `_ffc_form_config` /
+ * `_ffc_form_fields` post meta onto the context. Rejects on a missing form
+ * id or absent field config (always an admin-side state — deleted form /
+ * unsaved config — never the user's fault, so the message points them at
+ * the organizer).
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Form id + config resolution gate.
+ */
+class FormConfigResolver {
+
+	/**
+	 * Resolve form id + config onto the context.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When the form id is invalid or config is absent.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce verified upstream by NonceGuard.
+		$form_id = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
+		if ( ! $form_id ) {
+			throw new SubmissionRejected( array( 'message' => __( 'Invalid Form ID.', 'ffcertificate' ) ) );
+		}
+
+		$form_config = get_post_meta( $form_id, '_ffc_form_config', true );
+		if ( ! is_array( $form_config ) ) {
+			$form_config = array();
+		}
+
+		$fields_config = get_post_meta( $form_id, '_ffc_form_fields', true );
+		if ( ! $fields_config ) {
+			throw new SubmissionRejected( array( 'message' => __( 'This form is not available right now. Please contact the organizer.', 'ffcertificate' ) ) );
+		}
+
+		$ctx->form_id       = $form_id;
+		$ctx->form_config   = $form_config;
+		$ctx->fields_config = is_array( $fields_config ) ? $fields_config : array();
+	}
+}

--- a/includes/frontend/submission/class-ffc-geofence-guard.php
+++ b/includes/frontend/submission/class-ffc-geofence-guard.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * GeofenceGuard — pipeline stage 11 (#563 Sprint 1).
+ *
+ * Geofence validation (date/time + geolocation), run BEFORE the
+ * consolidated rate-limit check. Geofence::can_access_form is read-only
+ * (single get_post_meta + optional IP geolocation lookup); the rate-limit
+ * block, in contrast, records attempts (writes). Doing the cheaper
+ * read-only check first preserves a near-miss visitor's rate-limit budget
+ * for their next legitimate retry. The IP throttle (stage 2) already
+ * catches the DoS case before geofence — geofence is an authorization
+ * gate, not a DoS gate.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Date/time + geolocation authorization gate.
+ */
+class GeofenceGuard {
+
+	/**
+	 * Reject the request when the visitor is outside the geofence.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When geofence access is denied.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		if ( class_exists( '\FreeFormCertificate\Security\Geofence' ) ) {
+			// Get form geofence config to check if IP validation is enabled.
+			$geofence_config    = \FreeFormCertificate\Security\Geofence::get_form_config( $ctx->form_id );
+			$should_validate_ip = false;
+
+			// Backend validation logic:
+			// - Always validate datetime (server-side is authoritative)
+			// - Only validate IP geolocation if explicitly enabled.
+			// - GPS validation happens on the frontend (browser geolocation API).
+			if ( $geofence_config && ! empty( $geofence_config['geo_enabled'] ) && ! empty( $geofence_config['geo_ip_enabled'] ) ) {
+				$should_validate_ip = true;
+			}
+
+			$geofence_check = \FreeFormCertificate\Security\Geofence::can_access_form(
+				$ctx->form_id,
+				array(
+					'check_datetime' => true,                  // Always validate date/time server-side.
+					'check_geo'      => $should_validate_ip,   // Only validate IP if explicitly enabled.
+				)
+			);
+
+			if ( ! $geofence_check['allowed'] ) {
+				throw new SubmissionRejected(
+					array(
+						'message'          => $geofence_check['message'] ?? '',
+						'geofence_blocked' => true,
+						'reason'           => $geofence_check['reason'] ?? '',
+					)
+				);
+			}
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-ip-rate-limit-guard.php
+++ b/includes/frontend/submission/class-ffc-ip-rate-limit-guard.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * IpRateLimitGuard — pipeline stage 2 (#563 Sprint 1).
+ *
+ * Rate limit by IP, run BEFORE nonce/CAPTCHA to prevent brute-force and
+ * DoS attacks from consuming server resources on expensive checks.
+ *
+ * Skipped on the exception path: operators handing tablets at a venue
+ * routinely concentrate submissions on one outbound IP, and the signed
+ * token already binds the bypass to a 30-minute operator-issued window.
+ * Per-CPF rate-limits (in RateLimiter::check_all() later) still apply so a
+ * single participant can't replay the token across submissions.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Per-IP throttle gate.
+ */
+class IpRateLimitGuard {
+
+	/**
+	 * Reject the request when the visitor's IP is over the limit.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When the IP is rate-limited.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		if ( ! $ctx->has_exception && class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
+			$user_ip    = \FreeFormCertificate\Core\Utils::get_user_ip();
+			$rate_check = \FreeFormCertificate\Security\RateLimiter::check_ip_limit( $user_ip );
+			if ( ! $rate_check['allowed'] ) {
+				throw new SubmissionRejected(
+					array(
+						'message'      => $rate_check['message'] ?? __( 'Too many requests. Please wait.', 'ffcertificate' ),
+						'rate_limit'   => true,
+						'wait_seconds' => $rate_check['wait_seconds'] ?? 0,
+					)
+				);
+			}
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-nonce-guard.php
+++ b/includes/frontend/submission/class-ffc-nonce-guard.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * NonceGuard — pipeline stage 3 (#563 Sprint 1).
+ *
+ * Verifies the WP nonce. On failure, hands back a fresh nonce keyed to the
+ * visitor's current session cookie so the client (FFC.request) can
+ * transparently retry once. This works around cached HTML carrying another
+ * visitor's nonce on shared hosts, iOS Safari ITP / iCloud Private Relay
+ * rotating the session cookie between render and submit, and
+ * ffc-dynamic-fragments silently failing on some networks.
+ *
+ * Safety: a stale-nonce auto-refresh is not a CSRF weakening. The fresh
+ * nonce is bound to the cookie of the request that asks for it; an attacker
+ * who can't present a valid cookie can't use the returned nonce. Callers
+ * are guarded against retry loops (options._ffcNonceRetried in ffc-core.js).
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+use FreeFormCertificate\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WP nonce verification gate.
+ */
+class NonceGuard {
+
+	/**
+	 * Reject the request with a fresh nonce when verification fails.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When the nonce is invalid.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		if ( ! wp_verify_nonce( Utils::get_post_string( 'nonce' ), 'ffc_frontend_nonce' ) ) {
+			throw new SubmissionRejected(
+				array(
+					'message'       => __( 'Security check failed. Please refresh the page.', 'ffcertificate' ),
+					'refresh_nonce' => true,
+					'new_nonce'     => wp_create_nonce( 'ffc_frontend_nonce' ),
+				)
+			);
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-preflight-guard.php
+++ b/includes/frontend/submission/class-ffc-preflight-guard.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * PreflightGuard — pipeline stage 7 (#563 Sprint 1).
+ *
+ * Cheap O(1) presence checks BEFORE the field-validation loop: LGPD consent
+ * + email presence. Running them up front lets the user get both errors in a
+ * single response instead of fixing CPF first, resubmitting, then seeing the
+ * LGPD error. The combined `errors` array mirrors the legacy refresh_captcha
+ * shape so the client needs no new code path.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+use FreeFormCertificate\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * LGPD consent + email-presence preflight gate.
+ */
+class PreflightGuard {
+
+	/**
+	 * Reject the request when consent or email presence is missing.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected With every preflight error at once.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		$preflight_errors = array();
+
+		// LGPD: trivial string compare, no field loop dependency.
+		if ( Utils::get_post_string( 'ffc_lgpd_consent' ) !== '1' ) {
+			$preflight_errors[] = __( 'You must agree to the Privacy Policy to continue.', 'ffcertificate' );
+		}
+
+		// Email presence: peek at the admin-configured 'email' fields.
+		$email_field_names = array();
+		foreach ( $ctx->fields_config as $field ) {
+			if ( isset( $field['type'], $field['name'] ) && 'email' === $field['type'] ) {
+				$email_field_names[] = $field['name'];
+			}
+		}
+		if ( ! empty( $email_field_names ) ) {
+			$email_missing = false;
+			foreach ( $email_field_names as $email_field ) {
+				$raw_email = Utils::get_post_string( $email_field );
+				if ( '' === trim( $raw_email ) ) {
+					$email_missing = true;
+					break;
+				}
+			}
+			if ( $email_missing ) {
+				$preflight_errors[] = __( 'Email address is required.', 'ffcertificate' );
+			}
+		}
+
+		if ( ! empty( $preflight_errors ) ) {
+			throw new SubmissionRejected(
+				array(
+					// Backward-compatible: legacy single-error consumers read
+					// `message` (first error). New consumers read the full
+					// `errors` array to surface every missing field at once.
+					'message' => $preflight_errors[0],
+					'errors'  => $preflight_errors,
+				)
+			);
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-rate-limit-guard.php
+++ b/includes/frontend/submission/class-ffc-rate-limit-guard.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * RateLimitGuard — pipeline stage 12 (#563 Sprint 1).
+ *
+ * The consolidated rate-limit check (IP + email + CPF + device). Pre-runs
+ * ReprintDetector so a legitimate reprint from the same device whitelists
+ * the per-device gate (via skip_device). On pass it records the IP / email /
+ * CPF attempts and registers a deferred hook to persist the device-signal
+ * hashes once the submission row exists (the FK becomes available only
+ * after save, which the orchestrator performs in a later stage).
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Consolidated rate-limit gate.
+ */
+class RateLimitGuard {
+
+	/**
+	 * Reject the request when any rate-limit dimension is exceeded.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When a rate limit is exceeded.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		if ( ! class_exists( '\FreeFormCertificate\Security\RateLimiter' ) ) {
+			return;
+		}
+
+		$ip    = \FreeFormCertificate\Core\Utils::get_user_ip();
+		$email = $ctx->user_email;
+		$cpf   = $ctx->val_cpf;
+
+		// 6.3.10: a successful reprint of an already-issued certificate must
+		// not be blocked by the per-device limit — that gate stops the same
+		// device creating multiple FRESH submissions for different CPFs, not
+		// re-downloading one's own certificate. Pre-run ReprintDetector and
+		// whitelist the device check via the existing skip_device flag (same
+		// flag the manager bypass uses, so check_all stays untouched).
+		if ( ! $ctx->skip_device
+			&& '' !== $ctx->val_cpf
+			&& class_exists( '\FreeFormCertificate\Frontend\ReprintDetector' ) ) {
+			$reprint_preview = \FreeFormCertificate\Frontend\ReprintDetector::detect( $ctx->form_id, $ctx->val_cpf, $ctx->val_ticket );
+			if ( ! empty( $reprint_preview['is_reprint'] ) ) {
+				$ctx->skip_device = true;
+			}
+		}
+
+		$rate_check = \FreeFormCertificate\Security\RateLimiter::check_all( $ip, $email, $cpf, $ctx->form_id, $ctx->device_signals, $ctx->skip_device );
+
+		if ( ! $rate_check['allowed'] ) {
+			throw new SubmissionRejected(
+				array(
+					'message'      => $rate_check['message'] ?? 'Rate limit exceeded.',
+					'rate_limit'   => true,
+					'wait_seconds' => $rate_check['wait_seconds'] ?? 0,
+				)
+			);
+		}
+
+		// Record attempt.
+		\FreeFormCertificate\Security\RateLimiter::record_attempt( 'ip', $ip, $ctx->form_id );
+		\FreeFormCertificate\Security\RateLimiter::record_attempt( 'email', $email, $ctx->form_id );
+		if ( $cpf ) {
+			\FreeFormCertificate\Security\RateLimiter::record_attempt( 'cpf', \FreeFormCertificate\Core\DataSanitizer::normalize_cpf_rf( $cpf ), $ctx->form_id );
+		}
+
+		// Persist device fingerprint hashes once the submission row has been
+		// created (so the submission_id FK is available). Skipped when the
+		// manager bypass fired or when no usable signals arrived.
+		if ( ! $ctx->skip_device && is_array( $ctx->device_signals ) ) {
+			$signals_to_record = $ctx->device_signals;
+			$target_form_id    = $ctx->form_id;
+			add_action(
+				'ffcertificate_after_submission_save',
+				static function ( $submission_id, $saved_form_id ) use ( $signals_to_record, $target_form_id ) {
+					if ( (int) $saved_form_id !== (int) $target_form_id ) {
+						return;
+					}
+					\FreeFormCertificate\Security\RateLimiter::record_device_signals(
+						is_numeric( $submission_id ) ? (int) $submission_id : null,
+						(int) $saved_form_id,
+						$signals_to_record
+					);
+				},
+				10,
+				2
+			);
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-schedule-exception-guard.php
+++ b/includes/frontend/submission/class-ffc-schedule-exception-guard.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * ScheduleExceptionGuard — pipeline stage 1 (#563 Sprint 1).
+ *
+ * Reads + verifies the hidden schedule-exception token Sprint 5 embeds in
+ * the form. A valid payload means an operator staged this submission as an
+ * exception; downstream the orchestrator (a) skips the IP rate-limit gate,
+ * (b) persists the override TIME columns, (c) emits two audit rows. Run
+ * before the IP gate so the operator's bypass takes effect even when the
+ * venue's network has saturated the per-IP throttle.
+ *
+ * The token IS a signed credential (HMAC over the payload + 30 min expiry +
+ * form_id binding), so verifying it before the WP nonce check is safe — the
+ * token is the auth for the exception path, not the nonce.
+ *
+ * Never rejects: a missing/invalid token simply means "no exception".
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves the schedule-exception token into the submission context.
+ */
+class ScheduleExceptionGuard {
+
+	/**
+	 * Populate the schedule-exception state on the context.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput -- token verified via HMAC immediately below; form_id sanitized via absint.
+		if ( isset( $_POST['ffc_schedule_exception_token'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- HMAC verifies integrity.
+			$token_raw = (string) wp_unslash( $_POST['ffc_schedule_exception_token'] );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$token_form = isset( $_POST['form_id'] ) ? absint( wp_unslash( $_POST['form_id'] ) ) : 0;
+
+			$payload                         = self::live_exception_payload( $token_raw, $token_form );
+			$ctx->schedule_exception_payload = $payload;
+			$ctx->has_exception              = null !== $payload;
+		}
+	}
+
+	/**
+	 * Resolve a posted schedule-exception token to its payload IFF it is
+	 * still "live" — signature + expiry valid, scoped to the posted form,
+	 * and its `jti` not already in the consumed ledger (#Item11). Returns
+	 * null otherwise, which the caller treats as "no exception" (no IP-limit
+	 * bypass, no override). The authoritative atomic claim still happens at
+	 * persist time, so a double-click race resolves to one adjusted cert;
+	 * this early check only spares a known-spent token the bypass.
+	 *
+	 * @param string $token_raw  Raw token from the form body.
+	 * @param int    $token_form Posted form id the token must be scoped to.
+	 * @return array<string, mixed>|null Verified payload, or null when not live.
+	 */
+	public static function live_exception_payload( string $token_raw, int $token_form ): ?array {
+		$verified = \FreeFormCertificate\Frontend\ScheduleExceptionSession::verify_token( $token_raw );
+		if ( null === $verified || $token_form <= 0 || (int) ( $verified['form_id'] ?? 0 ) !== $token_form ) {
+			return null;
+		}
+		$jti = (string) ( $verified['jti'] ?? '' );
+		if ( '' === $jti || \FreeFormCertificate\Frontend\ScheduleExceptionSession::is_jti_consumed( $jti ) ) {
+			return null;
+		}
+		return $verified;
+	}
+}

--- a/includes/frontend/submission/class-ffc-security-fields-guard.php
+++ b/includes/frontend/submission/class-ffc-security-fields-guard.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * SecurityFieldsGuard — pipeline stages 4–5 (#563 Sprint 1).
+ *
+ * Emits the CAPTCHA debug trace, then validates the security fields
+ * (math CAPTCHA + honeypot) via SecurityService. On failure it mints a
+ * fresh CAPTCHA so the client can retry inline.
+ *
+ * Runs after NonceGuard, so the $_POST read here is nonce-verified.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+use FreeFormCertificate\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CAPTCHA + honeypot validation gate.
+ */
+class SecurityFieldsGuard {
+
+	/**
+	 * Reject the request when the security fields fail validation.
+	 *
+	 * @param SubmissionContext $ctx Submission context.
+	 * @throws SubmissionRejected When CAPTCHA / honeypot validation fails.
+	 */
+	public function apply( SubmissionContext $ctx ): void {
+		// ===== DEBUG CAPTCHA =====.
+		\FreeFormCertificate\Core\Debug::log_form( '===== CAPTCHA DEBUG =====' );
+		\FreeFormCertificate\Core\Debug::log_form( 'Answer received', Utils::get_post_string( 'ffc_captcha_ans', 'NOT SET' ) );
+		\FreeFormCertificate\Core\Debug::log_form( 'Hash received', Utils::get_post_string( 'ffc_captcha_hash', 'NOT SET' ) );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- isset() check only; values read via sanitized accessor below.
+		if ( isset( $_POST['ffc_captcha_ans'] ) && isset( $_POST['ffc_captcha_hash'] ) ) {
+			$test_answer    = trim( Utils::get_post_string( 'ffc_captcha_ans' ) );
+			$received_hash  = Utils::get_post_string( 'ffc_captcha_hash' );
+			$generated_hash = wp_hash( $test_answer . 'ffc_math_salt' );
+
+			\FreeFormCertificate\Core\Debug::log_form( 'Trimmed answer', $test_answer );
+			\FreeFormCertificate\Core\Debug::log_form( 'Generated hash from answer', $generated_hash );
+			\FreeFormCertificate\Core\Debug::log_form( 'Hashes match', $generated_hash === $received_hash ? 'YES' : 'NO' );
+
+			// Test with different variations.
+			\FreeFormCertificate\Core\Debug::log_form( 'Test with (int)', wp_hash( (int) $test_answer . 'ffc_math_salt' ) );
+			\FreeFormCertificate\Core\Debug::log_form( 'Test with (string)', wp_hash( (string) $test_answer . 'ffc_math_salt' ) );
+		}
+		\FreeFormCertificate\Core\Debug::log_form( '===== END CAPTCHA DEBUG =====' );
+		// ===== END DEBUG =====.
+
+		// Validate security fields (CAPTCHA + honeypot).
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- nonce verified by NonceGuard; SecurityService sanitizes internally.
+		$security_check = \FreeFormCertificate\Core\SecurityService::validate_security_fields( $_POST );
+		if ( true !== $security_check ) {
+			// Generate new captcha for retry.
+			$new_captcha = \FreeFormCertificate\Core\SecurityService::generate_simple_captcha();
+			throw new SubmissionRejected(
+				array(
+					'message'         => $security_check,
+					'refresh_captcha' => true,
+					'new_label'       => $new_captcha['label'],
+					'new_hash'        => $new_captcha['hash'],
+				)
+			);
+		}
+	}
+}

--- a/includes/frontend/submission/class-ffc-submission-context.php
+++ b/includes/frontend/submission/class-ffc-submission-context.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * SubmissionContext
+ *
+ * Mutable value object threaded through the submission entry guards
+ * (#563 Sprint 1). Each guard reads what it needs and writes back the
+ * state later stages depend on, replacing the long run of local
+ * variables the monolithic `handle_submission_ajax()` used to carry.
+ *
+ * Intentionally a plain DTO (public typed properties, no behaviour) so
+ * guards stay the unit under test and the context is trivial to assemble
+ * in tests.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared state for the submission pipeline.
+ */
+class SubmissionContext {
+
+	/**
+	 * Whether a valid schedule-exception token accompanied the request.
+	 *
+	 * @var bool
+	 */
+	public bool $has_exception = false;
+
+	/**
+	 * Verified schedule-exception payload, or null when none.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	public ?array $schedule_exception_payload = null;
+
+	/**
+	 * Resolved form post id.
+	 *
+	 * @var int
+	 */
+	public int $form_id = 0;
+
+	/**
+	 * `_ffc_form_config` post meta.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public array $form_config = array();
+
+	/**
+	 * `_ffc_form_fields` post meta.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $fields_config = array();
+
+	/**
+	 * Sanitized submission values keyed by field name.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public array $submission_data = array();
+
+	/**
+	 * Normalized (lowercased) submitter email.
+	 *
+	 * @var string
+	 */
+	public string $user_email = '';
+
+	/**
+	 * Restriction password captured from POST.
+	 *
+	 * @var string
+	 */
+	public string $val_password = '';
+
+	/**
+	 * Restriction ticket captured from POST (uppercased).
+	 *
+	 * @var string
+	 */
+	public string $val_ticket = '';
+
+	/**
+	 * Submitted CPF/RF digits, when present.
+	 *
+	 * @var string
+	 */
+	public string $val_cpf = '';
+
+	/**
+	 * Cleaned device-fingerprint signals, or null when none usable.
+	 *
+	 * @var array<string, string>|null
+	 */
+	public ?array $device_signals = null;
+
+	/**
+	 * Whether the per-device rate-limit gate is bypassed (manager / reprint).
+	 *
+	 * @var bool
+	 */
+	public bool $skip_device = false;
+
+	/**
+	 * Result of the access-restriction check (whitelist/ticket/etc.).
+	 *
+	 * @var array<string, mixed>
+	 */
+	public array $restriction_result = array();
+}

--- a/includes/frontend/submission/class-ffc-submission-rejected.php
+++ b/includes/frontend/submission/class-ffc-submission-rejected.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SubmissionRejected
+ *
+ * Single rejection channel for the submission pipeline (#563 Sprint 1).
+ * Each entry guard throws this exception carrying the exact array payload
+ * the legacy `handle_submission_ajax()` used to hand to
+ * `wp_send_json_error()`. The thin orchestrator catches it once and emits
+ * that payload, so the external JSON contract (keys, ordering, single exit)
+ * stays byte-identical while each gate becomes a pure, testable unit.
+ *
+ * @package FreeFormCertificate\Frontend\Submission
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Frontend\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Carries a `wp_send_json_error()` payload from a guard to the orchestrator.
+ */
+class SubmissionRejected extends \Exception {
+
+	/**
+	 * The error payload to hand to wp_send_json_error().
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $payload;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string, mixed> $payload Error payload (same shape the
+	 *                                      legacy handler passed to
+	 *                                      wp_send_json_error()).
+	 */
+	public function __construct( array $payload ) {
+		$this->payload = $payload;
+		$message       = isset( $payload['message'] ) && is_string( $payload['message'] ) ? $payload['message'] : '';
+		parent::__construct( $message );
+	}
+
+	/**
+	 * The error payload for wp_send_json_error().
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_payload(): array {
+		return $this->payload;
+	}
+}

--- a/includes/submissions/class-ffc-submission-handler.php
+++ b/includes/submissions/class-ffc-submission-handler.php
@@ -110,12 +110,12 @@ class SubmissionHandler {
 	 *
 	 * @uses Repository::insert()
 	 *
-	 * @param int                  $form_id         Form ID.
-	 * @param string               $form_title      Form title.
-	 * @param array<string, mixed> $submission_data Submission data (passed by reference).
-	 * @param string               $user_email      User email.
-	 * @param array<string, mixed> $fields_config   Fields configuration.
-	 * @param array<string, mixed> $form_config     Form configuration.
+	 * @param int                              $form_id         Form ID.
+	 * @param string                           $form_title      Form title.
+	 * @param array<string, mixed>             $submission_data Submission data (passed by reference).
+	 * @param string                           $user_email      User email.
+	 * @param array<int, array<string, mixed>> $fields_config   Fields configuration (list of field definitions).
+	 * @param array<string, mixed>             $form_config     Form configuration.
 	 * @return int|\WP_Error
 	 */
 	public function process_submission( int $form_id, string $form_title, array &$submission_data, string $user_email, array $fields_config, array $form_config ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -163,4 +163,18 @@
     <rule ref="Squiz.PHP.CommentedOutCode">
         <exclude name="Squiz.PHP.CommentedOutCode.Found"/>
     </rule>
+
+    <!--
+        #563 Sprint 1 — submission pipeline guards throw SubmissionRejected
+        carrying a wp_send_json_error() *payload array*, never an HTML-output
+        message. The exception is always caught by the FormProcessor
+        orchestrator and routed through wp_send_json_error() (JSON), so the
+        sniff's concern (an uncaught exception message echoed to the page)
+        cannot occur here. Escaping these translated strings with esc_html()
+        would corrupt apostrophes in the user-facing JSON messages. Scope the
+        exclusion narrowly to the guard directory.
+    -->
+    <rule ref="WordPress.Security.EscapeOutput.ExceptionNotEscaped">
+        <exclude-pattern>*/includes/frontend/submission/*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/tests/Unit/FormProcessorScheduleExceptionTest.php
+++ b/tests/Unit/FormProcessorScheduleExceptionTest.php
@@ -292,10 +292,10 @@ class FormProcessorScheduleExceptionTest extends TestCase {
      * @return array<string, mixed>|null
      */
     private function invoke_live( string $token, int $form ) {
-        $ref = new \ReflectionMethod( FormProcessor::class, 'live_exception_payload' );
-        $ref->setAccessible( true );
+        // #563 Sprint 1 — live_exception_payload moved to ScheduleExceptionGuard
+        // (stage 1). It is a public static resolver now, so call it directly.
         /** @var array<string, mixed>|null $out */
-        $out = $ref->invoke( null, $token, $form );
+        $out = \FreeFormCertificate\Frontend\Submission\ScheduleExceptionGuard::live_exception_payload( $token, $form );
         return $out;
     }
 

--- a/tests/Unit/SubmissionGuardsTest.php
+++ b/tests/Unit/SubmissionGuardsTest.php
@@ -1,0 +1,365 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Frontend\Submission\SubmissionContext;
+use FreeFormCertificate\Frontend\Submission\SubmissionRejected;
+use FreeFormCertificate\Frontend\Submission\IpRateLimitGuard;
+use FreeFormCertificate\Frontend\Submission\NonceGuard;
+use FreeFormCertificate\Frontend\Submission\SecurityFieldsGuard;
+use FreeFormCertificate\Frontend\Submission\FormConfigResolver;
+use FreeFormCertificate\Frontend\Submission\PreflightGuard;
+use FreeFormCertificate\Frontend\Submission\FieldSanitizer;
+use FreeFormCertificate\Frontend\Submission\DeviceSignalsResolver;
+use FreeFormCertificate\Frontend\Submission\GeofenceGuard;
+use FreeFormCertificate\Frontend\Submission\RateLimitGuard;
+use FreeFormCertificate\Frontend\Submission\AccessRestrictionGuard;
+use FreeFormCertificate\Frontend\Submission\ScheduleExceptionGuard;
+
+/**
+ * #563 Sprint 1 — unit tests for the extracted submission entry guards.
+ *
+ * Each guard is exercised in isolation against a SubmissionContext: this is
+ * the testability win the pipeline split delivers (the legacy monolith could
+ * only be driven end-to-end). Static collaborators are alias-mocked, so each
+ * test runs in its own process.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SubmissionGuardsTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_email' )->returnArg();
+		Functions\when( 'absint' )->alias( 'intval' );
+	}
+
+	protected function tearDown(): void {
+		$_POST = array();
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	private function ctx(): SubmissionContext {
+		return new SubmissionContext();
+	}
+
+	// ===================== ScheduleExceptionGuard =====================
+
+	public function test_schedule_exception_guard_is_noop_without_token(): void {
+		$_POST = array();
+		$ctx   = $this->ctx();
+		( new ScheduleExceptionGuard() )->apply( $ctx );
+		$this->assertFalse( $ctx->has_exception );
+		$this->assertNull( $ctx->schedule_exception_payload );
+	}
+
+	// ===================== IpRateLimitGuard =====================
+
+	public function test_ip_guard_throws_when_over_limit(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'check_ip_limit' )->andReturn(
+			array( 'allowed' => false, 'message' => 'slow down', 'wait_seconds' => 30 )
+		);
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		try {
+			( new IpRateLimitGuard() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$payload = $e->get_payload();
+			$this->assertTrue( $payload['rate_limit'] );
+			$this->assertSame( 30, $payload['wait_seconds'] );
+		}
+	}
+
+	public function test_ip_guard_passes_when_allowed(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'check_ip_limit' )->andReturn( array( 'allowed' => true ) );
+		$ctx = $this->ctx();
+		( new IpRateLimitGuard() )->apply( $ctx );
+		$this->assertFalse( $ctx->has_exception );
+	}
+
+	public function test_ip_guard_skipped_on_exception_path(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldNotReceive( 'check_ip_limit' );
+		$ctx                = $this->ctx();
+		$ctx->has_exception = true;
+		( new IpRateLimitGuard() )->apply( $ctx );
+		$this->assertTrue( $ctx->has_exception );
+	}
+
+	// ===================== NonceGuard =====================
+
+	public function test_nonce_guard_throws_with_fresh_nonce_when_invalid(): void {
+		Functions\when( 'wp_verify_nonce' )->justReturn( false );
+		Functions\when( 'wp_create_nonce' )->justReturn( 'fresh-nonce' );
+		$_POST = array( 'nonce' => 'stale' );
+
+		try {
+			( new NonceGuard() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$payload = $e->get_payload();
+			$this->assertTrue( $payload['refresh_nonce'] );
+			$this->assertSame( 'fresh-nonce', $payload['new_nonce'] );
+		}
+	}
+
+	public function test_nonce_guard_passes_when_valid(): void {
+		Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		$_POST = array( 'nonce' => 'ok' );
+		( new NonceGuard() )->apply( $this->ctx() );
+		$this->assertTrue( true );
+	}
+
+	// ===================== SecurityFieldsGuard =====================
+
+	public function test_security_guard_throws_with_new_captcha_on_failure(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Core\Debug' )
+			->shouldReceive( 'log_form' )->andReturnNull()->byDefault();
+		$svc = Mockery::mock( 'alias:\FreeFormCertificate\Core\SecurityService' );
+		$svc->shouldReceive( 'validate_security_fields' )->andReturn( 'Wrong answer.' );
+		$svc->shouldReceive( 'generate_simple_captcha' )->andReturn(
+			array( 'label' => '2 + 2', 'hash' => 'h' )
+		);
+		$_POST = array();
+
+		try {
+			( new SecurityFieldsGuard() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$payload = $e->get_payload();
+			$this->assertTrue( $payload['refresh_captcha'] );
+			$this->assertSame( '2 + 2', $payload['new_label'] );
+		}
+	}
+
+	public function test_security_guard_passes_when_valid(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Core\Debug' )
+			->shouldReceive( 'log_form' )->andReturnNull()->byDefault();
+		$svc = Mockery::mock( 'alias:\FreeFormCertificate\Core\SecurityService' );
+		$svc->shouldReceive( 'validate_security_fields' )->andReturn( true );
+		$_POST = array();
+		( new SecurityFieldsGuard() )->apply( $this->ctx() );
+		$this->assertTrue( true );
+	}
+
+	// ===================== FormConfigResolver =====================
+
+	public function test_form_config_resolver_rejects_missing_form_id(): void {
+		$_POST = array();
+		try {
+			( new FormConfigResolver() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertStringContainsString( 'Invalid Form ID', $e->get_payload()['message'] );
+		}
+	}
+
+	public function test_form_config_resolver_rejects_absent_fields(): void {
+		$_POST = array( 'form_id' => 7 );
+		Functions\when( 'get_post_meta' )->alias(
+			static fn( $id, $key ) => '_ffc_form_config' === $key ? array() : ''
+		);
+		try {
+			( new FormConfigResolver() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertStringContainsString( 'not available', $e->get_payload()['message'] );
+		}
+	}
+
+	public function test_form_config_resolver_populates_context(): void {
+		$_POST = array( 'form_id' => 7 );
+		Functions\when( 'get_post_meta' )->alias(
+			static fn( $id, $key ) => '_ffc_form_config' === $key
+				? array( 'quiz_enabled' => '0' )
+				: array( array( 'name' => 'email', 'type' => 'email' ) )
+		);
+		$ctx = $this->ctx();
+		( new FormConfigResolver() )->apply( $ctx );
+		$this->assertSame( 7, $ctx->form_id );
+		$this->assertSame( '0', $ctx->form_config['quiz_enabled'] );
+		$this->assertCount( 1, $ctx->fields_config );
+	}
+
+	// ===================== PreflightGuard =====================
+
+	public function test_preflight_collects_both_lgpd_and_email_errors(): void {
+		$_POST           = array(); // no consent, no email value.
+		$ctx             = $this->ctx();
+		$ctx->fields_config = array( array( 'name' => 'email', 'type' => 'email' ) );
+		try {
+			( new PreflightGuard() )->apply( $ctx );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$errors = $e->get_payload()['errors'];
+			$this->assertCount( 2, $errors );
+		}
+	}
+
+	public function test_preflight_passes_when_consent_and_email_present(): void {
+		$_POST              = array( 'ffc_lgpd_consent' => '1', 'email' => 'a@b.co' );
+		$ctx                = $this->ctx();
+		$ctx->fields_config = array( array( 'name' => 'email', 'type' => 'email' ) );
+		( new PreflightGuard() )->apply( $ctx );
+		$this->assertTrue( true );
+	}
+
+	// ===================== FieldSanitizer =====================
+
+	public function test_field_sanitizer_rejects_bad_cpf_length(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Core\DataSanitizer' )
+			->shouldReceive( 'recursive_sanitize' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$_POST              = array( 'cpf_rf' => '123' );
+		$ctx                = $this->ctx();
+		$ctx->fields_config = array( array( 'name' => 'cpf_rf', 'type' => 'text' ) );
+		try {
+			( new FieldSanitizer() )->apply( $ctx );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertStringContainsString( '7 or 11 digits', $e->get_payload()['message'] );
+		}
+	}
+
+	public function test_field_sanitizer_rejects_when_email_empty(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Core\DataSanitizer' )
+			->shouldReceive( 'recursive_sanitize' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		Functions\when( 'sanitize_email' )->justReturn( '' );
+		$_POST              = array( 'email' => 'not-an-email' );
+		$ctx                = $this->ctx();
+		$ctx->fields_config = array( array( 'name' => 'email', 'type' => 'email' ) );
+		try {
+			( new FieldSanitizer() )->apply( $ctx );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertStringContainsString( 'Email address is required', $e->get_payload()['message'] );
+		}
+	}
+
+	public function test_field_sanitizer_populates_context_on_happy_path(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Core\DataSanitizer' )
+			->shouldReceive( 'recursive_sanitize' )->andReturnUsing( static fn( $v ) => $v )->byDefault();
+		$_POST              = array( 'email' => 'USER@EX.CO', 'ffc_ticket' => 'abc' );
+		$ctx                = $this->ctx();
+		$ctx->fields_config = array( array( 'name' => 'email', 'type' => 'email' ) );
+		( new FieldSanitizer() )->apply( $ctx );
+		$this->assertSame( 'user@ex.co', $ctx->user_email );
+		$this->assertSame( '1', $ctx->submission_data['ffc_lgpd_consent'] );
+		$this->assertSame( 'ABC', $ctx->val_ticket );
+	}
+
+	// ===================== DeviceSignalsResolver =====================
+
+	public function test_device_resolver_null_when_globally_disabled(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'get_settings' )->andReturn( array( 'device' => array( 'enabled' => false ) ) );
+		Functions\when( 'get_post_meta' )->justReturn( '0' );
+		$ctx = $this->ctx();
+		( new DeviceSignalsResolver() )->apply( $ctx );
+		$this->assertNull( $ctx->device_signals );
+		$this->assertFalse( $ctx->skip_device );
+	}
+
+	public function test_device_resolver_sets_skip_on_manager_bypass(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'get_settings' )->andReturn( array( 'device' => array( 'enabled' => true ) ) );
+		$rl->shouldReceive( 'should_bypass_for_manager' )->andReturn( true );
+		$rl->shouldReceive( 'log_attempt' )->andReturnNull();
+		Functions\when( 'get_post_meta' )->justReturn( '1' );
+		Functions\when( 'get_current_user_id' )->justReturn( 5 );
+		$ctx = $this->ctx();
+		( new DeviceSignalsResolver() )->apply( $ctx );
+		$this->assertTrue( $ctx->skip_device );
+	}
+
+	// ===================== GeofenceGuard =====================
+
+	public function test_geofence_guard_throws_when_blocked(): void {
+		$gf = Mockery::mock( 'alias:\FreeFormCertificate\Security\Geofence' );
+		$gf->shouldReceive( 'get_form_config' )->andReturn( array( 'geo_enabled' => false ) );
+		$gf->shouldReceive( 'can_access_form' )->andReturn(
+			array( 'allowed' => false, 'message' => 'outside', 'reason' => 'geo_outside_radius' )
+		);
+		try {
+			( new GeofenceGuard() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$payload = $e->get_payload();
+			$this->assertTrue( $payload['geofence_blocked'] );
+			$this->assertSame( 'geo_outside_radius', $payload['reason'] );
+		}
+	}
+
+	public function test_geofence_guard_passes_when_allowed(): void {
+		$gf = Mockery::mock( 'alias:\FreeFormCertificate\Security\Geofence' );
+		$gf->shouldReceive( 'get_form_config' )->andReturn( array() );
+		$gf->shouldReceive( 'can_access_form' )->andReturn( array( 'allowed' => true ) );
+		( new GeofenceGuard() )->apply( $this->ctx() );
+		$this->assertTrue( true );
+	}
+
+	// ===================== RateLimitGuard =====================
+
+	public function test_rate_limit_guard_throws_when_blocked(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'check_all' )->andReturn(
+			array( 'allowed' => false, 'message' => 'limited', 'wait_seconds' => 12 )
+		);
+		$rl->shouldNotReceive( 'record_attempt' );
+		$ctx              = $this->ctx();
+		$ctx->user_email  = 'a@b.co';
+		try {
+			( new RateLimitGuard() )->apply( $ctx );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertTrue( $e->get_payload()['rate_limit'] );
+		}
+	}
+
+	public function test_rate_limit_guard_records_when_allowed(): void {
+		$rl = Mockery::mock( 'alias:\FreeFormCertificate\Security\RateLimiter' );
+		$rl->shouldReceive( 'check_all' )->andReturn( array( 'allowed' => true ) );
+		$rl->shouldReceive( 'record_attempt' )->atLeast()->once();
+		$ctx             = $this->ctx();
+		$ctx->user_email = 'a@b.co';
+		( new RateLimitGuard() )->apply( $ctx );
+		$this->assertTrue( true );
+	}
+
+	// ===================== AccessRestrictionGuard =====================
+
+	public function test_access_restriction_guard_throws_when_denied(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Frontend\AccessRestrictionChecker' )
+			->shouldReceive( 'check' )->andReturn( array( 'allowed' => false, 'message' => 'nope' ) );
+		try {
+			( new AccessRestrictionGuard() )->apply( $this->ctx() );
+			$this->fail( 'expected SubmissionRejected' );
+		} catch ( SubmissionRejected $e ) {
+			$this->assertSame( 'nope', $e->get_payload()['message'] );
+		}
+	}
+
+	public function test_access_restriction_guard_stores_result_when_allowed(): void {
+		Mockery::mock( 'alias:\FreeFormCertificate\Frontend\AccessRestrictionChecker' )
+			->shouldReceive( 'check' )->andReturn( array( 'allowed' => true, 'is_ticket' => true ) );
+		$ctx = $this->ctx();
+		( new AccessRestrictionGuard() )->apply( $ctx );
+		$this->assertTrue( $ctx->restriction_result['is_ticket'] );
+	}
+}


### PR DESCRIPTION
## #563 Sprint 1 — `FormProcessor` pipeline (PR 1a: entry guards)

First slice of the modular-monolith hardening roadmap. Extracts the **entry stages (1–13)** of the 740-line `FormProcessor::handle_submission_ajax()` god-method into discrete, unit-testable guard classes. **Behavior-preserving** — the JSON contract, gate ordering and exit semantics are unchanged.

### Design (as agreed before coding)
- **Rejection model:** each guard reads/writes a shared `SubmissionContext` DTO or throws `SubmissionRejected` carrying the *exact* `wp_send_json_error()` payload. A thin orchestrator runs the guards in order and translates a rejection into the single JSON error response.
- **Collaborators stay static** this PR (RateLimiter/Geofence/etc.); DI via façades is deferred to its dedicated sprints (4–5), per the issue.
- **Sliced:** stages 14–17 (quiz/normal save, PDF, success) remain inline pending **PR 1b**.

### New classes (`includes/frontend/submission/`)
`SubmissionContext` · `SubmissionRejected` · `ScheduleExceptionGuard` · `IpRateLimitGuard` · `NonceGuard` · `SecurityFieldsGuard` · `FormConfigResolver` · `PreflightGuard` · `FieldSanitizer` · `DeviceSignalsResolver` · `GeofenceGuard` · `RateLimitGuard` · `AccessRestrictionGuard`

### Result
- `FormProcessor` **1047 → 625 lines**; the orchestrator is now ~55 lines.
- `live_exception_payload` moved to `ScheduleExceptionGuard` (public static); `FormProcessorScheduleExceptionTest` retargeted.
- Corrected `SubmissionHandler::process_submission` `fields_config` PHPDoc to the accurate `array<int, array<string, mixed>>` (matches `calculate_quiz_score`) — surfaced once the context typed the value precisely.

### Tests / gates (local)
- New `SubmissionGuardsTest` — 24 tests, each guard's reject + pass branches.
- Existing FormProcessor characterization suite stays green (83 tests) — pins the unchanged external behavior.
- PHPStan L8 ✅ · WPCS ✅ (scoped, documented `EscapeOutput.ExceptionNotEscaped` exclusion for the guard dir — `SubmissionRejected` carries a JSON payload, never echoed).
- Coverage: only well-tested code added; floor unchanged at 66 for this push — I'll confirm the CI-reported number and ratchet the floor in a follow-up commit here if there's headroom (per the CLAUDE.md discipline).

No `FFC_VERSION` bump (targets `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_