### PR TITLE
@covers-gap audit: recover FormEditorSaveHandler + CsvValidator coverage; add Code of Conduct (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- Internal (#563 — coverage hygiene) — `@covers`-gap audit: `FormEditorSaveHandler` and `CsvValidator` were exercised by their dedicated tests (`FormEditorSaveHandlerTest`, `RecruitmentCsvImporterTest`) but filtered out of coverage because those tests `@covers`\'d only a sibling/parent class. Added the missing `@covers` (+ `class_exists()` preloads), attributing the existing execution — `FormEditorSaveHandler` 0%→70%, `CsvValidator` 0%→97%, overall PHP coverage 69.16%→70.17%. No new test code; no behavior change.
 - Internal (#563 — coverage hygiene) — ratcheted the PHP coverage floor `COVERAGE_FLOOR_LINES` 66 → 67 after the markup-extraction sweep (#605/#606/#607) moved ~788 uncovered statements into `templates/` (out of scope); re-measured 69.16%.
 - Internal (#563 — coverage hygiene) — `SubmissionHandlerTest` already exercises `SubmissionHandler` end-to-end (process/update/trash/restore/delete/bulk/decrypt/magic-token, 47 tests), but its `@covers` listed only the extracted `SubmissionLifecycleService`, so PHPUnit filtered the handler's executed lines out (reported 0%). Added the missing `@covers \\FreeFormCertificate\\Submissions\\SubmissionHandler` (+ a `class_exists()` preload), attributing the existing coverage — the handler goes 0%→90% and the `submissions` module 43%→76%. No new test code; no behavior change.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/tests/Unit/FormEditorSaveHandlerTest.php
+++ b/tests/Unit/FormEditorSaveHandlerTest.php
@@ -47,8 +47,9 @@ class FormEditorSaveHandlerTest extends TestCase {
         Monkey\setUp();
 
         // pcov does not record lines for files first autoloaded mid-test-method,
-        // so the extracted validator's coverage would attribute to nothing.
-        // Preload the class here so pcov attributes its lines to this test.
+        // so the handler + extracted validator coverage would attribute to nothing.
+        // Preload both classes here so pcov attributes their lines to this test.
+        class_exists( '\\FreeFormCertificate\\Admin\\FormEditorSaveHandler' );
         class_exists( '\\FreeFormCertificate\\Admin\\FormEditorSaveValidator' );
 
         Functions\when( '__' )->returnArg();

--- a/tests/Unit/FormEditorSaveHandlerTest.php
+++ b/tests/Unit/FormEditorSaveHandlerTest.php
@@ -16,6 +16,7 @@ use FreeFormCertificate\Admin\FormEditorSaveValidator;
  * Uses Reflection to access private methods for testing pure business logic.
  *
  * @covers \FreeFormCertificate\Admin\FormEditorSaveValidator
+ * @covers \FreeFormCertificate\Admin\FormEditorSaveHandler
  */
 class FormEditorSaveHandlerTest extends TestCase {
 

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -28,6 +28,7 @@ use FreeFormCertificate\Recruitment\CsvValidator;
  *     integration tests in sprint 13.
  *
  * @covers \FreeFormCertificate\Recruitment\RecruitmentCsvImporter
+ * @covers \FreeFormCertificate\Recruitment\CsvValidator
  */
 class RecruitmentCsvImporterTest extends TestCase {
 

--- a/tests/Unit/RecruitmentCsvImporterTest.php
+++ b/tests/Unit/RecruitmentCsvImporterTest.php
@@ -41,6 +41,11 @@ class RecruitmentCsvImporterTest extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 
+		// pcov does not record lines for files first autoloaded mid-test-method,
+		// so the extracted CsvValidator coverage would attribute to nothing.
+		// Preload it here so pcov attributes its lines to this test.
+		class_exists( '\\FreeFormCertificate\\Recruitment\\CsvValidator' );
+
 		global $wpdb;
 		$wpdb         = Mockery::mock( 'wpdb' )->makePartial();
 		$wpdb->prefix = 'wp_';


### PR DESCRIPTION
## `@covers`-gap audit (the cheap-win category surfaced by checking existing tests first)

Scanned the suite for classes that are **exercised by a dedicated test but filtered out of coverage** because the test's `@covers` listed only a sibling/parent. Two genuine gaps found and fixed (the rest of the low-coverage classes either overlap with other coverers or run unfiltered — they need real new tests, not annotations):

| Class | Test | Before | After |
|---|---|--:|--:|
| `FormEditorSaveHandler` | `FormEditorSaveHandlerTest` (`@covers`'d only the Validator) | 0% | **70%** (160/230) |
| `CsvValidator` | `RecruitmentCsvImporterTest` (`@covers`'d only the Importer) | 0% | **97%** (114/117) |

Added the missing `@covers` + `class_exists()` preloads (repo convention). **No new test code, no behavior change** — this attributes already-existing execution.

**Overall PHP coverage: 69.16% → 70.17%** (+449 covered statements, crosses 70%).

## Also (batched, docs-only)
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant, incorporated from `rpgmem-patch-1` (cherry-picked, original authorship preserved).

WPCS ✅ · target tests green · full suite running before ready-flip. Targets `develop`; CHANGELOG under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_