### PR TITLE
Add Settings shortcut to the Short URLs admin header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format follows [Keep a Changelog] (https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Short URLs admin page now shows a "Settings" shortcut (a standard `.page-title-action` button next to the page title) linking straight to the URL Shortener settings tab (`ffc-settings&tab=url_shortener`). Gated on the settings view cap so it only appears for users who can open that page. (#627)
+
 ### Fixed
 - Scheduling menu section separators ("Self"/"Audience") lost their dashicons and became clickable on admin screens that don't load `ffc-audience-admin.css` (e.g. the self-scheduling CPT list/new screens). The global fallback registered the separator styles via `wp_add_inline_style( 'admin-menu', … )` on `admin_head`, which fires after `admin_print_styles`, so the inline style was attached too late to ever output. Registered on `admin_enqueue_scripts` instead so the separators keep their icons and non-clickable styling on every admin page. (#625)
 - Recruitment admin tabs now highlight the open tab in the wp-admin sidebar. The tab submenus register slugs like `ffc-recruitment&tab=candidates`, but WordPress resolves the "current" row from the `?page=` value alone (always `ffc-recruitment`), so "Notices" stayed highlighted on every tab and internal pages didn't track the sidebar. Added a `submenu_file` filter mapping the current `?tab=` onto its submenu slug. (#625)

--- a/templates/admin/url-shortener/short-urls-page.php
+++ b/templates/admin/url-shortener/short-urls-page.php
@@ -33,6 +33,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 		<div class="wrap">
 			<h1 class="wp-heading-inline"><?php esc_html_e( 'Short URLs', 'ffcertificate' ); ?></h1>
+			<?php if ( \FreeFormCertificate\Core\Capabilities::current_user_can_admin_or( 'ffc_view_settings' ) ) : ?>
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=ffc_form&page=ffc-settings&tab=url_shortener' ) ); ?>" class="page-title-action">
+					<?php esc_html_e( 'Settings', 'ffcertificate' ); ?>
+				</a>
+			<?php endif; ?>
 			<hr class="wp-header-end">
 
 			<?php if ( 'trashed' === $msg ) : ?>

--- a/tests/Unit/UrlShortenerAdminPageTest.php
+++ b/tests/Unit/UrlShortenerAdminPageTest.php
@@ -703,6 +703,10 @@ class UrlShortenerAdminPageTest extends TestCase {
         Functions\when( 'add_query_arg' )->justReturn( 'https://example.com/x' );
         Functions\when( 'admin_url' )->returnArg();
         Functions\when( 'paginate_links' )->justReturn( '' );
+        // The header now renders a Settings shortcut gated on the settings
+        // view cap (Capabilities::current_user_can_admin_or); grant it so the
+        // link branch renders.
+        Functions\when( 'current_user_can' )->justReturn( true );
 
         $repo = Mockery::mock( UrlShortenerRepository::class );
         $repo->shouldReceive( 'findPaginated' )->once()->andReturn(


### PR DESCRIPTION
## Summary

- Adds a Settings shortcut on the Short URLs page (`admin.php?page=ffc-short-urls`) so users can jump straight to the module configuration (`edit.php?post_type=ffc_form&page=ffc-settings&tab=url_shortener`) without hunting for it.
- Implemented as the WordPress-standard `.page-title-action` button next to the page title (same slot as "Add New" on list screens) — no new CSS.
- Gated on the settings view cap via `Capabilities::current_user_can_admin_or( 'ffc_view_settings' )`, so it only appears for users who can actually open that page (a `ffc_view_url_shortener`-only user won't see a link that would 403).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would alter existing behavior)
- [ ] Refactor / chore (no functional change)
- [ ] Documentation only

## Test plan

- [x] `vendor/bin/phpunit --filter UrlShortenerAdminPageTest` passes (31 tests) — `test_render_page_includes_template` now grants the settings cap so the new link branch renders
- [x] WPCS clean on the template
- [ ] Manual: Settings button appears next to the title and lands on the URL Shortener settings tab; hidden for users without settings access

## Checklist

- [x] No source CSS/JS changed (markup-only, in `templates/` — outside coverage scope)
- [ ] `CHANGELOG.md` updated — follow-up commit on this branch
- [x] No new PHPStan baseline entries
- [x] No secrets, tokens, or PII in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d

---
_Generated by [Claude Code](https://claude.ai/code/session_014QgDNjPLKv2gQWMhdG7d6d)_