### PR TITLE
test: cover RecruitmentAdminPage::highlight_active_tab

### DIFF
--- a/tests/Unit/RecruitmentAdminPageTest.php
+++ b/tests/Unit/RecruitmentAdminPageTest.php
@@ -46,6 +46,10 @@ class RecruitmentAdminPageTest extends TestCase {
         Functions\when( 'esc_html__' )->returnArg();
         Functions\when( 'esc_html' )->returnArg();
         Functions\when( 'esc_attr' )->returnArg();
+        Functions\when( 'wp_unslash' )->returnArg();
+        Functions\when( 'sanitize_key' )->alias(
+            static fn( $key ) => strtolower( (string) preg_replace( '/[^a-z0-9_\-]/i', '', (string) $key ) )
+        );
 
         $this->settingsMock = Mockery::mock( 'alias:FreeFormCertificate\Recruitment\RecruitmentSettings' );
         $this->settingsMock->shouldReceive( 'all' )->andReturn(
@@ -145,5 +149,51 @@ class RecruitmentAdminPageTest extends TestCase {
             \FreeFormCertificate\Recruitment\RecruitmentAdjutancyReader::DEFAULT_COLOR,
             $html
         );
+    }
+
+    // ==================================================================
+    // highlight_active_tab() — submenu_file filter for tab highlighting
+    // ==================================================================
+
+    public function test_highlight_active_tab_passes_through_on_other_pages(): void {
+        $_GET = array( 'page' => 'some-other-page' );
+        $this->assertSame(
+            'some-other-page.php',
+            RecruitmentAdminPage::highlight_active_tab( 'some-other-page.php' )
+        );
+        $_GET = array();
+    }
+
+    public function test_highlight_active_tab_defaults_to_notices_without_tab(): void {
+        $_GET = array( 'page' => 'ffc-recruitment' );
+        $this->assertSame(
+            'ffc-recruitment',
+            RecruitmentAdminPage::highlight_active_tab( 'ffc-recruitment' )
+        );
+        $_GET = array();
+    }
+
+    public function test_highlight_active_tab_maps_known_tab_to_submenu_slug(): void {
+        $_GET = array(
+            'page' => 'ffc-recruitment',
+            'tab'  => 'candidates',
+        );
+        $this->assertSame(
+            'ffc-recruitment&tab=candidates',
+            RecruitmentAdminPage::highlight_active_tab( 'ffc-recruitment' )
+        );
+        $_GET = array();
+    }
+
+    public function test_highlight_active_tab_falls_back_to_notices_for_invalid_tab(): void {
+        $_GET = array(
+            'page' => 'ffc-recruitment',
+            'tab'  => 'bogus',
+        );
+        $this->assertSame(
+            'ffc-recruitment',
+            RecruitmentAdminPage::highlight_active_tab( 'ffc-recruitment' )
+        );
+        $_GET = array();
     }
 }


### PR DESCRIPTION
## Summary

- Follow-up to #625, which added `RecruitmentAdminPage::highlight_active_tab()` (a `submenu_file` filter so the recruitment sidebar highlights the open tab). That PR merged before coverage for the new method could land — CI flagged it as an uncovered patch (not a floor breach; overall was 86.4% > floor 82).
- Adds 4 unit tests exercising every branch: pass-through on non-recruitment pages, the no-tab → "notices" default, known-tab → `ffc-recruitment&tab=<tab>` mapping, and the invalid-tab → "notices" fallback.

Tests only; no production code change.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would alter existing behavior)
- [ ] Refactor / chore (no functional change)
- [ ] Documentation only
- [x] Tests only

## Test plan

- [x] `vendor/bin/phpunit --filter RecruitmentAdminPageTest` passes (14 tests, incl. the 4 new)
- [x] Tests only — no runtime surface changed

## Checklist

- [x] No source CSS/JS changed
- [x] No CHANGELOG entry needed (tests only)
- [x] No new PHPStan baseline entries
- [x] No secrets, tokens, or PII in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_