### PR TITLE
B3: introduce AdminLoader — single bootstrap entry for the Admin module (pilot)

### DIFF
--- a/includes/admin/class-ffc-admin-loader.php
+++ b/includes/admin/class-ffc-admin-loader.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Admin module loader.
+ *
+ * Single bootstrap entry point for the Admin module — wires every admin-only
+ * `Admin\…` class behind one call so the plugin orchestrator (`Loader`) touches
+ * a single symbol (`AdminLoader`) instead of newing-up ~20 Admin classes
+ * directly. Mirrors the per-module loader pattern already used by
+ * `AudienceLoader` / `RecruitmentLoader` / `UrlShortenerLoader`, and narrows
+ * the `Root → Admin` dependency surface (#563 B3 coupling reduction).
+ *
+ * `init()` must be called only in the `is_admin()` context, exactly as the
+ * inline block it replaces was guarded.
+ *
+ * @package FreeFormCertificate\Admin
+ * @since   6.12.0
+ */
+
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Admin;
+
+use FreeFormCertificate\Submissions\SubmissionHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Bootstraps the admin-only surface of the Admin module.
+ */
+class AdminLoader {
+
+	/**
+	 * Shared submission handler, injected from the orchestrator.
+	 *
+	 * @var SubmissionHandler
+	 */
+	private SubmissionHandler $submission_handler;
+
+	/**
+	 * CSV exporter — held to keep the instance alive for its hooks.
+	 *
+	 * @var CsvExporter|null
+	 */
+	protected ?CsvExporter $csv_exporter = null;
+
+	/**
+	 * Admin screens controller — held to keep the instance alive for its hooks.
+	 *
+	 * @var Admin|null
+	 */
+	protected ?Admin $admin = null;
+
+	/**
+	 * Admin AJAX controller — held to keep the instance alive for its hooks.
+	 *
+	 * @var AdminAjax|null
+	 */
+	protected ?AdminAjax $admin_ajax = null;
+
+	/**
+	 * Inject the shared submission handler the Admin screens depend on.
+	 *
+	 * @param SubmissionHandler $submission_handler Shared handler the Admin screens depend on.
+	 */
+	public function __construct( SubmissionHandler $submission_handler ) {
+		$this->submission_handler = $submission_handler;
+	}
+
+	/**
+	 * Wire every admin-only Admin-module class. Call only when `is_admin()`.
+	 *
+	 * Order matches the previous inline sequence in `Loader::init_plugin()`
+	 * exactly — behavior-preserving.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		$this->csv_exporter = new CsvExporter();
+		$this->admin        = new Admin( $this->submission_handler, $this->csv_exporter );
+		$this->admin_ajax   = new AdminAjax();
+
+		AdminUserColumns::init();
+		AdminUserCapabilities::init();
+		RoleCapabilityEditor::init();
+		AdminMenuVisibility::init();
+		DeviceThresholdUpgradeNotice::init();
+		SettingsAjaxEndpoint::init();
+		FormMetaAjaxEndpoint::init();
+		LocationsAjaxEndpoint::init();
+		CacheActionsAjaxEndpoint::init();
+		FormFeaturesAjaxEndpoint::init();
+		MigrationActionsAjaxEndpoint::init();
+		ActivityLogAjaxEndpoint::init();
+		SubmissionsBulkActionsAjaxEndpoint::init();
+		ExpiredTicketsCleanup::init();
+		FormListColumns::init();
+		AdminUserCustomFields::init();
+	}
+}

--- a/includes/class-ffc-loader.php
+++ b/includes/class-ffc-loader.php
@@ -15,14 +15,9 @@ namespace FreeFormCertificate;
 
 use FreeFormCertificate\Submissions\SubmissionHandler;
 use FreeFormCertificate\Integrations\EmailHandler;
-use FreeFormCertificate\Admin\CsvExporter;
+use FreeFormCertificate\Admin\AdminLoader;
 use FreeFormCertificate\Admin\CPT;
-use FreeFormCertificate\Admin\Admin;
-use FreeFormCertificate\Admin\AdminUserColumns;
-use FreeFormCertificate\Admin\AdminUserCapabilities;
-use FreeFormCertificate\Admin\FormListColumns;
 use FreeFormCertificate\Frontend\Frontend;
-use FreeFormCertificate\Admin\AdminAjax;
 use FreeFormCertificate\API\RestController;
 use FreeFormCertificate\Shortcodes\DashboardShortcode;
 use FreeFormCertificate\UserDashboard\AccessControl;
@@ -39,7 +34,6 @@ use FreeFormCertificate\SelfScheduling\AppointmentCsvExporter;
 use FreeFormCertificate\SelfScheduling\SelfSchedulingShortcode;
 use FreeFormCertificate\Audience\AudienceLoader;
 use FreeFormCertificate\Privacy\PrivacyHandler;
-use FreeFormCertificate\Admin\AdminUserCustomFields;
 use FreeFormCertificate\Core\ActivityLogSubscriber;
 use FreeFormCertificate\Reregistration\ReregistrationAdmin;
 use FreeFormCertificate\Reregistration\ReregistrationFrontend;
@@ -70,11 +64,11 @@ class Loader {
 	 */
 	protected $email_handler;
 	/**
-	 * Csv exporter.
+	 * Admin module loader.
 	 *
-	 * @var \FreeFormCertificate\Admin\CsvExporter|null
+	 * @var \FreeFormCertificate\Admin\AdminLoader|null
 	 */
-	protected $csv_exporter;
+	protected $admin_loader;
 	/**
 	 * Cpt.
 	 *
@@ -82,23 +76,11 @@ class Loader {
 	 */
 	protected $cpt;
 	/**
-	 * Admin.
-	 *
-	 * @var \FreeFormCertificate\Admin\Admin|null
-	 */
-	protected $admin;
-	/**
 	 * Frontend.
 	 *
 	 * @var \FreeFormCertificate\Frontend\Frontend
 	 */
 	protected $frontend;
-	/**
-	 * Admin ajax.
-	 *
-	 * @var \FreeFormCertificate\Admin\AdminAjax|null
-	 */
-	protected $admin_ajax;
 	/**
 	 * Self scheduling cpt.
 	 *
@@ -246,25 +228,11 @@ class Loader {
 
 		// Admin-only classes skipped on frontend.
 		if ( is_admin() ) {
-			$this->csv_exporter = new CsvExporter();
-			$this->admin        = new Admin( $this->submission_handler, $this->csv_exporter );
-			$this->admin_ajax   = new AdminAjax();
-			AdminUserColumns::init();
-			AdminUserCapabilities::init();
-			\FreeFormCertificate\Admin\RoleCapabilityEditor::init();
-			\FreeFormCertificate\Admin\AdminMenuVisibility::init();
-			\FreeFormCertificate\Admin\DeviceThresholdUpgradeNotice::init();
-			\FreeFormCertificate\Admin\SettingsAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\FormMetaAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\LocationsAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\CacheActionsAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\FormFeaturesAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\MigrationActionsAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\ActivityLogAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\SubmissionsBulkActionsAjaxEndpoint::init();
-			\FreeFormCertificate\Admin\ExpiredTicketsCleanup::init();
-			FormListColumns::init();
-			AdminUserCustomFields::init();
+			// Admin module — single bootstrap entry point (#563 B3): wires
+			// every admin-only Admin\… class behind one symbol instead of
+			// newing-up ~20 classes here. Mirrors AudienceLoader/RecruitmentLoader.
+			$this->admin_loader = new AdminLoader( $this->submission_handler );
+			$this->admin_loader->init();
 			$reregistration_admin = new ReregistrationAdmin();
 			$reregistration_admin->init();
 			$this->self_scheduling_admin        = new SelfSchedulingAdmin();

--- a/tests/Unit/AdminLoaderTest.php
+++ b/tests/Unit/AdminLoaderTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace FreeFormCertificate\Tests\Unit;
+
+use Brain\Monkey;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use FreeFormCertificate\Admin\AdminLoader;
+
+/**
+ * Tests for AdminLoader — the single bootstrap entry point for the Admin
+ * module (#563 B3 coupling reduction). Pins that init() constructs the
+ * stateful trio (CsvExporter / Admin / AdminAjax) and fires ::init() on every
+ * admin-only endpoint exactly once, so a future refactor can't silently drop
+ * one when the orchestrator stops newing them up directly.
+ *
+ * @covers \FreeFormCertificate\Admin\AdminLoader
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class AdminLoaderTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		// pcov does not attribute coverage to a class first autoloaded mid-test;
+		// preload AdminLoader so its lines attribute to this test.
+		class_exists( '\\FreeFormCertificate\\Admin\\AdminLoader' );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_init_wires_every_admin_module_class(): void {
+		// Stateful trio — overload so construction is a side-effect-free no-op.
+		Mockery::mock( 'overload:FreeFormCertificate\Admin\CsvExporter' );
+		Mockery::mock( 'overload:FreeFormCertificate\Admin\Admin' );
+		Mockery::mock( 'overload:FreeFormCertificate\Admin\AdminAjax' );
+
+		// Static endpoints — each ::init() must fire exactly once.
+		$static_endpoints = array(
+			'AdminUserColumns',
+			'AdminUserCapabilities',
+			'RoleCapabilityEditor',
+			'AdminMenuVisibility',
+			'DeviceThresholdUpgradeNotice',
+			'SettingsAjaxEndpoint',
+			'FormMetaAjaxEndpoint',
+			'LocationsAjaxEndpoint',
+			'CacheActionsAjaxEndpoint',
+			'FormFeaturesAjaxEndpoint',
+			'MigrationActionsAjaxEndpoint',
+			'ActivityLogAjaxEndpoint',
+			'SubmissionsBulkActionsAjaxEndpoint',
+			'ExpiredTicketsCleanup',
+			'FormListColumns',
+			'AdminUserCustomFields',
+		);
+		foreach ( $static_endpoints as $cls ) {
+			Mockery::mock( 'alias:FreeFormCertificate\Admin\\' . $cls )
+				->shouldReceive( 'init' )->once();
+		}
+
+		$handler = Mockery::mock( 'FreeFormCertificate\Submissions\SubmissionHandler' );
+
+		( new AdminLoader( $handler ) )->init();
+
+		// Mockery's ->once() expectations are verified on tearDown; assert here
+		// too so the test never counts as risky/assertion-less.
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
First step of the coupling-reduction work (#563 B3, hotspot #2 from the graph analysis), as a **pilot**.

### Context
The graph analysis showed the orchestrator `Loader` is a wide composition root, and `Root→Admin` was the fattest non-Core edge: the loader newed-up ~20 `Admin\…` classes inline in `init_plugin()`. The repo already has the right pattern elsewhere (`AudienceLoader`, `RecruitmentLoader`, `UrlShortenerLoader`) — Admin just lacked it.

### Change
- New **`Admin\AdminLoader`** owns the admin-only Admin-module wiring: the stateful trio (`CsvExporter` / `Admin` / `AdminAjax`) + the 16 `::init()` endpoints. Held-alive instances kept as properties, exactly as the loader did.
- `Loader::init_plugin()` now calls `new AdminLoader($this->submission_handler)->init()` and drops the 7 now-unused `Admin` `use` imports + 3 dead properties. `CPT` stays (shared block), so the **`Root→Admin` edge persists** — the boundary graph is unchanged at **130 edges** (guard green; this pilot narrows the *surface*, it doesn't remove the edge).
- `AdminLoaderTest` pins the wiring (trio constructed + every endpoint `::init()` fires once); `AdminLoader` at **20/22 statements covered**.

### Verification
- Module-boundary guard: 130 edges, no new/removed (green).
- PHPStan L8 + WPCS clean; `LoaderTest` + `AdminLoaderTest` green.
- Behavior-preserving: same classes, same order, same `is_admin()` guard.
- No `FFC_VERSION` bump (develop PR).

**Why a pilot:** this is runtime/bootstrap wiring (higher blast radius than the recent docs work), so it ships on its own first to validate on testes before the remaining root-wired modules follow in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_