### PR TITLE
docs: backfill release commit refs on 6.11.1/6.11.2/6.7.6 headers + document the rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 - Internal refactor (#591) — split the remaining admin/handler god-classes behind same-signature delegators (`FormEditorSaveHandler`, `AudienceAdminAudience`, `PrivacyHandler`, `AdminAssetsManager`, and the critical-path `SubmissionHandler` → `SubmissionLifecycleService`); read/write-split the smaller repositories (recruitment notice/adjutancy/reason/call, url-shortener, reregistration-submission); extracted `SettingsActionHandler` from `Settings`; removed the lone dead `DateFormatter::flush_cache()` shim and dead back-compat entry points. The remaining migration-tail shims (`Encryption` plaintext fallback, `cpf_rf_encrypted`, ficha `generation_date`) stay — evidence-gated, not dead code. Behavior-preserving.
 - Internal architecture (#563 — module boundaries) — added a dependency-free module-boundary guard (`tests/Unit/ModuleBoundaryTest.php` + committed baseline, 130 edges) that fails CI on any new cross-module coupling and can only shrink — regenerate with `FFC_UPDATE_BOUNDARY_BASELINE=1 vendor/bin/phpunit --filter ModuleBoundary` (#593). Then retired the nine static repository façades, migrating every caller to the `*Reader` / `*Writer` classes directly (row-shape types + public constants rehomed onto the readers; `class_exists()` availability guards and `@phpstan-import-type` consumers repointed). The three **instance** façades (`AppointmentRepository`, `SubmissionRepository`, `UrlShortenerRepository`) are kept by design — they are the transactional aggregate root (`begin_transaction()` → `FOR UPDATE` read → write → `commit()` on one `$wpdb`), not dead delegators. Graph unchanged at 130 edges; full suite green (5513 tests); PHPStan L8 + WPCS clean. (#594)
 
-## [6.11.2] (2026-06-21)
+## [6.11.2] (2026-06-21) — `1b1b90d`
 
 ### Security
 
@@ -28,7 +28,7 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 - Vendored thumbmarkjs 1.9.0 → 1.9.1 (MIT, `libs/js/`). Patch release; the server algorithm, fingerprint schema, contract and LGPD posture are unchanged, and the telemetry beacon stays unconditionally disabled. (#571)
 
-## [6.11.1] (2026-06-17)
+## [6.11.1] (2026-06-17) — `97278ec`
 
 ### Added
 
@@ -187,7 +187,7 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 - 5 geofence/spinner messages were unreachable for translators — now flow through `__()` + `wp_localize_script` (English fallback kept).
 
-## [6.7.6] (2026-05-23)
+## [6.7.6] (2026-05-23) — `73c9c9c`
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ When the batch on develop is validated against the testes site and ready to ship
 1. Open a single PR `develop → main`.
 2. In that PR (committed onto `develop` immediately before opening):
    - Bump `FFC_VERSION` in the three sync sites (`ffcertificate.php` header, `FFC_VERSION` constant, `readme.txt` `Stable tag`). See "Versioning".
-   - Rename the `[Unreleased]` heading in `CHANGELOG.md` to `[X.Y.Z] (YYYY-MM-DD)` and add a fresh empty `[Unreleased]` heading above it.
+   - Rename the `[Unreleased]` heading in `CHANGELOG.md` to `[X.Y.Z] (YYYY-MM-DD)` and add a fresh empty `[Unreleased]` heading above it. **Then, once the release PR squash-merges into `main`, backfill the release commit reference onto that heading** by appending `` — `<short-sha>` `` (the 7-char short SHA of the squash commit on `main`), matching every other shipped version header. A missing suffix means the backfill was skipped (as for 6.11.1 / 6.11.2, fixed retroactively).
    - Run `npm run build:js` if any JS/CSS in `assets/` changed across the batch and the bundles weren't already rebuilt mid-flight (the "Verify minified assets are up to date" gate would catch this anyway).
 3. Auto-merge SQUASH into `main`. The squash commit subject should follow main's convention: `X.Y.Z — <short summary of the batch>`.
 4. After merge, rebase `develop` on `main` (see Sync below) so the next batch starts from the bumped baseline.


### PR DESCRIPTION
You spotted that the `6.11.1` and `6.11.2` version headers don't carry the release/PR reference that the other versions do.

### What was wrong
Every shipped version header follows `## [X.Y.Z] (YYYY-MM-DD) — \`<short-sha>\`` (the short SHA of the release squash-commit on `main`). Three headers were missing it: **6.11.2**, **6.11.1**, and **6.7.6**.

**Root cause — and yes, it traces to CLAUDE.md:** the "Release PR" step only said to rename `[Unreleased]` to `[X.Y.Z] (YYYY-MM-DD)`. It never documented the `— \`<short-sha>\`` suffix, so that backfill step was undocumented and got skipped on those releases.

### Fix
- **CHANGELOG** — backfilled the headers from the release commits on `main`:
  - `6.11.2` → `1b1b90d` (release #574)
  - `6.11.1` → `97278ec` (release #561)
  - `6.7.6` → `73c9c9c` (shipped in the same commit as 6.7.7)
- **CLAUDE.md** — the Release PR step now requires backfilling `— \`<short-sha>\`` onto the version heading once the release squash-merges into `main`, so this can't silently recur.

Docs-only; no `FFC_VERSION` bump (develop PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_