### PR TITLE
B3-A follow-up: correct the kept instance-façade docblocks (design note, not "to retire")

### DIFF
--- a/includes/repositories/ffc-appointment-repository.php
+++ b/includes/repositories/ffc-appointment-repository.php
@@ -12,9 +12,11 @@
  * use it directly are unaffected. The façade, reader and writer all bind the
  * same global $wpdb, so transactions and FOR UPDATE locks remain coherent.
  *
- * Tech-debt (#563 B3): migrate call sites to depend on AppointmentReader /
- * AppointmentWriter directly (read vs write at the call site), then retire this
- * delegating façade. Tracked under the modular-monolith roadmap.
+ * Design note (#563 B3-A): unlike the static repository façades (retired in
+ * B3-A), this instance façade is kept by design. It is the transactional
+ * aggregate root — `begin_transaction()` → `FOR UPDATE` read → write →
+ * `commit()` run on the one shared $wpdb the façade, reader and writer all
+ * bind — so it must NOT be retired into separate reader/writer call sites.
  *
  * @package FreeFormCertificate\Repositories
  * @since 4.1.0

--- a/includes/repositories/ffc-submission-repository.php
+++ b/includes/repositories/ffc-submission-repository.php
@@ -11,8 +11,11 @@
  * writer all bind the same global $wpdb, so transactions and locks remain
  * coherent.
  *
- * Tech-debt (#563 B3): migrate call sites to depend on SubmissionReader /
- * SubmissionWriter directly, then retire this delegating façade.
+ * Design note (#563 B3-A): unlike the static repository façades (retired in
+ * B3-A), this instance façade is kept by design — it is the transactional
+ * aggregate root (read → write → commit on the one shared $wpdb the façade,
+ * reader and writer all bind), so it must NOT be retired into separate
+ * reader/writer call sites.
  *
  * V3.3.0: Added strict types and type hints for better code safety
  * v3.2.0: Migrated to namespace (Phase 2)

--- a/includes/url-shortener/class-ffc-url-shortener-repository.php
+++ b/includes/url-shortener/class-ffc-url-shortener-repository.php
@@ -12,8 +12,11 @@
  * façade, reader and writer all bind the same global $wpdb, so caching and
  * queries remain coherent.
  *
- * Tech-debt (#563 B3): migrate call sites to depend on UrlShortenerReader /
- * UrlShortenerWriter directly, then retire this delegating façade.
+ * Design note (#563 B3-A): unlike the static repository façades (retired in
+ * B3-A), this instance façade is kept by design — it is the transactional
+ * aggregate root (composing reader + writer on the one shared $wpdb, with the
+ * inherited generic CRUD), so it must NOT be retired into separate
+ * reader/writer call sites.
  *
  * @package FreeFormCertificate\UrlShortener
  * @since 5.1.0


### PR DESCRIPTION
Follow-up doc cleanup found while auditing the post-B3-A codebase.

The three **instance** repository façades kept in B3-A (`AppointmentRepository`, `SubmissionRepository`, `UrlShortenerRepository`) still carried the original pre-B3-A tech-debt note: *"migrate call sites … then retire this delegating façade."* That now contradicts the deliberate B3-A decision to keep them — they are the **transactional aggregate root** (`begin_transaction()` → `FOR UPDATE` read → write → `commit()` on the one shared `$wpdb` the façade/reader/writer all bind), not dead delegators. Left as-is, the stale note would lead a future contributor (or a cold-start session) to undo the decision.

Reworded each to a **design note** stating they must NOT be retired into separate reader/writer call sites.

Comment-only — no behavior change; WPCS clean. No `FFC_VERSION` bump (develop PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_